### PR TITLE
fix(resume): PDF improvements - no wrap for titles/contact, no link emoji

### DIFF
--- a/components/profile/resume/ResumePreview.tsx
+++ b/components/profile/resume/ResumePreview.tsx
@@ -79,6 +79,14 @@ export const ResumePreview = forwardRef<HTMLDivElement, ResumePreviewProps>(
             "& p, & li, & span, & div": {
               lineHeight: "inherit",
             },
+            "& [data-resume-section-title], & [data-resume-nowrap]": {
+              whiteSpace: "nowrap",
+            },
+            "& [data-resume-contact-item]": {
+              whiteSpace: "nowrap",
+              overflow: "visible",
+              textOverflow: "clip",
+            },
             "@media print": {
               boxShadow: "none",
               transform: "none",

--- a/components/profile/resume/templates/AccentBarTemplate.tsx
+++ b/components/profile/resume/templates/AccentBarTemplate.tsx
@@ -13,6 +13,7 @@ interface AccentBarTemplateProps {
 function SectionTitle({ children }: { children: string }) {
   return (
     <Typography
+      data-resume-section-title
       sx={{
         fontSize: "0.7rem",
         fontWeight: 700,
@@ -104,6 +105,7 @@ export function AccentBarTemplate({ data }: AccentBarTemplateProps) {
                   <IconWrapper icon={item.icon} size={11} color={ACCENT} />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.65rem",
                     ...(item.icon === "mdi:email-outline"
@@ -133,7 +135,7 @@ export function AccentBarTemplate({ data }: AccentBarTemplateProps) {
               <Box key={exp.id} sx={{ mb: 1.5 }}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 0.5 }}>
                   <Box>
-                    <Typography sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>
+                    <Typography data-resume-nowrap sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>
                       {exp.position}
                     </Typography>
                     <Typography sx={{ fontSize: "0.65rem", color: ACCENT }}>{exp.company}</Typography>
@@ -165,7 +167,7 @@ export function AccentBarTemplate({ data }: AccentBarTemplateProps) {
             {data.education.map((edu) => (
               <Box key={edu.id} sx={{ mb: 1.25 }}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-                  <Typography sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>{edu.degree}</Typography>
+                  <Typography data-resume-nowrap sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>{edu.degree}</Typography>
                   <Typography sx={{ fontSize: "0.6rem", color: "#64748b", whiteSpace: "nowrap", ml: 2 }}>
                     {formatDate(edu.startDate, edu.endDate)}
                   </Typography>
@@ -197,7 +199,7 @@ export function AccentBarTemplate({ data }: AccentBarTemplateProps) {
             {data.projects.map((proj) => (
               <Box key={proj.id} sx={{ mb: 1.25 }}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 1 }}>
-                  <Typography sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>{proj.name}</Typography>
+                  <Typography data-resume-nowrap sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#0f172a" }}>{proj.name}</Typography>
                   {proj.link && (
                     <Typography
                       component="a"
@@ -206,7 +208,7 @@ export function AccentBarTemplate({ data }: AccentBarTemplateProps) {
                       rel="noopener noreferrer"
                       sx={{ fontSize: "0.6rem", color: ACCENT, fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap", textDecoration: "none" }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>
@@ -238,7 +240,7 @@ export function AccentBarTemplate({ data }: AccentBarTemplateProps) {
                       rel="noopener noreferrer"
                       sx={{ fontSize: "0.55rem", color: ACCENT, fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap" }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>

--- a/components/profile/resume/templates/BubbleTemplate.tsx
+++ b/components/profile/resume/templates/BubbleTemplate.tsx
@@ -38,6 +38,7 @@ function BubbleSectionHead({
         <IconWrapper icon={icon} size={14} color="#1f2937" />
       </Box>
       <Typography
+        data-resume-section-title
         sx={{
           fontSize: "0.95rem",
           fontWeight: 700,
@@ -77,6 +78,7 @@ function SidebarSectionHead({
         <IconWrapper icon={icon} size={14} color="#1f2937" />
       </Box>
       <Typography
+        data-resume-section-title
         sx={{
           fontSize: "0.95rem",
           fontWeight: 700,
@@ -235,7 +237,7 @@ export function BubbleTemplate({ data }: BubbleTemplateProps) {
                 startYear={getYear(exp.startDate)}
                 endYear={exp.current ? "present" : getYear(exp.endDate)}
               >
-                <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
+                <Typography data-resume-nowrap sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
                   {exp.position}
                 </Typography>
                 <Typography sx={{ fontSize: "0.62rem", fontStyle: "italic", color: "#6b7280" }}>
@@ -266,7 +268,7 @@ export function BubbleTemplate({ data }: BubbleTemplateProps) {
                 startYear={getYear(edu.startDate)}
                 endYear={getYear(edu.endDate)}
               >
-                <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
+                <Typography data-resume-nowrap sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
                   {edu.degree}
                 </Typography>
                 <Typography sx={{ fontSize: "0.62rem", fontStyle: "italic", color: "#6b7280" }}>
@@ -292,7 +294,7 @@ export function BubbleTemplate({ data }: BubbleTemplateProps) {
             {data.projects.map((proj) => (
               <TimelineEvent key={proj.id}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 1 }}>
-                  <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
+                  <Typography data-resume-nowrap sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#1f2937" }}>
                     {proj.name}
                   </Typography>
                   {proj.link && (
@@ -303,7 +305,7 @@ export function BubbleTemplate({ data }: BubbleTemplateProps) {
                       rel="noopener noreferrer"
                       sx={{ fontSize: "0.58rem", color: "#1f2937", fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap", textDecoration: "none" }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>
@@ -354,6 +356,7 @@ export function BubbleTemplate({ data }: BubbleTemplateProps) {
                 <IconWrapper icon={item.icon} size={14} color="#1f2937" />
               </Box>
               <Typography
+                data-resume-contact-item
                 sx={{
                   fontSize: "0.58rem",
                   color: "#4b5563",
@@ -413,7 +416,7 @@ export function BubbleTemplate({ data }: BubbleTemplateProps) {
                       rel="noopener noreferrer"
                       sx={{ fontSize: "0.52rem", color: "#4b5563", fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap" }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>

--- a/components/profile/resume/templates/ClassicTemplate.tsx
+++ b/components/profile/resume/templates/ClassicTemplate.tsx
@@ -110,6 +110,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
                   <IconWrapper icon={item.icon} size={11} color="#4b5563" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.625rem",
                     ...(item.icon === "mdi:email-outline"
@@ -160,6 +161,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
       {data.workExperience.length > 0 && (
         <Box sx={{ mb: 2 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.75rem",
               fontWeight: 700,
@@ -186,6 +188,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
               >
                 <Box>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.75rem",
                       fontWeight: 600,
@@ -248,6 +251,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
       {data.education.length > 0 && (
         <Box sx={{ mb: 2 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.75rem",
               fontWeight: 700,
@@ -273,6 +277,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
               >
                 <Box>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.75rem",
                       fontWeight: 600,
@@ -333,6 +338,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
       {data.skills.length > 0 && (
         <Box sx={{ mb: 2 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.75rem",
               fontWeight: 700,
@@ -365,6 +371,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
       {data.projects.length > 0 && (
         <Box sx={{ mb: 2 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.75rem",
               fontWeight: 700,
@@ -393,6 +400,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
                 }}
               >
                 <Typography
+                  data-resume-nowrap
                   sx={{
                     fontSize: "0.75rem",
                     fontWeight: 600,
@@ -416,7 +424,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
                       textDecoration: "none",
                     }}
                   >
-                    🔗Link
+                    Link
                   </Typography>
                 )}
               </Box>
@@ -458,6 +466,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
       {data.certifications.length > 0 && (
         <Box>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.75rem",
               fontWeight: 700,
@@ -505,7 +514,7 @@ export function ClassicTemplate({ data }: ClassicTemplateProps) {
                         whiteSpace: "nowrap",
                       }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>

--- a/components/profile/resume/templates/CreativeTemplate.tsx
+++ b/components/profile/resume/templates/CreativeTemplate.tsx
@@ -113,6 +113,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                   <IconWrapper icon={item.icon} size={13} color="rgba(255,255,255,0.8)" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.7rem",
                     lineHeight: 1.3,
@@ -134,6 +135,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
         {data.skills.length > 0 && (
           <Box>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.8rem",
                 fontWeight: 700,
@@ -183,6 +185,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
         {data.education.length > 0 && (
           <Box>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.8rem",
                 fontWeight: 700,
@@ -196,7 +199,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
 
             {data.education.map((edu) => (
               <Box key={edu.id} sx={{ mb: 2 }}>
-                <Typography sx={{ fontSize: "0.85rem", fontWeight: 600, mb: 0.5 }}>
+                <Typography data-resume-nowrap sx={{ fontSize: "0.85rem", fontWeight: 600, mb: 0.5 }}>
                   {edu.degree}
                 </Typography>
                 <Typography sx={{ fontSize: "0.75rem", color: "rgba(255, 255, 255, 0.8)" }}>
@@ -277,6 +280,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                 }}
               />
               <Typography
+                data-resume-section-title
                 sx={{
                   fontSize: "1.1rem",
                   fontWeight: 700,
@@ -301,6 +305,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 0.5 }}>
                   <Box>
                     <Typography
+                      data-resume-nowrap
                       sx={{ fontSize: "1rem", fontWeight: 600, color: "#1f2937" }}
                     >
                       {exp.position}
@@ -371,6 +376,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                 }}
               />
               <Typography
+                data-resume-section-title
                 sx={{
                   fontSize: "1.1rem",
                   fontWeight: 700,
@@ -402,6 +408,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                   }}
                 >
                   <Typography
+                    data-resume-nowrap
                     sx={{ fontSize: "0.95rem", fontWeight: 600, color: "#1f2937" }}
                   >
                     {project.name}
@@ -421,7 +428,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                         textDecoration: "none",
                       }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>
@@ -484,6 +491,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                 }}
               />
               <Typography
+                data-resume-section-title
                 sx={{
                   fontSize: "1.1rem",
                   fontWeight: 700,
@@ -520,7 +528,7 @@ export function CreativeTemplate({ data }: CreativeTemplateProps) {
                           textDecoration: "none",
                         }}
                       >
-                        🔗Link
+                        Link
                       </Typography>
                     )}
                   </Box>

--- a/components/profile/resume/templates/ExecutiveTemplate.tsx
+++ b/components/profile/resume/templates/ExecutiveTemplate.tsx
@@ -106,6 +106,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
                   <IconWrapper icon={item.icon} size={14} color="#d4af37" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.85rem",
                     ...(item.icon === "mdi:email-outline"
@@ -154,6 +155,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
       {data.workExperience.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.9rem",
               fontWeight: 700,
@@ -181,6 +183,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
               >
                 <Box>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.9rem",
                       fontWeight: 700,
@@ -249,6 +252,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
       {data.education.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.9rem",
               fontWeight: 700,
@@ -269,6 +273,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
               <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
                 <Box>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.85rem",
                       fontWeight: 600,
@@ -309,6 +314,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
         {data.skills.length > 0 && (
           <Box>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.9rem",
                 fontWeight: 700,
@@ -359,6 +365,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
         {data.certifications.length > 0 && (
           <Box>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.9rem",
                 fontWeight: 700,
@@ -393,7 +400,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
                         whiteSpace: "nowrap",
                       }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>
@@ -410,6 +417,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
       {data.projects.length > 0 && (
         <Box sx={{ mt: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.9rem",
               fontWeight: 700,
@@ -439,6 +447,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
                 }}
               >
                 <Typography
+                  data-resume-nowrap
                   sx={{
                     fontSize: "0.85rem",
                     fontWeight: 600,
@@ -462,7 +471,7 @@ export function ExecutiveTemplate({ data }: ExecutiveTemplateProps) {
                       textDecoration: "none",
                     }}
                   >
-                    🔗Link
+                    Link
                   </Typography>
                 )}
               </Box>

--- a/components/profile/resume/templates/LuxSleekTemplate.tsx
+++ b/components/profile/resume/templates/LuxSleekTemplate.tsx
@@ -14,6 +14,7 @@ function HeadLeft({ children }: { children: string }) {
   return (
     <Box sx={{ mt: 2.5, mb: 0.75 }}>
       <Typography
+        data-resume-section-title
         sx={{
           fontSize: "0.7rem",
           fontWeight: 700,
@@ -42,6 +43,7 @@ function HeadRight({ children }: { children: string }) {
   return (
     <Box sx={{ mt: 2, mb: 0.5 }}>
       <Typography
+        data-resume-section-title
         sx={{
           fontSize: "1.05rem",
           fontWeight: 400,
@@ -209,6 +211,7 @@ export function LuxSleekTemplate({ data }: LuxSleekTemplateProps) {
                   <IconWrapper icon={item.icon} size={12} color="#ffffff" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.58rem",
                     lineHeight: 1.4,
@@ -269,6 +272,7 @@ export function LuxSleekTemplate({ data }: LuxSleekTemplateProps) {
             >
               <Box
                 component="span"
+                data-resume-nowrap
                 sx={{ fontVariant: "small-caps", fontWeight: 600, letterSpacing: "0.02em" }}
               >
                 {exp.position}
@@ -315,6 +319,7 @@ export function LuxSleekTemplate({ data }: LuxSleekTemplateProps) {
             >
               <Box
                 component="span"
+                data-resume-nowrap
                 sx={{ fontVariant: "small-caps", fontWeight: 600, letterSpacing: "0.02em" }}
               >
                 {edu.degree}.
@@ -350,6 +355,7 @@ export function LuxSleekTemplate({ data }: LuxSleekTemplateProps) {
                 >
                   <Box
                     component="span"
+                    data-resume-nowrap
                     sx={{ fontVariant: "small-caps", fontWeight: 600, letterSpacing: "0.02em" }}
                   >
                     {proj.name}.
@@ -371,7 +377,7 @@ export function LuxSleekTemplate({ data }: LuxSleekTemplateProps) {
                         textDecoration: "none",
                       }}
                     >
-                      🔗Link
+                      Link
                       </Typography>
                     </>
                   )}
@@ -431,7 +437,7 @@ export function LuxSleekTemplate({ data }: LuxSleekTemplateProps) {
                           textDecoration: "none",
                         }}
                       >
-                        🔗Link
+                        Link
                       </Box>
                     </>
                   )}

--- a/components/profile/resume/templates/MinimalTemplate.tsx
+++ b/components/profile/resume/templates/MinimalTemplate.tsx
@@ -91,6 +91,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
                   <IconWrapper icon={item.icon} size={11} color="#666666" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.625rem",
                     fontWeight: 400,
@@ -129,6 +130,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
       {data.workExperience.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.625rem",
               fontWeight: 700,
@@ -152,6 +154,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
                   }}
                 >
                   <Typography
+                    data-resume-nowrap
                     sx={{ fontSize: "0.75rem", fontWeight: 500, color: "#000000" }}
                   >
                     {exp.position}
@@ -210,6 +213,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
       {data.education.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.625rem",
               fontWeight: 700,
@@ -232,6 +236,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
                 }}
               >
                 <Typography
+                  data-resume-nowrap
                   sx={{ fontSize: "0.75rem", fontWeight: 500, color: "#000000" }}
                 >
                   {edu.degree}
@@ -268,6 +273,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
       {data.skills.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.625rem",
               fontWeight: 700,
@@ -297,6 +303,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
       {data.projects.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.625rem",
               fontWeight: 700,
@@ -321,6 +328,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
                 }}
               >
                 <Typography
+                  data-resume-nowrap
                   sx={{ fontSize: "0.75rem", fontWeight: 500, color: "#000000" }}
                 >
                   {project.name}
@@ -340,7 +348,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
                       textDecoration: "none",
                     }}
                   >
-                    🔗Link
+                    Link
                   </Typography>
                 )}
               </Box>
@@ -379,6 +387,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
       {data.certifications.length > 0 && (
         <Box>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.625rem",
               fontWeight: 700,
@@ -422,7 +431,7 @@ export function MinimalTemplate({ data }: MinimalTemplateProps) {
                         whiteSpace: "nowrap",
                       }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>

--- a/components/profile/resume/templates/ModernTemplate.tsx
+++ b/components/profile/resume/templates/ModernTemplate.tsx
@@ -102,6 +102,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                   <IconWrapper icon={item.icon} size={16} color="#94a3b8" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.625rem",
                     ...(item.icon === "mdi:email-outline"
@@ -122,6 +123,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
         {data.skills.length > 0 && (
           <Box sx={{ mb: 4 }}>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.625rem",
                 fontWeight: 700,
@@ -168,6 +170,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
         {data.certifications.length > 0 && (
           <Box>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.625rem",
                 fontWeight: 700,
@@ -199,7 +202,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                         whiteSpace: "nowrap",
                       }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>
@@ -267,6 +270,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
         {data.workExperience.length > 0 && (
           <Box sx={{ mb: 3 }}>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.75rem",
                 fontWeight: 700,
@@ -295,6 +299,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                 >
                   <Box sx={{ backgroundColor: "transparent" }}>
                     <Typography
+                      data-resume-nowrap
                       sx={{
                         fontSize: "0.75rem",
                         fontWeight: 600,
@@ -357,6 +362,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
         {data.education.length > 0 && (
           <Box sx={{ mb: 3 }}>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.75rem",
                 fontWeight: 700,
@@ -380,6 +386,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                 >
                   <Box>
                     <Typography
+                      data-resume-nowrap
                       sx={{
                         fontSize: "0.75rem",
                         fontWeight: 600,
@@ -433,6 +440,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
         {data.projects.length > 0 && (
           <Box>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.75rem",
                 fontWeight: 700,
@@ -457,6 +465,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                   }}
                 >
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.75rem",
                       fontWeight: 600,
@@ -480,7 +489,7 @@ export function ModernTemplate({ data }: ModernTemplateProps) {
                         textDecoration: "none",
                       }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>

--- a/components/profile/resume/templates/RightSidebarTemplate.tsx
+++ b/components/profile/resume/templates/RightSidebarTemplate.tsx
@@ -55,6 +55,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
         {data.workExperience.length > 0 && (
           <Box sx={{ mb: 3 }}>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.75rem",
                 fontWeight: 700,
@@ -70,7 +71,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
               <Box key={exp.id} sx={{ mb: 2.5 }}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", mb: 0.5 }}>
                   <Box>
-                    <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>
+                    <Typography data-resume-nowrap sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>
                       {exp.position}
                     </Typography>
                     <Typography sx={{ fontSize: "0.625rem", color: "#6366f1", fontWeight: 500 }}>
@@ -101,6 +102,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
         {data.education.length > 0 && (
           <Box sx={{ mb: 3 }}>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.75rem",
                 fontWeight: 700,
@@ -116,7 +118,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
               <Box key={edu.id} sx={{ mb: 2 }}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
                   <Box>
-                    <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>{edu.degree}</Typography>
+                    <Typography data-resume-nowrap sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>{edu.degree}</Typography>
                     <Typography sx={{ fontSize: "0.625rem", color: "#6366f1" }}>{edu.institution}</Typography>
                     {edu.location && (
                       <Typography sx={{ fontSize: "0.625rem", color: "#64748b" }}>{edu.location}</Typography>
@@ -142,6 +144,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
         {data.projects.length > 0 && (
           <Box>
             <Typography
+              data-resume-section-title
               sx={{
                 fontSize: "0.75rem",
                 fontWeight: 700,
@@ -156,7 +159,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
             {data.projects.map((project) => (
               <Box key={project.id} sx={{ mb: 2 }}>
                 <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 0.5, gap: 1 }}>
-                  <Typography sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>
+                  <Typography data-resume-nowrap sx={{ fontSize: "0.75rem", fontWeight: 600, color: "#1e293b" }}>
                     {project.name}
                   </Typography>
                   {project.link && (
@@ -167,7 +170,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
                       rel="noopener noreferrer"
                       sx={{ fontSize: "0.625rem", color: "#6366f1", fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap", textDecoration: "none" }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>
@@ -243,6 +246,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
                   <IconWrapper icon={item.icon} size={16} color="#94a3b8" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.625rem",
                     ...(item.icon === "mdi:email-outline"
@@ -261,7 +265,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
 
         {data.skills.length > 0 && (
           <Box sx={{ mb: 4 }}>
-            <Typography sx={{ fontSize: "0.625rem", fontWeight: 700, letterSpacing: "0.1em", mb: 2, color: "#94a3b8", whiteSpace: "nowrap" }}>
+            <Typography data-resume-section-title sx={{ fontSize: "0.625rem", fontWeight: 700, letterSpacing: "0.1em", mb: 2, color: "#94a3b8", whiteSpace: "nowrap" }}>
               SKILLS
             </Typography>
             {data.skills.map((skill) => (
@@ -292,7 +296,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
 
         {data.certifications.length > 0 && (
           <Box>
-            <Typography sx={{ fontSize: "0.625rem", fontWeight: 700, letterSpacing: "0.1em", mb: 2, color: "#94a3b8", whiteSpace: "nowrap" }}>
+            <Typography data-resume-section-title sx={{ fontSize: "0.625rem", fontWeight: 700, letterSpacing: "0.1em", mb: 2, color: "#94a3b8", whiteSpace: "nowrap" }}>
               CERTIFICATIONS
             </Typography>
             {data.certifications.map((cert) => (
@@ -307,7 +311,7 @@ export function RightSidebarTemplate({ data }: RightSidebarTemplateProps) {
                       rel="noopener noreferrer"
                       sx={{ fontSize: "0.55rem", color: "#6366f1", fontWeight: 600, flexShrink: 0, whiteSpace: "nowrap" }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>

--- a/components/profile/resume/templates/TechnicalTemplate.tsx
+++ b/components/profile/resume/templates/TechnicalTemplate.tsx
@@ -103,6 +103,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                   <IconWrapper icon={item.icon} size={12} color="#50fa7b" />
                 </Box>
                 <Typography
+                  data-resume-contact-item
                   sx={{
                     fontSize: "0.75rem",
                     fontFamily: "'Courier New', monospace",
@@ -164,6 +165,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
       {data.skills.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.8rem",
               fontWeight: 700,
@@ -231,6 +233,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
       {data.workExperience.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.8rem",
               fontWeight: 700,
@@ -265,6 +268,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
               >
                 <Box>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.85rem",
                       fontWeight: 700,
@@ -332,6 +336,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
       {data.projects.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.8rem",
               fontWeight: 700,
@@ -366,6 +371,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                 }}
               >
                 <Typography
+                  data-resume-nowrap
                   sx={{
                     fontSize: "0.8rem",
                     fontWeight: 700,
@@ -391,7 +397,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                       textDecoration: "none",
                     }}
                   >
-                    🔗Link
+                    Link
                   </Typography>
                 )}
               </Box>
@@ -444,6 +450,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
       {data.education.length > 0 && (
         <Box sx={{ mb: 2.5 }}>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.8rem",
               fontWeight: 700,
@@ -477,6 +484,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
               >
                 <Box>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.8rem",
                       fontWeight: 700,
@@ -530,6 +538,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
       {data.certifications.length > 0 && (
         <Box>
           <Typography
+            data-resume-section-title
             sx={{
               fontSize: "0.8rem",
               fontWeight: 700,
@@ -588,7 +597,7 @@ export function TechnicalTemplate({ data }: TechnicalTemplateProps) {
                         whiteSpace: "nowrap",
                       }}
                     >
-                      🔗Link
+                      Link
                     </Typography>
                   )}
                 </Box>

--- a/components/profile/resume/templates/TwoColumnTemplate.tsx
+++ b/components/profile/resume/templates/TwoColumnTemplate.tsx
@@ -16,6 +16,7 @@ function SectionHead({ children }: { children: string }) {
   return (
     <Box sx={{ mt: 2, mb: 1 }}>
       <Typography
+        data-resume-section-title
         sx={{
           fontSize: "0.9rem",
           fontWeight: 400,
@@ -148,6 +149,7 @@ export function TwoColumnTemplate({ data }: TwoColumnTemplateProps) {
                 {exp.company}
               </Typography>
               <Typography
+                data-resume-nowrap
                 sx={{
                   fontSize: "0.72rem",
                   fontWeight: 700,
@@ -192,6 +194,7 @@ export function TwoColumnTemplate({ data }: TwoColumnTemplateProps) {
               </Typography>
               <Box>
                 <Typography
+                  data-resume-nowrap
                   sx={{
                     fontSize: "0.7rem",
                     fontWeight: 700,
@@ -268,6 +271,7 @@ export function TwoColumnTemplate({ data }: TwoColumnTemplateProps) {
                     <IconWrapper icon={item.icon} size={12} color={MAROON} />
                   </Box>
                   <Typography
+                    data-resume-contact-item
                     sx={{
                       fontSize: "0.58rem",
                       color: "#1a1a1a",
@@ -307,6 +311,7 @@ export function TwoColumnTemplate({ data }: TwoColumnTemplateProps) {
                   <Box>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                       <Typography
+                        data-resume-nowrap
                         sx={{
                           fontSize: "0.68rem",
                           fontWeight: 700,
@@ -330,7 +335,7 @@ export function TwoColumnTemplate({ data }: TwoColumnTemplateProps) {
                             textDecoration: "none",
                           }}
                         >
-                          🔗Link
+                          Link
                         </Typography>
                       )}
                     </Box>
@@ -456,7 +461,7 @@ export function TwoColumnTemplate({ data }: TwoColumnTemplateProps) {
                             whiteSpace: "nowrap",
                           }}
                         >
-                          🔗Link
+                          Link
                         </Typography>
                       )}
                     </Box>

--- a/components/profile/resume/templates/WesternTemplate.tsx
+++ b/components/profile/resume/templates/WesternTemplate.tsx
@@ -22,6 +22,7 @@ interface WesternTemplateProps {
 function SectionTitle({ children }: { children: string }) {
   return (
     <Typography
+      data-resume-section-title
       sx={{
         fontSize: "1.1rem",
         fontWeight: 700,
@@ -142,6 +143,7 @@ export function WesternTemplate({ data }: WesternTemplateProps) {
                     <IconWrapper icon={item.icon} size={14} color={COLORS.body} />
                   </Box>
                   <Typography
+                    data-resume-contact-item
                     sx={{
                       fontSize: "0.7rem",
                       ...(item.icon === "mdi:email-outline"
@@ -193,6 +195,7 @@ export function WesternTemplate({ data }: WesternTemplateProps) {
               {data.workExperience.map((exp) => (
                 <Box key={exp.id} sx={{ mb: 1.5 }}>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.8rem",
                       fontWeight: 700,
@@ -253,6 +256,7 @@ export function WesternTemplate({ data }: WesternTemplateProps) {
                     }}
                   >
                     <Typography
+                      data-resume-nowrap
                       sx={{
                         fontSize: "0.8rem",
                         fontWeight: 700,
@@ -276,7 +280,7 @@ export function WesternTemplate({ data }: WesternTemplateProps) {
                           textDecoration: "none",
                         }}
                       >
-                        🔗Link
+                        Link
                       </Typography>
                     )}
                   </Box>
@@ -380,7 +384,7 @@ export function WesternTemplate({ data }: WesternTemplateProps) {
                           whiteSpace: "nowrap",
                         }}
                       >
-                        🔗Link
+                        Link
                       </Typography>
                     )}
                   </Box>
@@ -494,6 +498,7 @@ export function WesternTemplate({ data }: WesternTemplateProps) {
               {data.education.map((edu) => (
                 <Box key={edu.id} sx={{ mb: 1.5 }}>
                   <Typography
+                    data-resume-nowrap
                     sx={{
                       fontSize: "0.8rem",
                       fontWeight: 700,


### PR DESCRIPTION

- Prevent section titles and labels (Work Experience, Education, position, degree, project name) from wrapping in PDF
- Prevent email/link text truncation and keep email (e.g. .com) on one line in PDF
- Add data-resume-section-title, data-resume-nowrap, data-resume-contact-item across all 12 templates
- Remove link emoji (🔗) from project/certification links, keep 'Link' text only
