### PR TITLE
fix: standardize payment type formatting in payment APIs

### DIFF
--- a/src/features/learn/components/assessment/RoadmapPage.tsx
+++ b/src/features/learn/components/assessment/RoadmapPage.tsx
@@ -408,10 +408,10 @@ const RoadmapPage = () => {
           assessmentPaymentState.step === "error"
             ? "creating"
             : (assessmentPaymentState.step as
-                | "creating"
-                | "processing"
-                | "verifying"
-                | "complete")
+              | "creating"
+              | "processing"
+              | "verifying"
+              | "complete")
         }
         onClose={() => {
           // Handle processing modal close if needed

--- a/src/services/payment/paymentGatewayApis.ts
+++ b/src/services/payment/paymentGatewayApis.ts
@@ -35,7 +35,7 @@ export const createOrder = async (
   try {
     let requestPayload: CreateOrderRequest = {
       amount: amount.toString(),
-      payment_type: paymentType || PaymentType.COURSE,
+      payment_type: (paymentType || PaymentType.COURSE).toString().toUpperCase(),
     };
 
     // Include type_id for all payment types if available in metadata
@@ -107,7 +107,7 @@ export const verifyPayment = async (
       order_id: paymentData.order_id,
       payment_id: paymentData.payment_id,
       signature: paymentData.signature,
-      payment_type: paymentData.payment_type || PaymentType.COURSE,
+      payment_type: String(paymentData.payment_type || PaymentType.COURSE).toUpperCase(),
       ...(paymentData.type_id && { type_id: paymentData.type_id }), // Include type_id if provided
     };
 


### PR DESCRIPTION
- Updated payment_type in createOrder and verifyPayment functions to ensure consistent uppercase formatting.
- Improved type handling for payment_type to prevent potential issues with case sensitivity.