### PR TITLE
feat: add college tagging to assessments

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -121,6 +121,7 @@ export default function AssessmentEditPage() {
   const [currency, setCurrency] = useState<string>("INR");
   const [isActive, setIsActive] = useState(true);
   const [courseIds, setCourseIds] = useState<number[]>([]);
+  const [colleges, setColleges] = useState<string[]>([]);
   const [proctoringEnabled, setProctoringEnabled] = useState(true);
 
   const [questionsPage, setQuestionsPage] = useState(1);
@@ -152,6 +153,7 @@ export default function AssessmentEditPage() {
       setCurrency(anyData.currency ?? "INR");
       setIsActive(data.is_active ?? true);
       setCourseIds(Array.isArray((data as any).course_ids) ? (data as any).course_ids : []);
+      setColleges(Array.isArray((data as any).colleges) ? (data as any).colleges : []);
       setProctoringEnabled((data as any).proctoring_enabled ?? true);
     } catch (e: any) {
       showToast(e?.message || "Failed to load assessment", "error");
@@ -239,6 +241,7 @@ export default function AssessmentEditPage() {
         is_active: isActive,
         proctoring_enabled: proctoringEnabled,
         course_ids: courseIds.length ? courseIds : undefined,
+        colleges: colleges.length ? colleges : undefined,
       };
       Object.keys(payload).forEach((k) => {
         if ((payload as any)[k] === undefined) delete (payload as any)[k];
@@ -504,6 +507,7 @@ export default function AssessmentEditPage() {
                   courseIds={courseIds}
                   courses={courses}
                   loadingCourses={loadingCourses}
+                  colleges={colleges}
                   proctoringEnabled={proctoringEnabled}
                   onDurationChange={setDurationMinutes}
                   onStartTimeChange={setStartTime}
@@ -513,6 +517,7 @@ export default function AssessmentEditPage() {
                   onCurrencyChange={setCurrency}
                   onActiveChange={setIsActive}
                   onCourseIdsChange={setCourseIds}
+                  onCollegesChange={setColleges}
                   onProctoringEnabledChange={setProctoringEnabled}
                 />
                 <Box sx={{ display: "flex", justifyContent: "flex-end" }}>

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -55,6 +55,7 @@ export default function CreateAssessmentPage() {
   const [currency, setCurrency] = useState<string>("INR");
   const [isActive, setIsActive] = useState(true);
   const [courseIds, setCourseIds] = useState<number[]>([]);
+  const [colleges, setColleges] = useState<string[]>([]);
   const [proctoringEnabled, setProctoringEnabled] = useState(true);
 
   // Multiple sections
@@ -653,6 +654,16 @@ export default function CreateAssessmentPage() {
         proctoring_enabled: proctoringEnabled,
       };
 
+      // Add course_ids if any courses are selected
+      if (courseIds.length > 0) {
+        payload.course_ids = courseIds;
+      }
+
+      // Add colleges if any colleges are specified
+      if (colleges.length > 0) {
+        payload.colleges = colleges;
+      }
+
       // Remove undefined fields to match exact API format
       Object.keys(payload).forEach((key) => {
         if (payload[key as keyof typeof payload] === undefined) {
@@ -782,6 +793,7 @@ export default function CreateAssessmentPage() {
               courseIds={courseIds}
               courses={courses}
               loadingCourses={loadingCourses}
+              colleges={colleges}
               proctoringEnabled={proctoringEnabled}
               onDurationChange={setDurationMinutes}
               onStartTimeChange={setStartTime}
@@ -791,6 +803,7 @@ export default function CreateAssessmentPage() {
               onCurrencyChange={setCurrency}
               onActiveChange={setIsActive}
               onCourseIdsChange={setCourseIds}
+              onCollegesChange={setColleges}
               onProctoringEnabledChange={setProctoringEnabled}
             />
             <Divider />

--- a/components/admin/assessment/AssessmentSettingsSection.tsx
+++ b/components/admin/assessment/AssessmentSettingsSection.tsx
@@ -14,6 +14,8 @@ import {
   ListItemText,
   OutlinedInput,
   CircularProgress,
+  Autocomplete,
+  Chip,
 } from "@mui/material";
 
 interface AssessmentSettingsSectionProps {
@@ -28,6 +30,7 @@ interface AssessmentSettingsSectionProps {
   courseIds: number[];
   courses: any[];
   loadingCourses: boolean;
+  colleges: string[];
   onDurationChange: (value: number) => void;
   onStartTimeChange: (value: string) => void;
   onEndTimeChange: (value: string) => void;
@@ -37,6 +40,7 @@ interface AssessmentSettingsSectionProps {
   onActiveChange: (value: boolean) => void;
   onProctoringEnabledChange: (value: boolean) => void;
   onCourseIdsChange: (value: number[]) => void;
+  onCollegesChange: (value: string[]) => void;
 }
 
 export function AssessmentSettingsSection({
@@ -51,6 +55,7 @@ export function AssessmentSettingsSection({
   courseIds,
   courses,
   loadingCourses,
+  colleges,
   onDurationChange,
   onStartTimeChange,
   onEndTimeChange,
@@ -60,6 +65,7 @@ export function AssessmentSettingsSection({
   onActiveChange,
   onProctoringEnabledChange,
   onCourseIdsChange,
+  onCollegesChange,
 }: AssessmentSettingsSectionProps) {
   return (
     <Box>
@@ -125,6 +131,33 @@ export function AssessmentSettingsSection({
             )}
           </Select>
         </FormControl>
+        <Autocomplete
+          multiple
+          freeSolo
+          options={[]}
+          value={colleges}
+          onChange={(_, newValue) => {
+            onCollegesChange(newValue);
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="Colleges (optional)"
+              placeholder="Type and press Enter to add college"
+              helperText="Add college names. Press Enter after each name."
+            />
+          )}
+          renderTags={(value, getTagProps) =>
+            value.map((option, index) => (
+              <Chip
+                label={option}
+                {...getTagProps({ index })}
+                key={index}
+                size="small"
+              />
+            ))
+          }
+        />
         <Box
           sx={{
             display: "grid",

--- a/components/admin/assessment/AssessmentTable.tsx
+++ b/components/admin/assessment/AssessmentTable.tsx
@@ -54,6 +54,27 @@ export function AssessmentTable({
     return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
   };
 
+  const formatCourses = (courses?: Array<{ id: number; title: string }>) => {
+    if (!courses || courses.length === 0) return { display: "—", full: "" };
+    const titles = courses.map((c) => c.title);
+    const full = titles.join(", ");
+    if (titles.length <= 2) {
+      return { display: full, full };
+    }
+    const display = titles.slice(0, 2).join(", ") + "...";
+    return { display, full };
+  };
+
+  const formatColleges = (colleges?: string[]) => {
+    if (!colleges || colleges.length === 0) return { display: "—", full: "" };
+    const full = colleges.join(", ");
+    if (colleges.length <= 2) {
+      return { display: full, full };
+    }
+    const display = colleges.slice(0, 2).join(", ") + "...";
+    return { display, full };
+  };
+
   return (
     <TableContainer sx={{ overflowX: "auto" }}>
       <Table size="small" sx={{ minWidth: 640 }}>
@@ -69,6 +90,30 @@ export function AssessmentTable({
               }}
             >
               Title
+            </TableCell>
+            <TableCell
+              sx={{
+                fontWeight: 600,
+                color: "#374151",
+                fontSize: { xs: "0.75rem", sm: "0.875rem" },
+                display: { xs: "none", lg: "table-cell" },
+                minWidth: 150,
+                py: 1.5,
+              }}
+            >
+              Courses
+            </TableCell>
+            <TableCell
+              sx={{
+                fontWeight: 600,
+                color: "#374151",
+                fontSize: { xs: "0.75rem", sm: "0.875rem" },
+                display: { xs: "none", lg: "table-cell" },
+                minWidth: 150,
+                py: 1.5,
+              }}
+            >
+              Colleges
             </TableCell>
             <TableCell
               sx={{
@@ -140,7 +185,7 @@ export function AssessmentTable({
         <TableBody>
           {assessments.length === 0 ? (
             <TableRow>
-              <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+              <TableCell colSpan={8} align="center" sx={{ py: 4 }}>
                 <Typography variant="body2" color="text.secondary">
                   No assessments found
                 </Typography>
@@ -180,6 +225,90 @@ export function AssessmentTable({
                       />
                     )}
                   </Box>
+                </TableCell>
+                <TableCell
+                  sx={{
+                    display: { xs: "none", lg: "table-cell" },
+                    py: 1.5,
+                    maxWidth: 200,
+                  }}
+                >
+                  {(() => {
+                    const { display, full } = formatCourses(assessment.courses);
+                    if (!full) {
+                      return (
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: "#9ca3af",
+                            fontSize: { xs: "0.8125rem", sm: "0.875rem" },
+                            fontStyle: "italic",
+                          }}
+                        >
+                          {display}
+                        </Typography>
+                      );
+                    }
+                    return (
+                      <Tooltip title={full} arrow>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: "#6b7280",
+                            fontSize: { xs: "0.8125rem", sm: "0.875rem" },
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                            cursor: "help",
+                          }}
+                        >
+                          {display}
+                        </Typography>
+                      </Tooltip>
+                    );
+                  })()}
+                </TableCell>
+                <TableCell
+                  sx={{
+                    display: { xs: "none", lg: "table-cell" },
+                    py: 1.5,
+                    maxWidth: 200,
+                  }}
+                >
+                  {(() => {
+                    const { display, full } = formatColleges(assessment.colleges);
+                    if (!full) {
+                      return (
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: "#9ca3af",
+                            fontSize: { xs: "0.8125rem", sm: "0.875rem" },
+                            fontStyle: "italic",
+                          }}
+                        >
+                          {display}
+                        </Typography>
+                      );
+                    }
+                    return (
+                      <Tooltip title={full} arrow>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: "#6b7280",
+                            fontSize: { xs: "0.8125rem", sm: "0.875rem" },
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                            cursor: "help",
+                          }}
+                        >
+                          {display}
+                        </Typography>
+                      </Tooltip>
+                    );
+                  })()}
                 </TableCell>
                 <TableCell
                   sx={{

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -99,6 +99,7 @@ export interface GenerateCodingProblemResponse {
 export interface CreateAssessmentPayload {
   title: string;
   course_ids?: number[];
+  colleges?: string[];
   instructions: string;
   description?: string;
   duration_minutes: number;
@@ -150,6 +151,8 @@ export interface Assessment {
   created_at: string;
   total_questions: number;
   quiz_sections_count: number;
+  courses?: Array<{ id: number; title: string }>;
+  colleges?: string[];
 }
 
 export interface AssessmentDetail extends Assessment {


### PR DESCRIPTION
- Add colleges field to assessment create/update payloads
- Add Courses and Colleges columns to assessment table with truncation and hover tooltips
- Add college selection UI in assessment settings using Autocomplete
- Update TypeScript interfaces to include courses and colleges fields
- Support college tagging in both create and edit assessment pages