### PR TITLE
fix: allow course card edit without slug uniqueness error

### DIFF
--- a/app/admin/course-builder/[id]/edit/page.tsx
+++ b/app/admin/course-builder/[id]/edit/page.tsx
@@ -66,15 +66,18 @@ export default function CourseEditPage() {
   const handleSave = async () => {
     try {
       setSaving(true);
+      const effectiveSlug = formData.slug.trim() || formData.title
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9-]/g, "");
+      const slugChanged = course && effectiveSlug !== (course.slug ?? "");
       const courseData: CourseData = {
         title: formData.title.trim(),
         description: formData.description.trim(),
-        slug: formData.slug.trim() || formData.title
-          .toLowerCase()
-          .replace(/\s+/g, "-")
-          .replace(/[^a-z0-9-]/g, ""),
         ...(formData.difficulty_level && { difficulty_level: formData.difficulty_level }),
+        ...(slugChanged && { slug: effectiveSlug }),
       };
+      // Only send slug when user changed it to avoid backend "slug already exists" on same course
 
       await adminCourseBuilderService.updateCourse(courseId, courseData);
       showToast("Course updated successfully", "success");

--- a/components/admin/course-builder/CourseCard.tsx
+++ b/components/admin/course-builder/CourseCard.tsx
@@ -90,13 +90,10 @@ export function CourseCard({ course, onEditClick, onUpdate }: CourseCardProps) {
       const courseData: CourseData = {
         title: editData.title.trim(),
         description: editData.description.trim(),
-        slug: course.title
-          .toLowerCase()
-          .replace(/\s+/g, "-")
-          .replace(/[^a-z0-9-]/g, ""),
         rating: editData.rating,
         tags: editData.tags, // Send as array
       };
+      // Omit slug so backend keeps existing slug and does not run uniqueness check (which fails for same course)
 
       await adminCourseBuilderService.updateCourse(course.id, courseData);
       showToast("Course updated successfully", "success");

--- a/lib/services/admin/admin-course-builder.service.ts
+++ b/lib/services/admin/admin-course-builder.service.ts
@@ -6,7 +6,7 @@ import { AxiosError } from "axios";
 export interface CourseData {
   title: string;
   description: string;
-  slug: string; // Required field
+  slug?: string; // Optional on update; omit when unchanged to avoid backend uniqueness false positive
   difficulty_level?: string; // Valid values: 'Easy', 'Medium', 'Hard'
   rating?: number; // Course rating 0-5
   is_pro?: boolean;
@@ -93,13 +93,16 @@ export const adminCourseBuilderService = {
       return res.data;
     } catch (error: unknown) {
       const apiError = error as AxiosError<ApiErrorPayload>;
-      throw new Error(
+      const data = apiError.response?.data as Record<string, unknown> | undefined;
+      const slugErrors = data?.slug as string[] | undefined;
+      const message =
+        (Array.isArray(slugErrors) && slugErrors[0]) ||
         apiError.response?.data?.detail ||
-          apiError.response?.data?.error ||
-          apiError.response?.data?.message ||
-          apiError.message ||
-          "Failed to update course"
-      );
+        apiError.response?.data?.error ||
+        apiError.response?.data?.message ||
+        apiError.message ||
+        "Failed to update course";
+      throw new Error(message);
     }
   },
 


### PR DESCRIPTION
- Omit slug from PATCH when unchanged so backend does not re-validate
- CourseCard: stop sending slug on inline save (keeps existing slug)
- Edit page: send slug only when user changed it
- CourseData.slug optional; improve updateCourse error message for slug errors