### PR TITLE
feat: Loading states, leaderboard user rank, toast safety, assessment cards, and course filter by tags

### DIFF
--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -77,13 +77,29 @@ export default function AssessmentDetailPage({
     }
   };
 
+  if (loading) {
+    return (
+      <MainLayout>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: 400,
+            py: 8,
+          }}
+        >
+          <CircularProgress size={40} sx={{ color: "#6366f1" }} />
+        </Box>
+      </MainLayout>
+    );
+  }
+
   if (!assessment) {
     return (
       <MainLayout>
         <Container>
-          <Typography>
-            {" "}
-          </Typography>
+          <Typography>{t("assessments.failedToLoadDetails")}</Typography>
         </Container>
       </MainLayout>
     );

--- a/app/courses/[id]/submodule/[submoduleId]/page.tsx
+++ b/app/courses/[id]/submodule/[submoduleId]/page.tsx
@@ -584,11 +584,22 @@ export default function SubmoduleDetailPage() {
     return `${mins}m`;
   };
 
-  if (!submoduleData || !courseDetail) {
-    return null;
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          minHeight: 400,
+          py: 8,
+        }}
+      >
+        <CircularProgress size={40} sx={{ color: "#6366f1" }} />
+      </Box>
+    );
   }
 
-  // Early return if data is not loaded
   if (!submoduleData || !courseDetail) {
     return null;
   }

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -17,16 +17,16 @@ import {
   FormControl,
   LinearProgress,
 } from "@mui/material";
-import { MainLayout } from "@/components/layout/MainLayout";
 import {
   coursesService,
   Course as ServiceCourse,
 } from "@/lib/services/courses.service";
-import { Course as CourseCardCourse } from "@/components/course/interfaces";
-import { useToast } from "@/components/common/Toast";
+import { MainLayout } from "@/components/layout/MainLayout";
 import { CourseCard } from "@/components/course/CourseCard";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
 import { usePayment } from "@/hooks/usePayment";
+import type { Course as CourseCardCourse } from "@/components/course/interfaces";
 import { PaymentType } from "@/lib/services/payment.service";
 
 const ITEMS_PER_PAGE = 12;
@@ -98,67 +98,37 @@ export default function CoursesPage() {
         })
       );
       setCourses(mappedCourses);
-    } catch (error: any) {
+    } catch {
       showToast(t("courses.failedToLoad"), "error");
     } finally {
       setLoading(false);
     }
   };
 
-  // Helper function to check if course matches category based on tags
+  // Filter by category = filter by course tags (same tags set in admin course builder)
   const matchesCategory = (
     course: CourseCardCourse,
     category: string
   ): boolean => {
     if (category === "All") return true;
-
-    // Map category names to tag keywords
-    const categoryTagMap: Record<string, string[]> = {
-      "Full Stack Development": [
-        "fullstack",
-        "full-stack",
-        "mern",
-        "mean",
-        "stack",
-      ],
-      "Front-End Development": [
-        "frontend",
-        "front-end",
-        "react",
-        "vue",
-        "angular",
-        "javascript",
-      ],
-      "Back-End Development": [
-        "backend",
-        "back-end",
-        "server",
-        "api",
-        "node",
-        "python",
-        "django",
-      ],
-      "UI/UX Design": ["ui", "ux", "design", "figma", "sketch"],
-      "Data Science & Analytics": [
-        "data",
-        "science",
-        "analytics",
-        "machine learning",
-        "ml",
-        "ai",
-      ],
-      Marketing: ["marketing", "seo", "social", "digital"],
-      Business: ["business", "management", "strategy", "finance"],
-    };
-
-    const courseTags = (course.tags || []).map((tag) => tag.toLowerCase());
-    const keywords = categoryTagMap[category] || [];
-
-    // Check if any tag matches any keyword for this category
-    return keywords.some((keyword) =>
-      courseTags.some((tag) => tag.includes(keyword.toLowerCase()))
+    const courseTags = (course.tags || []).map((t) =>
+      t.trim().toLowerCase()
     );
+    const selected = category.trim().toLowerCase();
+    return courseTags.some((tag) => tag === selected);
   };
+
+  // Category options = unique tags from all courses (from admin course builder)
+  const categoryOptions = useMemo(() => {
+    const set = new Set<string>();
+    courses.forEach((c) =>
+      (c.tags || []).forEach((tag) => {
+        const t = tag.trim();
+        if (t) set.add(t);
+      })
+    );
+    return ["All", ...Array.from(set).sort((a, b) => a.localeCompare(b))];
+  }, [courses]);
 
   // Calculate counts
   const totalCount = courses.length;
@@ -274,7 +244,7 @@ export default function CoursesPage() {
       await coursesService.enrollInCourse(courseId);
       showToast(t("courses.enrolledSuccess"), "success");
       loadCourses();
-    } catch (error: any) {
+    } catch {
       showToast("Failed to enroll in course", "error");
     } finally {
       setEnrollingCourseId(null);
@@ -612,7 +582,11 @@ export default function CoursesPage() {
                 {t("courses.category")}
               </Typography>
               <Select
-                value={filters.category || "All"}
+                value={
+                  categoryOptions.includes(filters.category || "All")
+                    ? filters.category || "All"
+                    : "All"
+                }
                 onChange={(e) => handleFilterChange("category", e.target.value)}
                 sx={{
                   backgroundColor: "#f9fafb",
@@ -627,22 +601,11 @@ export default function CoursesPage() {
                   },
                 }}
               >
-                <MenuItem value="All">{t("courses.allCategories")}</MenuItem>
-                <MenuItem value="Full Stack Development">
-                  {t("courses.fullStack")}
-                </MenuItem>
-                <MenuItem value="Front-End Development">
-                  {t("courses.frontEnd")}
-                </MenuItem>
-                <MenuItem value="Back-End Development">
-                  {t("courses.backEnd")}
-                </MenuItem>
-                <MenuItem value="UI/UX Design">{t("courses.uiUx")}</MenuItem>
-                <MenuItem value="Data Science & Analytics">
-                  {t("courses.dataScience")}
-                </MenuItem>
-                <MenuItem value="Marketing">{t("courses.marketing")}</MenuItem>
-                <MenuItem value="Business">{t("courses.business")}</MenuItem>
+                {categoryOptions.map((opt) => (
+                  <MenuItem key={opt} value={opt}>
+                    {opt === "All" ? t("courses.allCategories") : opt}
+                  </MenuItem>
+                ))}
               </Select>
             </FormControl>
 

--- a/app/mock-interview/[id]/result/page.tsx
+++ b/app/mock-interview/[id]/result/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Box, Container } from "@mui/material";
+import { Box, Container, CircularProgress } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import mockInterviewService from "@/lib/services/mock-interview.service";
 import { useToast } from "@/components/common/Toast";
@@ -169,6 +169,24 @@ export default function InterviewResultPage() {
     router.push("/mock-interview/previous");
   }, [router]);
 
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: 400,
+            py: 8,
+          }}
+        >
+          <CircularProgress size={40} sx={{ color: "#6366f1" }} />
+        </Box>
+      </MainLayout>
+    );
+  }
 
   if (!result) {
     return null;

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Box, Container, Tabs, Tab } from "@mui/material";
+import { Box, Container, Tabs, Tab, CircularProgress } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { CoverPhoto } from "@/components/profile/CoverPhoto";
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
@@ -78,6 +78,7 @@ export default function ProfilePage() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [heatmapData, setHeatmapData] = useState<HeatmapData>({});
   const [activeTab, setActiveTab] = useState(0);
+  const [loading, setLoading] = useState(true);
   const { showToast } = useToast();
   const { clientInfo } = useClientInfo();
 
@@ -91,6 +92,7 @@ export default function ProfilePage() {
 
   const loadProfileData = async () => {
     try {
+      setLoading(true);
       const profileData = await profileService.getUserProfile();
       setProfile(mergeWithLocalFallback(profileData));
 
@@ -102,6 +104,8 @@ export default function ProfilePage() {
       }
     } catch {
       showToast("Failed to load profile", "error");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -134,6 +138,26 @@ export default function ProfilePage() {
       showToast("Profile saved locally", "info");
     }
   };
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <Container maxWidth="lg">
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              minHeight: 400,
+              py: 8,
+            }}
+          >
+            <CircularProgress size={40} sx={{ color: "#6366f1" }} />
+          </Box>
+        </Container>
+      </MainLayout>
+    );
+  }
 
   if (!profile) {
     return (

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -215,63 +215,26 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             }
           : {},
       }}
+      role={isClickable ? "button" : undefined}
+      tabIndex={isClickable ? 0 : undefined}
       onClick={handleClick}
+      onKeyDown={
+        isClickable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleClick();
+              }
+            }
+          : undefined
+      }
+      aria-label={
+        isClickable
+          ? `${stripHtmlTags(assessment.title || "").trim() || assessment.title} - ${buttonLabel}`
+          : undefined
+      }
     >
-      {/* Status Badges - RTL-aware position and icon order */}
-      <Box
-        sx={{
-          position: "absolute",
-          top: 10,
-          insetInlineEnd: 10,
-          zIndex: 2,
-          display: "flex",
-          flexDirection: "row",
-          gap: 1,
-        }}
-      >
-        {assessment.proctoring_enabled && (
-          <Chip
-            icon={<IconWrapper icon="mdi:shield-account" size={14} />}
-            label={t("assessments.proctored")}
-            size="small"
-            sx={{
-              backgroundColor: "#fef3c7",
-              color: "#92400e",
-              fontWeight: 600,
-              fontSize: "0.7rem",
-              height: 22,
-              flexDirection: isRtl ? "row-reverse" : "row",
-              "& .MuiChip-icon": {
-                color: "#92400e",
-                marginInlineStart: isRtl ? "4px" : 0,
-                marginInlineEnd: isRtl ? 0 : "4px",
-              },
-            }}
-          />
-        )}
-        {showResults && (
-          <Chip
-            icon={<IconWrapper icon="mdi:check-circle" size={14} />}
-            label={t("assessments.completed")}
-            size="small"
-            sx={{
-              backgroundColor: "#d1fae5",
-              color: "#065f46",
-              fontWeight: 600,
-              fontSize: "0.7rem",
-              height: 22,
-              flexDirection: isRtl ? "row-reverse" : "row",
-              "& .MuiChip-icon": {
-                color: "#065f46",
-                marginInlineStart: isRtl ? "4px" : 0,
-                marginInlineEnd: isRtl ? 0 : "4px",
-              },
-            }}
-          />
-        )}
-      </Box>
-
-      {/* Header Section */}
+      {/* Header Section - Title and tags in clear rows to avoid overlap */}
       <Box
         sx={{
           background: isPsychometric
@@ -301,27 +264,91 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             }}
           />
         )}
-        
-        <Box sx={{ position: "relative", zIndex: 1 }}>
+
+        <Box
+          sx={{
+            position: "relative",
+            zIndex: 1,
+            display: "flex",
+            flexDirection: "column",
+            gap: 1,
+          }}
+        >
+          {/* Row 1: Status badges only - no overlap with title */}
+          {(assessment.proctoring_enabled || showResults) && (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: isRtl ? "row-reverse" : "row",
+                justifyContent: "flex-end",
+                gap: 1,
+                flexShrink: 0,
+              }}
+            >
+              {assessment.proctoring_enabled && (
+                <Chip
+                  icon={<IconWrapper icon="mdi:shield-account" size={14} />}
+                  label={t("assessments.proctored")}
+                  size="small"
+                  sx={{
+                    backgroundColor: showResults ? "#fef3c7" : "rgba(255, 255, 255, 0.25)",
+                    color: showResults ? "#92400e" : "#ffffff",
+                    fontWeight: 600,
+                    fontSize: "0.7rem",
+                    height: 24,
+                    flexDirection: isRtl ? "row-reverse" : "row",
+                    border: showResults ? "none" : "1px solid rgba(255, 255, 255, 0.4)",
+                    "& .MuiChip-icon": {
+                      color: "inherit",
+                      marginInlineStart: isRtl ? "4px" : 0,
+                      marginInlineEnd: isRtl ? 0 : "4px",
+                    },
+                  }}
+                />
+              )}
+              {showResults && (
+                <Chip
+                  icon={<IconWrapper icon="mdi:check-circle" size={14} />}
+                  label={t("assessments.completed")}
+                  size="small"
+                  sx={{
+                    backgroundColor: showResults ? "#d1fae5" : "rgba(255, 255, 255, 0.25)",
+                    color: showResults ? "#065f46" : "#ffffff",
+                    fontWeight: 600,
+                    fontSize: "0.7rem",
+                    height: 24,
+                    flexDirection: isRtl ? "row-reverse" : "row",
+                    border: showResults ? "none" : "1px solid rgba(255, 255, 255, 0.4)",
+                    "& .MuiChip-icon": {
+                      color: "inherit",
+                      marginInlineStart: isRtl ? "4px" : 0,
+                      marginInlineEnd: isRtl ? 0 : "4px",
+                    },
+                  }}
+                />
+              )}
+            </Box>
+          )}
+
+          {/* Row 2: Title - full width, no overlap */}
           <Typography
             variant="h6"
             sx={{
               color: showResults ? "#1f2937" : "#ffffff",
               fontWeight: 700,
-              fontSize: "1rem",
-              mb: 0.5,
-              pr: showResults || isPsychometric ? 10 : 0,
-              pl: isPsychometric && !showResults ? 0 : 0,
-              minHeight: 40,
+              fontSize: "1.0625rem",
+              lineHeight: 1.35,
               display: "-webkit-box",
               WebkitLineClamp: 2,
               WebkitBoxOrient: "vertical",
               overflow: "hidden",
-              lineHeight: 1.3,
+              minHeight: 40,
             }}
           >
             {stripHtmlTags(assessment.title || "").trim() || assessment.title || "\u00A0"}
           </Typography>
+
+          {/* Row 3: Subtitle / instructions */}
           <Typography
             variant="body2"
             sx={{
@@ -336,15 +363,15 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
           >
             {(stripHtmlTags(assessment.instructions || "").trim() || "\u00A0")}
           </Typography>
-          
-          {/* Tags for psychometric assessments */}
+
+          {/* Psychometric tags */}
           {isPsychometric && psychometricTags.length > 0 && (
             <Box
               sx={{
                 display: "flex",
                 flexWrap: "wrap",
                 gap: 1,
-                mt: 1.5,
+                mt: 0.5,
               }}
             >
               {psychometricTags.slice(0, 3).map((tag, index) => (

--- a/components/common/Toast.tsx
+++ b/components/common/Toast.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import { Snackbar, Alert, AlertColor } from '@mui/material';
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import { createContext, useContext, useState, useCallback, ReactNode } from "react";
+import { Snackbar, Alert, AlertColor } from "@mui/material";
 
 interface ToastContextType {
   showToast: (message: string, severity?: AlertColor) => void;
@@ -12,7 +12,11 @@ const ToastContext = createContext<ToastContextType | undefined>(undefined);
 export const useToast = () => {
   const context = useContext(ToastContext);
   if (!context) {
-    throw new Error('useToast must be used within ToastProvider');
+    return {
+      showToast: (_message: string, _severity?: AlertColor) => {
+        // No-op when used outside ToastProvider (e.g. during SSR or prefetch)
+      },
+    };
   }
   return context;
 };
@@ -26,7 +30,7 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
   const [message, setMessage] = useState('');
   const [severity, setSeverity] = useState<AlertColor>('info');
 
-  const showToast = useCallback((msg: string, sev: AlertColor = 'info') => {
+  const showToast = useCallback((msg: string, sev: AlertColor = "info") => {
     setMessage(msg);
     setSeverity(sev);
     setOpen(true);
@@ -43,9 +47,9 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
         open={open}
         autoHideDuration={6000}
         onClose={handleClose}
-        anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
       >
-        <Alert onClose={handleClose} severity={severity} sx={{ width: '100%' }}>
+        <Alert onClose={handleClose} severity={severity} sx={{ width: "100%" }}>
           {message}
         </Alert>
       </Snackbar>

--- a/components/course/CourseLeaderboard.tsx
+++ b/components/course/CourseLeaderboard.tsx
@@ -7,10 +7,12 @@ import {
   Avatar,
   Tooltip,
   IconButton,
+  Divider,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { LeaderboardEntry } from "@/lib/services/courses.service";
+import { useAuth } from "@/lib/auth/auth-context";
 
 interface CourseLeaderboardProps {
   leaderboard: LeaderboardEntry[];
@@ -18,6 +20,7 @@ interface CourseLeaderboardProps {
 
 export function CourseLeaderboard({ leaderboard }: CourseLeaderboardProps) {
   const { t } = useTranslation("common");
+  const { user } = useAuth();
   const getRankColor = (rank?: number | null) => {
     if (!rank || rank === 0) return "#6B7280";
     if (rank === 1) return "#FFD700"; // Gold
@@ -35,9 +38,37 @@ export function CourseLeaderboard({ leaderboard }: CourseLeaderboardProps) {
   };
 
   const getDisplayName = (entry: LeaderboardEntry) => {
-    // Current structure has name directly
     return entry.name || "User";
   };
+
+  const currentUserEntry = (() => {
+    if (!user || leaderboard.length === 0) return undefined;
+
+    const fullName = `${user.first_name} ${user.last_name}`.trim().toLowerCase();
+    const userName = (user.user_name || "").toLowerCase();
+    const userEmail = (user.email || "").toLowerCase();
+    const firstName = (user.first_name || "").toLowerCase();
+    const lastName = (user.last_name || "").toLowerCase();
+
+    return leaderboard.find((entry) => {
+      const entryName = (entry?.name || "").toLowerCase().trim();
+      const entryEmail = (entry?.email || "").toLowerCase();
+      const entryUserName = (entry?.user_name || "").toLowerCase();
+
+      if (userEmail && entryEmail && userEmail === entryEmail) return true;
+      if (userName && entryUserName && userName === entryUserName) return true;
+      if (fullName && entryName && fullName === entryName) return true;
+      if (userName && entryName && userName === entryName) return true;
+      if (
+        firstName &&
+        lastName &&
+        entryName.includes(firstName) &&
+        entryName.includes(lastName)
+      )
+        return true;
+      return false;
+    });
+  })();
 
   const markingScheme = [
     { type: "VideoTutorial", marks: 10 },
@@ -376,6 +407,112 @@ export function CourseLeaderboard({ leaderboard }: CourseLeaderboardProps) {
           </Box>
         )}
       </Box>
+
+      {/* Current User Rank - Pinned at Bottom */}
+      {currentUserEntry && leaderboard.length > 0 && (
+        <Box sx={{ mt: 2 }}>
+          <Divider sx={{ mb: 1.5 }} />
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              p: 1.5,
+              borderRadius: 2,
+              background:
+                "linear-gradient(135deg, rgba(99, 102, 241, 0.06) 0%, rgba(139, 92, 246, 0.06) 100%)",
+              border: "1px solid rgba(99, 102, 241, 0.2)",
+            }}
+          >
+            <Box
+              sx={{
+                minWidth: 32,
+                height: 32,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "50%",
+                background:
+                  "linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)",
+                color: "#ffffff",
+                fontWeight: 700,
+                fontSize: "0.8125rem",
+                flexShrink: 0,
+                boxShadow: "0 2px 8px rgba(99, 102, 241, 0.3)",
+              }}
+            >
+              {currentUserEntry.rank ?? "?"}
+            </Box>
+            <Avatar
+              src={
+                currentUserEntry.profile_pic_url ||
+                user?.profile_picture ||
+                undefined
+              }
+              alt={getDisplayName(currentUserEntry)}
+              sx={{
+                width: 36,
+                height: 36,
+                flexShrink: 0,
+                border: "2px solid rgba(99, 102, 241, 0.3)",
+                boxShadow: "0 2px 8px rgba(99, 102, 241, 0.15)",
+              }}
+            >
+              {getDisplayName(currentUserEntry)[0]}
+            </Avatar>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 700,
+                  color: "#1a1f2e",
+                  fontSize: "0.875rem",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  lineHeight: 1.3,
+                }}
+              >
+                {getDisplayName(currentUserEntry)}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: "#6366f1",
+                  fontSize: "0.75rem",
+                  fontWeight: 500,
+                  lineHeight: 1.2,
+                }}
+              >
+                {t("courses.scoreLabel")}:{" "}
+                {(currentUserEntry.score ?? 0).toFixed(0)}
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                px: 1.5,
+                py: 0.5,
+                borderRadius: 1.5,
+                background:
+                  "linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)",
+                flexShrink: 0,
+                boxShadow: "0 2px 4px rgba(99, 102, 241, 0.2)",
+              }}
+            >
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 700,
+                  color: "#ffffff",
+                  fontSize: "0.8125rem",
+                }}
+              >
+                #{currentUserEntry.rank ?? "?"}
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      )}
     </Card>
   );
 }

--- a/components/course/submodule/QuizStartScreen.tsx
+++ b/components/course/submodule/QuizStartScreen.tsx
@@ -76,156 +76,74 @@ export function QuizStartScreen({
       </Box>
 
       {/* Quiz Details Grid */}
-      <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid size={{ xs: 6, sm: 3 }}>
-          <Box
-            sx={{
-              backgroundColor: "#f9fafb",
-              borderRadius: 2,
-              p: 2,
-              border: "1px solid #e5e7eb",
-              textAlign: "center",
-            }}
-          >
-            <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
-              <IconWrapper icon="mdi:clock-outline" size={24} color="#6366f1" />
+      <Grid container spacing={2} sx={{ mb: 3, alignItems: "stretch" }}>
+        {[
+          {
+            icon: "mdi:clock-outline",
+            value: duration,
+            label: t("courses.minutes"),
+          },
+          {
+            icon: "mdi:help-circle-outline",
+            value: totalQuestions,
+            label: t("courses.questions"),
+          },
+          {
+            icon: "mdi:star-outline",
+            value: marks,
+            label: t("courses.totalMarks"),
+          },
+          {
+            icon: "mdi:file-document-outline",
+            value: content.content_type || "Quiz",
+            label: t("courses.typeLabel"),
+            capitalize: true,
+          },
+        ].map((item, idx) => (
+          <Grid key={idx} size={{ xs: 6, sm: 3 }}>
+            <Box
+              sx={{
+                backgroundColor: "#f9fafb",
+                borderRadius: 2,
+                p: 2,
+                border: "1px solid #e5e7eb",
+                textAlign: "center",
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
+                <IconWrapper icon={item.icon} size={24} color="#6366f1" />
+              </Box>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 700,
+                  color: "#1a1f2e",
+                  fontSize: "1.5rem",
+                  mb: 0.5,
+                  ...(item.capitalize && { textTransform: "capitalize" }),
+                }}
+              >
+                {item.value}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: "#6b7280",
+                  fontSize: "0.75rem",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.5px",
+                }}
+              >
+                {item.label}
+              </Typography>
             </Box>
-            <Typography
-              variant="h6"
-              sx={{
-                fontWeight: 700,
-                color: "#1a1f2e",
-                fontSize: "1.5rem",
-                mb: 0.5,
-              }}
-            >
-              {duration}
-            </Typography>
-            <Typography
-              variant="caption"
-              sx={{
-                color: "#6b7280",
-                fontSize: "0.75rem",
-                textTransform: "uppercase",
-                letterSpacing: "0.5px",
-              }}
-            >
-              {t("courses.minutes")}
-            </Typography>
-          </Box>
-        </Grid>
-        <Grid size={{ xs: 6, sm: 3 }}>
-          <Box
-            sx={{
-              backgroundColor: "#f9fafb",
-              borderRadius: 2,
-              p: 2,
-              border: "1px solid #e5e7eb",
-              textAlign: "center",
-            }}
-          >
-            <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
-              <IconWrapper icon="mdi:help-circle-outline" size={24} color="#6366f1" />
-            </Box>
-            <Typography
-              variant="h6"
-              sx={{
-                fontWeight: 700,
-                color: "#1a1f2e",
-                fontSize: "1.5rem",
-                mb: 0.5,
-              }}
-            >
-              {totalQuestions}
-            </Typography>
-            <Typography
-              variant="caption"
-              sx={{
-                color: "#6b7280",
-                fontSize: "0.75rem",
-                textTransform: "uppercase",
-                letterSpacing: "0.5px",
-              }}
-            >
-              {t("courses.questions")}
-            </Typography>
-          </Box>
-        </Grid>
-        <Grid size={{ xs: 6, sm: 3 }}>
-          <Box
-            sx={{
-              backgroundColor: "#f9fafb",
-              borderRadius: 2,
-              p: 2,
-              border: "1px solid #e5e7eb",
-              textAlign: "center",
-            }}
-          >
-            <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
-              <IconWrapper icon="mdi:star-outline" size={24} color="#6366f1" />
-            </Box>
-            <Typography
-              variant="h6"
-              sx={{
-                fontWeight: 700,
-                color: "#1a1f2e",
-                fontSize: "1.5rem",
-                mb: 0.5,
-              }}
-            >
-              {marks}
-            </Typography>
-            <Typography
-              variant="caption"
-              sx={{
-                color: "#6b7280",
-                fontSize: "0.75rem",
-                textTransform: "uppercase",
-                letterSpacing: "0.5px",
-              }}
-            >
-              {t("courses.totalMarks")}
-            </Typography>
-          </Box>
-        </Grid>
-        <Grid size={{ xs: 6, sm: 3 }}>
-          <Box
-            sx={{
-              backgroundColor: "#f9fafb",
-              borderRadius: 2,
-              p: 2,
-              border: "1px solid #e5e7eb",
-              textAlign: "center",
-            }}
-          >
-            <Box sx={{ mb: 1, display: "flex", justifyContent: "center" }}>
-              <IconWrapper icon="mdi:file-document-outline" size={24} color="#6366f1" />
-            </Box>
-            <Typography
-              variant="h6"
-              sx={{
-                fontWeight: 700,
-                color: "#1a1f2e",
-                fontSize: "1.125rem",
-                mb: 0.5,
-                textTransform: "capitalize",
-              }}
-            >
-              {content.content_type || "Quiz"}
-            </Typography>
-            <Typography
-              variant="caption"
-              sx={{
-                color: "#6b7280",
-                fontSize: "0.75rem",
-                textTransform: "uppercase",
-                letterSpacing: "0.5px",
-              }}
-            >
-              {t("courses.typeLabel")}
-            </Typography>
-          </Box>
-        </Grid>
+          </Grid>
+        ))}
       </Grid>
 
       {/* Start Button */}

--- a/components/dashboard/Leaderboard.tsx
+++ b/components/dashboard/Leaderboard.tsx
@@ -2,12 +2,20 @@
 
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Box, Typography, Card, Avatar, LinearProgress } from "@mui/material";
+import {
+  Box,
+  Typography,
+  Card,
+  Avatar,
+  LinearProgress,
+  Divider,
+} from "@mui/material";
 import {
   dashboardService,
   OverallLeaderboardEntry,
 } from "@/lib/services/dashboard.service";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { useAuth } from "@/lib/auth/auth-context";
 
 const LEADERBOARD_STORAGE_KEY = "leaderboard_data";
 
@@ -47,60 +55,98 @@ interface LeaderboardProps {
   courseId?: number; // Kept for backward compatibility but not used
 }
 
-export const Leaderboard = ({ courseId }: LeaderboardProps) => {
+export const Leaderboard = ({ courseId: _courseId }: LeaderboardProps) => {
   const { t } = useTranslation("common");
+  const { user } = useAuth();
   const [loading, setLoading] = useState(false);
   const [leaderboard, setLeaderboard] = useState<OverallLeaderboardEntry[]>([]);
+  const [myRankEntry, setMyRankEntry] = useState<OverallLeaderboardEntry | null>(null);
   const hasLoadedRef = useRef(false);
+
+  const findUserEntry = useCallback(
+    (data: OverallLeaderboardEntry[]) => {
+      if (!user || !data?.length) return undefined;
+
+      const fullName = `${user.first_name} ${user.last_name}`
+        .trim()
+        .toLowerCase();
+      const userName = (user.user_name || "").toLowerCase();
+      const userEmail = (user.email || "").toLowerCase();
+      const firstName = (user.first_name || "").toLowerCase();
+      const lastName = (user.last_name || "").toLowerCase();
+
+      return data.find((entry) => {
+        const entryName = (entry?.name || "").toLowerCase().trim();
+        const entryEmail = (entry?.email || "").toLowerCase();
+        const entryUserName = (entry?.user_name || "").toLowerCase();
+
+        if (userEmail && entryEmail && userEmail === entryEmail) return true;
+        if (userName && entryUserName && userName === entryUserName) return true;
+        if (fullName && entryName && fullName === entryName) return true;
+        if (userName && entryName && userName === entryName) return true;
+        if (
+          firstName &&
+          lastName &&
+          entryName.includes(firstName) &&
+          entryName.includes(lastName)
+        )
+          return true;
+        return false;
+      });
+    },
+    [user]
+  );
 
   const loadLeaderboard = useCallback(async () => {
     try {
       setLoading(true);
-      
-      // Get overall leaderboard (default limit is handled by API)
+
       const data = await dashboardService.getOverallLeaderboard();
 
-      // Ensure data is an array - multiple checks
-      if (!data) {
+      if (!data || !Array.isArray(data)) {
         setLeaderboard([]);
         setStoredLeaderboard([]);
         return;
       }
 
-      if (!Array.isArray(data)) {
-        setLeaderboard([]);
-        setStoredLeaderboard([]);
-        return;
-      }
-
-      // Update state and localStorage with fresh data
       setLeaderboard(data);
       setStoredLeaderboard(data);
+
+      const foundInTop = findUserEntry(data);
+      if (foundInTop) {
+        setMyRankEntry(foundInTop);
+      } else {
+        try {
+          const fullData = await dashboardService.getOverallLeaderboard(10000);
+          if (fullData && Array.isArray(fullData)) {
+            const foundInFull = findUserEntry(fullData);
+            setMyRankEntry(foundInFull ?? null);
+          }
+        } catch {
+          // Silently fail — user rank is optional
+        }
+      }
     } catch {
-      // On error, try to load from localStorage if available
       const storedData = getStoredLeaderboard();
       if (storedData) {
         setLeaderboard(storedData);
       } else {
         setLeaderboard([]);
       }
-      // Don't show toast for optional data
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [findUserEntry]);
 
   useEffect(() => {
     if (hasLoadedRef.current) return;
     hasLoadedRef.current = true;
 
-    // Load from localStorage first to show cached data immediately
     const storedData = getStoredLeaderboard();
     if (storedData && storedData.length > 0) {
       setLeaderboard(storedData);
     }
 
-    // Always fetch fresh data from API
     loadLeaderboard();
   }, [loadLeaderboard]);
 
@@ -128,6 +174,8 @@ export const Leaderboard = ({ courseId }: LeaderboardProps) => {
     }
     return leaderboard;
   }, [leaderboard]);
+
+  const currentUserEntry = myRankEntry;
 
   return (
     <Box>
@@ -389,6 +437,111 @@ export const Leaderboard = ({ courseId }: LeaderboardProps) => {
           </Box>
         )}
       </Card>
+
+      {/* Current User Rank - Pinned at Bottom */}
+      {currentUserEntry && safeLeaderboard.length > 0 && (
+        <Box sx={{ mt: 1.5 }}>
+          <Divider sx={{ mb: 1.5 }} />
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              p: 1.5,
+              borderRadius: 2,
+              background:
+                "linear-gradient(135deg, rgba(99, 102, 241, 0.06) 0%, rgba(139, 92, 246, 0.06) 100%)",
+              border: "1px solid rgba(99, 102, 241, 0.2)",
+            }}
+          >
+            <Box
+              sx={{
+                minWidth: 28,
+                height: 28,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "50%",
+                background:
+                  "linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)",
+                color: "#ffffff",
+                fontWeight: 700,
+                fontSize: "0.75rem",
+                flexShrink: 0,
+                boxShadow: "0 2px 8px rgba(99, 102, 241, 0.3)",
+              }}
+            >
+              {currentUserEntry.rank ?? "?"}
+            </Box>
+            <Avatar
+              src={
+                currentUserEntry.profile_pic_url ||
+                user?.profile_picture ||
+                undefined
+              }
+              alt={currentUserEntry.name || "You"}
+              sx={{
+                width: 32,
+                height: 32,
+                flexShrink: 0,
+                border: "2px solid rgba(99, 102, 241, 0.3)",
+                boxShadow: "0 2px 8px rgba(99, 102, 241, 0.15)",
+              }}
+            >
+              {(currentUserEntry.name || "U")[0]}
+            </Avatar>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 700,
+                  color: "#1a1f2e",
+                  fontSize: "0.8125rem",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  lineHeight: 1.3,
+                }}
+              >
+                {currentUserEntry.name || "You"}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  color: "#6366f1",
+                  fontSize: "0.6875rem",
+                  fontWeight: 500,
+                  lineHeight: 1.2,
+                }}
+              >
+                {t("dashboard.score")}: {currentUserEntry.marks ?? 0}
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                px: 1.5,
+                py: 0.5,
+                borderRadius: 1.5,
+                background:
+                  "linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%)",
+                flexShrink: 0,
+                boxShadow: "0 2px 4px rgba(99, 102, 241, 0.2)",
+              }}
+            >
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 700,
+                  color: "#ffffff",
+                  fontSize: "0.8125rem",
+                }}
+              >
+                #{currentUserEntry.rank ?? "?"}
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -34,6 +34,7 @@ import { Settings } from "lucide-react";
 import { LanguageSelect } from "@/components/common/LanguageSelect";
 import { useTranslation } from "react-i18next";
 import { isRtl } from "@/lib/i18n";
+import { useToast } from "@/components/common/Toast";
 
 interface AppBarProps {
   onMenuClick?: () => void;
@@ -46,6 +47,7 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
   const { clientInfo } = useClientInfo();
   const hideLeaderboardView = useHideLeaderboardView();
   const { isAdminMode, toggleAdminMode } = useAdminMode();
+  const { showToast } = useToast();
 
   // Check if user can access admin mode
   const isAdminOrInstructor =
@@ -833,6 +835,8 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
 
           {/* Notifications */}
           <IconButton
+            aria-label="Notifications"
+            onClick={() => showToast("No New Notifications", "info")}
             sx={{
               color: "#6b7280",
               width: 40,

--- a/lib/services/courses.service.ts
+++ b/lib/services/courses.service.ts
@@ -182,6 +182,8 @@ export interface LeaderboardEntry {
   profile_pic_url?: string;
   score: number;
   rank: number;
+  email?: string;
+  user_name?: string;
 }
 
 export const coursesService = {

--- a/lib/services/dashboard.service.ts
+++ b/lib/services/dashboard.service.ts
@@ -31,8 +31,10 @@ export interface OverallLeaderboardEntry {
   course_name?: number;
   rank?: number;
   profile_pic_url?: string;
-  college?: string; // College/University name
-  linkedin_url?: string; // LinkedIn profile URL
+  college?: string;
+  linkedin_url?: string;
+  email?: string;
+  user_name?: string;
 }
 
 export const dashboardService = {
@@ -231,15 +233,17 @@ export const dashboardService = {
 
       // Validate and sanitize each entry
       const validatedData = leaderboardData
-        .filter((entry) => entry != null) // Remove null/undefined entries
+        .filter((entry) => entry != null)
         .map((entry) => ({
-          name: entry?.name ?? " User",
+          name: entry?.name ?? entry?.full_name ?? entry?.user?.name ?? " User",
           marks: entry?.marks ?? entry?.score ?? 0,
           course_name: entry?.course_name ?? " Course",
           rank: entry?.rank ?? 0,
           profile_pic_url: entry?.profile_pic_url ?? entry?.user?.profile_pic_url ?? "",
           college: entry?.college ?? entry?.college_name ?? entry?.university ?? undefined,
           linkedin_url: entry?.linkedin_url ?? entry?.linkedin_profile_url ?? entry?.social_links?.linkedin ?? undefined,
+          email: entry?.email ?? entry?.user?.email ?? undefined,
+          user_name: entry?.user_name ?? entry?.username ?? entry?.user?.user_name ?? undefined,
         })) as OverallLeaderboardEntry[];
 
       return validatedData;


### PR DESCRIPTION
- Loading states on profile, assessments, course submodule, and mock-interview result so a loader shows instead of "not found" or empty content.
- Leaderboard: pinned "your rank" card at bottom on dashboard and course; dashboard fetches full list when user is not in top N.
- Toast: safe use outside provider; bell shows "No New Notifications" when empty; aria-label on bell.
- Assessment cards: chips in separate row above title to fix overlap; keyboard and aria-label on clickable cards.
- Course filter: category uses actual course tags from admin; dropdown from unique tags.
- Guideline tweaks (imports, types, a11y). 