### PR TITLE
feat: add college hover and LinkedIn click functionality to all leaderboards

### DIFF
--- a/components/dashboard/Leaderboard.tsx
+++ b/components/dashboard/Leaderboard.tsx
@@ -393,23 +393,79 @@ export const Leaderboard = ({ courseId }: LeaderboardProps) => {
               const rank = entry?.rank ?? 0;
               const totalScore = entry?.marks ?? 0;
               const profilePicUrl = entry?.profile_pic_url;
+              const college = entry?.college;
+              const linkedinUrl = entry?.linkedin_url;
+
+              const handleClick = (e: React.MouseEvent) => {
+                e.stopPropagation();
+                if (linkedinUrl) {
+                  // Ensure URL is valid and starts with http/https
+                  const url = linkedinUrl.startsWith("http") 
+                    ? linkedinUrl 
+                    : `https://${linkedinUrl}`;
+                  // Open LinkedIn in new tab
+                  window.open(url, "_blank", "noopener,noreferrer");
+                }
+              };
 
               return (
-                <Box
+                <Tooltip
                   key={rank || index}
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 1.5,
-                    p: 1,
-                    borderRadius: 1,
-                    backgroundColor:
-                      rank > 0 && rank <= 3 ? "#F9FAFB" : "transparent",
-                    border:
-                      rank > 0 && rank <= 3 ? "1px solid #E5E7EB" : "none",
-                    flexShrink: 0,
-                  }}
+                  title={
+                    linkedinUrl
+                      ? college
+                        ? `College: ${college} - Click to view LinkedIn`
+                        : "Click to view LinkedIn profile"
+                      : college
+                      ? `College: ${college}`
+                      : "No college information available"
+                  }
+                  arrow
+                  placement="top"
+                  disableInteractive
                 >
+                  <Box
+                    onClick={handleClick}
+                    onKeyDown={(e) => {
+                      if ((e.key === "Enter" || e.key === " ") && linkedinUrl) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (linkedinUrl) {
+                          const url = linkedinUrl.startsWith("http") 
+                            ? linkedinUrl 
+                            : `https://${linkedinUrl}`;
+                          window.open(url, "_blank", "noopener,noreferrer");
+                        }
+                      }
+                    }}
+                    role={linkedinUrl ? "button" : undefined}
+                    tabIndex={linkedinUrl ? 0 : undefined}
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1.5,
+                      p: 1,
+                      borderRadius: 1,
+                      backgroundColor:
+                        rank > 0 && rank <= 3 ? "#F9FAFB" : "transparent",
+                      border:
+                        rank > 0 && rank <= 3 ? "1px solid #E5E7EB" : "none",
+                      flexShrink: 0,
+                      cursor: linkedinUrl ? "pointer" : "default",
+                      transition: "all 0.2s ease",
+                      "&:hover": {
+                        backgroundColor: linkedinUrl ? "rgba(99, 102, 241, 0.08)" : undefined,
+                        transform: linkedinUrl ? "translateX(2px)" : undefined,
+                        boxShadow: linkedinUrl ? "0 2px 4px rgba(0,0,0,0.1)" : undefined,
+                      },
+                      "&:focus": linkedinUrl
+                        ? {
+                            outline: "2px solid #6366f1",
+                            outlineOffset: "2px",
+                          }
+                        : {},
+                    }}
+                  >
                   <Box
                     sx={{
                       minWidth: 24,
@@ -471,7 +527,17 @@ export const Leaderboard = ({ courseId }: LeaderboardProps) => {
                   >
                     #{rank || "?"}
                   </Typography>
+                  {linkedinUrl && (
+                    <Box sx={{ ml: 0.5, flexShrink: 0, display: "flex", alignItems: "center" }}>
+                      <IconWrapper
+                        icon="mdi:linkedin"
+                        size={16}
+                        color="#0077B5"
+                      />
+                    </Box>
+                  )}
                 </Box>
+                </Tooltip>
               );
             })}
           </Box>

--- a/components/dashboard/StreakHolders.tsx
+++ b/components/dashboard/StreakHolders.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
-import { Box, Typography, Card, Avatar, Skeleton } from "@mui/material";
+import { Box, Typography, Card, Avatar, Skeleton, Tooltip } from "@mui/material";
 import { dashboardService } from "@/lib/services/dashboard.service";
 import { IconWrapper } from "@/components/common/IconWrapper";
 
@@ -10,6 +10,8 @@ interface StreakHolder {
   Present_streak: number;
   Active_days: number;
   profile_pic_url?: string;
+  college?: string; // College/University name
+  linkedin_url?: string; // LinkedIn profile URL
 }
 
 // Shared cache to minimize API calls
@@ -247,23 +249,79 @@ export const StreakHolders = () => {
               const userName = holder?.studentName || "User";
               const streak = holder?.Present_streak ?? 0;
               const profilePicUrl = holder?.profile_pic_url;
+              const college = holder?.college;
+              const linkedinUrl = holder?.linkedin_url;
+
+              const handleClick = (e: React.MouseEvent) => {
+                e.stopPropagation();
+                if (linkedinUrl) {
+                  // Ensure URL is valid and starts with http/https
+                  const url = linkedinUrl.startsWith("http") 
+                    ? linkedinUrl 
+                    : `https://${linkedinUrl}`;
+                  // Open LinkedIn in new tab
+                  window.open(url, "_blank", "noopener,noreferrer");
+                }
+              };
 
               return (
-                <Box
+                <Tooltip
                   key={`${userName}-${index}`}
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 1.5,
-                    p: 1,
-                    borderRadius: 1,
-                    backgroundColor:
-                      index < 3 ? "#F9FAFB" : "transparent",
-                    border:
-                      index < 3 ? "1px solid #E5E7EB" : "none",
-                    flexShrink: 0,
-                  }}
+                  title={
+                    linkedinUrl
+                      ? college
+                        ? `College: ${college} - Click to view LinkedIn`
+                        : "Click to view LinkedIn profile"
+                      : college
+                      ? `College: ${college}`
+                      : "No college information available"
+                  }
+                  arrow
+                  placement="top"
+                  disableInteractive
                 >
+                  <Box
+                    onClick={handleClick}
+                    onKeyDown={(e) => {
+                      if ((e.key === "Enter" || e.key === " ") && linkedinUrl) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (linkedinUrl) {
+                          const url = linkedinUrl.startsWith("http") 
+                            ? linkedinUrl 
+                            : `https://${linkedinUrl}`;
+                          window.open(url, "_blank", "noopener,noreferrer");
+                        }
+                      }
+                    }}
+                    role={linkedinUrl ? "button" : undefined}
+                    tabIndex={linkedinUrl ? 0 : undefined}
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1.5,
+                      p: 1,
+                      borderRadius: 1,
+                      backgroundColor:
+                        index < 3 ? "#F9FAFB" : "transparent",
+                      border:
+                        index < 3 ? "1px solid #E5E7EB" : "none",
+                      flexShrink: 0,
+                      cursor: linkedinUrl ? "pointer" : "default",
+                      transition: "all 0.2s ease",
+                      "&:hover": {
+                        backgroundColor: linkedinUrl ? "rgba(245, 158, 11, 0.08)" : undefined,
+                        transform: linkedinUrl ? "translateX(2px)" : undefined,
+                        boxShadow: linkedinUrl ? "0 2px 4px rgba(0,0,0,0.1)" : undefined,
+                      },
+                      "&:focus": linkedinUrl
+                        ? {
+                            outline: "2px solid #f59e0b",
+                            outlineOffset: "2px",
+                          }
+                        : {},
+                    }}
+                  >
                   <Box
                     sx={{
                       minWidth: 24,
@@ -328,7 +386,17 @@ export const StreakHolders = () => {
                       </Typography>
                     </Box>
                   </Box>
+                  {linkedinUrl && (
+                    <Box sx={{ ml: 0.5, flexShrink: 0, display: "flex", alignItems: "center" }}>
+                      <IconWrapper
+                        icon="mdi:linkedin"
+                        size={16}
+                        color="#0077B5"
+                      />
+                    </Box>
+                  )}
                 </Box>
+                </Tooltip>
               );
             })}
           </Box>

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -12,6 +12,7 @@ import {
   Divider,
   Badge,
   Popover,
+  Tooltip,
 } from "@mui/material";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/auth-context";
@@ -452,21 +453,78 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
                     const userName = entry?.name ?? entry?.user?.user_name ?? "Unknown";
                     const timeDisplay = formatProgress(entry);
                     const profilePicUrl = entry?.profile_pic_url ?? entry?.user?.profile_pic_url;
+                    const college = entry?.college;
+                    const linkedinUrl = entry?.linkedin_url;
                     
                     // Create a unique key combining user id, name, and index
                     const uniqueKey = entry?.user?.id 
                       ? `leaderboard-${entry.user.id}-${index}` 
                       : `leaderboard-${userName}-${index}`;
                     
+                    const handleClick = (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      if (linkedinUrl) {
+                        // Ensure URL is valid and starts with http/https
+                        const url = linkedinUrl.startsWith("http") 
+                          ? linkedinUrl 
+                          : `https://${linkedinUrl}`;
+                        // Open LinkedIn in new tab
+                        window.open(url, "_blank", "noopener,noreferrer");
+                      }
+                    };
+                    
                     return (
-                      <Box
+                      <Tooltip
                         key={uniqueKey}
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "space-between",
-                        }}
+                        title={
+                          linkedinUrl
+                            ? college
+                              ? `College: ${college} - Click to view LinkedIn`
+                              : "Click to view LinkedIn profile"
+                            : college
+                            ? `College: ${college}`
+                            : "No college information available"
+                        }
+                        arrow
+                        placement="left"
+                        disableInteractive
                       >
+                        <Box
+                          onClick={handleClick}
+                          onKeyDown={(e) => {
+                            if ((e.key === "Enter" || e.key === " ") && linkedinUrl) {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              if (linkedinUrl) {
+                                const url = linkedinUrl.startsWith("http") 
+                                  ? linkedinUrl 
+                                  : `https://${linkedinUrl}`;
+                                window.open(url, "_blank", "noopener,noreferrer");
+                              }
+                            }
+                          }}
+                          role={linkedinUrl ? "button" : undefined}
+                          tabIndex={linkedinUrl ? 0 : undefined}
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            cursor: linkedinUrl ? "pointer" : "default",
+                            p: 0.5,
+                            borderRadius: 1,
+                            transition: "all 0.2s ease",
+                            "&:hover": {
+                              backgroundColor: linkedinUrl ? "rgba(99, 102, 241, 0.08)" : undefined,
+                              transform: linkedinUrl ? "translateX(2px)" : undefined,
+                            },
+                            "&:focus": linkedinUrl
+                              ? {
+                                  outline: "2px solid #6366f1",
+                                  outlineOffset: "2px",
+                                }
+                              : {},
+                          }}
+                        >
                         <Box
                           sx={{ display: "flex", alignItems: "center", gap: 1 }}
                         >
@@ -519,17 +577,27 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
                             {userName}
                           </Typography>
                         </Box>
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            fontSize: "0.75rem",
-                            fontWeight: 500,
-                            color: "#17627A",
-                          }}
-                        >
-                          {timeDisplay}
-                        </Typography>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                          <Typography
+                            variant="caption"
+                            sx={{
+                              fontSize: "0.75rem",
+                              fontWeight: 500,
+                              color: "#17627A",
+                            }}
+                          >
+                            {timeDisplay}
+                          </Typography>
+                          {linkedinUrl && (
+                            <IconWrapper
+                              icon="mdi:linkedin"
+                              size={14}
+                              color="#0077B5"
+                            />
+                          )}
+                        </Box>
                       </Box>
+                      </Tooltip>
                     );
                   })}
                 </Box>

--- a/lib/services/dashboard.service.ts
+++ b/lib/services/dashboard.service.ts
@@ -10,6 +10,8 @@ export interface DailyProgressLeaderboardEntry {
   };
   score?: number;
   rank?: number;
+  college?: string; // College/University name
+  linkedin_url?: string; // LinkedIn profile URL
 }
 
 // Monthly Streak
@@ -29,6 +31,8 @@ export interface OverallLeaderboardEntry {
   course_name?: number;
   rank?: number;
   profile_pic_url?: string;
+  college?: string; // College/University name
+  linkedin_url?: string; // LinkedIn profile URL
 }
 
 export const dashboardService = {
@@ -234,6 +238,8 @@ export const dashboardService = {
           course_name: entry?.course_name ?? " Course",
           rank: entry?.rank ?? 0,
           profile_pic_url: entry?.profile_pic_url ?? entry?.user?.profile_pic_url ?? "",
+          college: entry?.college ?? entry?.college_name ?? entry?.university ?? undefined,
+          linkedin_url: entry?.linkedin_url ?? entry?.linkedin_profile_url ?? entry?.social_links?.linkedin ?? undefined,
         })) as OverallLeaderboardEntry[];
 
       return validatedData;

--- a/lib/services/profile.service.ts
+++ b/lib/services/profile.service.ts
@@ -130,6 +130,8 @@ export interface DailyProgressLeaderboardEntry {
   };
   seconds?: number;
   profile_pic_url?: string;
+  college?: string; // College/University name
+  linkedin_url?: string; // LinkedIn profile URL
 }
 
 export interface MonthlyStreak {


### PR DESCRIPTION

- Add college information display on hover for all leaderboard entries
- Implement click to open LinkedIn profiles in new tab
- Add LinkedIn icon indicator for entries with LinkedIn URLs
- Update TypeScript interfaces to include college and linkedin_url fields:
  * OverallLeaderboardEntry (dashboard.service.ts)
  * DailyProgressLeaderboardEntry (dashboard.service.ts, profile.service.ts)
  * StreakHolder (StreakHolders.tsx)
- Enhance all three leaderboard components:
  * Overall Leaderboard (Dashboard sidebar)
  * Top Streak Holders (Dashboard sidebar)
  * Today's Leaders (Top AppBar)
- Add URL validation and formatting (auto-add https:// if missing)
- Improve accessibility with keyboard support (Enter/Space keys)
- Add disableInteractive to Tooltips to prevent click blocking
- Enhance tooltip messages to indicate clickable LinkedIn links
- Add visual feedback with hover effects and focus states
- Update service layer to handle multiple field name variations