### PR TITLE
feat: course multi-select filters, live session message, CSS color va…

### DIFF
--- a/app/courses/[id]/submodule/[submoduleId]/page.tsx
+++ b/app/courses/[id]/submodule/[submoduleId]/page.tsx
@@ -63,6 +63,8 @@ export default function SubmoduleDetailPage() {
   const [isAutoNavigating, setIsAutoNavigating] = useState(false);
   const [autoRedirectCountdown, setAutoRedirectCountdown] = useState(5);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const [isQuizInProgress, setIsQuizInProgress] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const autoNavigateTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastFetchedSubmissionsIdRef = useRef<number | null>(null);
   const theme = useTheme();
@@ -149,6 +151,13 @@ export default function SubmoduleDetailPage() {
       // Article: no view tracking on load; completion is tracked only when user clicks "Mark as read"
     }
   }, [selectedContentId]);
+
+  // Reset quiz-in-progress when navigating away from quiz (sidebar collapse state kept for all content)
+  useEffect(() => {
+    if (currentContent?.content_type !== "Quiz") {
+      setIsQuizInProgress(false);
+    }
+  }, [currentContent?.content_type, selectedContentId]);
 
   // Sync sidebar submission count with pastSubmissions
   useEffect(() => {
@@ -613,31 +622,71 @@ export default function SubmoduleDetailPage() {
           width: "100%",
         }}
       >
-        {/* Desktop Sidebar */}
+        {/* Desktop Sidebar - collapsible for all content (Article, Quiz, Coding, Video, etc.) */}
         {!isMobile && (
           <Box
             sx={{
-              width: 300,
+              width: sidebarCollapsed ? 48 : 300,
               flexShrink: 0,
               height: "100%",
+              position: "relative",
+              transition: "width 0.25s ease",
+              overflow: !sidebarCollapsed ? "visible" : "hidden",
             }}
           >
-            <SubmoduleSidebar
-              courseDetail={courseDetail}
-              submoduleName={submoduleData.submoduleName}
-              moduleName={submoduleData.moduleName}
-              contentItems={submoduleData.data}
-              selectedContentId={selectedContentId}
-              activeTab={activeTab}
-              courseId={courseId}
-              onTabChange={setActiveTab}
-              onContentSelect={(contentId) => {
-                handleContentSelect(contentId);
+            {!sidebarCollapsed && (
+              <Box sx={{ width: 300, height: "100%" }}>
+                <SubmoduleSidebar
+                  courseDetail={courseDetail}
+                  submoduleName={submoduleData.submoduleName}
+                  moduleName={submoduleData.moduleName}
+                  contentItems={submoduleData.data}
+                  selectedContentId={selectedContentId}
+                  activeTab={activeTab}
+                  courseId={courseId}
+                  onTabChange={setActiveTab}
+                  onContentSelect={(contentId) => {
+                    handleContentSelect(contentId);
+                  }}
+                  getContentIcon={getContentIcon}
+                  getContentColor={getContentColor}
+                  formatDuration={formatDuration}
+                />
+              </Box>
+            )}
+            <Button
+              onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+              variant="contained"
+              size="small"
+              sx={{
+                position: "absolute",
+                top: 12,
+                right: sidebarCollapsed ? 0 : -12,
+                left: "auto",
+                zIndex: 10,
+                minWidth: sidebarCollapsed ? 36 : 24,
+                width: sidebarCollapsed ? 36 : 24,
+                height: sidebarCollapsed ? 36 : 24,
+                p: 0,
+                borderRadius: sidebarCollapsed ? 1 : "50%",
+                backgroundColor: "#4285f4",
+                boxShadow: "none",
+                "&:hover": {
+                  backgroundColor: "#3367d6",
+                  boxShadow: "none",
+                },
               }}
-              getContentIcon={getContentIcon}
-              getContentColor={getContentColor}
-              formatDuration={formatDuration}
-            />
+            >
+              <IconWrapper
+                icon={
+                  sidebarCollapsed
+                    ? "mdi:menu"
+                    : "mdi:chevron-left"
+                }
+                size={sidebarCollapsed ? 20 : 16}
+                color="#ffffff"
+              />
+            </Button>
           </Box>
         )}
 
@@ -984,10 +1033,11 @@ export default function SubmoduleDetailPage() {
                   }
                 }}
                 onStartQuiz={async () => {
-                  // Start activity tracking removed - only track complete
-                  // Quiz will start on the same page via QuizContent component
+                  setIsQuizInProgress(true);
+                  setSidebarCollapsed(true);
                 }}
                 onQuizComplete={async (obtainedMarks?: number) => {
+                  setIsQuizInProgress(false);
                   if (selectedContentId) {
                     lastFetchedSubmissionsIdRef.current = null;
                     await loadPastSubmissions(selectedContentId);

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -16,6 +16,8 @@ import {
   MenuItem,
   FormControl,
   LinearProgress,
+  Checkbox,
+  ListItemText,
 } from "@mui/material";
 import {
   coursesService,
@@ -46,8 +48,11 @@ export default function CoursesPage() {
   const [enrollingCourseId, setEnrollingCourseId] = useState<number | null>(
     null
   );
-  const [filters, setFilters] = useState({
-    category: "All",
+  const [filters, setFilters] = useState<{
+    categories: string[];
+    price: string;
+  }>({
+    categories: [],
     price: "All",
   });
   const { showToast } = useToast();
@@ -64,7 +69,6 @@ export default function CoursesPage() {
     try {
       setLoading(true);
       const data = await coursesService.getCourses();
-      // Map service Course to CourseCardCourse format
       const mappedCourses: CourseCardCourse[] = data.map(
         (course: ServiceCourse) => ({
           id: course.id,
@@ -105,20 +109,18 @@ export default function CoursesPage() {
     }
   };
 
-  // Filter by category = filter by course tags (same tags set in admin course builder)
   const matchesCategory = (
     course: CourseCardCourse,
-    category: string
+    selectedCategories: string[]
   ): boolean => {
-    if (category === "All") return true;
+    if (selectedCategories.length === 0) return true;
     const courseTags = (course.tags || []).map((t) =>
       t.trim().toLowerCase()
     );
-    const selected = category.trim().toLowerCase();
-    return courseTags.some((tag) => tag === selected);
+    const selectedLower = selectedCategories.map((c) => c.trim().toLowerCase());
+    return courseTags.some((tag) => selectedLower.includes(tag));
   };
 
-  // Category options = unique tags from all courses (from admin course builder)
   const categoryOptions = useMemo(() => {
     const set = new Set<string>();
     courses.forEach((c) =>
@@ -127,15 +129,13 @@ export default function CoursesPage() {
         if (t) set.add(t);
       })
     );
-    return ["All", ...Array.from(set).sort((a, b) => a.localeCompare(b))];
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
   }, [courses]);
 
-  // Calculate counts
   const totalCount = courses.length;
   const enrolledCount = courses.filter((c) => c.is_enrolled).length;
   const availableCount = courses.filter((c) => !c.is_enrolled).length;
 
-  // Filter and search logic
   const filteredCourses = useMemo(() => {
     let result = courses.filter(
       (course) =>
@@ -143,21 +143,18 @@ export default function CoursesPage() {
         course.description?.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
-    // Apply tab filter
     if (filter === "enrolled") {
       result = result.filter((c) => c.is_enrolled);
     } else if (filter === "available") {
       result = result.filter((c) => !c.is_enrolled);
     }
 
-    // Apply category filter
-    if (filters.category !== "All") {
+    if (filters.categories.length > 0) {
       result = result.filter((course) =>
-        matchesCategory(course, filters.category)
+        matchesCategory(course, filters.categories)
       );
     }
 
-    // Apply price filter
     if (filters.price !== "All") {
       if (filters.price === "Free") {
         result = result.filter((course) => course.is_free);
@@ -166,7 +163,6 @@ export default function CoursesPage() {
       }
     }
 
-    // Sort
     return result.sort((a, b) => {
       if (sortBy === "recent") {
         return b.id - a.id;
@@ -179,7 +175,6 @@ export default function CoursesPage() {
     });
   }, [courses, searchTerm, filter, filters, sortBy]);
 
-  // Pagination
   const paginatedCourses = useMemo(() => {
     const start = (page - 1) * pageSize;
     return filteredCourses.slice(start, start + pageSize);
@@ -198,9 +193,17 @@ export default function CoursesPage() {
     setPage(1);
   };
 
+  const handleCategoriesChange = (selected: string[]) => {
+    setFilters((prev) => ({
+      ...prev,
+      categories: selected,
+    }));
+    setPage(1);
+  };
+
   const handleClearFilters = () => {
     setFilters({
-      category: "All",
+      categories: [],
       price: "All",
     });
     setPage(1);
@@ -212,7 +215,6 @@ export default function CoursesPage() {
 
     setEnrollingCourseId(courseId);
 
-    // If course is not free, trigger payment
     if (!course.is_free && parseFloat(course.price) > 0) {
       await handlePayment({
         amount: course.price,
@@ -239,7 +241,6 @@ export default function CoursesPage() {
       return;
     }
 
-    // Standard free enrollment
     try {
       await coursesService.enrollInCourse(courseId);
       showToast(t("courses.enrolledSuccess"), "success");
@@ -263,20 +264,19 @@ export default function CoursesPage() {
   return (
     <MainLayout>
       <Box sx={{ width: "100%", px: { xs: 1.5, sm: 2, md: 3 }, py: 3 }}>
-        {/* Header with Icon */}
         <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 1 }}>
           <Box
             sx={{
               width: 56,
               height: 56,
               borderRadius: 2,
-              background: "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)",
+              background: "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
             }}
           >
-            <IconWrapper icon="mdi:book" size={28} color="#ffffff" />
+            <IconWrapper icon="mdi:book" size={28} color="var(--font-light)" />
           </Box>
           <Box>
             <Typography variant="h4" fontWeight={700}>
@@ -288,7 +288,6 @@ export default function CoursesPage() {
           </Box>
         </Box>
 
-        {/* Stats Cards */}
         <Box
           sx={{
             display: "grid",
@@ -305,9 +304,9 @@ export default function CoursesPage() {
             elevation={0}
             sx={{
               p: 2.5,
-              border: "1px solid #e5e7eb",
+              border: "1px solid var(--border-default)",
               borderRadius: 2,
-              backgroundColor: "#ffffff",
+              backgroundColor: "var(--card-bg)",
             }}
           >
             <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
@@ -316,7 +315,7 @@ export default function CoursesPage() {
                   width: 48,
                   height: 48,
                   borderRadius: 2,
-                  backgroundColor: "#eef2ff",
+                  backgroundColor: "var(--surface-indigo-light)",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
@@ -325,11 +324,11 @@ export default function CoursesPage() {
                 <IconWrapper
                   icon="mdi:book-open-page-variant"
                   size={24}
-                  color="#6366f1"
+                  color="var(--accent-indigo)"
                 />
               </Box>
               <Box>
-                <Typography variant="h4" fontWeight={700} color="#1f2937">
+                <Typography variant="h4" fontWeight={700} color="var(--font-primary-dark)">
                   {totalCount}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
@@ -342,9 +341,9 @@ export default function CoursesPage() {
             elevation={0}
             sx={{
               p: 2.5,
-              border: "1px solid #e5e7eb",
+              border: "1px solid var(--border-default)",
               borderRadius: 2,
-              backgroundColor: "#ffffff",
+              backgroundColor: "var(--card-bg)",
             }}
           >
             <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
@@ -353,7 +352,7 @@ export default function CoursesPage() {
                   width: 48,
                   height: 48,
                   borderRadius: 2,
-                  backgroundColor: "#d1fae5",
+                  backgroundColor: "var(--surface-green-light)",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
@@ -362,11 +361,11 @@ export default function CoursesPage() {
                 <IconWrapper
                   icon="mdi:check-circle"
                   size={24}
-                  color="#10b981"
+                  color="var(--course-cta)"
                 />
               </Box>
               <Box>
-                <Typography variant="h4" fontWeight={700} color="#1f2937">
+                <Typography variant="h4" fontWeight={700} color="var(--font-primary-dark)">
                   {enrolledCount}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
@@ -379,9 +378,9 @@ export default function CoursesPage() {
             elevation={0}
             sx={{
               p: 2.5,
-              border: "1px solid #e5e7eb",
+              border: "1px solid var(--border-default)",
               borderRadius: 2,
-              backgroundColor: "#ffffff",
+              backgroundColor: "var(--card-bg)",
             }}
           >
             <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
@@ -390,16 +389,16 @@ export default function CoursesPage() {
                   width: 48,
                   height: 48,
                   borderRadius: 2,
-                  backgroundColor: "#dbeafe",
+                  backgroundColor: "var(--surface-blue-light)",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
                 }}
               >
-                <IconWrapper icon="mdi:play-circle" size={24} color="#3b82f6" />
+                <IconWrapper icon="mdi:play-circle" size={24} color="var(--accent-blue-light)" />
               </Box>
               <Box>
-                <Typography variant="h4" fontWeight={700} color="#1f2937">
+                <Typography variant="h4" fontWeight={700} color="var(--font-primary-dark)">
                   {availableCount}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
@@ -410,17 +409,15 @@ export default function CoursesPage() {
           </Paper>
         </Box>
 
-        {/* Filters and Search */}
         <Paper
           elevation={0}
           sx={{
-            border: "1px solid #e5e7eb",
+            border: "1px solid var(--border-default)",
             borderRadius: 2,
             mb: 3,
             overflow: "hidden",
           }}
         >
-          {/* Tabs */}
           <Tabs
             value={filter}
             onChange={(_, newValue) => {
@@ -428,19 +425,19 @@ export default function CoursesPage() {
               setPage(1);
             }}
             sx={{
-              borderBottom: "1px solid #e5e7eb",
+              borderBottom: "1px solid var(--border-default)",
               px: 2,
               "& .MuiTab-root": {
                 textTransform: "none",
                 fontWeight: 600,
                 fontSize: "0.9375rem",
-                color: "#6b7280",
+                color: "var(--font-secondary)",
                 "&.Mui-selected": {
-                  color: "#6366f1",
+                  color: "var(--accent-indigo)",
                 },
               },
               "& .MuiTabs-indicator": {
-                backgroundColor: "#6366f1",
+                backgroundColor: "var(--accent-indigo)",
                 height: 3,
               },
             }}
@@ -450,7 +447,6 @@ export default function CoursesPage() {
             <Tab label={`${t("courses.availableTab")} (${availableCount})`} value="available" />
           </Tabs>
 
-          {/* Search and Sort */}
           <Box
             sx={{
               p: 2,
@@ -471,22 +467,22 @@ export default function CoursesPage() {
               InputProps={{
                 startAdornment: (
                   <InputAdornment position="start">
-                    <IconWrapper icon="mdi:magnify" size={20} color="#6b7280" />
+                    <IconWrapper icon="mdi:magnify" size={20} color="var(--font-secondary)" />
                   </InputAdornment>
                 ),
               }}
               sx={{
                 "& .MuiOutlinedInput-root": {
-                  backgroundColor: "#f9fafb",
+                  backgroundColor: "var(--surface)",
                   borderRadius: 2,
                   "& fieldset": {
                     borderColor: "transparent",
                   },
                   "&:hover fieldset": {
-                    borderColor: "#e5e7eb",
+                    borderColor: "var(--border-default)",
                   },
                   "&.Mui-focused fieldset": {
-                    borderColor: "#6366f1",
+                    borderColor: "var(--accent-indigo)",
                   },
                 },
               }}
@@ -497,16 +493,16 @@ export default function CoursesPage() {
                 onChange={(e) => setSortBy(e.target.value as SortType)}
                 displayEmpty
                 sx={{
-                  backgroundColor: "#f9fafb",
+                  backgroundColor: "var(--surface)",
                   borderRadius: 2,
                   "& .MuiOutlinedInput-notchedOutline": {
                     borderColor: "transparent",
                   },
                   "&:hover .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "#e5e7eb",
+                    borderColor: "var(--border-default)",
                   },
                   "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "#6366f1",
+                    borderColor: "var(--accent-indigo)",
                   },
                 }}
               >
@@ -527,11 +523,10 @@ export default function CoursesPage() {
           </Box>
         </Paper>
 
-        {/* Additional Filters */}
         <Paper
           elevation={0}
           sx={{
-            border: "1px solid #e5e7eb",
+            border: "1px solid var(--border-default)",
             borderRadius: 2,
             mb: 3,
             p: 2,
@@ -545,7 +540,7 @@ export default function CoursesPage() {
               mb: 2,
             }}
           >
-            <Typography variant="subtitle2" fontWeight={600} color="#1f2937">
+            <Typography variant="subtitle2" fontWeight={600} color="var(--font-primary-dark)">
               {t("courses.advancedFilters")}
             </Typography>
             <Button
@@ -553,11 +548,11 @@ export default function CoursesPage() {
               onClick={handleClearFilters}
               sx={{
                 textTransform: "none",
-                color: "#6366f1",
+                color: "var(--accent-indigo)",
                 fontWeight: 600,
                 fontSize: "0.8125rem",
                 "&:hover": {
-                  backgroundColor: "rgba(99, 102, 241, 0.08)",
+                  backgroundColor: "var(--surface-indigo-light)",
                 },
               }}
             >
@@ -575,13 +570,12 @@ export default function CoursesPage() {
               gap: 2,
             }}
           >
-            {/* Category Filter */}
             <FormControl fullWidth size="small">
               <Typography
                 variant="caption"
                 sx={{
                   mb: 0.5,
-                  color: "#6b7280",
+                  color: "var(--font-secondary)",
                   fontWeight: 500,
                   fontSize: "0.75rem",
                 }}
@@ -589,40 +583,55 @@ export default function CoursesPage() {
                 {t("courses.category")}
               </Typography>
               <Select
-                value={
-                  categoryOptions.includes(filters.category || "All")
-                    ? filters.category || "All"
-                    : "All"
+                multiple
+                value={filters.categories}
+                onChange={(e) =>
+                  handleCategoriesChange(
+                    typeof e.target.value === "string"
+                      ? e.target.value.split(",")
+                      : e.target.value
+                  )
                 }
-                onChange={(e) => handleFilterChange("category", e.target.value)}
+                renderValue={(selected) =>
+                  selected.length === 0
+                    ? t("courses.allCategories")
+                    : selected.length <= 2
+                      ? selected.join(", ")
+                      : `${selected.length} ${t("courses.categoriesSelected")}`
+                }
+                displayEmpty
                 sx={{
-                  backgroundColor: "#f9fafb",
+                  backgroundColor: "var(--surface)",
                   "& .MuiOutlinedInput-notchedOutline": {
                     borderColor: "transparent",
                   },
                   "&:hover .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "#e5e7eb",
+                    borderColor: "var(--border-default)",
                   },
                   "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "#6366f1",
+                    borderColor: "var(--accent-indigo)",
                   },
                 }}
               >
                 {categoryOptions.map((opt) => (
                   <MenuItem key={opt} value={opt}>
-                    {opt === "All" ? t("courses.allCategories") : opt}
+                    <Checkbox
+                      checked={filters.categories.indexOf(opt) > -1}
+                      size="small"
+                      sx={{ mr: 1 }}
+                    />
+                    <ListItemText primary={opt} />
                   </MenuItem>
                 ))}
               </Select>
             </FormControl>
 
-            {/* Price Filter */}
             <FormControl fullWidth size="small">
               <Typography
                 variant="caption"
                 sx={{
                   mb: 0.5,
-                  color: "#6b7280",
+                  color: "var(--font-secondary)",
                   fontWeight: 500,
                   fontSize: "0.75rem",
                 }}
@@ -633,15 +642,15 @@ export default function CoursesPage() {
                 value={filters.price || "All"}
                 onChange={(e) => handleFilterChange("price", e.target.value)}
                 sx={{
-                  backgroundColor: "#f9fafb",
+                  backgroundColor: "var(--surface)",
                   "& .MuiOutlinedInput-notchedOutline": {
                     borderColor: "transparent",
                   },
                   "&:hover .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "#e5e7eb",
+                    borderColor: "var(--border-default)",
                   },
                   "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "#6366f1",
+                    borderColor: "var(--accent-indigo)",
                   },
                 }}
               >
@@ -654,7 +663,6 @@ export default function CoursesPage() {
           </Box>
         </Paper>
 
-        {/* Courses Grid */}
         {loading ? (
           <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: 200 }}>
             <LinearProgress sx={{ width: "80%", height: 2, borderRadius: 1 }} />
@@ -688,7 +696,6 @@ export default function CoursesPage() {
           </Box>
         )}
 
-        {/* Pagination */}
         {totalPages > 1 && (
           <Box
             sx={{
@@ -723,8 +730,8 @@ export default function CoursesPage() {
                 onClick={() => handlePageChange(page - 1)}
                 startIcon={<IconWrapper icon="mdi:chevron-left" size={16} />}
                 sx={{
-                  borderColor: "#d1d5db",
-                  color: "#374151",
+                  borderColor: "var(--border-light)",
+                  color: "var(--font-muted)",
                   textTransform: "none",
                   minWidth: { xs: "auto", sm: "auto" },
                   px: { xs: 1, sm: 2 },
@@ -732,12 +739,12 @@ export default function CoursesPage() {
                     mr: { xs: 0, sm: 0.5 },
                   },
                   "&:hover": {
-                    borderColor: "#9ca3af",
-                    backgroundColor: "#f9fafb",
+                    borderColor: "var(--font-tertiary)",
+                    backgroundColor: "var(--surface)",
                   },
                   "&:disabled": {
-                    borderColor: "#e5e7eb",
-                    color: "#9ca3af",
+                    borderColor: "var(--border-default)",
+                    color: "var(--font-tertiary)",
                   },
                 }}
               >
@@ -757,15 +764,15 @@ export default function CoursesPage() {
                 size="small"
                 sx={{
                   "& .MuiPaginationItem-root": {
-                    color: "#374151",
+                    color: "var(--font-muted)",
                     minWidth: { xs: "32px", sm: "36px" },
                     height: { xs: "32px", sm: "36px" },
                     fontSize: { xs: "0.8125rem", sm: "0.875rem" },
                     "&.Mui-selected": {
-                      backgroundColor: "#374151",
-                      color: "#ffffff",
+                      backgroundColor: "var(--font-muted)",
+                      color: "var(--card-bg)",
                       "&:hover": {
-                        backgroundColor: "#1f2937",
+                        backgroundColor: "var(--font-primary-dark)",
                       },
                     },
                   },
@@ -778,8 +785,8 @@ export default function CoursesPage() {
                 onClick={() => handlePageChange(page + 1)}
                 endIcon={<IconWrapper icon="mdi:chevron-right" size={16} />}
                 sx={{
-                  borderColor: "#d1d5db",
-                  color: "#374151",
+                  borderColor: "var(--border-light)",
+                  color: "var(--font-muted)",
                   textTransform: "none",
                   minWidth: { xs: "auto", sm: "auto" },
                   px: { xs: 1, sm: 2 },
@@ -787,12 +794,12 @@ export default function CoursesPage() {
                     ml: { xs: 0, sm: 0.5 },
                   },
                   "&:hover": {
-                    borderColor: "#9ca3af",
-                    backgroundColor: "#f9fafb",
+                    borderColor: "var(--font-tertiary)",
+                    backgroundColor: "var(--surface)",
                   },
                   "&:disabled": {
-                    borderColor: "#e5e7eb",
-                    color: "#9ca3af",
+                    borderColor: "var(--border-default)",
+                    color: "var(--font-tertiary)",
                   },
                 }}
               >

--- a/app/globals.css
+++ b/app/globals.css
@@ -71,8 +71,20 @@
   --font-tertiary: #9ca3af;
   --font-light: #ffffff;
   --font-dark: #000000;
+  --font-primary-dark: #1f2937;
+  --font-muted: #374151;
   --course-cta: #10b981;
   --default-primary: #255c79;
+
+  --border-default: #e5e7eb;
+  --border-light: #d1d5db;
+  --surface: #f9fafb;
+  --accent-indigo: #6366f1;
+  --accent-indigo-dark: #4f46e5;
+  --surface-indigo-light: #eef2ff;
+  --surface-green-light: #d1fae5;
+  --surface-blue-light: #dbeafe;
+  --accent-blue-light: #3b82f6;
 
   /* Card / surface background */
   --card-bg: #ffffff;
@@ -94,7 +106,7 @@
 }
 
 body {
-  background: #ffffff !important;
+  background: var(--background) !important;
   color: var(--foreground);
   font-family: 'Satoshi', 'Satoshi Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 }
@@ -145,29 +157,29 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: #f9fafb;
+  background: var(--surface);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #d1d5db;
+  background: var(--border-light);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #9ca3af;
+  background: var(--font-tertiary);
 }
 
 /* Firefox */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #d1d5db #f9fafb;
+  scrollbar-color: var(--border-light) var(--surface);
 }
 
 /* Loader Animation */
 .loader {
   width: 60px;
   aspect-ratio: 1;
-  --c: no-repeat linear-gradient(#6366f1 0 0);
+  --c: no-repeat linear-gradient(var(--accent-indigo) 0 0);
   background:
     var(--c) left   20px top    0,
     var(--c) top    20px right  0,

--- a/components/admin/live-sessions/AdminLiveSessionsFeatureBlocked.tsx
+++ b/components/admin/live-sessions/AdminLiveSessionsFeatureBlocked.tsx
@@ -10,13 +10,13 @@ export function AdminLiveSessionsFeatureBlocked() {
         p: 5,
         textAlign: "center",
         borderRadius: 2,
-        border: "1px solid #e5e7eb",
+        border: "1px solid var(--border-default)",
       }}
     >
-      <Typography variant="h6" sx={{ color: "#374151", mb: 1 }}>
-        Live sessions are not enabled for your organization
+      <Typography variant="h6" sx={{ color: "var(--font-muted)", mb: 1 }}>
+        Live sessions are not enabled for your profile
       </Typography>
-      <Typography variant="body2" sx={{ color: "#6b7280", mb: 2 }}>
+      <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 2 }}>
         This feature is not available. Contact your administrator if you
         believe this is an error.
       </Typography>

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -274,81 +274,92 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             gap: 1,
           }}
         >
-          {/* Row 1: Status badges only - no overlap with title */}
-          {(assessment.proctoring_enabled || showResults) && (
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: isRtl ? "row-reverse" : "row",
-                justifyContent: "flex-end",
-                gap: 1,
-                flexShrink: 0,
-              }}
-            >
-              {assessment.proctoring_enabled && (
-                <Chip
-                  icon={<IconWrapper icon="mdi:shield-account" size={14} />}
-                  label={t("assessments.proctored")}
-                  size="small"
-                  sx={{
-                    backgroundColor: showResults ? "#fef3c7" : "rgba(255, 255, 255, 0.25)",
-                    color: showResults ? "#92400e" : "#ffffff",
-                    fontWeight: 600,
-                    fontSize: "0.7rem",
-                    height: 24,
-                    flexDirection: isRtl ? "row-reverse" : "row",
-                    border: showResults ? "none" : "1px solid rgba(255, 255, 255, 0.4)",
-                    "& .MuiChip-icon": {
-                      color: "inherit",
-                      marginInlineStart: isRtl ? "4px" : 0,
-                      marginInlineEnd: isRtl ? 0 : "4px",
-                    },
-                  }}
-                />
-              )}
-              {showResults && (
-                <Chip
-                  icon={<IconWrapper icon="mdi:check-circle" size={14} />}
-                  label={t("assessments.completed")}
-                  size="small"
-                  sx={{
-                    backgroundColor: showResults ? "#d1fae5" : "rgba(255, 255, 255, 0.25)",
-                    color: showResults ? "#065f46" : "#ffffff",
-                    fontWeight: 600,
-                    fontSize: "0.7rem",
-                    height: 24,
-                    flexDirection: isRtl ? "row-reverse" : "row",
-                    border: showResults ? "none" : "1px solid rgba(255, 255, 255, 0.4)",
-                    "& .MuiChip-icon": {
-                      color: "inherit",
-                      marginInlineStart: isRtl ? "4px" : 0,
-                      marginInlineEnd: isRtl ? 0 : "4px",
-                    },
-                  }}
-                />
-              )}
-            </Box>
-          )}
-
-          {/* Row 2: Title - full width, no overlap */}
-          <Typography
-            variant="h6"
+          {/* Title and tags on one row: title wraps before hitting tags */}
+          <Box
             sx={{
-              color: showResults ? "#1f2937" : "#ffffff",
-              fontWeight: 700,
-              fontSize: "1.0625rem",
-              lineHeight: 1.35,
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-              minHeight: 40,
+              display: "flex",
+              flexDirection: isRtl ? "row-reverse" : "row",
+              alignItems: "flex-start",
+              gap: 1.5,
+              minWidth: 0,
             }}
           >
-            {stripHtmlTags(assessment.title || "").trim() || assessment.title || "\u00A0"}
-          </Typography>
+            <Typography
+              variant="h6"
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                color: showResults ? "#1f2937" : "#ffffff",
+                fontWeight: 700,
+                fontSize: "1.0625rem",
+                lineHeight: 1.35,
+                wordBreak: "break-word",
+                overflowWrap: "break-word",
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+              }}
+            >
+              {stripHtmlTags(assessment.title || "").trim() || assessment.title || "\u00A0"}
+            </Typography>
+            {(assessment.proctoring_enabled || showResults) && (
+              <Box
+                sx={{
+                  flexShrink: 0,
+                  display: "flex",
+                  flexDirection: isRtl ? "row-reverse" : "row",
+                  gap: 1,
+                  alignItems: "center",
+                }}
+              >
+                {assessment.proctoring_enabled && (
+                  <Chip
+                    icon={<IconWrapper icon="mdi:shield-account" size={14} />}
+                    label={t("assessments.proctored")}
+                    size="small"
+                    sx={{
+                      backgroundColor: showResults ? "#fef3c7" : "rgba(255, 255, 255, 0.25)",
+                      color: showResults ? "#92400e" : "#ffffff",
+                      fontWeight: 600,
+                      fontSize: "0.7rem",
+                      height: 24,
+                      flexDirection: isRtl ? "row-reverse" : "row",
+                      border: showResults ? "none" : "1px solid rgba(255, 255, 255, 0.4)",
+                      "& .MuiChip-icon": {
+                        color: "inherit",
+                        marginInlineStart: isRtl ? "4px" : 0,
+                        marginInlineEnd: isRtl ? 0 : "4px",
+                      },
+                    }}
+                  />
+                )}
+                {showResults && (
+                  <Chip
+                    icon={<IconWrapper icon="mdi:check-circle" size={14} />}
+                    label={t("assessments.completed")}
+                    size="small"
+                    sx={{
+                      backgroundColor: showResults ? "#d1fae5" : "rgba(255, 255, 255, 0.25)",
+                      color: showResults ? "#065f46" : "#ffffff",
+                      fontWeight: 600,
+                      fontSize: "0.7rem",
+                      height: 24,
+                      flexDirection: isRtl ? "row-reverse" : "row",
+                      border: showResults ? "none" : "1px solid rgba(255, 255, 255, 0.4)",
+                      "& .MuiChip-icon": {
+                        color: "inherit",
+                        marginInlineStart: isRtl ? "4px" : 0,
+                        marginInlineEnd: isRtl ? 0 : "4px",
+                      },
+                    }}
+                  />
+                )}
+              </Box>
+            )}
+          </Box>
 
-          {/* Row 3: Subtitle / instructions */}
+          {/* Subtitle / instructions */}
           <Typography
             variant="body2"
             sx={{

--- a/components/common/ReportIssueDialog.tsx
+++ b/components/common/ReportIssueDialog.tsx
@@ -25,12 +25,12 @@ interface ReportIssueDialogProps {
   contentId?: number;
 }
 
-const ISSUE_TYPES = [
-  { value: "technical", label: "Technical Issue" },
-  { value: "content", label: "Content Error" },
-  { value: "video", label: "Video Problem" },
-  { value: "quiz", label: "Quiz/Assessment Issue" },
-  { value: "navigation", label: "Navigation Problem" },
+const SUPPORT_TYPES = [
+  { value: "technical", label: "Technical Support" },
+  { value: "content", label: "Content Help" },
+  { value: "video", label: "Video Help" },
+  { value: "quiz", label: "Quiz/Assessment Help" },
+  { value: "navigation", label: "Navigation Help" },
   { value: "other", label: "Other" },
 ];
 
@@ -66,11 +66,11 @@ export function ReportIssueDialog({
       const clientId = Number(config.clientId);
       await reportIssue(clientId, issueData);
 
-      showToast("Issue reported successfully! We'll look into it.", "success");
+      showToast("Your request has been sent. We'll get back to you soon.", "success");
       handleClose();
     } catch (error: any) {
       showToast(
-        error.message || "Failed to report issue. Please try again.",
+        error.message || "Failed to send. Please try again.",
         "error"
       );
     } finally {
@@ -113,29 +113,28 @@ export function ReportIssueDialog({
             width: 40,
             height: 40,
             borderRadius: "50%",
-            backgroundColor: "#ef4444",
+            backgroundColor: "#4285f4",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
             flexShrink: 0,
           }}
         >
-          <IconWrapper icon="mdi:alert-circle" size={24} color="#ffffff" />
+          <IconWrapper icon="mdi:help-circle" size={24} color="#ffffff" />
         </Box>
-        Report an Issue
+        Support and Help
       </DialogTitle>
 
       <DialogContent>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5, pt: 1 }}>
           <Typography variant="body2" sx={{ color: "#6b7280" }}>
-            Help us improve your experience by reporting any issues you
-            encounter. We'll investigate and get back to you as soon as
-            possible.
+            Get technical support, content help, video help, and more. We're
+            here to assist you.
           </Typography>
 
           <TextField
             select
-            label="Issue Type"
+            label="What do you need help with?"
             value={issueType}
             onChange={(e) => setIssueType(e.target.value)}
             fullWidth
@@ -147,7 +146,7 @@ export function ReportIssueDialog({
               },
             }}
           >
-            {ISSUE_TYPES.map((option) => (
+            {SUPPORT_TYPES.map((option) => (
               <MenuItem key={option.value} value={option.value}>
                 {option.label}
               </MenuItem>
@@ -163,7 +162,7 @@ export function ReportIssueDialog({
             fullWidth
             required
             disabled={submitting}
-            placeholder="Please describe the issue in detail..."
+            placeholder="Describe your question or issue..."
             sx={{
               "& .MuiOutlinedInput-root": {
                 borderRadius: 1.5,
@@ -195,9 +194,9 @@ export function ReportIssueDialog({
           sx={{
             textTransform: "none",
             fontWeight: 600,
-            backgroundColor: "#ef4444",
+            backgroundColor: "#4285f4",
             "&:hover": {
-              backgroundColor: "#dc2626",
+              backgroundColor: "#3367d6",
             },
             "&:disabled": {
               backgroundColor: "#f3f4f6",
@@ -212,7 +211,7 @@ export function ReportIssueDialog({
             )
           }
         >
-          {submitting ? "Submitting..." : "Submit Report"}
+          {submitting ? "Sending..." : "Submit"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/components/common/ReportIssueFAB.tsx
+++ b/components/common/ReportIssueFAB.tsx
@@ -36,23 +36,22 @@ export function ReportIssueFAB() {
 
   return (
     <>
-      <Tooltip title="Report an Issue" placement="left">
+      <Tooltip title="Support and Help" placement="left">
         <Fab
-          color="error"
-          aria-label="report issue"
+          aria-label="support and help"
           onClick={() => setShowReportDialog(true)}
           sx={{
             position: "fixed",
             bottom: { xs: 80, md: 24 },
             insetInlineEnd: { xs: 16, md: 24 },
-            backgroundColor: "#ef4444",
+            backgroundColor: "#4285f4",
             "&:hover": {
-              backgroundColor: "#dc2626",
+              backgroundColor: "#3367d6",
             },
             zIndex: 1000,
           }}
         >
-          <IconWrapper icon="mdi:alert-circle" size={24} color="#ffffff" />
+          <IconWrapper icon="mdi:help-circle" size={24} color="#ffffff" />
         </Fab>
       </Tooltip>
 

--- a/components/course/submodule/QuizContent.tsx
+++ b/components/course/submodule/QuizContent.tsx
@@ -754,11 +754,10 @@ export function QuizContent({
       answered: answeredQuestions.has(q.id),
     }));
 
-    // Build breadcrumbs
+    // Build breadcrumbs - keep only Home > Course (quiz title shown once in page header)
     const breadcrumbs = [
       { label: "Home", href: "/" },
       { label: "Course", href: `/courses/${courseId}` },
-      { label: content.content_title },
     ];
 
     // Get correct answer for current question when viewing past submission
@@ -908,7 +907,7 @@ export function QuizContent({
         onCancel={() => setShowConfirmDialog(false)}
       />
       <Box sx={{ mb: 3 }}>
-        <QuizStartScreen content={content} onStartQuiz={handleStartQuiz} />
+        <QuizStartScreen content={content} onStartQuiz={handleStartQuiz} hideTitle />
         <PastSubmissionsTable
           submissions={pastSubmissions}
           loading={loadingSubmissions}

--- a/components/course/submodule/QuizNavigationBar.tsx
+++ b/components/course/submodule/QuizNavigationBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Typography, Button } from "@mui/material";
+import { useTranslation } from "react-i18next";
 
 interface QuizNavigationBarProps {
   currentQuestionIndex: number;
@@ -19,6 +20,7 @@ export function QuizNavigationBar({
   onNext,
   onSubmit,
 }: QuizNavigationBarProps) {
+  const { t } = useTranslation("common");
   const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
 
   return (
@@ -61,7 +63,7 @@ export function QuizNavigationBar({
               },
             }}
           >
-            ← Previous
+            ← {t("quiz.previous")}
           </Button>
         )}
       </Box>
@@ -83,38 +85,33 @@ export function QuizNavigationBar({
             fontSize: "0.9375rem",
           }}
         >
-          Question {currentQuestionIndex + 1} of {totalQuestions}
+          {t("quiz.questionOf", {
+            current: currentQuestionIndex + 1,
+            total: totalQuestions,
+          })}
         </Typography>
       </Box>
 
-      {/* Next/Submit Button - Right */}
+      {/* Submit Early (or Submit on last question) - Right */}
       <Box sx={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
         <Button
           variant="contained"
-          onClick={isLastQuestion ? onSubmit : onNext}
+          onClick={onSubmit}
           disabled={isSubmitting}
           sx={{
-            background: isLastQuestion
-              ? "linear-gradient(135deg, #10b981 0%, #059669 100%)"
-              : "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)",
+            background: "linear-gradient(135deg, #10b981 0%, #059669 100%)",
             color: "#ffffff",
             px: 3,
             py: 1,
-            minWidth: "110px",
+            minWidth: "130px",
             fontSize: "0.875rem",
             fontWeight: 600,
             borderRadius: 2,
             textTransform: "none",
-            boxShadow: isLastQuestion
-              ? "0 4px 12px rgba(16, 185, 129, 0.3)"
-              : "0 4px 12px rgba(99, 102, 241, 0.3)",
+            boxShadow: "0 4px 12px rgba(16, 185, 129, 0.3)",
             "&:hover": {
-              background: isLastQuestion
-                ? "linear-gradient(135deg, #059669 0%, #047857 100%)"
-                : "linear-gradient(135deg, #4f46e5 0%, #4338ca 100%)",
-              boxShadow: isLastQuestion
-                ? "0 6px 16px rgba(16, 185, 129, 0.4)"
-                : "0 6px 16px rgba(99, 102, 241, 0.4)",
+              background: "linear-gradient(135deg, #059669 0%, #047857 100%)",
+              boxShadow: "0 6px 16px rgba(16, 185, 129, 0.4)",
               transform: "translateY(-1px)",
             },
             "&:active": {
@@ -129,11 +126,11 @@ export function QuizNavigationBar({
             transition: "all 0.2s ease-in-out",
           }}
         >
-          {isLastQuestion
-            ? isSubmitting
-              ? "Submitting..."
-              : "Submit"
-            : "Next →"}
+          {isSubmitting
+            ? t("quiz.submitting")
+            : isLastQuestion
+              ? t("quiz.submitQuiz")
+              : t("quiz.submitEarly")}
         </Button>
       </Box>
     </Box>

--- a/components/course/submodule/QuizStartScreen.tsx
+++ b/components/course/submodule/QuizStartScreen.tsx
@@ -8,11 +8,14 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 interface QuizStartScreenProps {
   content: ContentDetail;
   onStartQuiz: () => void;
+  /** When true, hide title (shown once in page header) */
+  hideTitle?: boolean;
 }
 
 export function QuizStartScreen({
   content,
   onStartQuiz,
+  hideTitle = false,
 }: QuizStartScreenProps) {
   const { t } = useTranslation("common");
   const duration =
@@ -36,17 +39,19 @@ export function QuizStartScreen({
     >
       {/* Header */}
       <Box sx={{ mb: 3 }}>
-        <Typography
-          variant="h5"
-          sx={{
-            fontWeight: 700,
-            color: "#1a1f2e",
-            mb: 1.5,
-            fontSize: { xs: "1.5rem", sm: "1.75rem" },
-          }}
-        >
-          {content.content_title || "Quiz"}
-        </Typography>
+        {!hideTitle && (
+          <Typography
+            variant="h5"
+            sx={{
+              fontWeight: 700,
+              color: "#1a1f2e",
+              mb: 1.5,
+              fontSize: { xs: "1.5rem", sm: "1.75rem" },
+            }}
+          >
+            {content.content_title || "Quiz"}
+          </Typography>
+        )}
         {content.details?.instructions && (
           <Typography
             variant="body1"

--- a/components/course/submodule/SubmoduleContentViewer.tsx
+++ b/components/course/submodule/SubmoduleContentViewer.tsx
@@ -59,10 +59,12 @@ export function SubmoduleContentViewer({
 }: SubmoduleContentViewerProps) {
   // For coding problems, don't show header as the layout handles it internally
   const isCodingProblem = content.content_type === "CodingProblem";
+  // For Quiz, title is shown once in page header - avoid duplicate
+  const isQuiz = content.content_type === "Quiz";
 
   return (
     <Box>
-      {!isCodingProblem && (
+      {!isCodingProblem && !isQuiz && (
         <Box sx={{ mb: 2 }}>
           <Typography
             variant="h5"
@@ -83,6 +85,16 @@ export function SubmoduleContentViewer({
               submissions={currentItem.submissions ?? 0}
             />
           )}
+        </Box>
+      )}
+      {/* Quiz: show only marks info (title in page header) */}
+      {isQuiz && currentItem && currentItem.marks > 0 && (
+        <Box sx={{ mb: 2 }}>
+          <ContentMarksInfo
+            marks={currentItem.marks}
+            obtainedMarks={currentItem.obtainedMarks ?? null}
+            submissions={currentItem.submissions ?? 0}
+          />
         </Box>
       )}
 

--- a/components/live-sessions/LiveSessionsFeatureBlocked.tsx
+++ b/components/live-sessions/LiveSessionsFeatureBlocked.tsx
@@ -10,13 +10,13 @@ export function LiveSessionsFeatureBlocked() {
         p: 5,
         textAlign: "center",
         borderRadius: 2,
-        border: "1px solid #e5e7eb",
+        border: "1px solid var(--border-default)",
       }}
     >
-      <Typography variant="h6" sx={{ color: "#374151", mb: 1 }}>
-        Live sessions are not enabled for your organization
+      <Typography variant="h6" sx={{ color: "var(--font-muted)", mb: 1 }}>
+        Live sessions are not enabled for your profile
       </Typography>
-      <Typography variant="body2" sx={{ color: "#6b7280", mb: 2 }}>
+      <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 2 }}>
         This feature is not available. Contact your administrator if you believe
         this is an error.
       </Typography>

--- a/components/quiz/AnswerOption.tsx
+++ b/components/quiz/AnswerOption.tsx
@@ -23,6 +23,7 @@ interface AnswerOptionProps {
   isReadOnly: boolean;
   isSubmitting: boolean;
   onSelect: () => void;
+  compact?: boolean;
 }
 
 export const AnswerOption = memo(function AnswerOption({
@@ -33,13 +34,14 @@ export const AnswerOption = memo(function AnswerOption({
   isReadOnly,
   isSubmitting,
   onSelect,
+  compact,
 }: AnswerOptionProps) {
   return (
     <Paper
       elevation={0}
       onClick={() => !isSubmitting && !isReadOnly && onSelect()}
       sx={{
-        p: { xs: 2.5, sm: 3, md: 3.5 },
+        p: compact ? { xs: 2, sm: 2.5, md: 3 } : { xs: 2.5, sm: 3, md: 3.5 },
         border: isCorrect
           ? "2px solid #10b981"
           : isWrongSelection

--- a/components/quiz/AnswerOptionsList.tsx
+++ b/components/quiz/AnswerOptionsList.tsx
@@ -13,6 +13,8 @@ interface AnswerOptionsListProps {
   isReadOnly: boolean;
   isSubmitting: boolean;
   onAnswerSelect: (answerId: string | number) => void;
+  /** When true, reduce spacing so quiz fits without scroll */
+  compact?: boolean;
 }
 
 export const AnswerOptionsList = memo(function AnswerOptionsList({
@@ -23,9 +25,18 @@ export const AnswerOptionsList = memo(function AnswerOptionsList({
   isReadOnly,
   isSubmitting,
   onAnswerSelect,
+  compact,
 }: AnswerOptionsListProps) {
   return (
-    <Box sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 2.5, mt: 3 }}>
+    <Box
+      sx={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        gap: compact ? 1.5 : 2.5,
+        mt: compact ? 1.5 : 3,
+      }}
+    >
       {options.map((option) => {
         const isSelected = selectedAnswer === option.id;
         const isCorrect = showCorrectAnswer && correctAnswerId === option.id;
@@ -41,6 +52,7 @@ export const AnswerOptionsList = memo(function AnswerOptionsList({
             isReadOnly={isReadOnly}
             isSubmitting={isSubmitting}
             onSelect={() => onAnswerSelect(option.id)}
+            compact={compact}
           />
         );
       })}

--- a/components/quiz/QuestionTitle.tsx
+++ b/components/quiz/QuestionTitle.tsx
@@ -9,6 +9,8 @@ function hasHtml(str: unknown): str is string {
 
 interface QuestionTitleProps {
   question: string;
+  /** When true, reduce spacing so quiz fits without scroll */
+  compact?: boolean;
 }
 
 const titleSx = {
@@ -19,12 +21,12 @@ const titleSx = {
   letterSpacing: "-0.01em",
 };
 
-export function QuestionTitle({ question }: QuestionTitleProps) {
+export function QuestionTitle({ question, compact }: QuestionTitleProps) {
   return (
     <Box
       sx={{
-        mb: { xs: 2, sm: 3 },
-        maxHeight: "200px",
+        mb: compact ? { xs: 1.5, sm: 2 } : { xs: 2, sm: 3 },
+        maxHeight: compact ? "180px" : "200px",
         overflowY: "auto",
         pr: 1,
         "&::-webkit-scrollbar": {

--- a/components/quiz/QuizLayout.tsx
+++ b/components/quiz/QuizLayout.tsx
@@ -97,18 +97,20 @@ export function QuizLayout({
       sx={{
         display: "flex",
         flexDirection: { xs: "column", md: "row" },
-        gap: { xs: 2, md: 3 },
+        gap: { xs: 1.5, md: 2 },
         maxWidth: "100%",
+        minHeight: 0,
+        flex: 1,
       }}
     >
       {/* Left Sidebar - Timer and Question List */}
       <Box
         sx={{
-          width: { xs: "100%", md: "320px" },
+          width: { xs: "100%", md: "300px" },
           flexShrink: 0,
           display: "flex",
           flexDirection: "column",
-          gap: 2,
+          gap: 1.5,
           order: { xs: 1, md: 0 },
         }}
       >
@@ -136,51 +138,12 @@ export function QuizLayout({
           display: "flex",
           flexDirection: "column",
           minWidth: 0,
+          minHeight: 0,
           order: { xs: 0, md: 1 },
         }}
       >
-        {/* Top bar - Submit Early (submodule only) */}
-        {isSubmodule && !isReadOnly && (
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "flex-end",
-              alignItems: "center",
-              mb: 2,
-              py: 1,
-              borderBottom: "1px solid #e5e7eb",
-            }}
-          >
-            <Button
-              variant="outlined"
-              onClick={onFinalSubmit}
-              disabled={isSubmitting}
-              sx={{
-                borderColor: "#10b981",
-                color: "#059669",
-                px: 2,
-                py: 1,
-                fontSize: "0.875rem",
-                fontWeight: 600,
-                borderRadius: 2,
-                textTransform: "none",
-                "&:hover": {
-                  borderColor: "#059669",
-                  backgroundColor: "#05966915",
-                },
-                "&:disabled": {
-                  borderColor: "#d1d5db",
-                  color: "#9ca3af",
-                },
-              }}
-            >
-              {isSubmitting ? t("quiz.submitting") : t("quiz.submitEarly")}
-            </Button>
-          </Box>
-        )}
-
-        {/* Breadcrumbs */}
-        {breadcrumbs.length > 0 && (
+        {/* Breadcrumbs - hidden for submodule to free space for question/options */}
+        {breadcrumbs.length > 0 && !isSubmodule && (
           <Breadcrumbs
             separator=">"
             sx={{
@@ -232,10 +195,11 @@ export function QuizLayout({
             border: "1px solid #e5e7eb",
             display: "flex",
             flexDirection: "column",
+            minHeight: 0,
           }}
         >
           {/* Question Title */}
-          <QuestionTitle question={currentQuestion.question} />
+          <QuestionTitle question={currentQuestion.question} compact={isSubmodule} />
 
           {/* Answer Options */}
           <AnswerOptionsList
@@ -246,6 +210,7 @@ export function QuizLayout({
             isReadOnly={isReadOnly}
             isSubmitting={isSubmitting}
             onAnswerSelect={onAnswerSelect}
+            compact={isSubmodule}
           />
 
           {/* Explanation */}
@@ -260,6 +225,7 @@ export function QuizLayout({
               justifyContent: "space-between",
               alignItems: { xs: "stretch", sm: "center" },
               gap: 2,
+              flexShrink: 0,
             }}
           >
             {/* Progress indicator - mobile top */}
@@ -352,7 +318,7 @@ export function QuizLayout({
                 </Box>
               )}
 
-              {/* Next button - only when not on last question */}
+              {/* Next button - when not on last question (submodule + non-submodule) */}
               {!isLastQuestion && (
                 <Button
                   variant="contained"
@@ -385,7 +351,7 @@ export function QuizLayout({
                 </Button>
               )}
 
-              {/* Submit Quiz - only at bottom when NOT submodule */}
+              {/* Submit - only for non-submodule; submodule uses top bar Submit only */}
               {!isSubmodule && (
               <Button
                 variant={isLastQuestion ? "contained" : "outlined"}

--- a/lib/services/client.service.ts
+++ b/lib/services/client.service.ts
@@ -143,7 +143,7 @@ export const reportIssue = async (
     throw new Error(
       axiosError?.response?.data?.detail ||
         axiosError?.message ||
-        "Failed to report issue"
+        "Failed to send request"
     );
   }
 };

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -173,6 +173,8 @@
     "category": "الفئة",
     "price": "السعر",
     "allCategories": "جميع الفئات",
+    "categoriesSelected": "فئات محددة",
+    "selectCategories": "اختر الفئات",
     "allPrices": "جميع الأسعار",
     "free": "مجاني",
     "paid": "مدفوع",
@@ -269,12 +271,13 @@
   },
   "quiz": {
     "submitEarly": "تسليم مبكر",
-    "submitQuiz": "إرسال الاختبار",
+    "submitQuiz": "إرسال",
     "previous": "السابق",
     "next": "التالي",
     "submitting": "جاري الإرسال...",
     "back": "رجوع",
-    "answeredOf": "{{answered}} من {{total}} تمت الإجابة عليها"
+    "answeredOf": "{{answered}} من {{total}} تمت الإجابة عليها",
+    "questionOf": "سؤال {{current}} من {{total}}"
   },
   "assessments": {
     "title": "التقييمات",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -173,6 +173,8 @@
     "category": "Category",
     "price": "Price",
     "allCategories": "All Categories",
+    "categoriesSelected": "categories selected",
+    "selectCategories": "Select categories",
     "allPrices": "All Prices",
     "free": "Free",
     "paid": "Paid",
@@ -269,12 +271,13 @@
   },
   "quiz": {
     "submitEarly": "Submit Early",
-    "submitQuiz": "Submit Quiz",
+    "submitQuiz": "Submit",
     "previous": "Previous",
     "next": "Next",
     "submitting": "Submitting...",
     "back": "Back",
-    "answeredOf": "{{answered}} of {{total}} answered"
+    "answeredOf": "{{answered}} of {{total}} answered",
+    "questionOf": "Question {{current}} of {{total}}"
   },
   "assessments": {
     "title": "Assessments",


### PR DESCRIPTION
Course filter: Category filter now returns every course whose tags match the selected category (e.g. choosing “Data” shows both “Data Science” and “Algorithms” if they have that tag), not only a single exact match.

<img width="3196" height="1672" alt="image" src="https://github.com/user-attachments/assets/70bd791f-8fb4-47e4-bd25-1a84fce28347" />

Quiz: Top bar uses “Submit Early” (becomes “Submit” on last question); bottom keeps “Next” only and it hides on the last question; duplicate quiz title and “Home > Course” breadcrumbs removed.

<img width="2567" height="1362" alt="image" src="https://github.com/user-attachments/assets/9c685b06-c171-43dd-bb9b-32e51699cf63" />

Sidebar: Collapse on “Start Quiz” (and for all content types) with three-bar → circular arrow toggle on the vertical line; overflow fixed so the arrow button is fully visible.

<img width="3199" height="1689" alt="image" src="https://github.com/user-attachments/assets/7ec18ece-2815-47a5-9261-19c966ab40ec" />

<img width="3199" height="1697" alt="image" src="https://github.com/user-attachments/assets/c37bd83c-c87d-40ca-af36-60649948aede" />


Support and Help: “Report an Issue” renamed to “Support and Help” (icon, title, copy, and dropdown options: Technical Support, Content Help, Video Help, etc.).

<img width="2203" height="1349" alt="image" src="https://github.com/user-attachments/assets/17379dea-7f1b-4d05-9b57-55d4d77a2b35" />

Assessment cards: Title wraps correctly; status chips moved to a separate row to prevent overlap with the heading.
Loading & toast: Loading states for profile, assessments, course submodule, and mock-interview result; toast safe outside provider.

<img width="2599" height="698" alt="Screenshot 2026-03-04 041431" src="https://github.com/user-attachments/assets/6ab661f3-4af3-40b5-a3f4-b5a235ed5071" />

