### PR TITLE
Resume builder: PDF quality, single-page, certifications layout, file…

### DIFF
--- a/components/profile/resume/ResumeBuilder.tsx
+++ b/components/profile/resume/ResumeBuilder.tsx
@@ -7,7 +7,7 @@ import { ResumeForm } from "./ResumeForm";
 import { ResumePreview } from "./ResumePreview";
 import { ResumeData } from "./types";
 import { useToast } from "@/components/common/Toast";
-import html2canvas from "html2canvas";
+import { toPng } from "html-to-image";
 import { jsPDF } from "jspdf";
 
 interface ResumeBuilderProps {
@@ -122,7 +122,7 @@ const getDummyData = (initialData?: Partial<ResumeData>): ResumeData => ({
 export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
   const { showToast } = useToast();
   const [selectedTemplate, setSelectedTemplate] = useState<
-    "modern" | "classic" | "minimal" | "executive" | "creative" | "technical"
+    "modern" | "classic" | "minimal" | "executive" | "creative" | "technical" | "western" | "luxsleek" | "twocolumn" | "accentbar" | "rightsidebar" | "bubble"
   >("modern");
   const [templateMenuAnchor, setTemplateMenuAnchor] =
     useState<null | HTMLElement>(null);
@@ -173,82 +173,179 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
     return () => clearTimeout(timeoutId);
   }, [resumeData]);
 
+  /** Convert img elements to data URLs so they can be embedded in the PDF (avoids CORS issues). */
+  const convertImagesInElementToDataUrls = async (el: HTMLElement) => {
+    const imgs = el.querySelectorAll("img[src]");
+    await Promise.all(
+      Array.from(imgs).map(
+        (img) =>
+          new Promise<void>((resolve) => {
+            const src = (img as HTMLImageElement).getAttribute("src");
+            if (!src || src.startsWith("data:")) {
+              resolve();
+              return;
+            }
+            const image = new Image();
+            image.crossOrigin = "anonymous";
+            image.onload = () => {
+              try {
+                const canvas = document.createElement("canvas");
+                canvas.width = image.naturalWidth;
+                canvas.height = image.naturalHeight;
+                const ctx = canvas.getContext("2d");
+                if (ctx) {
+                  ctx.drawImage(image, 0, 0);
+                  (img as HTMLImageElement).setAttribute(
+                    "src",
+                    canvas.toDataURL("image/png")
+                  );
+                }
+              } finally {
+                resolve();
+              }
+            };
+            image.onerror = () => resolve();
+            image.src = src;
+          })
+      )
+    );
+  };
+
   const handleDownloadPDF = async () => {
     if (!previewRef.current) return;
+
+    // Patch CSSStyleSheet.cssRules to prevent SecurityError on cross-origin
+    // stylesheets (Google Fonts, CDN CSS) — html-to-image reads all rules.
+    const origDescriptor = Object.getOwnPropertyDescriptor(
+      CSSStyleSheet.prototype,
+      "cssRules"
+    );
+    let patched = false;
+    try {
+      Object.defineProperty(CSSStyleSheet.prototype, "cssRules", {
+        get: function () {
+          try {
+            return origDescriptor?.get?.call(this) ?? [];
+          } catch {
+            return [];
+          }
+        },
+        configurable: true,
+        enumerable: origDescriptor?.enumerable ?? true,
+      });
+      patched = true;
+    } catch {
+      /* continue without patch */
+    }
 
     try {
       showToast("Generating PDF...", "info");
 
-      // Get the element to capture
       const element = previewRef.current;
 
-      // Wait a bit for any rendering to complete
       await new Promise((resolve) => setTimeout(resolve, 300));
+      await convertImagesInElementToDataUrls(element);
 
-      // Capture the element as canvas
-      // html2canvas captures the full element including scrollHeight
-      const canvas = await html2canvas(element, {
-        scale: 2, // Higher quality for better text rendering
-        useCORS: true,
-        logging: false,
-        backgroundColor: "#ffffff",
-        allowTaint: true,
-        scrollX: 0,
-        scrollY: 0,
+      // Off-screen wrapper at left:-9999px avoids any visible flash.
+      const wrapper = document.createElement("div");
+      wrapper.style.cssText =
+        "position:fixed;left:-9999px;top:0;width:210mm;height:297mm;overflow:visible;pointer-events:none;z-index:-1;";
+      document.body.appendChild(wrapper);
+
+      const clone = element.cloneNode(true) as HTMLElement;
+      clone.style.setProperty("transform", "none", "important");
+      clone.style.setProperty("box-shadow", "none", "important");
+      clone.style.setProperty("width", "210mm", "important");
+      clone.style.setProperty("height", "297mm", "important");
+      clone.style.setProperty("overflow", "hidden");
+      wrapper.appendChild(clone);
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Measure link positions from the untransformed clone
+      const cloneRect = clone.getBoundingClientRect();
+      const linkAnnotations: {
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        url: string;
+      }[] = [];
+
+      clone.querySelectorAll("a[href]").forEach((a) => {
+        const href = (a as HTMLAnchorElement).getAttribute("href");
+        if (!href) return;
+        const r = a.getBoundingClientRect();
+        linkAnnotations.push({
+          x: ((r.left - cloneRect.left) / cloneRect.width) * 210,
+          y: ((r.top - cloneRect.top) / cloneRect.height) * 297,
+          w: (r.width / cloneRect.width) * 210,
+          h: (r.height / cloneRect.height) * 297,
+          url: href,
+        });
       });
 
-      // Calculate PDF dimensions (A4 size in mm)
-      const imgWidth = 210; // A4 width in mm
-      const imgHeight = (canvas.height * imgWidth) / canvas.width;
+      // html-to-image uses SVG foreignObject — the browser's own CSS engine
+      // handles rendering, so the output is pixel-perfect.
+      // The cssRules patch above handles CORS for cross-origin stylesheets.
+      const dataUrl = await toPng(clone, {
+        pixelRatio: 3,
+        backgroundColor: "#ffffff",
+        cacheBust: true,
+      });
+
+      document.body.removeChild(wrapper);
+
+      const img = new Image();
+      img.src = dataUrl;
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = () => reject(new Error("Image load failed"));
+      });
+
+      const imgWidth = 210;
+      const pageHeight = 297;
+      const rawHeight = (img.naturalHeight * imgWidth) / img.naturalWidth;
+      const imgHeight = Math.min(rawHeight, pageHeight);
+
+      // Compress to JPEG (quality 0.92) to keep PDF under 5 MB with minimal visual loss.
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Canvas context unavailable");
+      ctx.drawImage(img, 0, 0);
+      const jpegDataUrl = canvas.toDataURL("image/jpeg", 0.97);
+
       const pdf = new jsPDF("p", "mm", "a4");
+      pdf.addImage(jpegDataUrl, "JPEG", 0, 0, imgWidth, imgHeight);
 
-      // Add the image to PDF
-      const imgData = canvas.toDataURL("image/png", 1.0);
-      const pageHeight = 297; // A4 height in mm
+      linkAnnotations.forEach((link) => {
+        const pageIndex = Math.floor(link.y / pageHeight);
+        const yOnPage = link.y - pageIndex * pageHeight;
+        pdf.setPage(pageIndex + 1);
+        pdf.link(link.x, yOnPage, link.w, link.h, { url: link.url });
+      });
 
-      // If content fits on one page
-      if (imgHeight <= pageHeight) {
-        pdf.addImage(
-          imgData,
-          "PNG",
-          0,
-          0,
-          imgWidth,
-          imgHeight,
-          undefined,
-          "FAST"
-        );
-      } else {
-        // Split into multiple pages if content is taller than one page
-        let heightLeft = imgHeight;
-        let position = 0;
-
-        while (heightLeft > 0) {
-          if (position !== 0) {
-            pdf.addPage();
-          }
-          pdf.addImage(
-            imgData,
-            "PNG",
-            0,
-            -position,
-            imgWidth,
-            imgHeight,
-            undefined,
-            "FAST"
-          );
-          heightLeft -= pageHeight;
-          position -= pageHeight;
-        }
-      }
-
-      // Save the PDF
       const fileName = `${resumeData.basicInfo.firstName}_${resumeData.basicInfo.lastName}_Resume.pdf`;
       pdf.save(fileName);
 
       showToast("PDF downloaded successfully!", "success");
     } catch (error) {
+      console.error("PDF generation error:", error);
       showToast("Failed to generate PDF. Please try again.", "error");
+    } finally {
+      if (patched && origDescriptor) {
+        try {
+          Object.defineProperty(
+            CSSStyleSheet.prototype,
+            "cssRules",
+            origDescriptor
+          );
+        } catch {
+          /* ignore */
+        }
+      }
     }
   };
 
@@ -268,6 +365,12 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
       | "executive"
       | "creative"
       | "technical"
+      | "western"
+      | "luxsleek"
+      | "twocolumn"
+      | "accentbar"
+      | "rightsidebar"
+      | "bubble"
   ) => {
     setSelectedTemplate(template);
     handleTemplateMenuClose();
@@ -371,6 +474,24 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
             </MenuItem>
             <MenuItem onClick={() => handleTemplateSelect("technical")}>
               Technical Template
+            </MenuItem>
+            <MenuItem onClick={() => handleTemplateSelect("western")}>
+              Western Template
+            </MenuItem>
+            <MenuItem onClick={() => handleTemplateSelect("luxsleek")}>
+              LuxSleek Template
+            </MenuItem>
+            <MenuItem onClick={() => handleTemplateSelect("twocolumn")}>
+              Two Column Template
+            </MenuItem>
+            <MenuItem onClick={() => handleTemplateSelect("accentbar")}>
+              Accent Bar Template
+            </MenuItem>
+            <MenuItem onClick={() => handleTemplateSelect("rightsidebar")}>
+              Right Sidebar Template
+            </MenuItem>
+            <MenuItem onClick={() => handleTemplateSelect("bubble")}>
+              Bubble Template
             </MenuItem>
           </Menu>
         </Box>

--- a/components/profile/resume/ResumeForm.tsx
+++ b/components/profile/resume/ResumeForm.tsx
@@ -363,6 +363,85 @@ export function ResumeForm({ resumeData, setResumeData }: ResumeFormProps) {
               placeholder="e.g., San Francisco, CA"
             />
 
+            {/* Profile Photo / Logo - used by templates that support it (e.g. Western = photo, IIIT Vadodara = logo); stored as data URL so it appears in PDF */}
+            <Box>
+              <Typography sx={{ fontSize: "0.875rem", color: "#374151", mb: 1 }}>
+                Profile Photo / Logo
+              </Typography>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                {resumeData.basicInfo.photo ? (
+                  <Avatar
+                    src={resumeData.basicInfo.photo}
+                    alt="Profile"
+                    sx={{ width: 64, height: 64 }}
+                  />
+                ) : (
+                  <Avatar sx={{ width: 64, height: 64, bgcolor: "#e5e7eb" }}>
+                    <IconWrapper icon="mdi:account" color="#9ca3af" />
+                  </Avatar>
+                )}
+                <Box>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    component="label"
+                    startIcon={<IconWrapper icon="mdi:upload" size={20} />}
+                    sx={{ textTransform: "none" }}
+                  >
+                    Upload photo
+                    <input
+                      type="file"
+                      accept="image/*"
+                      hidden
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (!file) return;
+                        const reader = new FileReader();
+                        reader.onload = () => {
+                          const dataUrl = reader.result as string;
+                          setResumeData({
+                            ...resumeData,
+                            basicInfo: {
+                              ...resumeData.basicInfo,
+                              photo: dataUrl,
+                            },
+                          });
+                        };
+                        reader.readAsDataURL(file);
+                        e.target.value = "";
+                      }}
+                    />
+                  </Button>
+                  {resumeData.basicInfo.photo && (
+                    <Button
+                      size="small"
+                      onClick={() =>
+                        setResumeData({
+                          ...resumeData,
+                          basicInfo: {
+                            ...resumeData.basicInfo,
+                            photo: "",
+                          },
+                        })
+                      }
+                      sx={{
+                        textTransform: "none",
+                        color: "#dc2626",
+                        ml: 1,
+                      }}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </Box>
+              </Box>
+              <Typography
+                sx={{ fontSize: "0.75rem", color: "#6b7280", mt: 0.5 }}
+              >
+                Used as profile picture (e.g. Western) or logo (e.g. IIIT Vadodara). Stored so it appears in the PDF.
+              </Typography>
+            </Box>
+
             <Box
               sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}
             >

--- a/components/profile/resume/ResumePreview.tsx
+++ b/components/profile/resume/ResumePreview.tsx
@@ -9,6 +9,12 @@ import { MinimalTemplate } from "./templates/MinimalTemplate";
 import { ExecutiveTemplate } from "./templates/ExecutiveTemplate";
 import { CreativeTemplate } from "./templates/CreativeTemplate";
 import { TechnicalTemplate } from "./templates/TechnicalTemplate";
+import { WesternTemplate } from "./templates/WesternTemplate";
+import { LuxSleekTemplate } from "./templates/LuxSleekTemplate";
+import { TwoColumnTemplate } from "./templates/TwoColumnTemplate";
+import { AccentBarTemplate } from "./templates/AccentBarTemplate";
+import { RightSidebarTemplate } from "./templates/RightSidebarTemplate";
+import { BubbleTemplate } from "./templates/BubbleTemplate";
 
 interface ResumePreviewProps {
   resumeData: ResumeData;
@@ -18,7 +24,13 @@ interface ResumePreviewProps {
     | "minimal"
     | "executive"
     | "creative"
-    | "technical";
+    | "technical"
+    | "western"
+    | "luxsleek"
+    | "twocolumn"
+    | "accentbar"
+    | "rightsidebar"
+    | "bubble";
 }
 
 export const ResumePreview = forwardRef<HTMLDivElement, ResumePreviewProps>(
@@ -81,6 +93,12 @@ export const ResumePreview = forwardRef<HTMLDivElement, ResumePreviewProps>(
           {template === "executive" && <ExecutiveTemplate data={resumeData} />}
           {template === "creative" && <CreativeTemplate data={resumeData} />}
           {template === "technical" && <TechnicalTemplate data={resumeData} />}
+          {template === "western" && <WesternTemplate data={resumeData} />}
+          {template === "luxsleek" && <LuxSleekTemplate data={resumeData} />}
+          {template === "twocolumn" && <TwoColumnTemplate data={resumeData} />}
+          {template === "accentbar" && <AccentBarTemplate data={resumeData} />}
+          {template === "rightsidebar" && <RightSidebarTemplate data={resumeData} />}
+          {template === "bubble" && <BubbleTemplate data={resumeData} />}
         </Box>
       </Box>
     );

--- a/components/profile/resume/templates/AccentBarTemplate.tsx
+++ b/components/profile/resume/templates/AccentBarTemplate.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ResumeData } from "../types";
+
+const ACCENT = "#0d9488";
+
+interface AccentBarTemplateProps {
+  data: ResumeData;
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <Typography
+      sx={{
+        fontSize: "0.7rem",
+        fontWeight: 700,
+        letterSpacing: "0.08em",
+        color: "#0f172a",
+        textTransform: "uppercase",
+        mb: 1.25,
+        pb: 0.5,
+        borderBottom: `2px solid ${ACCENT}`,
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+export function AccentBarTemplate({ data }: AccentBarTemplateProps) {
+  const formatDate = (start: string, end: string, current?: boolean) => {
+    if (!start) return "";
+    const fmt = (d: string) => {
+      if (!d) return "";
+      const [y, m] = d.split("-");
+      const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+      return m ? `${months[parseInt(m, 10) - 1]} ${y}` : y;
+    };
+    return current ? `${fmt(start)} - Present` : `${fmt(start)} - ${fmt(end)}`;
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "297mm",
+        width: "100%",
+        backgroundColor: "#ffffff",
+        WebkitPrintColorAdjust: "exact !important",
+        printColorAdjust: "exact !important",
+      }}
+    >
+      <Box sx={{ px: 2.5, pt: 2, pb: 1 }}>
+        <Typography sx={{ fontSize: "1.4rem", fontWeight: 700, color: "#0f172a" }}>
+          {data.basicInfo.firstName} {data.basicInfo.lastName}
+        </Typography>
+        {data.basicInfo.professionalTitle && (
+          <Typography sx={{ fontSize: "0.85rem", color: "#475569", mt: 0.25 }}>
+            {data.basicInfo.professionalTitle}
+          </Typography>
+        )}
+      </Box>
+      <Box
+        sx={{
+          height: 6,
+          backgroundColor: `${ACCENT} !important`,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+          colorAdjust: "exact !important",
+        }}
+      />
+      <Box sx={{ px: 2.5, py: 2 }}>
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 1,
+            mb: 1.5,
+            fontSize: "0.65rem",
+            color: "#64748b",
+          }}
+        >
+          {data.basicInfo.email && <a href={`mailto:${data.basicInfo.email}`} style={{ textDecoration: "none", color: "inherit" }}>{data.basicInfo.email}</a>}
+          {data.basicInfo.phone && <span>|</span>}
+          {data.basicInfo.phone && <a href={`tel:${data.basicInfo.phone}`} style={{ textDecoration: "none", color: "inherit" }}>{data.basicInfo.phone}</a>}
+          {data.basicInfo.location && <span>|</span>}
+          {data.basicInfo.location && <span>{data.basicInfo.location}</span>}
+          {data.basicInfo.linkedin && <span>|</span>}
+          {data.basicInfo.linkedin && <a href={`https://linkedin.com/in/${data.basicInfo.linkedin}`} target="_blank" rel="noopener noreferrer" style={{ textDecoration: "none", color: "inherit" }}>linkedin.com/in/{data.basicInfo.linkedin}</a>}
+          {data.basicInfo.github && <span>|</span>}
+          {data.basicInfo.github && <a href={`https://github.com/${data.basicInfo.github}`} target="_blank" rel="noopener noreferrer" style={{ textDecoration: "none", color: "inherit" }}>github.com/{data.basicInfo.github}</a>}
+        </Box>
+
+        {data.basicInfo.summary && (
+          <Typography sx={{ fontSize: "0.65rem", color: "#475569", lineHeight: 1.5, mb: 2 }}>
+            {data.basicInfo.summary}
+          </Typography>
+        )}
+
+        {data.workExperience.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <SectionTitle>Work Experience</SectionTitle>
+            {data.workExperience.map((exp) => (
+              <Box key={exp.id} sx={{ mb: 1.5 }}>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: 0.5 }}>
+                  <Box>
+                    <Typography sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>
+                      {exp.position}
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.65rem", color: ACCENT }}>{exp.company}</Typography>
+                  </Box>
+                  <Typography sx={{ fontSize: "0.6rem", color: "#64748b" }}>
+                    {formatDate(exp.startDate, exp.endDate, exp.current)}
+                  </Typography>
+                </Box>
+                {exp.location && (
+                  <Typography sx={{ fontSize: "0.6rem", color: "#64748b", mb: 0.5 }}>{exp.location}</Typography>
+                )}
+                {exp.description.filter((d) => d.trim()).length > 0 && (
+                  <Box component="ul" sx={{ m: 0, pl: 2 }}>
+                    {exp.description.filter((d) => d.trim()).map((d, i) => (
+                      <Typography key={i} component="li" sx={{ fontSize: "0.6rem", color: "#475569", lineHeight: 1.45 }}>
+                        {d}
+                      </Typography>
+                    ))}
+                  </Box>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {data.education.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <SectionTitle>Education</SectionTitle>
+            {data.education.map((edu) => (
+              <Box key={edu.id} sx={{ mb: 1.25 }}>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap" }}>
+                  <Typography sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>{edu.degree}</Typography>
+                  <Typography sx={{ fontSize: "0.6rem", color: "#64748b" }}>
+                    {formatDate(edu.startDate, edu.endDate)}
+                  </Typography>
+                </Box>
+                <Typography sx={{ fontSize: "0.65rem", color: ACCENT }}>{edu.institution}</Typography>
+                {edu.gpa && (
+                  <Typography sx={{ fontSize: "0.6rem", color: "#475569" }}>GPA: {edu.gpa}</Typography>
+                )}
+                {edu.description && (
+                  <Typography sx={{ fontSize: "0.6rem", color: "#475569", lineHeight: 1.45 }}>{edu.description}</Typography>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {data.skills.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <SectionTitle>Skills</SectionTitle>
+            <Typography sx={{ fontSize: "0.65rem", color: "#475569" }}>
+              {data.skills.map((s) => s.name).join(" \u2022 ")}
+            </Typography>
+          </Box>
+        )}
+
+        {data.projects.length > 0 && (
+          <Box sx={{ mb: 2 }}>
+            <SectionTitle>Projects</SectionTitle>
+            {data.projects.map((proj) => (
+              <Box key={proj.id} sx={{ mb: 1.25 }}>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 0.5 }}>
+                  <Typography sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>{proj.name}</Typography>
+                  {proj.link && (
+                    <Typography
+                      component="a"
+                      href={proj.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ fontSize: "0.6rem", color: ACCENT, fontWeight: 600 }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
+                {proj.description && (
+                  <Typography sx={{ fontSize: "0.6rem", color: "#475569", lineHeight: 1.45 }}>{proj.description}</Typography>
+                )}
+                {proj.technologies.filter((t) => t.trim()).length > 0 && (
+                  <Typography sx={{ fontSize: "0.58rem", color: "#64748b", mt: 0.25 }}>
+                    {proj.technologies.filter((t) => t.trim()).join(", ")}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {data.certifications.length > 0 && (
+          <Box>
+            <SectionTitle>Certifications</SectionTitle>
+            {data.certifications.map((cert) => (
+              <Box key={cert.id} sx={{ mb: 0.75 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography sx={{ fontSize: "0.68rem", fontWeight: 600, color: "#0f172a", flex: 1, minWidth: 0 }}>{cert.name}</Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ fontSize: "0.55rem", color: ACCENT, fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap" }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
+                <Typography sx={{ fontSize: "0.6rem", color: "#64748b" }}>
+                  {cert.issuer}
+                  {cert.date ? ` \u2022 ${cert.date.split("-")[0]}` : ""}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/profile/resume/templates/BubbleTemplate.tsx
+++ b/components/profile/resume/templates/BubbleTemplate.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ResumeData } from "../types";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+interface BubbleTemplateProps {
+  data: ResumeData;
+}
+
+const ICON_SIZE = 28;
+const TIMELINE_DOT = 8;
+const TIMELINE_COLOR = "#d1d5db";
+
+function BubbleSectionHead({
+  icon,
+  children,
+}: {
+  icon: string;
+  children: string;
+}) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.25, mt: 2 }}>
+      <Box
+        sx={{
+          width: ICON_SIZE,
+          height: ICON_SIZE,
+          borderRadius: "50%",
+          border: "2px solid #1f2937",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+        }}
+      >
+        <IconWrapper icon={icon} size={14} color="#1f2937" />
+      </Box>
+      <Typography
+        sx={{
+          fontSize: "0.95rem",
+          fontWeight: 700,
+          color: "#1f2937",
+        }}
+      >
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+function SidebarSectionHead({
+  icon,
+  children,
+}: {
+  icon: string;
+  children: string;
+}) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.25, mt: 2.5 }}>
+      <Box
+        sx={{
+          width: ICON_SIZE,
+          height: ICON_SIZE,
+          borderRadius: "50%",
+          border: "2px solid #1f2937",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+        }}
+      >
+        <IconWrapper icon={icon} size={14} color="#1f2937" />
+      </Box>
+      <Typography
+        sx={{
+          fontSize: "0.95rem",
+          fontWeight: 700,
+          color: "#1f2937",
+        }}
+      >
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+function TimelineEvent({
+  startYear,
+  endYear,
+  children,
+}: {
+  startYear?: string;
+  endYear?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box sx={{ display: "flex", gap: 1.5, position: "relative", mb: 2 }}>
+      {/* Year labels + timeline */}
+      <Box
+        sx={{
+          width: 50,
+          flexShrink: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          position: "relative",
+          pt: 0.25,
+        }}
+      >
+        {endYear && (
+          <Typography sx={{ fontSize: "0.55rem", color: "#6b7280", lineHeight: 1.2 }}>
+            {endYear}
+          </Typography>
+        )}
+        {startYear && (
+          <Typography sx={{ fontSize: "0.55rem", color: "#6b7280", lineHeight: 1.2 }}>
+            {startYear}
+          </Typography>
+        )}
+      </Box>
+      {/* Timeline dot + line */}
+      <Box
+        sx={{
+          width: 12,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          flexShrink: 0,
+          pt: 0.5,
+        }}
+      >
+        <Box
+          sx={{
+            width: TIMELINE_DOT,
+            height: TIMELINE_DOT,
+            borderRadius: "50%",
+            backgroundColor: `${TIMELINE_COLOR} !important`,
+            flexShrink: 0,
+            WebkitPrintColorAdjust: "exact !important",
+            printColorAdjust: "exact !important",
+            colorAdjust: "exact !important",
+          }}
+        />
+        <Box
+          sx={{
+            width: 3,
+            flex: 1,
+            backgroundColor: `${TIMELINE_COLOR} !important`,
+            WebkitPrintColorAdjust: "exact !important",
+            printColorAdjust: "exact !important",
+            colorAdjust: "exact !important",
+          }}
+        />
+      </Box>
+      {/* Content */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+export function BubbleTemplate({ data }: BubbleTemplateProps) {
+  const getYear = (d: string) => (d ? d.split("-")[0] : "");
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "297mm",
+        height: "297mm",
+        width: "100%",
+        backgroundColor: "#ffffff",
+        WebkitPrintColorAdjust: "exact !important",
+        printColorAdjust: "exact !important",
+        colorAdjust: "exact !important",
+      }}
+    >
+      {/* ===== LEFT COLUMN (timeline) ===== */}
+      <Box sx={{ width: "62%", p: 2.5, minWidth: 0, overflow: "hidden" }}>
+        {/* Header: photo + name */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 1.5 }}>
+          {data.basicInfo.photo && (
+            <Box
+              component="img"
+              src={data.basicInfo.photo}
+              alt=""
+              crossOrigin="anonymous"
+              sx={{
+                width: 70,
+                height: 70,
+                objectFit: "cover",
+                borderRadius: "50%",
+                flexShrink: 0,
+              }}
+            />
+          )}
+          <Box>
+            <Typography sx={{ fontSize: "1.3rem", fontWeight: 700, color: "#1f2937" }}>
+              {data.basicInfo.firstName} {data.basicInfo.lastName}
+            </Typography>
+            {data.basicInfo.professionalTitle && (
+              <Typography sx={{ fontSize: "0.8rem", color: "#6b7280" }}>
+                {data.basicInfo.professionalTitle}
+              </Typography>
+            )}
+          </Box>
+        </Box>
+
+        {/* Profile (summary) */}
+        {data.basicInfo.summary && (
+          <>
+            <BubbleSectionHead icon="mdi:text-box-outline">Profile</BubbleSectionHead>
+            <Typography
+              sx={{ fontSize: "0.62rem", color: "#4b5563", lineHeight: 1.5, pl: 0.5 }}
+            >
+              {data.basicInfo.summary}
+            </Typography>
+          </>
+        )}
+
+        {/* Work Experience */}
+        {data.workExperience.length > 0 && (
+          <>
+            <BubbleSectionHead icon="mdi:briefcase-outline">Work Experience</BubbleSectionHead>
+            {data.workExperience.map((exp) => (
+              <TimelineEvent
+                key={exp.id}
+                startYear={getYear(exp.startDate)}
+                endYear={exp.current ? "present" : getYear(exp.endDate)}
+              >
+                <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
+                  {exp.position}
+                </Typography>
+                <Typography sx={{ fontSize: "0.62rem", fontStyle: "italic", color: "#6b7280" }}>
+                  {exp.company}
+                  {exp.location ? `, ${exp.location}` : ""}
+                </Typography>
+                {exp.description.filter((d) => d.trim()).length > 0 && (
+                  <Box component="ul" sx={{ m: 0, pl: 2, mt: 0.25 }}>
+                    {exp.description.filter((d) => d.trim()).map((d, i) => (
+                      <Typography key={i} component="li" sx={{ fontSize: "0.58rem", color: "#4b5563", lineHeight: 1.4 }}>
+                        {d}
+                      </Typography>
+                    ))}
+                  </Box>
+                )}
+              </TimelineEvent>
+            ))}
+          </>
+        )}
+
+        {/* Education */}
+        {data.education.length > 0 && (
+          <>
+            <BubbleSectionHead icon="mdi:school-outline">Education</BubbleSectionHead>
+            {data.education.map((edu) => (
+              <TimelineEvent
+                key={edu.id}
+                startYear={getYear(edu.startDate)}
+                endYear={getYear(edu.endDate)}
+              >
+                <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
+                  {edu.degree}
+                </Typography>
+                <Typography sx={{ fontSize: "0.62rem", fontStyle: "italic", color: "#6b7280" }}>
+                  {edu.institution}
+                  {edu.location ? `, ${edu.location}` : ""}
+                </Typography>
+                {edu.description && (
+                  <Box component="ul" sx={{ m: 0, pl: 2, mt: 0.25 }}>
+                    <Typography component="li" sx={{ fontSize: "0.58rem", color: "#4b5563", lineHeight: 1.4 }}>
+                      {edu.description}
+                    </Typography>
+                  </Box>
+                )}
+              </TimelineEvent>
+            ))}
+          </>
+        )}
+
+        {/* Projects */}
+        {data.projects.length > 0 && (
+          <>
+            <BubbleSectionHead icon="mdi:target">Projects</BubbleSectionHead>
+            {data.projects.map((proj) => (
+              <TimelineEvent key={proj.id}>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 0.5 }}>
+                  <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
+                    {proj.name}
+                  </Typography>
+                  {proj.link && (
+                    <Typography
+                      component="a"
+                      href={proj.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ fontSize: "0.58rem", color: "#1f2937", fontWeight: 600, flexShrink: 0 }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
+                {proj.description && (
+                  <Typography sx={{ fontSize: "0.58rem", color: "#4b5563", lineHeight: 1.4 }}>
+                    {proj.description}
+                  </Typography>
+                )}
+              </TimelineEvent>
+            ))}
+          </>
+        )}
+      </Box>
+
+      {/* ===== RIGHT SIDEBAR ===== */}
+      <Box
+        sx={{
+          width: "38%",
+          backgroundColor: "#f3f4f6 !important",
+          p: 2.5,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+          colorAdjust: "exact !important",
+        }}
+      >
+        {/* Contact */}
+        <SidebarSectionHead icon="mdi:card-account-details-outline">Contact</SidebarSectionHead>
+        <Box sx={{ "& > div": { display: "flex", alignItems: "flex-start", gap: 1, mb: 1 } }}>
+          {data.basicInfo.email && (
+            <Box>
+              <IconWrapper icon="mdi:email-outline" size={14} color="#1f2937" />
+              <Box>
+                <Typography sx={{ fontSize: "0.6rem", fontWeight: 700, color: "#1f2937" }}>Email</Typography>
+                <Typography component="a" href={`mailto:${data.basicInfo.email}`} sx={{ fontSize: "0.58rem", color: "#4b5563", textDecoration: "none" }}>{data.basicInfo.email}</Typography>
+              </Box>
+            </Box>
+          )}
+          {data.basicInfo.phone && (
+            <Box>
+              <IconWrapper icon="mdi:phone-outline" size={14} color="#1f2937" />
+              <Box>
+                <Typography sx={{ fontSize: "0.6rem", fontWeight: 700, color: "#1f2937" }}>Phone</Typography>
+                <Typography component="a" href={`tel:${data.basicInfo.phone}`} sx={{ fontSize: "0.58rem", color: "#4b5563", textDecoration: "none" }}>{data.basicInfo.phone}</Typography>
+              </Box>
+            </Box>
+          )}
+          {data.basicInfo.location && (
+            <Box>
+              <IconWrapper icon="mdi:home-outline" size={14} color="#1f2937" />
+              <Box>
+                <Typography sx={{ fontSize: "0.6rem", fontWeight: 700, color: "#1f2937" }}>Address</Typography>
+                <Typography sx={{ fontSize: "0.58rem", color: "#4b5563" }}>{data.basicInfo.location}</Typography>
+              </Box>
+            </Box>
+          )}
+          {data.basicInfo.github && (
+            <Box>
+              <IconWrapper icon="mdi:web" size={14} color="#1f2937" />
+              <Box>
+                <Typography sx={{ fontSize: "0.6rem", fontWeight: 700, color: "#1f2937" }}>Website</Typography>
+                <Typography component="a" href={`https://github.com/${data.basicInfo.github}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.58rem", color: "#4b5563", textDecoration: "none" }}>github.com/{data.basicInfo.github}</Typography>
+              </Box>
+            </Box>
+          )}
+          {data.basicInfo.linkedin && (
+            <Box>
+              <IconWrapper icon="mdi:linkedin" size={14} color="#1f2937" />
+              <Box>
+                <Typography sx={{ fontSize: "0.6rem", fontWeight: 700, color: "#1f2937" }}>LinkedIn</Typography>
+                <Typography component="a" href={`https://linkedin.com/in/${data.basicInfo.linkedin}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.58rem", color: "#4b5563", textDecoration: "none" }}>linkedin.com/in/{data.basicInfo.linkedin}</Typography>
+              </Box>
+            </Box>
+          )}
+        </Box>
+
+        {/* Skills */}
+        {data.skills.length > 0 && (
+          <>
+            <SidebarSectionHead icon="mdi:lightning-bolt">Skills</SidebarSectionHead>
+            {data.skills.map((skill) => (
+              <Box key={skill.id} sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.75 }}>
+                <Box
+                  sx={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    backgroundColor: "#1f2937 !important",
+                    flexShrink: 0,
+                    WebkitPrintColorAdjust: "exact !important",
+                    printColorAdjust: "exact !important",
+                    colorAdjust: "exact !important",
+                  }}
+                />
+                <Typography sx={{ fontSize: "0.62rem", color: "#1f2937" }}>{skill.name}</Typography>
+              </Box>
+            ))}
+          </>
+        )}
+
+        {/* Certifications (mapped from "Languages" in the LaTeX) */}
+        {data.certifications.length > 0 && (
+          <>
+            <SidebarSectionHead icon="mdi:certificate-outline">Certifications</SidebarSectionHead>
+            {data.certifications.map((cert) => (
+              <Box key={cert.id} sx={{ mb: 1 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography sx={{ fontSize: "0.65rem", fontWeight: 700, color: "#1f2937", flex: 1, minWidth: 0 }}>
+                    {cert.name}
+                  </Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ fontSize: "0.52rem", color: "#4b5563", fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap" }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
+                <Typography sx={{ fontSize: "0.58rem", color: "#6b7280" }}>
+                  {cert.issuer}
+                </Typography>
+                {cert.date && (
+                  <Typography sx={{ fontSize: "0.55rem", color: "#6b7280" }}>
+                    {cert.date.split("-")[0]}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/profile/resume/templates/ClassicTemplate.tsx
+++ b/components/profile/resume/templates/ClassicTemplate.tsx
@@ -87,7 +87,11 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
           }}
         >
           {data.basicInfo.email && (
-            <Typography sx={{ fontSize: "0.625rem" }}>
+            <Typography
+              component="a"
+              href={`mailto:${data.basicInfo.email}`}
+              sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}
+            >
               {data.basicInfo.email}
             </Typography>
           )}
@@ -95,7 +99,11 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
             <Typography sx={{ fontSize: "0.625rem" }}>•</Typography>
           )}
           {data.basicInfo.phone && (
-            <Typography sx={{ fontSize: "0.625rem" }}>
+            <Typography
+              component="a"
+              href={`tel:${data.basicInfo.phone}`}
+              sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}
+            >
               {data.basicInfo.phone}
             </Typography>
           )}
@@ -111,7 +119,13 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
             <Typography sx={{ fontSize: "0.625rem" }}>•</Typography>
           )}
           {data.basicInfo.github && (
-            <Typography sx={{ fontSize: "0.625rem" }}>
+            <Typography
+              component="a"
+              href={`https://github.com/${data.basicInfo.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}
+            >
               github.com/{data.basicInfo.github}
             </Typography>
           )}
@@ -119,7 +133,13 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
             <Typography sx={{ fontSize: "0.625rem" }}>•</Typography>
           )}
           {data.basicInfo.linkedin && (
-            <Typography sx={{ fontSize: "0.625rem" }}>
+            <Typography
+              component="a"
+              href={`https://linkedin.com/in/${data.basicInfo.linkedin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}
+            >
               linkedin.com/in/{data.basicInfo.linkedin}
             </Typography>
           )}
@@ -167,7 +187,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
               textTransform: "uppercase",
             }}
           >
-            Professional Experience
+            Work Experience
           </Typography>
 
           {data.workExperience.map((exp, index) => (
@@ -382,16 +402,41 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
                 mb: index < Math.min(data.projects.length, 2) - 1 ? 1.5 : 0,
               }}
             >
-              <Typography
+              <Box
                 sx={{
-                  fontSize: "0.75rem",
-                  fontWeight: 600,
-                  color: "#1f2937",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
                   mb: 0.3,
+                  gap: 1,
                 }}
               >
-                {project.name}
-              </Typography>
+                <Typography
+                  sx={{
+                    fontSize: "0.75rem",
+                    fontWeight: 600,
+                    color: "#1f2937",
+                  }}
+                >
+                  {project.name}
+                </Typography>
+                {project.link && (
+                  <Typography
+                    component="a"
+                    href={project.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{
+                      fontSize: "0.625rem",
+                      color: "#1d4ed8",
+                      fontWeight: 600,
+                      flexShrink: 0,
+                    }}
+                  >
+                    🔗Link
+                  </Typography>
+                )}
+              </Box>
 
               {project.description && (
                 <Typography
@@ -451,15 +496,36 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
               }}
             >
               <Box>
-                <Typography
-                  sx={{
-                    fontSize: "0.625rem",
-                    fontWeight: 600,
-                    color: "#1f2937",
-                  }}
-                >
-                  {cert.name}
-                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.625rem",
+                      fontWeight: 600,
+                      color: "#1f2937",
+                      flex: 1,
+                      minWidth: 0,
+                    }}
+                  >
+                    {cert.name}
+                  </Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.55rem",
+                        color: "#1d4ed8",
+                        fontWeight: 600,
+                        flexShrink: 0,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
                 <Typography sx={{ fontSize: "0.625rem", color: "#4b5563" }}>
                   {cert.issuer}
                 </Typography>

--- a/components/profile/resume/templates/CreativeTemplate.tsx
+++ b/components/profile/resume/templates/CreativeTemplate.tsx
@@ -70,13 +70,21 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
           </Typography>
 
           {data.basicInfo.email && (
-            <Typography sx={{ fontSize: "0.75rem", mb: 1.5, wordBreak: "break-word" }}>
+            <Typography
+              component="a"
+              href={`mailto:${data.basicInfo.email}`}
+              sx={{ fontSize: "0.75rem", mb: 1.5, wordBreak: "break-word", textDecoration: "none", color: "inherit" }}
+            >
               {data.basicInfo.email}
             </Typography>
           )}
 
           {data.basicInfo.phone && (
-            <Typography sx={{ fontSize: "0.75rem", mb: 1.5 }}>
+            <Typography
+              component="a"
+              href={`tel:${data.basicInfo.phone}`}
+              sx={{ fontSize: "0.75rem", mb: 1.5, textDecoration: "none", color: "inherit" }}
+            >
               {data.basicInfo.phone}
             </Typography>
           )}
@@ -112,17 +120,23 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                   sx={{
                     width: "100%",
                     height: 6,
-                    backgroundColor: "rgba(255, 255, 255, 0.2)",
+                    backgroundColor: "rgba(255, 255, 255, 0.2) !important",
                     borderRadius: 3,
                     overflow: "hidden",
+                    WebkitPrintColorAdjust: "exact !important",
+                    printColorAdjust: "exact !important",
+                    colorAdjust: "exact !important",
                   }}
                 >
                   <Box
                     sx={{
                       width: `${(skill.level || 3) * 20}%`,
                       height: "100%",
-                      backgroundColor: "#fbbf24",
+                      backgroundColor: "#fbbf24 !important",
                       borderRadius: 3,
+                      WebkitPrintColorAdjust: "exact !important",
+                      printColorAdjust: "exact !important",
+                      colorAdjust: "exact !important",
                     }}
                   />
                 </Box>
@@ -236,7 +250,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                   letterSpacing: "0.05em",
                 }}
               >
-                Experience
+                Work Experience
               </Typography>
             </Box>
 
@@ -342,11 +356,37 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                   borderLeft: "2px solid #e5e7eb",
                 }}
               >
-                <Typography
-                  sx={{ fontSize: "0.95rem", fontWeight: 600, color: "#1f2937", mb: 0.5 }}
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    mb: 0.5,
+                    gap: 1,
+                  }}
                 >
-                  {project.name}
-                </Typography>
+                  <Typography
+                    sx={{ fontSize: "0.95rem", fontWeight: 600, color: "#1f2937" }}
+                  >
+                    {project.name}
+                  </Typography>
+                  {project.link && (
+                    <Typography
+                      component="a"
+                      href={project.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.75rem",
+                        color: "#667eea",
+                        fontWeight: 600,
+                        flexShrink: 0,
+                      }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
 
                 {project.description && (
                   <Typography
@@ -418,11 +458,30 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
             <Box sx={{ pl: 2.5, display: "grid", gridTemplateColumns: "1fr 1fr", gap: 2 }}>
               {data.certifications.map((cert) => (
                 <Box key={cert.id}>
-                  <Typography
-                    sx={{ fontSize: "0.85rem", fontWeight: 600, color: "#1f2937" }}
-                  >
-                    {cert.name}
-                  </Typography>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                    <Typography
+                      sx={{ fontSize: "0.85rem", fontWeight: 600, color: "#1f2937", flex: 1, minWidth: 0 }}
+                    >
+                      {cert.name}
+                    </Typography>
+                    {cert.link && (
+                      <Typography
+                        component="a"
+                        href={cert.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{
+                          fontSize: "0.65rem",
+                          color: "#667eea",
+                          fontWeight: 600,
+                          flexShrink: 0,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        🔗Link
+                      </Typography>
+                    )}
+                  </Box>
                   <Typography sx={{ fontSize: "0.75rem", color: "#6b7280" }}>
                     {cert.issuer}
                   </Typography>

--- a/components/profile/resume/templates/ExecutiveTemplate.tsx
+++ b/components/profile/resume/templates/ExecutiveTemplate.tsx
@@ -83,12 +83,20 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
           }}
         >
           {data.basicInfo.email && (
-            <Typography sx={{ fontSize: "0.85rem" }}>
+            <Typography
+              component="a"
+              href={`mailto:${data.basicInfo.email}`}
+              sx={{ fontSize: "0.85rem", textDecoration: "none", color: "inherit" }}
+            >
               {data.basicInfo.email}
             </Typography>
           )}
           {data.basicInfo.phone && (
-            <Typography sx={{ fontSize: "0.85rem" }}>
+            <Typography
+              component="a"
+              href={`tel:${data.basicInfo.phone}`}
+              sx={{ fontSize: "0.85rem", textDecoration: "none", color: "inherit" }}
+            >
               {data.basicInfo.phone}
             </Typography>
           )}
@@ -98,12 +106,24 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
             </Typography>
           )}
           {data.basicInfo.github && (
-            <Typography sx={{ fontSize: "0.85rem" }}>
+            <Typography
+              component="a"
+              href={`https://github.com/${data.basicInfo.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ fontSize: "0.85rem", textDecoration: "none", color: "inherit" }}
+            >
               github.com/{data.basicInfo.github}
             </Typography>
           )}
           {data.basicInfo.linkedin && (
-            <Typography sx={{ fontSize: "0.85rem" }}>
+            <Typography
+              component="a"
+              href={`https://linkedin.com/in/${data.basicInfo.linkedin}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ fontSize: "0.85rem", textDecoration: "none", color: "inherit" }}
+            >
               linkedin.com/in/{data.basicInfo.linkedin}
             </Typography>
           )}
@@ -150,7 +170,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
               letterSpacing: "0.05em",
             }}
           >
-            Professional Experience
+            Work Experience
           </Typography>
 
           {data.workExperience.map((exp, index) => (
@@ -315,19 +335,22 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
                   >
                     {skill.name}
                   </Typography>
-                  <Box sx={{ display: "flex", gap: 0.5 }}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: "4px", height: 6 }}>
                     {[...Array(5)].map((_, index) => (
                       <Box
                         key={index}
+                        component="span"
                         sx={{
+                          display: "block",
                           width: 24,
-                          height: 3,
+                          height: 6,
                           backgroundColor:
                             index < (skill.level || 3)
                               ? "#d4af37 !important"
                               : "#e5e7eb !important",
                           WebkitPrintColorAdjust: "exact !important",
                           printColorAdjust: "exact !important",
+                          colorAdjust: "exact !important",
                         }}
                       />
                     ))}
@@ -356,11 +379,30 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
 
             {data.certifications.map((cert) => (
               <Box key={cert.id} sx={{ mb: 1 }}>
-                <Typography
-                  sx={{ fontSize: "0.8rem", fontWeight: 600, color: "#1a1a1a" }}
-                >
-                  {cert.name}
-                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography
+                    sx={{ fontSize: "0.8rem", fontWeight: 600, color: "#1a1a1a", flex: 1, minWidth: 0 }}
+                  >
+                    {cert.name}
+                  </Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.65rem",
+                        color: "#d4af37",
+                        fontWeight: 600,
+                        flexShrink: 0,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
                 <Typography sx={{ fontSize: "0.7rem", color: "#4a4a4a" }}>
                   {cert.issuer}
                 </Typography>
@@ -383,7 +425,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
               letterSpacing: "0.05em",
             }}
           >
-            Key Projects
+            Projects
           </Typography>
 
           {data.projects.slice(0, 2).map((project, index) => (
@@ -393,16 +435,41 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
                 mb: index < Math.min(data.projects.length, 2) - 1 ? 1.5 : 0,
               }}
             >
-              <Typography
+              <Box
                 sx={{
-                  fontSize: "0.85rem",
-                  fontWeight: 600,
-                  color: "#1a1a1a",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
                   mb: 0.3,
+                  gap: 1,
                 }}
               >
-                {project.name}
-              </Typography>
+                <Typography
+                  sx={{
+                    fontSize: "0.85rem",
+                    fontWeight: 600,
+                    color: "#1a1a1a",
+                  }}
+                >
+                  {project.name}
+                </Typography>
+                {project.link && (
+                  <Typography
+                    component="a"
+                    href={project.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{
+                      fontSize: "0.7rem",
+                      color: "#d4af37",
+                      fontWeight: 600,
+                      flexShrink: 0,
+                    }}
+                  >
+                    🔗Link
+                  </Typography>
+                )}
+              </Box>
               {project.description && (
                 <Typography
                   sx={{

--- a/components/profile/resume/templates/LuxSleekTemplate.tsx
+++ b/components/profile/resume/templates/LuxSleekTemplate.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ResumeData } from "../types";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+const CVBLUE = "#304263";
+
+interface LuxSleekTemplateProps {
+  data: ResumeData;
+}
+
+function HeadLeft({ children }: { children: string }) {
+  return (
+    <Box sx={{ mt: 2.5, mb: 0.75 }}>
+      <Typography
+        sx={{
+          fontSize: "0.7rem",
+          fontWeight: 700,
+          fontVariant: "small-caps",
+          letterSpacing: "0.06em",
+          color: "#ffffff",
+        }}
+      >
+        {children}
+      </Typography>
+      <Box
+        sx={{
+          mt: 0.25,
+          height: "1px",
+          backgroundColor: "rgba(255,255,255,0.5) !important",
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+        }}
+      />
+    </Box>
+  );
+}
+
+function HeadRight({ children }: { children: string }) {
+  return (
+    <Box sx={{ mt: 2, mb: 0.5 }}>
+      <Typography
+        sx={{
+          fontSize: "1.05rem",
+          fontWeight: 400,
+          fontVariant: "small-caps",
+          letterSpacing: "0.04em",
+          color: CVBLUE,
+        }}
+      >
+        {children}
+      </Typography>
+      <Box
+        sx={{
+          mt: -0.25,
+          height: "1.5px",
+          backgroundColor: `${CVBLUE} !important`,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+        }}
+      />
+    </Box>
+  );
+}
+
+export function LuxSleekTemplate({ data }: LuxSleekTemplateProps) {
+  const fmtDate = (start: string, end: string, current?: boolean) => {
+    if (!start) return "";
+    const fmt = (d: string) => {
+      if (!d) return "";
+      const [y, m] = d.split("-");
+      return m ? `${y}.${m.padStart(2, "0")}` : y;
+    };
+    const s = fmt(start);
+    if (current) return `${s}\u2013pres.`;
+    if (!end) return s;
+    return `${s}\u2013${fmt(end)}`;
+  };
+
+  const fmtYear = (start: string, end: string) => {
+    if (!start) return "";
+    const sy = start.split("-")[0];
+    if (!end) return sy;
+    const ey = end.split("-")[0];
+    return `${sy}\u2013${ey}`;
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "297mm",
+        height: "297mm",
+        width: "100%",
+        backgroundColor: "#ffffff",
+        fontFamily: "'Fira Sans', 'Segoe UI', 'Roboto', sans-serif",
+        WebkitPrintColorAdjust: "exact !important",
+        printColorAdjust: "exact !important",
+        colorAdjust: "exact !important",
+      }}
+    >
+      {/* ===== LEFT SIDEBAR ===== */}
+      <Box
+        sx={{
+          width: "33%",
+          display: "flex",
+          flexDirection: "column",
+          backgroundColor: `${CVBLUE} !important`,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+        }}
+      >
+        {/* Darker top bar */}
+        <Box
+          sx={{
+            height: 6,
+            backgroundColor: `${CVBLUE} !important`,
+            flexShrink: 0,
+            WebkitPrintColorAdjust: "exact !important",
+            printColorAdjust: "exact !important",
+          }}
+        />
+        {/* Sidebar content */}
+        <Box
+          sx={{
+            flex: 1,
+            backgroundColor: "rgba(48,66,99,0.92) !important",
+            color: "#ffffff",
+            px: 2,
+            pt: 2,
+            pb: 2,
+            WebkitPrintColorAdjust: "exact !important",
+            printColorAdjust: "exact !important",
+          }}
+        >
+          {/* Name */}
+          <Typography
+            sx={{
+              fontSize: "1.15rem",
+              lineHeight: 1.3,
+              mb: 1.5,
+            }}
+          >
+            {data.basicInfo.firstName}{" "}
+            <Box
+              component="span"
+              sx={{ fontWeight: 700, fontVariant: "small-caps", letterSpacing: "0.04em" }}
+            >
+              {data.basicInfo.lastName}
+            </Box>
+          </Typography>
+
+          {/* Oval photo */}
+          {data.basicInfo.photo && (
+            <Box sx={{ display: "flex", justifyContent: "center", mb: 1.5 }}>
+              <Box
+                component="img"
+                src={data.basicInfo.photo}
+                alt=""
+                crossOrigin="anonymous"
+                sx={{
+                  width: "65%",
+                  aspectRatio: "3/4",
+                  objectFit: "cover",
+                  borderRadius: "50%",
+                }}
+              />
+            </Box>
+          )}
+
+          {/* Profile */}
+          <HeadLeft>Profile</HeadLeft>
+          {data.basicInfo.summary && (
+            <Typography
+              sx={{
+                fontSize: "0.62rem",
+                lineHeight: 1.55,
+                color: "rgba(255,255,255,0.92)",
+              }}
+            >
+              {data.basicInfo.summary}
+            </Typography>
+          )}
+
+          {/* Contact details */}
+          <HeadLeft>Contact details</HeadLeft>
+          <Box sx={{ "& > div": { display: "flex", alignItems: "flex-start", gap: 0.75, mb: 0.5 } }}>
+            {data.basicInfo.email && (
+              <Box>
+                <IconWrapper icon="mdi:at" size={12} color="#ffffff" />
+                <Typography component="a" href={`mailto:${data.basicInfo.email}`} sx={{ fontSize: "0.58rem", lineHeight: 1.4, textDecoration: "none", color: "inherit" }}>
+                  {data.basicInfo.email}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.phone && (
+              <Box>
+                <IconWrapper icon="mdi:cellphone" size={12} color="#ffffff" />
+                <Typography component="a" href={`tel:${data.basicInfo.phone}`} sx={{ fontSize: "0.58rem", lineHeight: 1.4, textDecoration: "none", color: "inherit" }}>
+                  {data.basicInfo.phone}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.github && (
+              <Box>
+                <IconWrapper icon="mdi:web" size={12} color="#ffffff" />
+                <Typography component="a" href={`https://github.com/${data.basicInfo.github}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.58rem", lineHeight: 1.4, textDecoration: "none", color: "inherit" }}>
+                  github.com/{data.basicInfo.github}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.linkedin && (
+              <Box>
+                <IconWrapper icon="mdi:linkedin" size={12} color="#ffffff" />
+                <Typography component="a" href={`https://linkedin.com/in/${data.basicInfo.linkedin}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.58rem", lineHeight: 1.4, textDecoration: "none", color: "inherit" }}>
+                  linkedin.com/in/{data.basicInfo.linkedin}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.location && (
+              <Box>
+                <IconWrapper icon="mdi:email-outline" size={12} color="#ffffff" />
+                <Typography sx={{ fontSize: "0.58rem", lineHeight: 1.4 }}>
+                  {data.basicInfo.location}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+
+          {/* Skills */}
+          <HeadLeft>Skills</HeadLeft>
+          <Box
+            component="ul"
+            sx={{
+              m: 0,
+              pl: 1.8,
+              "& li": {
+                fontSize: "0.62rem",
+                lineHeight: 1.5,
+                mb: 0.15,
+                color: "rgba(255,255,255,0.92)",
+                "::marker": { fontSize: "0.55rem" },
+              },
+            }}
+          >
+            {data.skills.map((skill) => (
+              <li key={skill.id}>{skill.name}</li>
+            ))}
+          </Box>
+        </Box>
+      </Box>
+
+      {/* ===== RIGHT COLUMN ===== */}
+      <Box
+        sx={{
+          flex: 1,
+          px: 2.5,
+          pt: 1.5,
+          pb: 2,
+          minWidth: 0,
+          overflow: "hidden",
+        }}
+      >
+        {/* Experience */}
+        <HeadRight>Work Experience</HeadRight>
+        {data.workExperience.map((exp) => (
+          <Box key={exp.id} sx={{ mb: 1.25 }}>
+            {/* Title line: SMALL-CAPS POSITION at *Company (Location).* **dates** */}
+            <Typography
+              sx={{ fontSize: "0.72rem", color: "#1f2937", lineHeight: 1.4 }}
+            >
+              <Box
+                component="span"
+                sx={{ fontVariant: "small-caps", fontWeight: 600, letterSpacing: "0.02em" }}
+              >
+                {exp.position}
+              </Box>
+              {" at "}
+              <Box component="span" sx={{ fontStyle: "italic" }}>
+                {exp.company}
+                {exp.location ? ` (${exp.location}).` : "."}
+              </Box>
+              {"  "}
+              <Box component="span" sx={{ fontWeight: 700, whiteSpace: "nowrap", float: "right" }}>
+                {fmtDate(exp.startDate, exp.endDate, exp.current)}
+              </Box>
+            </Typography>
+            {/* Description with diamond bullets */}
+            {exp.description.filter((d) => d.trim()).length > 0 && (
+              <Box sx={{ mt: 0.25 }}>
+                {exp.description
+                  .filter((d) => d.trim())
+                  .map((d, i) => (
+                    <Typography
+                      key={i}
+                      sx={{
+                        fontSize: "0.62rem",
+                        color: "#4b5563",
+                        lineHeight: 1.45,
+                      }}
+                    >
+                      <Box component="span" sx={{ fontSize: "0.5rem", mr: 0.5 }}>◇</Box>
+                      {d}
+                    </Typography>
+                  ))}
+              </Box>
+            )}
+          </Box>
+        ))}
+
+        {/* Education */}
+        <HeadRight>Education</HeadRight>
+        {data.education.map((edu) => (
+          <Box key={edu.id} sx={{ mb: 1.25 }}>
+            <Typography
+              sx={{ fontSize: "0.72rem", color: "#1f2937", lineHeight: 1.4 }}
+            >
+              <Box
+                component="span"
+                sx={{ fontVariant: "small-caps", fontWeight: 600, letterSpacing: "0.02em" }}
+              >
+                {edu.degree}.
+              </Box>
+              {" "}
+              <Box component="span" sx={{ fontStyle: "italic" }}>
+                {edu.institution}.
+              </Box>
+              {"  "}
+              <Box component="span" sx={{ fontWeight: 700, whiteSpace: "nowrap", float: "right" }}>
+                {fmtYear(edu.startDate, edu.endDate)}
+              </Box>
+            </Typography>
+            {edu.description && (
+              <Typography
+                sx={{ fontSize: "0.62rem", color: "#4b5563", lineHeight: 1.45 }}
+              >
+                <Box component="span" sx={{ fontSize: "0.5rem", mr: 0.5 }}>◇</Box>
+                {edu.description}
+              </Typography>
+            )}
+          </Box>
+        ))}
+
+        {/* Projects */}
+        {data.projects.length > 0 && (
+          <>
+            <HeadRight>Projects</HeadRight>
+            {data.projects.map((proj) => (
+              <Box key={proj.id} sx={{ mb: 1.25 }}>
+                <Typography
+                  sx={{ fontSize: "0.72rem", color: "#1f2937", lineHeight: 1.4 }}
+                >
+                  <Box
+                    component="span"
+                    sx={{ fontVariant: "small-caps", fontWeight: 600, letterSpacing: "0.02em" }}
+                  >
+                    {proj.name}.
+                  </Box>
+                  {proj.link && (
+                    <>
+                      {"  "}
+                      <Typography
+                        component="a"
+                        href={proj.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{
+                          fontSize: "0.62rem",
+                          color: CVBLUE,
+                          fontWeight: 600,
+                          whiteSpace: "nowrap",
+                          float: "right",
+                        }}
+                      >
+                        🔗Link
+                      </Typography>
+                    </>
+                  )}
+                </Typography>
+                {proj.description && (
+                  <Typography
+                    sx={{ fontSize: "0.62rem", color: "#4b5563", lineHeight: 1.45 }}
+                  >
+                    <Box component="span" sx={{ fontSize: "0.5rem", mr: 0.5 }}>◇</Box>
+                    {proj.description}
+                  </Typography>
+                )}
+                {proj.technologies.filter((t) => t.trim()).length > 0 && (
+                  <Typography
+                    sx={{ fontSize: "0.62rem", color: "#4b5563", lineHeight: 1.45 }}
+                  >
+                    <Box component="span" sx={{ fontSize: "0.5rem", mr: 0.5 }}>◇</Box>
+                    {proj.technologies.filter((t) => t.trim()).join(", ")}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </>
+        )}
+
+        {/* Additional education (Certifications) */}
+        {data.certifications.length > 0 && (
+          <>
+            <HeadRight>Certifications</HeadRight>
+            {data.certifications.map((cert) => (
+              <Box key={cert.id} sx={{ mb: 1.25 }}>
+                <Typography
+                  sx={{ fontSize: "0.72rem", color: "#1f2937", lineHeight: 1.4 }}
+                >
+                  <Box
+                    component="span"
+                    sx={{ fontVariant: "small-caps", fontWeight: 600, letterSpacing: "0.02em" }}
+                  >
+                    {cert.name}.
+                  </Box>
+                  {" "}
+                  <Box component="span" sx={{ fontStyle: "italic" }}>
+                    {cert.issuer}.
+                  </Box>
+                  {cert.link && (
+                    <>
+                      {"  "}
+                      <Box
+                        component="a"
+                        href={cert.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{
+                          fontSize: "0.55rem",
+                          color: CVBLUE,
+                          fontWeight: 600,
+                          textDecoration: "none",
+                        }}
+                      >
+                        🔗Link
+                      </Box>
+                    </>
+                  )}
+                  {cert.date && (
+                    <>
+                      {"  "}
+                      <Box component="span" sx={{ fontWeight: 700, whiteSpace: "nowrap", float: "right" }}>
+                        {cert.date.split("-")[0]}
+                      </Box>
+                    </>
+                  )}
+                </Typography>
+              </Box>
+            ))}
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/profile/resume/templates/MinimalTemplate.tsx
+++ b/components/profile/resume/templates/MinimalTemplate.tsx
@@ -69,16 +69,16 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
             fontWeight: 400,
           }}
         >
-          {data.basicInfo.email && <Typography sx={{ fontSize: "0.625rem" }}>{data.basicInfo.email}</Typography>}
-          {data.basicInfo.phone && <Typography sx={{ fontSize: "0.625rem" }}>{data.basicInfo.phone}</Typography>}
+          {data.basicInfo.email && <Typography component="a" href={`mailto:${data.basicInfo.email}`} sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}>{data.basicInfo.email}</Typography>}
+          {data.basicInfo.phone && <Typography component="a" href={`tel:${data.basicInfo.phone}`} sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}>{data.basicInfo.phone}</Typography>}
           {data.basicInfo.location && (
             <Typography sx={{ fontSize: "0.625rem" }}>{data.basicInfo.location}</Typography>
           )}
           {data.basicInfo.github && (
-            <Typography sx={{ fontSize: "0.625rem" }}>github.com/{data.basicInfo.github}</Typography>
+            <Typography component="a" href={`https://github.com/${data.basicInfo.github}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}>github.com/{data.basicInfo.github}</Typography>
           )}
           {data.basicInfo.linkedin && (
-            <Typography sx={{ fontSize: "0.625rem" }}>linkedin.com/in/{data.basicInfo.linkedin}</Typography>
+            <Typography component="a" href={`https://linkedin.com/in/${data.basicInfo.linkedin}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}>linkedin.com/in/{data.basicInfo.linkedin}</Typography>
           )}
         </Box>
       </Box>
@@ -112,7 +112,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
               textTransform: "uppercase",
             }}
           >
-            Experience
+            Work Experience
           </Typography>
 
           {data.workExperience.map((exp, index) => (
@@ -281,11 +281,37 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
 
           {data.projects.slice(0, 2).map((project, index) => (
             <Box key={project.id} sx={{ mb: index < Math.min(data.projects.length, 2) - 1 ? 1.5 : 0 }}>
-              <Typography
-                sx={{ fontSize: "0.75rem", fontWeight: 500, color: "#000000", mb: 0.3 }}
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  mb: 0.3,
+                  gap: 1,
+                }}
               >
-                {project.name}
-              </Typography>
+                <Typography
+                  sx={{ fontSize: "0.75rem", fontWeight: 500, color: "#000000" }}
+                >
+                  {project.name}
+                </Typography>
+                {project.link && (
+                  <Typography
+                    component="a"
+                    href={project.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{
+                      fontSize: "0.625rem",
+                      color: "#2563eb",
+                      fontWeight: 500,
+                      flexShrink: 0,
+                    }}
+                  >
+                    🔗Link
+                  </Typography>
+                )}
+              </Box>
 
               {project.description && (
                 <Typography
@@ -344,11 +370,30 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
               }}
             >
               <Box>
-                <Typography
-                  sx={{ fontSize: "0.625rem", fontWeight: 500, color: "#000000" }}
-                >
-                  {cert.name}
-                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography
+                    sx={{ fontSize: "0.625rem", fontWeight: 500, color: "#000000", flex: 1, minWidth: 0 }}
+                  >
+                    {cert.name}
+                  </Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.55rem",
+                        color: "#2563eb",
+                        fontWeight: 600,
+                        flexShrink: 0,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
                 <Typography sx={{ fontSize: "0.625rem", color: "#666666" }}>
                   {cert.issuer}
                 </Typography>

--- a/components/profile/resume/templates/ModernTemplate.tsx
+++ b/components/profile/resume/templates/ModernTemplate.tsx
@@ -84,7 +84,9 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
             >
               <IconWrapper icon="mdi:email" size={16} color="#94a3b8" />
               <Typography
-                sx={{ fontSize: "0.625rem", wordBreak: "break-word" }}
+                component="a"
+                href={`mailto:${data.basicInfo.email}`}
+                sx={{ fontSize: "0.625rem", wordBreak: "break-word", textDecoration: "none", color: "inherit" }}
               >
                 {data.basicInfo.email}
               </Typography>
@@ -94,7 +96,11 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
           {data.basicInfo.phone && (
             <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "center" }}>
               <IconWrapper icon="mdi:phone" size={16} color="#94a3b8" />
-              <Typography sx={{ fontSize: "0.625rem" }}>
+              <Typography
+                component="a"
+                href={`tel:${data.basicInfo.phone}`}
+                sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}
+              >
                 {data.basicInfo.phone}
               </Typography>
             </Box>
@@ -114,7 +120,13 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
           {data.basicInfo.github && (
             <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "center" }}>
               <IconWrapper icon="mdi:github" size={16} color="#94a3b8" />
-              <Typography sx={{ fontSize: "0.625rem" }}>
+              <Typography
+                component="a"
+                href={`https://github.com/${data.basicInfo.github}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}
+              >
                 github.com/{data.basicInfo.github}
               </Typography>
             </Box>
@@ -123,7 +135,13 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
           {data.basicInfo.linkedin && (
             <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "center" }}>
               <IconWrapper icon="mdi:linkedin" size={16} color="#94a3b8" />
-              <Typography sx={{ fontSize: "0.625rem" }}>
+              <Typography
+                component="a"
+                href={`https://linkedin.com/in/${data.basicInfo.linkedin}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}
+              >
                 linkedin.com/in/{data.basicInfo.linkedin}
               </Typography>
             </Box>
@@ -150,13 +168,15 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                 <Typography sx={{ fontSize: "0.625rem", mb: 0.5 }}>
                   {skill.name}
                 </Typography>
-                <Box sx={{ display: "flex", gap: 0.5 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: "4px", height: 6 }}>
                   {[...Array(5)].map((_, index) => (
                     <Box
                       key={index}
+                      component="span"
                       sx={{
+                        display: "block",
                         width: 24,
-                        height: 4,
+                        height: 6,
                         backgroundColor:
                           index < (skill.level || 3)
                             ? "#6366f1 !important"
@@ -164,6 +184,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                         borderRadius: 2,
                         WebkitPrintColorAdjust: "exact !important",
                         printColorAdjust: "exact !important",
+                        colorAdjust: "exact !important",
                       }}
                     />
                   ))}
@@ -190,9 +211,28 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
 
             {data.certifications.map((cert) => (
               <Box key={cert.id} sx={{ mb: 2 }}>
-                <Typography sx={{ fontSize: "0.625rem", fontWeight: 600 }}>
-                  {cert.name}
-                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography sx={{ fontSize: "0.625rem", fontWeight: 600, flex: 1, minWidth: 0 }}>
+                    {cert.name}
+                  </Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.55rem",
+                        color: "#6366f1",
+                        fontWeight: 600,
+                        flexShrink: 0,
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
                 <Typography sx={{ fontSize: "0.625rem", color: "#94a3b8" }}>
                   {cert.issuer}
                 </Typography>
@@ -437,16 +477,41 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
 
             {data.projects.map((project) => (
               <Box key={project.id} sx={{ mb: 2 }}>
-                <Typography
+                <Box
                   sx={{
-                    fontSize: "0.75rem",
-                    fontWeight: 600,
-                    color: "#1e293b",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
                     mb: 0.5,
+                    gap: 1,
                   }}
                 >
-                  {project.name}
-                </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "0.75rem",
+                      fontWeight: 600,
+                      color: "#1e293b",
+                    }}
+                  >
+                    {project.name}
+                  </Typography>
+                  {project.link && (
+                    <Typography
+                      component="a"
+                      href={project.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.625rem",
+                        color: "#6366f1",
+                        fontWeight: 600,
+                        flexShrink: 0,
+                      }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
 
                 {project.description && (
                   <Typography

--- a/components/profile/resume/templates/RightSidebarTemplate.tsx
+++ b/components/profile/resume/templates/RightSidebarTemplate.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ResumeData } from "../types";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+interface RightSidebarTemplateProps {
+  data: ResumeData;
+}
+
+export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
+  const formatDate = (startDate: string, endDate: string, current?: boolean) => {
+    const formatMonth = (date: string) => {
+      if (!date) return "";
+      const [year, month] = date.split("-");
+      const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+      return `${months[parseInt(month, 10) - 1]} ${year}`;
+    };
+    const start = formatMonth(startDate);
+    const end = current ? "Present" : formatMonth(endDate);
+    return `${start} - ${end}`;
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "297mm",
+        height: "297mm",
+        width: "100%",
+        backgroundColor: "#ffffff",
+        WebkitPrintColorAdjust: "exact !important",
+        printColorAdjust: "exact !important",
+        colorAdjust: "exact !important",
+      }}
+    >
+      {/* Left: Main content */}
+      <Box sx={{ width: "65%", p: 4, minWidth: 0 }}>
+        <Box sx={{ mb: 3 }}>
+          <Typography sx={{ fontSize: "1.5rem", fontWeight: 700, color: "#1e293b", mb: 0.5 }}>
+            {data.basicInfo.firstName} {data.basicInfo.lastName}
+          </Typography>
+          {data.basicInfo.professionalTitle && (
+            <Typography sx={{ fontSize: "0.875rem", color: "#6366f1", fontWeight: 600, mb: 2 }}>
+              {data.basicInfo.professionalTitle}
+            </Typography>
+          )}
+          {data.basicInfo.summary && (
+            <Typography sx={{ fontSize: "0.625rem", color: "#475569", lineHeight: 1.6 }}>
+              {data.basicInfo.summary}
+            </Typography>
+          )}
+        </Box>
+
+        {data.workExperience.length > 0 && (
+          <Box sx={{ mb: 3 }}>
+            <Typography
+              sx={{
+                fontSize: "0.75rem",
+                fontWeight: 700,
+                color: "#1e293b",
+                mb: 2,
+                pb: 0.5,
+                borderBottom: "2px solid #6366f1",
+              }}
+            >
+              WORK EXPERIENCE
+            </Typography>
+            {data.workExperience.map((exp) => (
+              <Box key={exp.id} sx={{ mb: 2.5 }}>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 0.5 }}>
+                  <Box>
+                    <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>
+                      {exp.position}
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.625rem", color: "#6366f1", fontWeight: 500 }}>
+                      {exp.company}
+                    </Typography>
+                  </Box>
+                  <Typography sx={{ fontSize: "0.625rem", color: "#64748b" }}>
+                    {formatDate(exp.startDate, exp.endDate, exp.current)}
+                  </Typography>
+                </Box>
+                {exp.location && (
+                  <Typography sx={{ fontSize: "0.625rem", color: "#64748b", mb: 1 }}>{exp.location}</Typography>
+                )}
+                {exp.description.filter((d) => d.trim()).length > 0 && (
+                  <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+                    {exp.description.filter((d) => d.trim()).map((d, i) => (
+                      <Typography key={i} component="li" sx={{ fontSize: "0.625rem", color: "#475569", lineHeight: 1.5, mb: 0.5 }}>
+                        {d}
+                      </Typography>
+                    ))}
+                  </Box>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {data.education.length > 0 && (
+          <Box sx={{ mb: 3 }}>
+            <Typography
+              sx={{
+                fontSize: "0.75rem",
+                fontWeight: 700,
+                color: "#1e293b",
+                mb: 2,
+                pb: 0.5,
+                borderBottom: "2px solid #6366f1",
+              }}
+            >
+              EDUCATION
+            </Typography>
+            {data.education.map((edu) => (
+              <Box key={edu.id} sx={{ mb: 2 }}>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+                  <Box>
+                    <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>{edu.degree}</Typography>
+                    <Typography sx={{ fontSize: "0.625rem", color: "#6366f1" }}>{edu.institution}</Typography>
+                    {edu.location && (
+                      <Typography sx={{ fontSize: "0.625rem", color: "#64748b" }}>{edu.location}</Typography>
+                    )}
+                  </Box>
+                  <Typography sx={{ fontSize: "0.625rem", color: "#64748b" }}>
+                    {formatDate(edu.startDate, edu.endDate)}
+                  </Typography>
+                </Box>
+                {edu.gpa && (
+                  <Typography sx={{ fontSize: "0.625rem", color: "#475569", mt: 0.5 }}>GPA: {edu.gpa}</Typography>
+                )}
+                {edu.description && (
+                  <Typography sx={{ fontSize: "0.625rem", color: "#475569", mt: 0.5, lineHeight: 1.5 }}>
+                    {edu.description}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {data.projects.length > 0 && (
+          <Box>
+            <Typography
+              sx={{
+                fontSize: "0.75rem",
+                fontWeight: 700,
+                color: "#1e293b",
+                mb: 2,
+                pb: 0.5,
+                borderBottom: "2px solid #6366f1",
+              }}
+            >
+              PROJECTS
+            </Typography>
+            {data.projects.map((project) => (
+              <Box key={project.id} sx={{ mb: 2 }}>
+                <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 0.5, gap: 1 }}>
+                  <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>
+                    {project.name}
+                  </Typography>
+                  {project.link && (
+                    <Typography
+                      component="a"
+                      href={project.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ fontSize: "0.625rem", color: "#6366f1", fontWeight: 600, flexShrink: 0 }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
+                {project.description && (
+                  <Typography sx={{ fontSize: "0.625rem", color: "#475569", lineHeight: 1.5, mb: 0.5 }}>
+                    {project.description}
+                  </Typography>
+                )}
+                {project.technologies.filter((t) => t.trim()).length > 0 && (
+                  <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.5 }}>
+                    {project.technologies.filter((t) => t.trim()).map((tech, i) => (
+                      <Box
+                        key={i}
+                        sx={{
+                          px: 1,
+                          py: 0.25,
+                          backgroundColor: "#f1f5f9 !important",
+                          color: "#475569",
+                          fontSize: "0.625rem",
+                          borderRadius: 1,
+                          fontWeight: 500,
+                          WebkitPrintColorAdjust: "exact !important",
+                          printColorAdjust: "exact !important",
+                        }}
+                      >
+                        {tech}
+                      </Box>
+                    ))}
+                  </Box>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+
+      {/* Right: Sidebar */}
+      <Box
+        sx={{
+          width: "35%",
+          backgroundColor: "#1e293b !important",
+          color: "#ffffff",
+          p: 4,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+          colorAdjust: "exact !important",
+        }}
+      >
+        <Box sx={{ mb: 4 }}>
+          <Typography sx={{ fontSize: "0.625rem", fontWeight: 700, letterSpacing: "0.1em", mb: 2, color: "#94a3b8" }}>
+            CONTACT
+          </Typography>
+          {data.basicInfo.email && (
+            <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "flex-start" }}>
+              <IconWrapper icon="mdi:email" size={16} color="#94a3b8" />
+              <Typography component="a" href={`mailto:${data.basicInfo.email}`} sx={{ fontSize: "0.625rem", wordBreak: "break-word", textDecoration: "none", color: "inherit" }}>{data.basicInfo.email}</Typography>
+            </Box>
+          )}
+          {data.basicInfo.phone && (
+            <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "center" }}>
+              <IconWrapper icon="mdi:phone" size={16} color="#94a3b8" />
+              <Typography component="a" href={`tel:${data.basicInfo.phone}`} sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}>{data.basicInfo.phone}</Typography>
+            </Box>
+          )}
+          {data.basicInfo.location && (
+            <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "flex-start" }}>
+              <IconWrapper icon="mdi:map-marker" size={16} color="#94a3b8" />
+              <Typography sx={{ fontSize: "0.625rem" }}>{data.basicInfo.location}</Typography>
+            </Box>
+          )}
+          {data.basicInfo.github && (
+            <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "center" }}>
+              <IconWrapper icon="mdi:github" size={16} color="#94a3b8" />
+              <Typography component="a" href={`https://github.com/${data.basicInfo.github}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}>github.com/{data.basicInfo.github}</Typography>
+            </Box>
+          )}
+          {data.basicInfo.linkedin && (
+            <Box sx={{ display: "flex", gap: 1, mb: 2, alignItems: "center" }}>
+              <IconWrapper icon="mdi:linkedin" size={16} color="#94a3b8" />
+              <Typography component="a" href={`https://linkedin.com/in/${data.basicInfo.linkedin}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.625rem", textDecoration: "none", color: "inherit" }}>linkedin.com/in/{data.basicInfo.linkedin}</Typography>
+            </Box>
+          )}
+        </Box>
+
+        {data.skills.length > 0 && (
+          <Box sx={{ mb: 4 }}>
+            <Typography sx={{ fontSize: "0.625rem", fontWeight: 700, letterSpacing: "0.1em", mb: 2, color: "#94a3b8" }}>
+              SKILLS
+            </Typography>
+            {data.skills.map((skill) => (
+              <Box key={skill.id} sx={{ mb: 2 }}>
+                <Typography sx={{ fontSize: "0.625rem", mb: 0.5 }}>{skill.name}</Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: "4px", height: 6 }}>
+                  {[1, 2, 3, 4, 5].map((i) => (
+                    <Box
+                      key={i}
+                      component="span"
+                      sx={{
+                        display: "block",
+                        width: 24,
+                        height: 6,
+                        borderRadius: 2,
+                        backgroundColor: i <= (skill.level ?? 3) ? "#6366f1 !important" : "#334155 !important",
+                        WebkitPrintColorAdjust: "exact !important",
+                        printColorAdjust: "exact !important",
+                        colorAdjust: "exact !important",
+                      }}
+                    />
+                  ))}
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {data.certifications.length > 0 && (
+          <Box>
+            <Typography sx={{ fontSize: "0.625rem", fontWeight: 700, letterSpacing: "0.1em", mb: 2, color: "#94a3b8" }}>
+              CERTIFICATIONS
+            </Typography>
+            {data.certifications.map((cert) => (
+              <Box key={cert.id} sx={{ mb: 2 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography sx={{ fontSize: "0.625rem", fontWeight: 600, flex: 1, minWidth: 0 }}>{cert.name}</Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{ fontSize: "0.55rem", color: "#6366f1", fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap" }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
+                <Typography sx={{ fontSize: "0.625rem", color: "#94a3b8" }}>{cert.issuer}</Typography>
+                {cert.date && (
+                  <Typography sx={{ fontSize: "0.625rem", color: "#94a3b8" }}>
+                    {formatDate(cert.date, "", false)}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/profile/resume/templates/TechnicalTemplate.tsx
+++ b/components/profile/resume/templates/TechnicalTemplate.tsx
@@ -80,9 +80,13 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
         <Box sx={{ mt: 1.5, fontSize: "0.7rem", color: "#f8f8f2" }}>
           {data.basicInfo.email && (
             <Typography
+              component="a"
+              href={`mailto:${data.basicInfo.email}`}
               sx={{
                 fontSize: "0.75rem",
                 fontFamily: "'Courier New', monospace",
+                textDecoration: "none",
+                color: "inherit",
               }}
             >
               email: {data.basicInfo.email}
@@ -90,9 +94,13 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
           )}
           {data.basicInfo.phone && (
             <Typography
+              component="a"
+              href={`tel:${data.basicInfo.phone}`}
               sx={{
                 fontSize: "0.75rem",
                 fontFamily: "'Courier New', monospace",
+                textDecoration: "none",
+                color: "inherit",
               }}
             >
               phone: {data.basicInfo.phone}
@@ -110,9 +118,15 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
           )}
           {data.basicInfo.github && (
             <Typography
+              component="a"
+              href={`https://github.com/${data.basicInfo.github}`}
+              target="_blank"
+              rel="noopener noreferrer"
               sx={{
                 fontSize: "0.75rem",
                 fontFamily: "'Courier New', monospace",
+                textDecoration: "none",
+                color: "inherit",
               }}
             >
               github: {data.basicInfo.github}
@@ -120,9 +134,15 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
           )}
           {data.basicInfo.linkedin && (
             <Typography
+              component="a"
+              href={`https://linkedin.com/in/${data.basicInfo.linkedin}`}
+              target="_blank"
+              rel="noopener noreferrer"
               sx={{
                 fontSize: "0.75rem",
                 fontFamily: "'Courier New', monospace",
+                textDecoration: "none",
+                color: "inherit",
               }}
             >
               linkedin: {data.basicInfo.linkedin}
@@ -181,7 +201,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
               fontFamily: "'Courier New', monospace",
             }}
           >
-            {">"} skills.list()
+            {">"} Skills
           </Typography>
           <Box
             sx={{
@@ -209,13 +229,15 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                 >
                   {skill.name}:
                 </Typography>
-                <Box sx={{ display: "flex", gap: 0.4 }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: "3px", height: 10 }}>
                   {[...Array(5)].map((_, index) => (
                     <Box
                       key={index}
+                      component="span"
                       sx={{
-                        width: 7,
-                        height: 7,
+                        display: "block",
+                        width: 8,
+                        height: 8,
                         backgroundColor:
                           index < (skill.level || 3)
                             ? "#50fa7b !important"
@@ -223,6 +245,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                         transform: "rotate(45deg)",
                         WebkitPrintColorAdjust: "exact !important",
                         printColorAdjust: "exact !important",
+                        colorAdjust: "exact !important",
                       }}
                     />
                   ))}
@@ -245,7 +268,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
               fontFamily: "'Courier New', monospace",
             }}
           >
-            {">"} experience.query()
+            {">"} Work Experience
           </Typography>
 
           {data.workExperience.map((exp, index) => (
@@ -346,7 +369,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
               fontFamily: "'Courier New', monospace",
             }}
           >
-            {">"} projects.showcase()
+            {">"} Projects
           </Typography>
 
           {data.projects.slice(0, 2).map((project, index) => (
@@ -362,17 +385,43 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                 printColorAdjust: "exact !important",
               }}
             >
-              <Typography
+              <Box
                 sx={{
-                  fontSize: "0.8rem",
-                  fontWeight: 700,
-                  color: "#282a36",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
                   mb: 0.3,
-                  fontFamily: "'Courier New', monospace",
+                  gap: 1,
                 }}
               >
-                {project.name}
-              </Typography>
+                <Typography
+                  sx={{
+                    fontSize: "0.8rem",
+                    fontWeight: 700,
+                    color: "#282a36",
+                    fontFamily: "'Courier New', monospace",
+                  }}
+                >
+                  {project.name}
+                </Typography>
+                {project.link && (
+                  <Typography
+                    component="a"
+                    href={project.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{
+                      fontSize: "0.65rem",
+                      color: "#50fa7b",
+                      fontWeight: 600,
+                      flexShrink: 0,
+                      fontFamily: "'Courier New', monospace",
+                    }}
+                  >
+                    🔗Link
+                  </Typography>
+                )}
+              </Box>
 
               {project.description && (
                 <Typography
@@ -430,7 +479,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
               fontFamily: "'Courier New', monospace",
             }}
           >
-            {">"} education.credentials()
+            {">"} Education
           </Typography>
 
           {data.education.map((edu, index) => (
@@ -515,7 +564,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
               fontFamily: "'Courier New', monospace",
             }}
           >
-            {">"} certifications.verify()
+            {">"} Certifications
           </Typography>
 
           <Box
@@ -537,16 +586,38 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                   printColorAdjust: "exact !important",
                 }}
               >
-                <Typography
-                  sx={{
-                    fontSize: "0.7rem",
-                    fontWeight: 600,
-                    color: "#282a36",
-                    fontFamily: "'Courier New', monospace",
-                  }}
-                >
-                  {cert.name}
-                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.7rem",
+                      fontWeight: 600,
+                      color: "#282a36",
+                      fontFamily: "'Courier New', monospace",
+                      flex: 1,
+                      minWidth: 0,
+                    }}
+                  >
+                    {cert.name}
+                  </Typography>
+                  {cert.link && (
+                    <Typography
+                      component="a"
+                      href={cert.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.55rem",
+                        color: "#50fa7b",
+                        fontWeight: 600,
+                        flexShrink: 0,
+                        fontFamily: "'Courier New', monospace",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      🔗Link
+                    </Typography>
+                  )}
+                </Box>
                 <Typography
                   sx={{
                     fontSize: "0.65rem",

--- a/components/profile/resume/templates/TwoColumnTemplate.tsx
+++ b/components/profile/resume/templates/TwoColumnTemplate.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ResumeData } from "../types";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+const MAROON = "#6b1c1c";
+const GOLD = "#c5a03f";
+const BG = "#f0ebe4";
+
+interface TwoColumnTemplateProps {
+  data: ResumeData;
+}
+
+function SectionHead({ children }: { children: string }) {
+  return (
+    <Box sx={{ mt: 2, mb: 1 }}>
+      <Typography
+        sx={{
+          fontSize: "0.9rem",
+          fontWeight: 400,
+          fontFamily: "'Georgia', 'Times New Roman', serif",
+          fontVariant: "small-caps",
+          letterSpacing: "0.06em",
+          color: MAROON,
+        }}
+      >
+        {children}
+      </Typography>
+      <Box
+        sx={{
+          mt: 0.25,
+          height: "1.5px",
+          backgroundColor: `${GOLD} !important`,
+          WebkitPrintColorAdjust: "exact !important",
+          printColorAdjust: "exact !important",
+        }}
+      />
+    </Box>
+  );
+}
+
+export function TwoColumnTemplate({ data }: TwoColumnTemplateProps) {
+  const fmtDateRange = (start: string, end: string, current?: boolean) => {
+    if (!start) return "";
+    const fmt = (d: string) => {
+      if (!d) return "";
+      const [y, m] = d.split("-");
+      if (!m) return y;
+      const months = [
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December",
+      ];
+      return `${months[parseInt(m, 10) - 1]} ${y}`;
+    };
+    const s = fmt(start);
+    if (current) return `${s} \u2013 Present`;
+    if (!end) return s;
+    return `${s} \u2013 ${fmt(end)}`;
+  };
+
+  const fmtYearRange = (start: string, end: string) => {
+    if (!start) return "";
+    const sy = start.split("-")[0];
+    if (!end) return sy;
+    const ey = end.split("-")[0];
+    if (sy === ey) return sy;
+    return `${sy} \u2013 ${ey}`;
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "297mm",
+        height: "297mm",
+        width: "100%",
+        backgroundColor: `${BG} !important`,
+        fontFamily: "'Georgia', 'Times New Roman', serif",
+        WebkitPrintColorAdjust: "exact !important",
+        printColorAdjust: "exact !important",
+        colorAdjust: "exact !important",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Header */}
+      <Box sx={{ textAlign: "center", pt: 2.5, pb: 0.5 }}>
+        <Typography
+          sx={{
+            fontSize: "1.6rem",
+            fontWeight: 400,
+            fontFamily: "'Georgia', 'Times New Roman', serif",
+            color: "#1a1a1a",
+            letterSpacing: "0.02em",
+          }}
+        >
+          {data.basicInfo.firstName} {data.basicInfo.lastName}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: "0.95rem",
+            fontStyle: "italic",
+            fontFamily: "'Georgia', 'Times New Roman', serif",
+            color: "#4a4a4a",
+            mt: -0.25,
+          }}
+        >
+          Curriculum Vitae
+        </Typography>
+      </Box>
+
+      {/* Two columns */}
+      <Box
+        sx={{
+          display: "flex",
+          flex: 1,
+          px: 2,
+          pb: 2,
+          gap: 2.5,
+          overflow: "hidden",
+        }}
+      >
+        {/* ===== LEFT COLUMN ===== */}
+        <Box sx={{ width: "48%" }}>
+          {/* Work Experience */}
+          <SectionHead>Work Experience</SectionHead>
+          {data.workExperience.map((exp) => (
+            <Box key={exp.id} sx={{ mb: 1.5 }}>
+              <Typography
+                sx={{
+                  fontSize: "0.62rem",
+                  fontVariant: "small-caps",
+                  letterSpacing: "0.04em",
+                  color: "#4a4a4a",
+                  textAlign: "right",
+                  mb: 0.25,
+                }}
+              >
+                {fmtDateRange(exp.startDate, exp.endDate, exp.current)}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: "0.65rem",
+                  color: "#1a1a1a",
+                }}
+              >
+                {exp.company}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: "0.72rem",
+                  fontWeight: 700,
+                  fontStyle: "italic",
+                  color: "#1a1a1a",
+                  mb: 0.3,
+                }}
+              >
+                {exp.position}
+              </Typography>
+              {exp.description.filter((d) => d.trim()).length > 0 && (
+                <Typography
+                  sx={{
+                    fontSize: "0.6rem",
+                    color: "#3a3a3a",
+                    lineHeight: 1.5,
+                    textAlign: "justify",
+                  }}
+                >
+                  {exp.description.filter((d) => d.trim()).join(". ")}
+                  {exp.description.filter((d) => d.trim()).length > 0 && "."}
+                </Typography>
+              )}
+            </Box>
+          ))}
+
+          {/* Education */}
+          <SectionHead>Education</SectionHead>
+          {data.education.map((edu) => (
+            <Box key={edu.id} sx={{ mb: 1.25, display: "flex", gap: 1.5 }}>
+              <Typography
+                sx={{
+                  fontSize: "0.6rem",
+                  color: "#4a4a4a",
+                  whiteSpace: "nowrap",
+                  minWidth: 55,
+                  flexShrink: 0,
+                  pt: 0.2,
+                }}
+              >
+                {fmtYearRange(edu.startDate, edu.endDate)}
+              </Typography>
+              <Box>
+                <Typography
+                  sx={{
+                    fontSize: "0.7rem",
+                    fontWeight: 700,
+                    color: "#1a1a1a",
+                  }}
+                >
+                  {edu.degree}
+                </Typography>
+                {edu.gpa && (
+                  <Typography
+                    sx={{
+                      fontSize: "0.6rem",
+                      fontVariant: "small-caps",
+                      letterSpacing: "0.03em",
+                      color: "#3a3a3a",
+                    }}
+                  >
+                    {edu.gpa}
+                  </Typography>
+                )}
+                <Typography
+                  sx={{
+                    fontSize: "0.6rem",
+                    fontStyle: "italic",
+                    color: "#4a4a4a",
+                  }}
+                >
+                  {edu.institution}
+                  {edu.location ? `, ${edu.location}` : ""}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+
+        {/* ===== RIGHT COLUMN ===== */}
+        <Box sx={{ width: "52%" }}>
+          {/* Contact info box */}
+          <Box
+            sx={{
+              border: "1px solid #d0c8be",
+              borderRadius: 0.5,
+              p: 1.25,
+              mb: 0.5,
+              "& > div": {
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 0.75,
+                mb: 0.4,
+              },
+            }}
+          >
+            {data.basicInfo.location && (
+              <Box>
+                <IconWrapper icon="mdi:map-marker" size={12} color={MAROON} />
+                <Typography sx={{ fontSize: "0.58rem", color: "#1a1a1a", lineHeight: 1.4 }}>
+                  {data.basicInfo.location}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.phone && (
+              <Box>
+                <IconWrapper icon="mdi:phone" size={12} color={MAROON} />
+                <Typography component="a" href={`tel:${data.basicInfo.phone}`} sx={{ fontSize: "0.58rem", color: "#1a1a1a", lineHeight: 1.4, textDecoration: "none" }}>
+                  {data.basicInfo.phone}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.email && (
+              <Box>
+                <IconWrapper icon="mdi:email" size={12} color={MAROON} />
+                <Typography component="a" href={`mailto:${data.basicInfo.email}`} sx={{ fontSize: "0.58rem", color: "#1a1a1a", lineHeight: 1.4, textDecoration: "none" }}>
+                  {data.basicInfo.email}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.github && (
+              <Box>
+                <IconWrapper icon="mdi:web" size={12} color={MAROON} />
+                <Typography component="a" href={`https://github.com/${data.basicInfo.github}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.58rem", color: "#1a1a1a", lineHeight: 1.4, textDecoration: "none" }}>
+                  github.com/{data.basicInfo.github}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.linkedin && (
+              <Box>
+                <IconWrapper icon="mdi:linkedin" size={12} color={MAROON} />
+                <Typography component="a" href={`https://linkedin.com/in/${data.basicInfo.linkedin}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.58rem", color: "#1a1a1a", lineHeight: 1.4, textDecoration: "none" }}>
+                  linkedin.com/in/{data.basicInfo.linkedin}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+
+          {/* Projects → Extra Curricular Activities style */}
+          {data.projects.length > 0 && (
+            <>
+              <SectionHead>Projects</SectionHead>
+              {data.projects.map((proj) => (
+                <Box key={proj.id} sx={{ mb: 0.75, display: "flex", gap: 1.5 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.6rem",
+                      color: "#4a4a4a",
+                      whiteSpace: "nowrap",
+                      minWidth: 30,
+                      flexShrink: 0,
+                      pt: 0.15,
+                    }}
+                  >
+                    {proj.technologies?.[0] || ""}
+                  </Typography>
+                  <Box>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <Typography
+                        sx={{
+                          fontSize: "0.68rem",
+                          fontWeight: 700,
+                          color: "#1a1a1a",
+                        }}
+                      >
+                        {proj.name}
+                      </Typography>
+                      {proj.link && (
+                        <Typography
+                          component="a"
+                          href={proj.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          sx={{
+                            fontSize: "0.58rem",
+                            color: MAROON,
+                            fontWeight: 600,
+                            flexShrink: 0,
+                          }}
+                        >
+                          🔗Link
+                        </Typography>
+                      )}
+                    </Box>
+                    {proj.description && (
+                      <Typography
+                        sx={{
+                          fontSize: "0.6rem",
+                          fontStyle: "italic",
+                          color: "#4a4a4a",
+                        }}
+                      >
+                        {proj.description}
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              ))}
+            </>
+          )}
+
+          {/* Skills */}
+          <SectionHead>Skills</SectionHead>
+          {data.skills.filter((s) => !s.level).length > 0 ? (
+            <Box>
+              {data.skills
+                .filter((s) => !s.level)
+                .map((skill) => (
+                  <Box key={skill.id} sx={{ display: "flex", gap: 1.5, mb: 0.3 }}>
+                    <Typography
+                      sx={{
+                        fontSize: "0.6rem",
+                        fontVariant: "small-caps",
+                        letterSpacing: "0.04em",
+                        color: "#3a3a3a",
+                        minWidth: 50,
+                        flexShrink: 0,
+                      }}
+                    >
+                      {skill.name}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: "0.6rem",
+                        color: "#1a1a1a",
+                      }}
+                    >
+                      {skill.category || ""}
+                    </Typography>
+                  </Box>
+                ))}
+            </Box>
+          ) : (
+            <Box>
+              {data.skills.slice(0, 3).map((skill) => (
+                <Box key={skill.id} sx={{ display: "flex", gap: 1.5, mb: 0.3 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.6rem",
+                      fontVariant: "small-caps",
+                      letterSpacing: "0.04em",
+                      color: "#3a3a3a",
+                      minWidth: 50,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {skill.name}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "0.6rem",
+                      color: "#1a1a1a",
+                    }}
+                  >
+                    {skill.category || ""}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          {/* Achievements (certifications) */}
+          {data.certifications.length > 0 && (
+            <>
+              <SectionHead>Certifications</SectionHead>
+              {data.certifications.map((cert) => (
+                <Box key={cert.id} sx={{ mb: 0.6, display: "flex", gap: 1.5 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.6rem",
+                      color: "#4a4a4a",
+                      whiteSpace: "nowrap",
+                      minWidth: 30,
+                      flexShrink: 0,
+                      pt: 0.15,
+                    }}
+                  >
+                    {cert.date ? cert.date.split("-")[0] : ""}
+                  </Typography>
+                  <Box>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                      <Typography
+                        sx={{
+                          fontSize: "0.68rem",
+                          fontWeight: 700,
+                          color: "#1a1a1a",
+                          flex: 1,
+                          minWidth: 0,
+                        }}
+                      >
+                        {cert.name}
+                      </Typography>
+                      {cert.link && (
+                        <Typography
+                          component="a"
+                          href={cert.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          sx={{
+                            fontSize: "0.5rem",
+                            color: MAROON,
+                            fontWeight: 600,
+                            flexShrink: 0,
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          🔗Link
+                        </Typography>
+                      )}
+                    </Box>
+                    {cert.issuer && (
+                      <Typography
+                        sx={{
+                          fontSize: "0.6rem",
+                          fontStyle: "italic",
+                          color: "#4a4a4a",
+                        }}
+                      >
+                        {cert.issuer}
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              ))}
+            </>
+          )}
+
+          {/* Skill Levels */}
+          {data.skills.filter((s) => s.level).length > 0 && (
+            <>
+              <SectionHead>Skill Levels</SectionHead>
+              {data.skills
+                .filter((s) => s.level)
+                .map((skill) => (
+                  <Box key={skill.id} sx={{ display: "flex", gap: 1.5, mb: 0.3 }}>
+                    <Typography
+                      sx={{
+                        fontSize: "0.6rem",
+                        fontVariant: "small-caps",
+                        letterSpacing: "0.04em",
+                        color: "#3a3a3a",
+                        minWidth: 55,
+                        flexShrink: 0,
+                      }}
+                    >
+                      {skill.level && skill.level >= 4
+                        ? "Good level"
+                        : skill.level && skill.level >= 2
+                          ? "Basic level"
+                          : "Beginner"}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: "0.6rem",
+                        color: "#1a1a1a",
+                      }}
+                    >
+                      {skill.name}
+                    </Typography>
+                  </Box>
+                ))}
+            </>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/components/profile/resume/templates/WesternTemplate.tsx
+++ b/components/profile/resume/templates/WesternTemplate.tsx
@@ -1,0 +1,546 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { ResumeData } from "../types";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+// AltaCV-inspired "Western" style: two columns, serif/sans hierarchy, accent colors
+const COLORS = {
+  name: "#000000",
+  tagline: "#8F0D0D",
+  heading: "#450808",
+  headingRule: "#E7D192",
+  accent: "#8F0D0D",
+  emphasis: "#2E2E2E",
+  body: "#666666",
+};
+
+interface WesternTemplateProps {
+  data: ResumeData;
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <Typography
+      sx={{
+        fontSize: "1.1rem",
+        fontWeight: 700,
+        fontFamily: "Georgia, serif",
+        color: COLORS.heading,
+        mb: 1,
+        pb: 0.5,
+        borderBottom: `2px solid ${COLORS.headingRule}`,
+        WebkitPrintColorAdjust: "exact !important",
+        printColorAdjust: "exact !important",
+      }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+export function WesternTemplate({ data }: WesternTemplateProps) {
+  const formatDate = (
+    startDate: string,
+    endDate: string,
+    current?: boolean
+  ) => {
+    const formatMonth = (date: string) => {
+      if (!date) return "";
+      const [year, month] = date.split("-");
+      const months = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+      ];
+      return `${months[parseInt(month, 10) - 1]} ${year}`;
+    };
+    const start = formatMonth(startDate);
+    const end = current ? "Present" : formatMonth(endDate);
+    return `${start} — ${end}`;
+  };
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "297mm",
+        height: "297mm",
+        width: "100%",
+        backgroundColor: "#ffffff",
+        WebkitPrintColorAdjust: "exact !important",
+        printColorAdjust: "exact !important",
+        colorAdjust: "exact !important",
+      }}
+    >
+      {/* Header: name, tagline, photo (right), personal info */}
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          px: 2.5,
+          pt: 1.5,
+          pb: 1,
+          gap: 2,
+        }}
+      >
+        <Box sx={{ flex: 1 }}>
+          <Typography
+            sx={{
+              fontSize: "1.75rem",
+              fontWeight: 700,
+              fontFamily: "Georgia, serif",
+              color: COLORS.name,
+              lineHeight: 1.2,
+            }}
+          >
+            {data.basicInfo.firstName} {data.basicInfo.lastName}
+          </Typography>
+          {data.basicInfo.professionalTitle && (
+            <Typography
+              sx={{
+                fontSize: "0.95rem",
+                color: COLORS.tagline,
+                fontWeight: 600,
+                mt: 0.25,
+              }}
+            >
+              {data.basicInfo.professionalTitle}
+            </Typography>
+          )}
+          <Box
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 1.25,
+              mt: 1,
+              fontSize: "0.7rem",
+              color: COLORS.body,
+            }}
+          >
+            {data.basicInfo.email && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <IconWrapper icon="mdi:email" size={14} color={COLORS.body} />
+                <Typography component="a" href={`mailto:${data.basicInfo.email}`} sx={{ fontSize: "0.7rem", textDecoration: "none", color: "inherit" }}>
+                  {data.basicInfo.email}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.phone && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <IconWrapper icon="mdi:phone" size={14} color={COLORS.body} />
+                <Typography component="a" href={`tel:${data.basicInfo.phone}`} sx={{ fontSize: "0.7rem", textDecoration: "none", color: "inherit" }}>
+                  {data.basicInfo.phone}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.location && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <IconWrapper icon="mdi:map-marker" size={14} color={COLORS.body} />
+                <Typography component="span" sx={{ fontSize: "0.7rem" }}>
+                  {data.basicInfo.location}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.linkedin && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <IconWrapper icon="mdi:linkedin" size={14} color={COLORS.body} />
+                <Typography component="a" href={`https://linkedin.com/in/${data.basicInfo.linkedin}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.7rem", textDecoration: "none", color: "inherit" }}>
+                  linkedin.com/in/{data.basicInfo.linkedin}
+                </Typography>
+              </Box>
+            )}
+            {data.basicInfo.github && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <IconWrapper icon="mdi:github" size={14} color={COLORS.body} />
+                <Typography component="a" href={`https://github.com/${data.basicInfo.github}`} target="_blank" rel="noopener noreferrer" sx={{ fontSize: "0.7rem", textDecoration: "none", color: "inherit" }}>
+                  github.com/{data.basicInfo.github}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        </Box>
+        {data.basicInfo.photo && (
+          <Box
+            component="img"
+            src={data.basicInfo.photo}
+            alt=""
+            crossOrigin="anonymous"
+            sx={{
+              width: "2.8cm",
+              height: "2.8cm",
+              objectFit: "cover",
+              borderRadius: 1,
+              flexShrink: 0,
+            }}
+          />
+        )}
+      </Box>
+
+      {/* Two columns: 60% left, 40% right */}
+      <Box
+        sx={{
+          display: "flex",
+          flex: 1,
+          overflow: "hidden",
+          px: 2.5,
+          pb: 2,
+        }}
+      >
+        {/* Left column — Experience, Projects */}
+        <Box sx={{ width: "60%", pr: 1.5 }}>
+          {data.workExperience.length > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <SectionTitle>Work Experience</SectionTitle>
+              {data.workExperience.map((exp) => (
+                <Box key={exp.id} sx={{ mb: 1.5 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.8rem",
+                      fontWeight: 700,
+                      color: COLORS.emphasis,
+                    }}
+                  >
+                    {exp.position}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "0.7rem",
+                      color: COLORS.accent,
+                      fontWeight: 600,
+                    }}
+                  >
+                    {exp.company}
+                  </Typography>
+                  <Typography sx={{ fontSize: "0.65rem", color: COLORS.body }}>
+                    {formatDate(exp.startDate, exp.endDate, exp.current)}
+                    {exp.location ? ` • ${exp.location}` : ""}
+                  </Typography>
+                  {exp.description.length > 0 && (
+                    <Box component="ul" sx={{ m: 0, pl: 2, mt: 0.5 }}>
+                      {exp.description
+                        .filter((d) => d.trim())
+                        .map((d, i) => (
+                          <Typography
+                            key={i}
+                            component="li"
+                            sx={{
+                              fontSize: "0.65rem",
+                              color: COLORS.body,
+                              lineHeight: 1.4,
+                              mb: 0.25,
+                            }}
+                          >
+                            {d}
+                          </Typography>
+                        ))}
+                    </Box>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          {data.projects.length > 0 && (
+            <Box>
+              <SectionTitle>Projects</SectionTitle>
+              {data.projects.map((proj) => (
+                <Box key={proj.id} sx={{ mb: 1.5 }}>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      gap: 1,
+                    }}
+                  >
+                    <Typography
+                      sx={{
+                        fontSize: "0.8rem",
+                        fontWeight: 700,
+                        color: COLORS.emphasis,
+                      }}
+                    >
+                      {proj.name}
+                    </Typography>
+                    {proj.link && (
+                      <Typography
+                        component="a"
+                        href={proj.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{
+                          fontSize: "0.65rem",
+                          color: COLORS.accent,
+                          fontWeight: 600,
+                          flexShrink: 0,
+                        }}
+                      >
+                        🔗Link
+                      </Typography>
+                    )}
+                  </Box>
+                  {proj.description && (
+                    <Typography
+                      sx={{
+                        fontSize: "0.65rem",
+                        color: COLORS.body,
+                        lineHeight: 1.4,
+                        mt: 0.25,
+                      }}
+                    >
+                      {proj.description}
+                    </Typography>
+                  )}
+                  {proj.technologies.filter((t) => t.trim()).length > 0 && (
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.5 }}>
+                      {proj.technologies
+                        .filter((t) => t.trim())
+                        .map((t, i) => (
+                          <Box
+                            key={i}
+                            sx={{
+                              px: 0.75,
+                              py: 0.2,
+                              fontSize: "0.6rem",
+                              backgroundColor: "#f5f5f5",
+                              color: COLORS.body,
+                              borderRadius: 0.5,
+                              WebkitPrintColorAdjust: "exact !important",
+                              printColorAdjust: "exact !important",
+                            }}
+                          >
+                            {t}
+                          </Box>
+                        ))}
+                    </Box>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+
+        {/* Right column — Philosophy, Most Proud Of, Strengths, Languages, Education */}
+        <Box
+          sx={{
+            width: "40%",
+            pl: 1.5,
+            borderLeft: `2px solid ${COLORS.headingRule}`,
+          }}
+        >
+          {data.basicInfo.summary && (
+            <Box sx={{ mb: 2 }}>
+              <SectionTitle>Summary</SectionTitle>
+              <Typography
+                component="blockquote"
+                sx={{
+                  fontSize: "0.7rem",
+                  color: COLORS.body,
+                  fontStyle: "italic",
+                  lineHeight: 1.5,
+                  m: 0,
+                  pl: 1.5,
+                  borderLeft: `3px solid ${COLORS.accent}`,
+                }}
+              >
+                &ldquo;{data.basicInfo.summary}&rdquo;
+              </Typography>
+            </Box>
+          )}
+
+          {data.certifications.length > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <SectionTitle>Certifications</SectionTitle>
+              {data.certifications.map((cert) => (
+                <Box key={cert.id} sx={{ mb: 1 }}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                    <Typography
+                      sx={{
+                        fontSize: "0.75rem",
+                        fontWeight: 700,
+                        color: COLORS.emphasis,
+                        flex: 1,
+                        minWidth: 0,
+                      }}
+                    >
+                      {cert.name}
+                    </Typography>
+                    {cert.link && (
+                      <Typography
+                        component="a"
+                        href={cert.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        sx={{
+                          fontSize: "0.58rem",
+                          color: COLORS.accent,
+                          fontWeight: 600,
+                          flexShrink: 0,
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        🔗Link
+                      </Typography>
+                    )}
+                  </Box>
+                  <Typography
+                    sx={{
+                      fontSize: "0.65rem",
+                      color: COLORS.body,
+                    }}
+                  >
+                    {cert.issuer}
+                    {cert.date ? ` • ${formatDate(cert.date, "", false)}` : ""}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          )}
+
+          {data.skills.length > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <SectionTitle>Skills</SectionTitle>
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                {data.skills.map((skill) => (
+                  <Box
+                    key={skill.id}
+                    sx={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      px: 1,
+                      py: 0.5,
+                      fontSize: "0.65rem",
+                      lineHeight: 1,
+                      backgroundColor: "#f0e6d8 !important",
+                      color: COLORS.emphasis,
+                      borderRadius: 0.5,
+                      fontWeight: 500,
+                      WebkitPrintColorAdjust: "exact !important",
+                      printColorAdjust: "exact !important",
+                      colorAdjust: "exact !important",
+                    }}
+                  >
+                    {skill.name}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          {data.skills.some((s) => s.level != null) && (
+            <Box sx={{ mb: 2 }}>
+              <SectionTitle>Skill Levels</SectionTitle>
+              {data.skills
+                .filter((s) => s.level != null)
+                .map((skill) => (
+                  <Box key={skill.id} sx={{ mb: 0.75 }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        mb: 0.5,
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          fontSize: "0.7rem",
+                          fontWeight: 600,
+                          color: COLORS.emphasis,
+                        }}
+                      >
+                        {skill.name}
+                      </Typography>
+                      <Typography
+                        sx={{
+                          fontSize: "0.65rem",
+                          color: COLORS.body,
+                        }}
+                      >
+                        {skill.level ?? 0}/5
+                      </Typography>
+                    </Box>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: "2px", height: 6 }}>
+                      {[1, 2, 3, 4, 5].map((i) => (
+                        <Box
+                          key={i}
+                          component="span"
+                          sx={{
+                            display: "block",
+                            width: 20,
+                            height: 6,
+                            borderRadius: 1,
+                            backgroundColor:
+                              i <= (skill.level ?? 0)
+                                ? `${COLORS.accent} !important`
+                                : "#e0e0e0 !important",
+                            WebkitPrintColorAdjust: "exact !important",
+                            printColorAdjust: "exact !important",
+                            colorAdjust: "exact !important",
+                          }}
+                        />
+                      ))}
+                    </Box>
+                  </Box>
+                ))}
+            </Box>
+          )}
+
+          {data.education.length > 0 && (
+            <Box>
+              <SectionTitle>Education</SectionTitle>
+              {data.education.map((edu) => (
+                <Box key={edu.id} sx={{ mb: 1.5 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.8rem",
+                      fontWeight: 700,
+                      color: COLORS.emphasis,
+                    }}
+                  >
+                    {edu.degree}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "0.7rem",
+                      color: COLORS.accent,
+                      fontWeight: 600,
+                    }}
+                  >
+                    {edu.institution}
+                  </Typography>
+                  <Typography sx={{ fontSize: "0.65rem", color: COLORS.body }}>
+                    {formatDate(edu.startDate, edu.endDate)}
+                    {edu.location ? ` • ${edu.location}` : ""}
+                  </Typography>
+                  {edu.gpa && (
+                    <Typography
+                      sx={{ fontSize: "0.65rem", color: COLORS.body, mt: 0.25 }}
+                    >
+                      GPA: {edu.gpa}
+                    </Typography>
+                  )}
+                  {edu.description && (
+                    <Typography
+                      sx={{
+                        fontSize: "0.65rem",
+                        color: COLORS.body,
+                        mt: 0.25,
+                        lineHeight: 1.4,
+                      }}
+                    >
+                      {edu.description}
+                    </Typography>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
PDF: Use html-to-image instead of html2canvas so the PDF matches the on-screen preview; no flash on download; CSS patch for cross-origin styles.
Certs: Fix name+link wrapping/overlap in 11 templates (flex layout: name gets flex: 1, link whiteSpace: nowrap).
Single page: Clamp image height to 297 mm so no blank second page.
Size/quality: JPEG 0.97, pixelRatio 3 — under ~5 MB, high quality.