### PR TITLE
feat: add k-sage as psychometric assessment type

### DIFF
--- a/app/assessments/result/[slug]/page.tsx
+++ b/app/assessments/result/[slug]/page.tsx
@@ -65,7 +65,9 @@ export default function AssessmentResultPage() {
         slugLower.includes("psychometric") ||
         slugLower === "psychometric" ||
         slugLower.includes("k-disha") ||
-        slugLower.includes("kdisha");
+        slugLower.includes("kdisha") ||
+        slugLower.includes("k-sage") ||
+        slugLower.includes("ksage");
       
       // For psychometric assessments, use mock data for now
       if (isPsychometric) {

--- a/lib/utils/psychometric-utils.ts
+++ b/lib/utils/psychometric-utils.ts
@@ -2,7 +2,7 @@ import { Assessment } from "@/lib/services/assessment.service";
 
 /**
  * Checks if an assessment is a psychometric assessment
- * by checking if the title or slug contains "psychometric" or "k-disha" (case-insensitive)
+ * by checking if the title or slug contains "psychometric", "k-disha", or "k-sage" (case-insensitive)
  */
 export function isPsychometricAssessment(assessment: Assessment): boolean {
   const title = assessment.title?.toLowerCase() || "";
@@ -14,7 +14,11 @@ export function isPsychometricAssessment(assessment: Assessment): boolean {
     title.includes("k-disha") ||
     slug.includes("k-disha") ||
     title.includes("kdisha") ||
-    slug.includes("kdisha")
+    slug.includes("kdisha") ||
+    title.includes("k-sage") ||
+    slug.includes("k-sage") ||
+    title.includes("ksage") ||
+    slug.includes("ksage")
   );
 }
 


### PR DESCRIPTION
- Updated isPsychometricAssessment() to recognize k-sage assessments
- Added k-sage detection in assessment result page
- Supports both 'k-sage' and 'ksage' variations (case-insensitive)
- Ensures k-sage assessments use psychometric result view