### PR TITLE
Feature/fix overall-progress decimal rounding

### DIFF
--- a/src/features/learn/components/Streak.tsx
+++ b/src/features/learn/components/Streak.tsx
@@ -28,7 +28,7 @@ const Streak = () => {
       completedHours += single.stats.video.completed;
     }
     if (totalHours == 0) totalHours = 1;
-    setProgress(Number(completedHours / totalHours));
+    setProgress(Number(completedHours / totalHours)*100);
   }, [courses]);
 
   useEffect(() => {
@@ -65,7 +65,7 @@ const Streak = () => {
           Your Streak: <span className="font-bold">{streak} days</span>
         </p>
         <p className="text-gray-500 text-sm md:text-base text-wrap">
-          Overall Course Progress: {progress}% complete
+          Overall Course Progress: {progress.toFixed(2)}% complete
         </p>
       </div>
       <div className="relative w-20 h-20">
@@ -88,7 +88,7 @@ const Streak = () => {
           </Pie>
         </PieChart>
         <div className="absolute inset-0 flex items-center justify-center">
-          <p className="text-xl font-bold text-gray-800">{progress}%</p>
+          <p className="text-xl font-bold text-gray-800">{progress.toFixed(2)}%</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
fixed streak progress data, from broken number to 2 places after decimal, in both pi chart and course completion
<img width="746" height="331" alt="Screenshot 2025-09-26 at 7 49 09 PM" src="https://github.com/user-attachments/assets/ba9ae160-c23d-4795-b4f1-ac7fd8e3601e" />
