### PR TITLE
feat(course-builder): duplicate course, is_free toggle, and edit slug…

### DIFF
--- a/app/admin/course-builder/[id]/edit/page.tsx
+++ b/app/admin/course-builder/[id]/edit/page.tsx
@@ -77,7 +77,6 @@ export default function CourseEditPage() {
         ...(formData.difficulty_level && { difficulty_level: formData.difficulty_level }),
         ...(slugChanged && { slug: effectiveSlug }),
       };
-      // Only send slug when user changed it to avoid backend "slug already exists" on same course
 
       await adminCourseBuilderService.updateCourse(courseId, courseData);
       showToast("Course updated successfully", "success");

--- a/app/admin/course-builder/page.tsx
+++ b/app/admin/course-builder/page.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
-import { Box, Paper, CircularProgress } from "@mui/material";
+import {
+  Box,
+  Paper,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
 import {
@@ -27,6 +37,9 @@ export default function CourseBuilderPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [creating, setCreating] = useState(false);
+  const [duplicateDialogOpen, setDuplicateDialogOpen] = useState(false);
+  const [courseToDuplicate, setCourseToDuplicate] = useState<Course | null>(null);
+  const [duplicatingId, setDuplicatingId] = useState<number | null>(null);
 
   useEffect(() => {
     loadCourses();
@@ -111,6 +124,35 @@ export default function CourseBuilderPage() {
 
   const handleEditCourse = (courseId: number) => {
     window.location.href = `/admin/course-builder/${courseId}/edit`;
+  };
+
+  const handleDuplicateClick = (course: Course) => {
+    setCourseToDuplicate(course);
+    setDuplicateDialogOpen(true);
+  };
+
+  const handleDuplicateDialogClose = () => {
+    if (!duplicatingId) {
+      setDuplicateDialogOpen(false);
+      setCourseToDuplicate(null);
+    }
+  };
+
+  const handleDuplicateConfirm = async () => {
+    if (!courseToDuplicate) return;
+    try {
+      setDuplicatingId(courseToDuplicate.id);
+      const duplicated = await adminCourseBuilderService.duplicateCourse(courseToDuplicate.id);
+      const title = duplicated?.title ?? courseToDuplicate.title + " - copy";
+      showToast(`Course duplicated successfully. New course: "${title}"`, "success");
+      setDuplicateDialogOpen(false);
+      setCourseToDuplicate(null);
+      loadCourses();
+    } catch (error: any) {
+      showToast(error?.message ?? "Failed to duplicate course", "error");
+    } finally {
+      setDuplicatingId(null);
+    }
   };
 
   const draftCount = courses.filter((course) => !course.published).length;
@@ -215,6 +257,7 @@ export default function CourseBuilderPage() {
                   key={course.id}
                   course={course}
                   onEditClick={() => handleEditCourse(course.id)}
+                  onDuplicate={() => handleDuplicateClick(course)}
                   onUpdate={loadCourses}
                 />
               ))}
@@ -230,6 +273,54 @@ export default function CourseBuilderPage() {
           loading={creating}
           existingTitles={courses.map((c) => c.title)}
         />
+
+        {/* Duplicate Course Dialog */}
+        <Dialog
+          open={duplicateDialogOpen}
+          onClose={handleDuplicateDialogClose}
+          aria-labelledby="duplicate-course-dialog-title"
+          aria-describedby="duplicate-course-dialog-description"
+          PaperProps={{
+            sx: { borderRadius: 2, minWidth: 360 },
+          }}
+        >
+          <DialogTitle id="duplicate-course-dialog-title" sx={{ fontWeight: 600 }}>
+            Duplicate course?
+          </DialogTitle>
+          <DialogContent>
+            <DialogContentText id="duplicate-course-dialog-description">
+              {courseToDuplicate ? (
+                <>
+                  Create a copy of &quot;{courseToDuplicate.title}&quot;? The new course will
+                  include all modules and content.
+                </>
+              ) : null}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions sx={{ px: 3, pb: 2 }}>
+            <Button
+              onClick={handleDuplicateDialogClose}
+              disabled={!!duplicatingId}
+              color="inherit"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleDuplicateConfirm}
+              disabled={!!duplicatingId}
+              variant="contained"
+              sx={{ bgcolor: "#6366f1", "&:hover": { bgcolor: "#4f46e5" } }}
+              autoFocus
+              startIcon={
+                duplicatingId ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : null
+              }
+            >
+              {duplicatingId ? "Duplicating…" : "Duplicate"}
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Box>
     </MainLayout>
   );

--- a/components/admin/course-builder/CourseCard.tsx
+++ b/components/admin/course-builder/CourseCard.tsx
@@ -13,6 +13,8 @@ import {
   Rating,
   Autocomplete,
   CircularProgress,
+  Switch,
+  FormControlLabel,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
@@ -47,10 +49,11 @@ export interface Course {
 interface CourseCardProps {
   course: Course;
   onEditClick: () => void;
+  onDuplicate?: () => void;
   onUpdate?: () => void;
 }
 
-export function CourseCard({ course, onEditClick, onUpdate }: CourseCardProps) {
+export function CourseCard({ course, onEditClick, onDuplicate, onUpdate }: CourseCardProps) {
   const { showToast } = useToast();
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -60,6 +63,7 @@ export function CourseCard({ course, onEditClick, onUpdate }: CourseCardProps) {
     description: course.description,
     tags: course.tags || [],
     rating: course.rating || 0,
+    is_free: course.is_free ?? true,
   });
 
   const getDifficultyColor = (level: string) => {
@@ -91,7 +95,8 @@ export function CourseCard({ course, onEditClick, onUpdate }: CourseCardProps) {
         title: editData.title.trim(),
         description: editData.description.trim(),
         rating: editData.rating,
-        tags: editData.tags, // Send as array
+        tags: editData.tags,
+        is_free: editData.is_free,
       };
       // Omit slug so backend keeps existing slug and does not run uniqueness check (which fails for same course)
 
@@ -112,6 +117,7 @@ export function CourseCard({ course, onEditClick, onUpdate }: CourseCardProps) {
       description: course.description,
       tags: course.tags || [],
       rating: course.rating || 0,
+      is_free: course.is_free ?? true,
     });
     setEditing(false);
   };
@@ -263,6 +269,19 @@ export function CourseCard({ course, onEditClick, onUpdate }: CourseCardProps) {
                 >
                   <IconWrapper icon="mdi:open-in-new" size={18} />
                 </IconButton>
+                {onDuplicate && (
+                  <IconButton
+                    size="small"
+                    onClick={onDuplicate}
+                    sx={{
+                      color: "#6b7280",
+                      "&:hover": { bgcolor: "#f3f4f6" },
+                    }}
+                    title="Duplicate course"
+                  >
+                    <IconWrapper icon="mdi:content-copy" size={18} />
+                  </IconButton>
+                )}
                 {!course.published ? (
                   <IconButton
                     size="small"
@@ -356,6 +375,36 @@ export function CourseCard({ course, onEditClick, onUpdate }: CourseCardProps) {
               </Typography>
             </Box>
           )
+        )}
+
+        {/* Is free */}
+        {editing ? (
+          <Box sx={{ mb: 2 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={editData.is_free}
+                  onChange={(e) => setEditData({ ...editData, is_free: e.target.checked })}
+                  color="primary"
+                  size="small"
+                />
+              }
+              label="Free course"
+              sx={{ "& .MuiFormControlLabel-label": { fontSize: "0.875rem" } }}
+            />
+          </Box>
+        ) : (
+          <Box sx={{ mb: 2 }}>
+            <Chip
+              label={course.is_free ? "Free" : "Paid"}
+              size="small"
+              sx={{
+                bgcolor: course.is_free ? "#d1fae5" : "#fef3c7",
+                color: course.is_free ? "#065f46" : "#92400e",
+                fontSize: "0.75rem",
+              }}
+            />
+          </Box>
         )}
 
         {/* Tags */}

--- a/lib/services/admin/admin-course-builder.service.ts
+++ b/lib/services/admin/admin-course-builder.service.ts
@@ -10,6 +10,7 @@ export interface CourseData {
   difficulty_level?: string; // Valid values: 'Easy', 'Medium', 'Hard'
   rating?: number; // Course rating 0-5
   is_pro?: boolean;
+  is_free?: boolean;
   tags?: string | string[]; // Tags as comma-separated string or array
   [key: string]: string | number | boolean | string[] | undefined;
 }
@@ -103,6 +104,24 @@ export const adminCourseBuilderService = {
         apiError.message ||
         "Failed to update course";
       throw new Error(message);
+    }
+  },
+
+  duplicateCourse: async (courseId: number) => {
+    try {
+      const res = await apiClient.post(
+        `/admin-dashboard/api/clients/${config.clientId}/courses/${courseId}/duplicate/`
+      );
+      return res.data;
+    } catch (error: unknown) {
+      const apiError = error as AxiosError<ApiErrorPayload>;
+      throw new Error(
+        apiError.response?.data?.detail ||
+          apiError.response?.data?.error ||
+          apiError.response?.data?.message ||
+          apiError.message ||
+          "Failed to duplicate course"
+      );
     }
   },
 


### PR DESCRIPTION
… fix

- Add duplicate course API and duplicate button + confirmation dialog on course cards
- Add is_free toggle in course card edit section (default true)
- Omit slug from PATCH when unchanged to avoid backend uniqueness error on edit
- Edit page: send slug only when user changed it