### PR TITLE
refactor: Update iOS PWA Install Button behavior and visibility logic

### DIFF
--- a/src/commonComponents/mobileNavigation/MobileNavBar.tsx
+++ b/src/commonComponents/mobileNavigation/MobileNavBar.tsx
@@ -1,6 +1,5 @@
 import { useLocation, Link } from 'react-router-dom';
 import CoursesIconController from '../icons/sidebarIcons/CoursesIconController';
-import { IOSPWAInstallButton } from '../../components/IOSPWAInstallButton';
 
 const MobileNavBar = () => {
   const location = useLocation();
@@ -69,11 +68,6 @@ const MobileNavBar = () => {
           label="Live" 
           isActive={isActive('/live')}
         />
-        
-        {/* iOS PWA Install Button - Only shows on iOS devices */}
-        <div className="flex flex-col items-center justify-center">
-          <IOSPWAInstallButton variant="minimal" />
-        </div>
       </div>
     </div>
   );

--- a/src/components/IOSFloatingInstallButton.tsx
+++ b/src/components/IOSFloatingInstallButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Smartphone } from 'lucide-react';
+import { useIOSPWAInstall } from '../hooks/useIOSPWAInstall';
+
+export const IOSFloatingInstallButton: React.FC = () => {
+  const { isIOS, showPrompt } = useIOSPWAInstall();
+
+  if (!isIOS) return null;
+
+  return (
+    <button
+      onClick={showPrompt}
+      className="fixed bottom-20 right-4 z-50 w-12 h-12 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg flex items-center justify-center transition-all duration-200 hover:scale-110 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 touch-manipulation"
+      title="Install App"
+      aria-label="Install App"
+    >
+      <Smartphone className="w-6 h-6" />
+    </button>
+  );
+};
+
+export default IOSFloatingInstallButton;

--- a/src/components/IOSInstallBanner.tsx
+++ b/src/components/IOSInstallBanner.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Smartphone, X } from 'lucide-react';
+import { useIOSPWAInstall } from '../hooks/useIOSPWAInstall';
+
+export const IOSInstallBanner: React.FC = () => {
+  const { isIOS, isInstalled, showPrompt, dismissPrompt } = useIOSPWAInstall();
+
+  if (!isIOS || isInstalled) return null;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 bg-blue-600 text-white z-[9998] px-4 py-3 shadow-lg">
+      <div className="flex items-center justify-between max-w-sm mx-auto">
+        <div className="flex items-center space-x-3">
+          <Smartphone className="w-5 h-5 flex-shrink-0" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium truncate">
+              Install AiLinc for better experience
+            </p>
+            <p className="text-xs opacity-90 truncate">
+              Add to home screen for quick access
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center space-x-2 flex-shrink-0">
+          <button
+            onClick={showPrompt}
+            className="bg-white text-blue-600 px-3 py-1 rounded-full text-xs font-medium hover:bg-gray-100 transition-colors touch-manipulation"
+          >
+            Install
+          </button>
+          <button
+            onClick={dismissPrompt}
+            className="p-1 hover:bg-blue-700 rounded-full transition-colors touch-manipulation"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IOSInstallBanner;

--- a/src/components/IOSPWAInstallButton.tsx
+++ b/src/components/IOSPWAInstallButton.tsx
@@ -15,8 +15,8 @@ export const IOSPWAInstallButton: React.FC<IOSPWAInstallButtonProps> = ({
 }) => {
   const { isIOS, isInstalled, showPrompt } = useIOSPWAInstall();
 
-  // Don't show button if not iOS or already installed
-  if (!isIOS || isInstalled) {
+  // Always show button for iOS users, regardless of installation status
+  if (!isIOS) {
     return null;
   }
 
@@ -34,14 +34,14 @@ export const IOSPWAInstallButton: React.FC<IOSPWAInstallButtonProps> = ({
     <button
       onClick={showPrompt}
       className={`${baseClasses} ${variantClasses[variant]} ${className}`}
-      title="Install App"
+      title={isInstalled ? "Reinstall App" : "Install App"}
     >
       {variant === 'minimal' ? (
         <Smartphone className={iconSize} />
       ) : (
         <>
           <Download className={iconSize} />
-          <span>{children || 'Install App'}</span>
+          <span>{children || (isInstalled ? 'Reinstall App' : 'Install App')}</span>
         </>
       )}
     </button>

--- a/src/hooks/useIOSPWAInstall.ts
+++ b/src/hooks/useIOSPWAInstall.ts
@@ -18,75 +18,58 @@ export interface UseIOSPWAInstallReturn {
   isVisible: boolean;
 }
 
-const DISMISS_KEY = 'ios-pwa-install-dismissed';
-const TEMPORARY_DISMISS_KEY = 'ios-pwa-install-temp-dismissed';
-const DISMISS_DURATION = 24 * 60 * 60 * 1000; // 24 hours
-
 export const useIOSPWAInstall = (): UseIOSPWAInstallReturn => {
   const [isVisible, setIsVisible] = useState(false);
-  const [isManuallyDismissed, setIsManuallyDismissed] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
 
   const isIOS = isIOSDevice();
   const isInstalled = isPWAInstalled();
 
+  // Check if user has dismissed in this session
+  const isSessionDismissed = useCallback(() => {
+    return sessionStorage.getItem('ios-pwa-install-dismissed') === 'true';
+  }, []);
+
   // Check if user has permanently dismissed
   const isPermanentlyDismissed = useCallback(() => {
-    return localStorage.getItem(DISMISS_KEY) === 'true';
+    return localStorage.getItem('ios-pwa-install-dismissed') === 'true';
   }, []);
 
-  // Check if user has temporarily dismissed (within 24 hours)
-  const isTemporarilyDismissed = useCallback(() => {
-    const dismissedAt = localStorage.getItem(TEMPORARY_DISMISS_KEY);
-    if (!dismissedAt) return false;
-    
-    const dismissTime = parseInt(dismissedAt, 10);
-    const now = Date.now();
-    
-    // If more than 24 hours have passed, clear the temporary dismiss
-    if (now - dismissTime > DISMISS_DURATION) {
-      localStorage.removeItem(TEMPORARY_DISMISS_KEY);
-      return false;
-    }
-    
-    return true;
-  }, []);
-
-  // Determine if prompt should be shown
+  // Determine if prompt should be shown - show once per session for iOS users
   const shouldShowPrompt = isIOS && 
                           !isInstalled && 
                           !isPermanentlyDismissed() && 
-                          !isTemporarilyDismissed() && 
-                          !isManuallyDismissed;
+                          !isSessionDismissed() && 
+                          !isDismissed;
 
   const showPrompt = useCallback(() => {
     if (isIOS && !isInstalled && !isPermanentlyDismissed()) {
       setIsVisible(true);
-      setIsManuallyDismissed(false);
+      setIsDismissed(false);
     }
   }, [isIOS, isInstalled, isPermanentlyDismissed]);
 
   const dismissPrompt = useCallback(() => {
     setIsVisible(false);
-    setIsManuallyDismissed(true);
-    // Set temporary dismiss for 24 hours
-    localStorage.setItem(TEMPORARY_DISMISS_KEY, Date.now().toString());
+    setIsDismissed(true);
+    // Mark as dismissed for this session
+    sessionStorage.setItem('ios-pwa-install-dismissed', 'true');
   }, []);
 
   const dismissPermanently = useCallback(() => {
     setIsVisible(false);
-    setIsManuallyDismissed(true);
-    localStorage.setItem(DISMISS_KEY, 'true');
-    // Clear temporary dismiss since we're permanently dismissing
-    localStorage.removeItem(TEMPORARY_DISMISS_KEY);
+    setIsDismissed(true);
+    // Mark as permanently dismissed
+    localStorage.setItem('ios-pwa-install-dismissed', 'true');
+    sessionStorage.removeItem('ios-pwa-install-dismissed');
   }, []);
 
-  // Auto-show prompt after page load
+  // Auto-show prompt once per session for iOS users
   useEffect(() => {
     if (shouldShowPrompt) {
-      // Delay showing the prompt to avoid being too intrusive
       const timer = setTimeout(() => {
         setIsVisible(true);
-      }, 3000); // Show after 3 seconds
+      }, 1000); // Show after 1 second
 
       return () => clearTimeout(timer);
     }


### PR DESCRIPTION
- Removed the iOS PWA Install Button from the MobileNavBar component.
- Modified the IOSPWAInstallButton to always display for iOS users, regardless of installation status.
- Updated the button title and text to reflect installation state (Install/Reinstall).
- Simplified dismissal logic in useIOSPWAInstall hook, using session storage for temporary dismissals.