### PR TITLE
Fix: Replace 'not found' flashes with loading indicators

### DIFF
--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -15,6 +15,7 @@ import {
   MenuItem,
   FormControl,
   Chip,
+  LinearProgress,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
@@ -554,7 +555,11 @@ export default function AssessmentsPage() {
         </Paper>
 
         {/* All Assessments Grid */}
-        {filteredAssessments.length > 0 ? (
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: 200 }}>
+            <LinearProgress sx={{ width: "80%", height: 2, borderRadius: 1 }} />
+          </Box>
+        ) : filteredAssessments.length > 0 ? (
           <AssessmentsGrid
             assessments={paginatedAssessments}
             searchQuery={searchQuery}
@@ -616,16 +621,6 @@ export default function AssessmentsPage() {
                 : "Check back later for new assessments"}
             </Typography>
           </Paper>
-        )}
-
-        {/* Empty State */}
-        {regularCount === 0 && psychometricCount === 0 && (
-          <Box sx={{ width: "100%" }}>
-            <AssessmentsGrid
-              assessments={[]}
-            searchQuery={searchQuery}
-          />
-        </Box>
         )}
 
         {/* Pagination */}

--- a/app/courses/[id]/page.tsx
+++ b/app/courses/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Box, Typography, Fab, Tooltip } from "@mui/material";
+import { Box, Typography, Fab, Tooltip, CircularProgress } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
   coursesService,
@@ -189,6 +189,23 @@ export default function CourseDetailPage() {
   const handleNavigate = (submoduleId: number) => {
     router.push(`/courses/${courseId}/submodule/${submoduleId}`);
   };
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: 400,
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      </MainLayout>
+    );
+  }
 
   if (!course) {
     return (

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -14,6 +14,7 @@ import {
   Select,
   MenuItem,
   FormControl,
+  LinearProgress,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
@@ -685,7 +686,11 @@ export default function CoursesPage() {
         </Paper>
 
         {/* Courses Grid */}
-        {paginatedCourses.length === 0 ? (
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: 200 }}>
+            <LinearProgress sx={{ width: "80%", height: 2, borderRadius: 1 }} />
+          </Box>
+        ) : paginatedCourses.length === 0 ? (
           <Box sx={{ textAlign: "center", py: 8 }}>
             <Typography variant="body1" color="text.secondary">
               No courses found

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ export default function DashboardPage() {
       <Box sx={{ p: 3 }}>
         <DashboardContent
           courses={courses}
+          loading={loading}
           streakDays={[23, 25, 27]}
           currentStreak={3}
         />

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, useCallback, startTransition } from "react";
-import { Box } from "@mui/material";
+import { Box, LinearProgress } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { JobCard } from "@/components/jobs/JobCard";
 import { JobSearchBar } from "@/components/jobs/JobSearchBar";
@@ -250,7 +250,11 @@ export default function JobsPage() {
 
         {/* Desktop Job List */}
         <Box sx={{ flex: 1, p: 3 }}>
-          {paginatedJobs.length === 0 ? (
+          {loading ? (
+            <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: 300 }}>
+              <LinearProgress sx={{ width: "80%", height: 2, borderRadius: 1 }} />
+            </Box>
+          ) : paginatedJobs.length === 0 ? (
             <EmptyJobsState />
           ) : (
             <>
@@ -320,7 +324,11 @@ export default function JobsPage() {
             backgroundColor: "#f9fafb",
           }}
         >
-          {paginatedJobs.length === 0 ? (
+          {loading ? (
+            <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: 200 }}>
+              <LinearProgress sx={{ width: "80%", height: 2, borderRadius: 1 }} />
+            </Box>
+          ) : paginatedJobs.length === 0 ? (
             <EmptyJobsState />
           ) : (
             <>

--- a/components/dashboard/DashboardContent.tsx
+++ b/components/dashboard/DashboardContent.tsx
@@ -8,12 +8,14 @@ import { Course as CourseCardCourse } from "@/components/course/interfaces";
 
 interface DashboardContentProps {
   courses: CourseCardCourse[];
+  loading?: boolean;
   streakDays?: number[];
   currentStreak?: number;
 }
 
 export const DashboardContent = ({
   courses,
+  loading,
   streakDays,
   currentStreak,
 }: DashboardContentProps) => {
@@ -33,7 +35,7 @@ export const DashboardContent = ({
       <Box>
         <WelcomeMessage />
         <Box sx={{ mt: 3 }}>
-          <MyCoursesSection courses={courses} />
+          <MyCoursesSection courses={courses} loading={loading} />
         </Box>
       </Box>
       <DashboardSidebar streakDays={streakDays} currentStreak={currentStreak} />

--- a/components/dashboard/Leaderboard.tsx
+++ b/components/dashboard/Leaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
-import { Box, Typography, Card, Avatar, Skeleton, LinearProgress, Tooltip } from "@mui/material";
+import { Box, Typography, Card, Avatar, LinearProgress, Tooltip } from "@mui/material";
 import {
   dashboardService,
   OverallLeaderboardEntry,
@@ -213,72 +213,13 @@ export const Leaderboard = ({ courseId }: LeaderboardProps) => {
           <Box
             sx={{
               display: "flex",
-              flexDirection: "column",
-              gap: 1,
+              justifyContent: "center",
+              alignItems: "center",
+              minHeight: 200,
               p: 2,
             }}
           >
-            {[1, 2, 3, 4, 5].map((i) => (
-              <Box
-                key={i}
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1.5,
-                  p: 1,
-                  borderRadius: 1,
-                }}
-              >
-                <Skeleton
-                  variant="circular"
-                  width={24}
-                  height={24}
-                  animation="wave"
-                  sx={{
-                    bgcolor: "#E0E7FF",
-                  }}
-                />
-                <Skeleton
-                  variant="circular"
-                  width={32}
-                  height={32}
-                  animation="wave"
-                  sx={{
-                    bgcolor: "#E0E7FF",
-                  }}
-                />
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Skeleton
-                    variant="text"
-                    width="60%"
-                    height={16}
-                    animation="wave"
-                    sx={{
-                      bgcolor: "#E0E7FF",
-                    }}
-                  />
-                  <Skeleton
-                    variant="text"
-                    width="40%"
-                    height={12}
-                    animation="wave"
-                    sx={{
-                      mt: 0.5,
-                      bgcolor: "#E0E7FF",
-                    }}
-                  />
-                </Box>
-                <Skeleton
-                  variant="text"
-                  width={30}
-                  height={16}
-                  animation="wave"
-                  sx={{
-                    bgcolor: "#E0E7FF",
-                  }}
-                />
-              </Box>
-            ))}
+            <LinearProgress sx={{ width: "80%", height: 2, borderRadius: 1 }} />
           </Box>
         ) : safeLeaderboard.length === 0 ? (
           <Typography

--- a/components/dashboard/MyCoursesSection.tsx
+++ b/components/dashboard/MyCoursesSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Typography, Button, Paper } from "@mui/material";
+import { Box, Typography, Button, Paper, LinearProgress } from "@mui/material";
 import { CourseCard } from "@/components/course/CourseCard";
 import { Course as CourseCardCourse } from "@/components/course/interfaces";
 import { IconWrapper } from "@/components/common/IconWrapper";
@@ -8,9 +8,10 @@ import Link from "next/link";
 
 interface MyCoursesSectionProps {
   courses: CourseCardCourse[];
+  loading?: boolean;
 }
 
-export const MyCoursesSection = ({ courses }: MyCoursesSectionProps) => {
+export const MyCoursesSection = ({ courses, loading }: MyCoursesSectionProps) => {
   const hasCourses = courses && courses.length > 0;
 
   return (
@@ -35,7 +36,11 @@ export const MyCoursesSection = ({ courses }: MyCoursesSectionProps) => {
         </Typography>
       </Box>
 
-      {hasCourses ? (
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: 200 }}>
+          <LinearProgress sx={{ width: "80%", height: 2, borderRadius: 1 }} />
+        </Box>
+      ) : hasCourses ? (
         <Box
           sx={{
             display: "grid",

--- a/components/dashboard/StreakHolders.tsx
+++ b/components/dashboard/StreakHolders.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
-import { Box, Typography, Card, Avatar, Skeleton, Tooltip } from "@mui/material";
+import { Box, Typography, Card, Avatar, LinearProgress, Tooltip } from "@mui/material";
 import { dashboardService } from "@/lib/services/dashboard.service";
 import { IconWrapper } from "@/components/common/IconWrapper";
 
@@ -124,6 +124,22 @@ export const StreakHolders = () => {
       >
         Top Streak Holders
       </Typography>
+      
+      {/* Loading Progress Bar */}
+      {loading && (
+        <Box sx={{ mb: 2 }}>
+          <LinearProgress
+            sx={{
+              height: 2,
+              borderRadius: 1,
+              "& .MuiLinearProgress-bar": {
+                borderRadius: 1,
+              },
+            }}
+          />
+        </Box>
+      )}
+      
       <Card
         sx={{
           borderRadius: 2,
@@ -136,86 +152,7 @@ export const StreakHolders = () => {
           overflow: "hidden",
         }}
       >
-        {loading ? (
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 1,
-              p: 2,
-            }}
-          >
-            {[1, 2, 3, 4, 5].map((i) => (
-              <Box
-                key={i}
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1.5,
-                  p: 1,
-                  borderRadius: 1,
-                }}
-              >
-                <Skeleton
-                  variant="circular"
-                  width={24}
-                  height={24}
-                  animation="wave"
-                  sx={{
-                    bgcolor: "#FEF3C7",
-                  }}
-                />
-                <Skeleton
-                  variant="circular"
-                  width={32}
-                  height={32}
-                  animation="wave"
-                  sx={{
-                    bgcolor: "#FEF3C7",
-                  }}
-                />
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Skeleton
-                    variant="text"
-                    width="60%"
-                    height={16}
-                    animation="wave"
-                    sx={{
-                      bgcolor: "#FEF3C7",
-                    }}
-                  />
-                  <Box
-                    sx={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 0.5,
-                      mt: 0.5,
-                    }}
-                  >
-                    <Skeleton
-                      variant="circular"
-                      width={14}
-                      height={14}
-                      animation="wave"
-                      sx={{
-                        bgcolor: "#FEF3C7",
-                      }}
-                    />
-                    <Skeleton
-                      variant="text"
-                      width="40%"
-                      height={12}
-                      animation="wave"
-                      sx={{
-                        bgcolor: "#FEF3C7",
-                      }}
-                    />
-                  </Box>
-                </Box>
-              </Box>
-            ))}
-          </Box>
-        ) : streakHolders.length === 0 ? (
+        {streakHolders.length === 0 ? (
           <Typography
             variant="body2"
             sx={{ color: "#6B7280", textAlign: "center", py: 2, p: 2 }}


### PR DESCRIPTION
- Add loading guards to assessments, courses, jobs, and dashboard pages
- Show LinearProgress/CircularProgress instead of empty states during API calls
- Remove duplicate empty state component on assessments page
- Thread loading prop through dashboard components to prevent 'no courses chosen yet' flash
- Replace shimmer skeletons with LinearProgress bars in Leaderboard and StreakHolders
- Position StreakHolders loader outside container at top margin