### PR TITLE
fix(admin): course manager UX 

### DIFF
--- a/app/admin/course-builder/[id]/edit/page.tsx
+++ b/app/admin/course-builder/[id]/edit/page.tsx
@@ -29,12 +29,15 @@ import {
   adminCourseBuilderService,
   CourseData,
 } from "@/lib/services/admin/admin-course-builder.service";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isCourseManagerRole } from "@/lib/auth/auth-utils";
 
 export default function CourseEditPage() {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
   const router = useRouter();
   const params = useParams();
+  const { user, loading: authLoading } = useAuth();
   const courseId = Number(params.id);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -48,12 +51,6 @@ export default function CourseEditPage() {
     rating: 0,
     tags: [] as string[],
   });
-
-  useEffect(() => {
-    if (courseId) {
-      loadCourse();
-    }
-  }, [courseId]);
 
   const loadCourse = async () => {
     try {
@@ -75,6 +72,18 @@ export default function CourseEditPage() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (authLoading || !courseId) return;
+    if (isCourseManagerRole(user?.role)) {
+      router.replace(`/admin/course-builder/${courseId}`);
+    }
+  }, [authLoading, user?.role, courseId, router]);
+
+  useEffect(() => {
+    if (authLoading || !courseId || isCourseManagerRole(user?.role)) return;
+    void loadCourse();
+  }, [authLoading, courseId, user?.role]);
 
   const goToViewPage = () => router.push(`/admin/course-builder/${courseId}`);
 

--- a/app/admin/course-builder/[id]/page.tsx
+++ b/app/admin/course-builder/[id]/page.tsx
@@ -22,12 +22,16 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { adminCourseBuilderService } from "@/lib/services/admin/admin-course-builder.service";
 import { ModuleList } from "@/components/admin/course-builder/ModuleList";
 import { ConfirmDeleteDialog } from "@/components/admin/course-builder/ConfirmDeleteDialog";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isCourseManagerRole } from "@/lib/auth/auth-utils";
 
 export default function CourseViewPage() {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
   const router = useRouter();
   const params = useParams();
+  const { user } = useAuth();
+  const isCourseManager = isCourseManagerRole(user?.role);
   const courseId = Number(params.id);
 
   const [loading, setLoading] = useState(true);
@@ -223,48 +227,50 @@ export default function CourseViewPage() {
               )}
             </Box>
           </Box>
-          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-            <Tooltip title={isPublished ? t("adminCourseBuilder.unpublishCourseTooltip") : t("adminCourseBuilder.publishCourseTooltip")}>
+          {!isCourseManager ? (
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              <Tooltip title={isPublished ? t("adminCourseBuilder.unpublishCourseTooltip") : t("adminCourseBuilder.publishCourseTooltip")}>
+                <Button
+                  variant="outlined"
+                  onClick={handleTogglePublish}
+                  disabled={publishing}
+                  startIcon={
+                    publishing ? (
+                      <CircularProgress size={16} color="inherit" />
+                    ) : (
+                      <IconWrapper icon={isPublished ? "mdi:publish-off" : "mdi:publish"} size={18} />
+                    )
+                  }
+                  sx={{
+                    borderColor: isPublished ? "#d97706" : "#059669",
+                    color: isPublished ? "#d97706" : "#059669",
+                    "&:hover": {
+                      borderColor: isPublished ? "#b45309" : "#047857",
+                      bgcolor: isPublished ? "#fffbeb" : "#ecfdf5",
+                    },
+                  }}
+                >
+                  {isPublished ? t("adminCourseBuilder.unpublish") : t("adminCourseBuilder.publish")}
+                </Button>
+              </Tooltip>
               <Button
                 variant="outlined"
-                onClick={handleTogglePublish}
-                disabled={publishing}
-                startIcon={
-                  publishing ? (
-                    <CircularProgress size={16} color="inherit" />
-                  ) : (
-                    <IconWrapper icon={isPublished ? "mdi:publish-off" : "mdi:publish"} size={18} />
-                  )
-                }
-                sx={{
-                  borderColor: isPublished ? "#d97706" : "#059669",
-                  color: isPublished ? "#d97706" : "#059669",
-                  "&:hover": {
-                    borderColor: isPublished ? "#b45309" : "#047857",
-                    bgcolor: isPublished ? "#fffbeb" : "#ecfdf5",
-                  },
-                }}
+                color="error"
+                startIcon={<IconWrapper icon="mdi:delete" size={18} />}
+                onClick={() => setDeleteDialogOpen(true)}
               >
-                {isPublished ? t("adminCourseBuilder.unpublish") : t("adminCourseBuilder.publish")}
+                {t("adminCourseBuilder.deleteCourse")}
               </Button>
-            </Tooltip>
-            <Button
-              variant="outlined"
-              color="error"
-              startIcon={<IconWrapper icon="mdi:delete" size={18} />}
-              onClick={() => setDeleteDialogOpen(true)}
-            >
-              {t("adminCourseBuilder.deleteCourse")}
-            </Button>
-            <Button
-              variant="contained"
-              startIcon={<IconWrapper icon="mdi:pencil" size={18} />}
-              onClick={() => router.push(`/admin/course-builder/${courseId}/edit`)}
-              sx={{ bgcolor: "#6366f1", "&:hover": { bgcolor: "#4f46e5" } }}
-            >
-              {t("adminCourseBuilder.editCourse")}
-            </Button>
-          </Box>
+              <Button
+                variant="contained"
+                startIcon={<IconWrapper icon="mdi:pencil" size={18} />}
+                onClick={() => router.push(`/admin/course-builder/${courseId}/edit`)}
+                sx={{ bgcolor: "#6366f1", "&:hover": { bgcolor: "#4f46e5" } }}
+              >
+                {t("adminCourseBuilder.editCourse")}
+              </Button>
+            </Box>
+          ) : null}
         </Box>
 
         {/* Course Information Card */}
@@ -389,6 +395,7 @@ export default function CourseViewPage() {
               courseId={courseId}
               modules={modules}
               onModulesChanged={loadModules}
+              readOnly={isCourseManager}
             />
           )}
         </Paper>

--- a/app/admin/course-builder/page.tsx
+++ b/app/admin/course-builder/page.tsx
@@ -31,11 +31,15 @@ import { CourseSearchBar } from "@/components/admin/course-builder/CourseSearchB
 import { CourseStatisticsCards } from "@/components/admin/course-builder/CourseStatisticsCards";
 import { SearchResultsInfo } from "@/components/admin/course-builder/SearchResultsInfo";
 import { EmptyState } from "@/components/admin/course-builder/EmptyState";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isCourseManagerRole } from "@/lib/auth/auth-utils";
 
 export default function CourseBuilderPage() {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
   const router = useRouter();
+  const { user } = useAuth();
+  const isCourseManager = isCourseManagerRole(user?.role);
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
@@ -212,6 +216,7 @@ export default function CourseBuilderPage() {
               searchQuery={searchQuery}
               onSearchChange={setSearchQuery}
               onCreateClick={() => setIsModalOpen(true)}
+              showCreateButton={!isCourseManager}
             />
           </Box>
 
@@ -240,7 +245,9 @@ export default function CourseBuilderPage() {
           ) : filteredCourses.length === 0 ? (
             <EmptyState
               type="no-courses"
-              onCreateClick={() => setIsModalOpen(true)}
+              onCreateClick={
+                isCourseManager ? undefined : () => setIsModalOpen(true)
+              }
             />
           ) : (
             <Box
@@ -259,8 +266,11 @@ export default function CourseBuilderPage() {
                   key={course.id}
                   course={course}
                   onEditClick={() => handleEditCourse(course.id)}
-                  onDuplicate={() => handleDuplicateClick(course)}
+                  onDuplicate={
+                    isCourseManager ? undefined : () => handleDuplicateClick(course)
+                  }
                   onUpdate={loadCourses}
+                  readOnly={isCourseManager}
                 />
               ))}
             </Box>

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -31,12 +31,15 @@ import { StudentActiveDaysChart } from "@/components/admin/dashboard/StudentActi
 import { StudentRankingCard } from "@/components/admin/dashboard/StudentRankingCard";
 import { useToast } from "@/components/common/Toast";
 import { generateDashboardPdf } from "@/lib/utils/pdf-generation.utils";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isCourseManagerRole } from "@/lib/auth/role-utils";
 
 type TimePeriod = "weekly" | "bimonthly" | "monthly";
 
 function AdminDashboardPage() {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
+  const { user } = useAuth();
   const [timePeriod, setTimePeriod] = useState<TimePeriod>("weekly");
   const [selectedCourse, setSelectedCourse] = useState<string>("all");
   const [selectedCourseId, setSelectedCourseId] = useState<string>("");
@@ -57,6 +60,7 @@ function AdminDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [pdfGenerating, setPdfGenerating] = useState(false);
   const dashboardPdfRef = useRef<HTMLDivElement>(null);
+  const attendanceLoadSeqRef = useRef(0);
 
   // Calculate window size based on time period
   const windowSize = useMemo(() => {
@@ -137,9 +141,11 @@ function AdminDashboardPage() {
     }
   }, [dateRange.start, dateRange.end, selectedCourse]);
 
-  // Load attendance analytics
+  // Load attendance analytics — course managers: silent fail on optional charts (avoids false toasts). Admins: show errors.
   const loadAttendanceData = useCallback(async () => {
     if (!dateRange.start || !dateRange.end) return;
+    const seq = ++attendanceLoadSeqRef.current;
+    const courseManager = isCourseManagerRole(user?.role);
     try {
       const courseId =
         selectedCourse !== "all" ? Number(selectedCourse) : undefined;
@@ -148,14 +154,20 @@ function AdminDashboardPage() {
         start_date: dateRange.start,
         end_date: dateRange.end,
       });
+      if (seq !== attendanceLoadSeqRef.current) return;
       setAttendanceData(data);
-    } catch (error: any) {
-      showToast(
-        error?.response?.data?.detail || t("admin.dashboard.failedToLoadAttendance"),
-        "error"
-      );
+    } catch (error: unknown) {
+      if (seq !== attendanceLoadSeqRef.current) return;
+      setAttendanceData(null);
+      if (!courseManager) {
+        const err = error as { response?: { data?: { detail?: string } } };
+        showToast(
+          err?.response?.data?.detail || t("admin.dashboard.failedToLoadAttendance"),
+          "error"
+        );
+      }
     }
-  }, [dateRange.start, dateRange.end, selectedCourse, showToast, t]);
+  }, [dateRange.start, dateRange.end, selectedCourse, showToast, t, user?.role]);
 
   // Load core data immediately (doesn't require date range)
   useEffect(() => {

--- a/app/admin/manage-students/page.tsx
+++ b/app/admin/manage-students/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Box, Collapse, IconButton, Paper, Typography } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -10,8 +10,14 @@ import {
   adminStudentService,
   Student,
   CourseCompletionStats,
+  ManageStudentsResponse,
 } from "@/lib/services/admin/admin-student.service";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
+import { useAuth } from "@/lib/auth/auth-context";
+import {
+  isClientOrgAdminRole,
+  isCourseManagerRole,
+} from "@/lib/auth/role-utils";
 import { ManageStudentsHeader } from "../../../components/admin/manage-students/ManageStudentsHeader";
 import { StudentsFilters } from "../../../components/admin/manage-students/StudentsFilters";
 import { StudentsTable } from "../../../components/admin/manage-students/StudentsTable";
@@ -30,9 +36,32 @@ type SortOption =
   | "saved_resume";
 type SortOrder = "asc" | "desc";
 
+function apiErrorMessage(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  const data = (error as { response?: { data?: { detail?: unknown; error?: unknown } } })
+    .response?.data;
+  if (!data) return null;
+  if (typeof data.detail === "string") return data.detail;
+  if (typeof data.error === "string") return data.error;
+  return null;
+}
+
+function statsMapFromCompletionRows(
+  rows: CourseCompletionStats[]
+): Record<number, CourseCompletionStats> {
+  const statsMap: Record<number, CourseCompletionStats> = {};
+  for (const row of rows) {
+    statsMap[row.student_id] = row;
+  }
+  return statsMap;
+}
+
 export default function ManageStudentsPage() {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
+  const { user } = useAuth();
+  const showOrgAdminEnrollmentTools = isClientOrgAdminRole(user?.role);
+  const courseManagerUser = isCourseManagerRole(user?.role);
 
   // State - Original data from API
   const [allStudents, setAllStudents] = useState<Student[]>([]);
@@ -61,6 +90,7 @@ export default function ManageStudentsPage() {
   // Bulk Enrollment
   const [bulkEnrollDialogOpen, setBulkEnrollDialogOpen] = useState(false);
   const [showJobHistory, setShowJobHistory] = useState(false);
+  const loadStudentsSeqRef = useRef(0);
 
   // Load courses for filter
   useEffect(() => {
@@ -91,11 +121,59 @@ export default function ManageStudentsPage() {
   // Load students from API - only when course filter changes or initial load
   // All filtering, sorting, and pagination is done client-side to reduce API calls
   const loadStudents = useCallback(async () => {
+    const seq = ++loadStudentsSeqRef.current;
+    const courseManager = courseManagerUser;
+
+    // Course managers: empty course filter = load all students the API allows (scoped server-side).
+    // Admins: keep original behavior — require at least one selected course before loading.
     if (selectedCourses.length === 0) {
-      setAllStudents([]);
-      setCompletionStats({});
-      setLoading(false);
-      setLoadingStats(false);
+      if (!courseManager) {
+        setAllStudents([]);
+        setCompletionStats({});
+        setLoading(false);
+        setLoadingStats(false);
+        return;
+      }
+      try {
+        setLoading(true);
+        const response = await adminStudentService.getManageStudents({
+          page: 1,
+          limit: 10000,
+          sort_by: "name",
+          sort_order: "asc",
+        });
+        if (seq !== loadStudentsSeqRef.current) return;
+        setAllStudents(response?.students ?? []);
+
+        setLoadingStats(true);
+        try {
+          const statsRows = await adminStudentService.getCourseCompletionStats();
+          if (seq !== loadStudentsSeqRef.current) return;
+          setCompletionStats(
+            statsMapFromCompletionRows(Array.isArray(statsRows) ? statsRows : [])
+          );
+        } catch {
+          if (seq === loadStudentsSeqRef.current) {
+            setCompletionStats({});
+          }
+        } finally {
+          if (seq === loadStudentsSeqRef.current) {
+            setLoadingStats(false);
+          }
+        }
+      } catch (error: unknown) {
+        if (seq !== loadStudentsSeqRef.current) return;
+        showToast(
+          apiErrorMessage(error) || t("adminManageStudents.failedToLoadStudents"),
+          "error"
+        );
+        setAllStudents([]);
+        setCompletionStats({});
+      } finally {
+        if (seq === loadStudentsSeqRef.current) {
+          setLoading(false);
+        }
+      }
       return;
     }
 
@@ -103,50 +181,34 @@ export default function ManageStudentsPage() {
       setLoading(true);
       const selectedCourseIds = selectedCourses.map(Number).filter(Number.isFinite);
 
-      const studentResponses = await Promise.all(
-        selectedCourseIds.map((courseId) =>
-          adminStudentService.getManageStudents({
-            course_id: courseId,
-            page: 1,
-            limit: 10000,
-            sort_by: "name",
-            sort_order: "asc",
-          })
-        )
-      );
-
-      const studentMap = new Map<number, Student>();
-      studentResponses.forEach((response) => {
-        (response?.students ?? []).forEach((student) => {
-          const key = student.user_id || student.id;
-          const existing = studentMap.get(key);
-          if (!existing) {
-            studentMap.set(key, student);
-          } else {
-            studentMap.set(key, {
-              ...existing,
-              enrollment_count: Math.max(
-                existing.enrollment_count ?? 0,
-                student.enrollment_count ?? 0
-              ),
-              has_saved_resume: Boolean(
-                existing.has_saved_resume || student.has_saved_resume
-              ),
-            });
-          }
+      const mergeStudentResponsesIntoMap = (
+        responses: Array<{ students?: Student[] } | undefined>
+      ) => {
+        const studentMap = new Map<number, Student>();
+        responses.forEach((response) => {
+          (response?.students ?? []).forEach((student) => {
+            const key = student.user_id || student.id;
+            const existing = studentMap.get(key);
+            if (!existing) {
+              studentMap.set(key, student);
+            } else {
+              studentMap.set(key, {
+                ...existing,
+                enrollment_count: Math.max(
+                  existing.enrollment_count ?? 0,
+                  student.enrollment_count ?? 0
+                ),
+                has_saved_resume: Boolean(
+                  existing.has_saved_resume || student.has_saved_resume
+                ),
+              });
+            }
+          });
         });
-      });
+        return studentMap;
+      };
 
-      setAllStudents(Array.from(studentMap.values()));
-
-      setLoadingStats(true);
-      try {
-        const statsResults = await Promise.all(
-          selectedCourseIds.map((courseId) =>
-            adminStudentService.getCourseCompletionStats(courseId)
-          )
-        );
-        const stats = statsResults.flat();
+      const aggregateStatsFromRows = (stats: CourseCompletionStats[]) => {
         const statsMap: Record<number, CourseCompletionStats> = {};
         const studentStatsMap: Record<
           number,
@@ -202,28 +264,116 @@ export default function ManageStudentsPage() {
         });
 
         setCompletionStats(statsMap);
-      } catch {
-      } finally {
-        setLoadingStats(false);
+      };
+
+      if (courseManager) {
+        const studentSettled = await Promise.allSettled(
+          selectedCourseIds.map((courseId) =>
+            adminStudentService.getManageStudents({
+              course_id: courseId,
+              page: 1,
+              limit: 10000,
+              sort_by: "name",
+              sort_order: "asc",
+            })
+          )
+        );
+
+        if (seq !== loadStudentsSeqRef.current) return;
+
+        const studentFailures = studentSettled.filter(
+          (r): r is PromiseRejectedResult => r.status === "rejected"
+        );
+        const allStudentRequestsFailed =
+          studentSettled.length > 0 &&
+          studentFailures.length === studentSettled.length;
+
+        if (allStudentRequestsFailed) {
+          const detail = apiErrorMessage(studentFailures[0].reason);
+          showToast(
+            detail || t("adminManageStudents.failedToLoadStudents"),
+            "error"
+          );
+          setAllStudents([]);
+          setCompletionStats({});
+        } else {
+          const fulfilledResponses = studentSettled
+            .filter(
+              (r): r is PromiseFulfilledResult<ManageStudentsResponse> =>
+                r.status === "fulfilled"
+            )
+            .map((r) => r.value);
+          setAllStudents(
+            Array.from(mergeStudentResponsesIntoMap(fulfilledResponses).values())
+          );
+
+          setLoadingStats(true);
+          try {
+            const statsSettled = await Promise.allSettled(
+              selectedCourseIds.map((courseId) =>
+                adminStudentService.getCourseCompletionStats(courseId)
+              )
+            );
+            if (seq !== loadStudentsSeqRef.current) return;
+            const stats = statsSettled.flatMap((r) =>
+              r.status === "fulfilled" ? r.value : []
+            );
+            aggregateStatsFromRows(stats);
+          } catch {
+          } finally {
+            if (seq === loadStudentsSeqRef.current) {
+              setLoadingStats(false);
+            }
+          }
+        }
+      } else {
+        const studentResponses = await Promise.all(
+          selectedCourseIds.map((courseId) =>
+            adminStudentService.getManageStudents({
+              course_id: courseId,
+              page: 1,
+              limit: 10000,
+              sort_by: "name",
+              sort_order: "asc",
+            })
+          )
+        );
+
+        if (seq !== loadStudentsSeqRef.current) return;
+
+        setAllStudents(
+          Array.from(mergeStudentResponsesIntoMap(studentResponses).values())
+        );
+
+        setLoadingStats(true);
+        try {
+          const statsResults = await Promise.all(
+            selectedCourseIds.map((courseId) =>
+              adminStudentService.getCourseCompletionStats(courseId)
+            )
+          );
+          if (seq !== loadStudentsSeqRef.current) return;
+          aggregateStatsFromRows(statsResults.flat());
+        } catch {
+        } finally {
+          if (seq === loadStudentsSeqRef.current) {
+            setLoadingStats(false);
+          }
+        }
       }
     } catch (error: unknown) {
-      const detail =
-        typeof error === "object" &&
-        error !== null &&
-        "response" in error &&
-        typeof (error as { response?: { data?: { detail?: unknown } } }).response
-          ?.data?.detail === "string"
-          ? (error as { response: { data: { detail: string } } }).response.data.detail
-          : null;
+      if (seq !== loadStudentsSeqRef.current) return;
       showToast(
-        detail || t("adminManageStudents.failedToLoadStudents"),
+        apiErrorMessage(error) || t("adminManageStudents.failedToLoadStudents"),
         "error"
       );
       setAllStudents([]);
     } finally {
-      setLoading(false);
+      if (seq === loadStudentsSeqRef.current) {
+        setLoading(false);
+      }
     }
-  }, [selectedCourses, showToast, t]);
+  }, [selectedCourses, showToast, t, courseManagerUser]);
 
   // Load students when course filter changes or on mount
   useEffect(() => {
@@ -455,13 +605,23 @@ export default function ManageStudentsPage() {
       <Box sx={{ p: { xs: 2, sm: 3, md: 4 } }}>
         <ManageStudentsHeader
           totalCount={totalCount}
-          onBulkEnrollClick={() => setBulkEnrollDialogOpen(true)}
-          onDownloadCsv={selectedCourses.length > 0 ? handleDownloadCsv : undefined}
+          onBulkEnrollClick={
+            showOrgAdminEnrollmentTools
+              ? () => setBulkEnrollDialogOpen(true)
+              : undefined
+          }
+          onDownloadCsv={
+            allStudents.length > 0 &&
+            (courseManagerUser || selectedCourses.length > 0)
+              ? handleDownloadCsv
+              : undefined
+          }
         />
 
         <StudentsFilters
           courses={courses}
           selectedCourses={selectedCourses}
+          emptySelectionMeansAllCourses={courseManagerUser}
           status={status}
           resumeFilter={resumeFilter}
           searchTerm={searchTerm}
@@ -471,40 +631,42 @@ export default function ManageStudentsPage() {
           onSearchChange={handleSearchChange}
         />
 
-        <Box sx={{ mb: 4 }}>
-          <Paper
-            sx={{
-              p: 2,
-              mb: 2,
-              cursor: "pointer",
-              "&:hover": {
-                backgroundColor: "#f9fafb",
-              },
-            }}
-            onClick={() => setShowJobHistory(!showJobHistory)}
-          >
-            <Box
+        {showOrgAdminEnrollmentTools ? (
+          <Box sx={{ mb: 4 }}>
+            <Paper
               sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
+                p: 2,
+                mb: 2,
+                cursor: "pointer",
+                "&:hover": {
+                  backgroundColor: "#f9fafb",
+                },
               }}
+              onClick={() => setShowJobHistory(!showJobHistory)}
             >
-              <Typography variant="h6" fontWeight={600}>
-                {t("adminManageStudents.enrollmentJobHistory")}
-              </Typography>
-              <IconButton size="small">
-                <IconWrapper
-                  icon={showJobHistory ? "mdi:chevron-up" : "mdi:chevron-down"}
-                  size={20}
-                />
-              </IconButton>
-            </Box>
-          </Paper>
-          <Collapse in={showJobHistory}>
-            <EnrollmentJobHistory />
-          </Collapse>
-        </Box>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Typography variant="h6" fontWeight={600}>
+                  {t("adminManageStudents.enrollmentJobHistory")}
+                </Typography>
+                <IconButton size="small">
+                  <IconWrapper
+                    icon={showJobHistory ? "mdi:chevron-up" : "mdi:chevron-down"}
+                    size={20}
+                  />
+                </IconButton>
+              </Box>
+            </Paper>
+            <Collapse in={showJobHistory}>
+              <EnrollmentJobHistory />
+            </Collapse>
+          </Box>
+        ) : null}
 
         <Box>
           <StudentsTable

--- a/components/admin/course-builder/ContentList.tsx
+++ b/components/admin/course-builder/ContentList.tsx
@@ -42,6 +42,7 @@ interface ContentItem {
 interface ContentListProps {
   courseId: number;
   submoduleId: number;
+  readOnly?: boolean;
 }
 
 const CONTENT_TYPE_CONFIG: Record<
@@ -74,7 +75,11 @@ const emptyForm: ContentData = {
   duration_in_minutes: 0,
 };
 
-export function ContentList({ courseId, submoduleId }: ContentListProps) {
+export function ContentList({
+  courseId,
+  submoduleId,
+  readOnly = false,
+}: ContentListProps) {
   const { showToast } = useToast();
 
   const [contents, setContents] = useState<ContentItem[]>([]);
@@ -248,28 +253,32 @@ export function ContentList({ courseId, submoduleId }: ContentListProps) {
                     )}
                   </Box>
                 </Box>
-                <Box sx={{ display: "flex", gap: 0.25, flexShrink: 0 }}>
-                  <IconButton size="small" onClick={() => openEdit(item)} sx={{ color: "#6366f1", p: 0.5 }}>
-                    <IconWrapper icon="mdi:pencil" size={14} />
-                  </IconButton>
-                  <IconButton size="small" onClick={() => setDeleteTarget(item)} sx={{ color: "#ef4444", p: 0.5 }}>
-                    <IconWrapper icon="mdi:delete" size={14} />
-                  </IconButton>
-                </Box>
+                {!readOnly ? (
+                  <Box sx={{ display: "flex", gap: 0.25, flexShrink: 0 }}>
+                    <IconButton size="small" onClick={() => openEdit(item)} sx={{ color: "#6366f1", p: 0.5 }}>
+                      <IconWrapper icon="mdi:pencil" size={14} />
+                    </IconButton>
+                    <IconButton size="small" onClick={() => setDeleteTarget(item)} sx={{ color: "#ef4444", p: 0.5 }}>
+                      <IconWrapper icon="mdi:delete" size={14} />
+                    </IconButton>
+                  </Box>
+                ) : null}
               </Box>
             );
           })}
         </Box>
       )}
 
-      <Button
-        size="small"
-        startIcon={<IconWrapper icon="mdi:plus" size={14} />}
-        onClick={openAdd}
-        sx={{ mt: 0.75, color: "#6366f1", textTransform: "none", fontWeight: 600, fontSize: "0.75rem" }}
-      >
-        Add Content
-      </Button>
+      {!readOnly ? (
+        <Button
+          size="small"
+          startIcon={<IconWrapper icon="mdi:plus" size={14} />}
+          onClick={openAdd}
+          sx={{ mt: 0.75, color: "#6366f1", textTransform: "none", fontWeight: 600, fontSize: "0.75rem" }}
+        >
+          Add Content
+        </Button>
+      ) : null}
 
       {/* Add / Edit Content Dialog */}
       <Dialog open={dialogOpen} onClose={saving ? undefined : closeDialog} maxWidth="sm" fullWidth>

--- a/components/admin/course-builder/CourseCard.tsx
+++ b/components/admin/course-builder/CourseCard.tsx
@@ -55,9 +55,17 @@ interface CourseCardProps {
   onEditClick: () => void;
   onDuplicate?: () => void;
   onUpdate?: () => void;
+  /** View-only: no inline edit, publish, or duplicate (course manager) */
+  readOnly?: boolean;
 }
 
-export function CourseCard({ course, onEditClick, onDuplicate, onUpdate }: CourseCardProps) {
+export function CourseCard({
+  course,
+  onEditClick: _onEditClick,
+  onDuplicate,
+  onUpdate,
+  readOnly = false,
+}: CourseCardProps) {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
   const router = useRouter();
@@ -229,7 +237,7 @@ export function CourseCard({ course, onEditClick, onDuplicate, onUpdate }: Cours
             )}
           </Box>
           <Box sx={{ display: "flex", gap: 0.5, ml: 1 }} onClick={(e) => e.stopPropagation()}>
-            {editing ? (
+            {readOnly ? null : editing ? (
               <>
                 <IconButton
                   size="small"
@@ -603,7 +611,7 @@ export function CourseCard({ course, onEditClick, onDuplicate, onUpdate }: Cours
                 fontSize: "0.8rem",
               }}
             >
-              {t("adminCourseBuilder.manage")}
+              {readOnly ? t("adminCourseBuilder.viewCourse") : t("adminCourseBuilder.manage")}
             </Button>
           </Box>
         </Box>

--- a/components/admin/course-builder/CourseSearchBar.tsx
+++ b/components/admin/course-builder/CourseSearchBar.tsx
@@ -8,12 +8,15 @@ interface CourseSearchBarProps {
   searchQuery: string;
   onSearchChange: (query: string) => void;
   onCreateClick: () => void;
+  /** When false, hides "Add new course" (e.g. course manager view-only) */
+  showCreateButton?: boolean;
 }
 
 export function CourseSearchBar({
   searchQuery,
   onSearchChange,
   onCreateClick,
+  showCreateButton = true,
 }: CourseSearchBarProps) {
   const { t } = useTranslation("common");
   return (
@@ -52,18 +55,20 @@ export function CourseSearchBar({
           ),
         }}
       />
-      <Button
-        variant="contained"
-        startIcon={<IconWrapper icon="mdi:plus" size={20} />}
-        onClick={onCreateClick}
-        sx={{
-          bgcolor: "#6366f1",
-          "&:hover": { bgcolor: "#4f46e5" },
-          whiteSpace: "nowrap",
-        }}
-      >
-        {t("adminCourseBuilder.addNewCourse")}
-      </Button>
+      {showCreateButton ? (
+        <Button
+          variant="contained"
+          startIcon={<IconWrapper icon="mdi:plus" size={20} />}
+          onClick={onCreateClick}
+          sx={{
+            bgcolor: "#6366f1",
+            "&:hover": { bgcolor: "#4f46e5" },
+            whiteSpace: "nowrap",
+          }}
+        >
+          {t("adminCourseBuilder.addNewCourse")}
+        </Button>
+      ) : null}
     </Box>
   );
 }

--- a/components/admin/course-builder/ModuleList.tsx
+++ b/components/admin/course-builder/ModuleList.tsx
@@ -43,11 +43,17 @@ interface ModuleListProps {
   courseId: number;
   modules: Module[];
   onModulesChanged: () => void;
+  readOnly?: boolean;
 }
 
 const emptyForm: ModuleData = { title: "", weekno: 1, description: "" };
 
-export function ModuleList({ courseId, modules, onModulesChanged }: ModuleListProps) {
+export function ModuleList({
+  courseId,
+  modules,
+  onModulesChanged,
+  readOnly = false,
+}: ModuleListProps) {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
 
@@ -225,56 +231,58 @@ export function ModuleList({ courseId, modules, onModulesChanged }: ModuleListPr
                 </Box>
 
                 {/* Edit & Delete - prevent expand on click */}
-                <Box
-                  component="span"
-                  sx={{ display: "flex", alignItems: "center", gap: 0.5, flexShrink: 0 }}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Tooltip title={t("adminCourseBuilder.editModuleTooltip")}>
-                    <IconButton
-                      component="span"
-                      size="small"
-                      onClick={() => openEdit(mod)}
-                      sx={{
-                        color: "#6366f1",
-                        bgcolor: "#eef2ff",
-                        "&:hover": { bgcolor: "#e0e7ff" },
-                      }}
-                      role="button"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          openEdit(mod);
-                        }
-                      }}
-                    >
-                      <IconWrapper icon="mdi:pencil" size={18} />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title={t("adminCourseBuilder.deleteModuleTooltip")}>
-                    <IconButton
-                      component="span"
-                      size="small"
-                      onClick={() => setDeleteTarget(mod)}
-                      sx={{
-                        color: "#ef4444",
-                        bgcolor: "#fef2f2",
-                        "&:hover": { bgcolor: "#fee2e2" },
-                      }}
-                      role="button"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          setDeleteTarget(mod);
-                        }
-                      }}
-                    >
-                      <IconWrapper icon="mdi:delete" size={18} />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
+                {!readOnly ? (
+                  <Box
+                    component="span"
+                    sx={{ display: "flex", alignItems: "center", gap: 0.5, flexShrink: 0 }}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <Tooltip title={t("adminCourseBuilder.editModuleTooltip")}>
+                      <IconButton
+                        component="span"
+                        size="small"
+                        onClick={() => openEdit(mod)}
+                        sx={{
+                          color: "#6366f1",
+                          bgcolor: "#eef2ff",
+                          "&:hover": { bgcolor: "#e0e7ff" },
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            openEdit(mod);
+                          }
+                        }}
+                      >
+                        <IconWrapper icon="mdi:pencil" size={18} />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title={t("adminCourseBuilder.deleteModuleTooltip")}>
+                      <IconButton
+                        component="span"
+                        size="small"
+                        onClick={() => setDeleteTarget(mod)}
+                        sx={{
+                          color: "#ef4444",
+                          bgcolor: "#fef2f2",
+                          "&:hover": { bgcolor: "#fee2e2" },
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            setDeleteTarget(mod);
+                          }
+                        }}
+                      >
+                        <IconWrapper icon="mdi:delete" size={18} />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                ) : null}
               </AccordionSummary>
               <AccordionDetails sx={{ px: 2, pb: 2, pt: 0, borderTop: "1px solid #f3f4f6" }}>
                 {loadingSubs[mod.id] ? (
@@ -285,6 +293,7 @@ export function ModuleList({ courseId, modules, onModulesChanged }: ModuleListPr
                     moduleId={mod.id}
                     submodules={submoduleMap[mod.id] || []}
                     onSubmodulesChanged={() => loadSubmodules(mod.id)}
+                    readOnly={readOnly}
                   />
                 )}
               </AccordionDetails>
@@ -293,21 +302,23 @@ export function ModuleList({ courseId, modules, onModulesChanged }: ModuleListPr
         </Box>
       )}
 
-      <Button
-        variant="outlined"
-        startIcon={<IconWrapper icon="mdi:plus" size={18} />}
-        onClick={openAdd}
-        sx={{
-          mt: 2,
-          textTransform: "none",
-          fontWeight: 600,
-          borderColor: "#6366f1",
-          color: "#6366f1",
-          "&:hover": { borderColor: "#4f46e5", bgcolor: "#eef2ff" },
-        }}
-      >
-        {t("adminCourseBuilder.addModule")}
-      </Button>
+      {!readOnly ? (
+        <Button
+          variant="outlined"
+          startIcon={<IconWrapper icon="mdi:plus" size={18} />}
+          onClick={openAdd}
+          sx={{
+            mt: 2,
+            textTransform: "none",
+            fontWeight: 600,
+            borderColor: "#6366f1",
+            color: "#6366f1",
+            "&:hover": { borderColor: "#4f46e5", bgcolor: "#eef2ff" },
+          }}
+        >
+          {t("adminCourseBuilder.addModule")}
+        </Button>
+      ) : null}
 
       {/* Add / Edit Dialog */}
       <Dialog open={dialogOpen} onClose={saving ? undefined : closeDialog} maxWidth="sm" fullWidth>

--- a/components/admin/course-builder/SubmoduleList.tsx
+++ b/components/admin/course-builder/SubmoduleList.tsx
@@ -43,6 +43,7 @@ interface SubmoduleListProps {
   moduleId: number;
   submodules: Submodule[];
   onSubmodulesChanged: () => void;
+  readOnly?: boolean;
 }
 
 const emptyForm: SubmoduleData = { title: "", description: "", order: 1 };
@@ -60,6 +61,7 @@ export function SubmoduleList({
   moduleId,
   submodules,
   onSubmodulesChanged,
+  readOnly = false,
 }: SubmoduleListProps) {
   const { showToast } = useToast();
 
@@ -245,27 +247,33 @@ export function SubmoduleList({
                       </Typography>
                     )}
                   </Box>
-                  <Box
-                    sx={{ display: "flex", gap: 0.5, ml: 1, flexShrink: 0 }}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <IconButton size="small" onClick={() => openEdit(sub)} sx={{ color: "#6366f1" }}>
-                      <IconWrapper icon="mdi:pencil" size={16} />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      onClick={() => setDeleteTarget(sub)}
-                      sx={{ color: "#ef4444" }}
+                  {!readOnly ? (
+                    <Box
+                      sx={{ display: "flex", gap: 0.5, ml: 1, flexShrink: 0 }}
+                      onClick={(e) => e.stopPropagation()}
                     >
-                      <IconWrapper icon="mdi:delete" size={16} />
-                    </IconButton>
-                  </Box>
+                      <IconButton size="small" onClick={() => openEdit(sub)} sx={{ color: "#6366f1" }}>
+                        <IconWrapper icon="mdi:pencil" size={16} />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        onClick={() => setDeleteTarget(sub)}
+                        sx={{ color: "#ef4444" }}
+                      >
+                        <IconWrapper icon="mdi:delete" size={16} />
+                      </IconButton>
+                    </Box>
+                  ) : null}
                 </Box>
 
                 {/* Expanded Content */}
                 <Collapse in={isExpanded}>
                   <Box sx={{ px: 2, pb: 1.5, borderTop: "1px solid #f3f4f6" }}>
-                    <ContentList courseId={courseId} submoduleId={sub.id} />
+                    <ContentList
+                      courseId={courseId}
+                      submoduleId={sub.id}
+                      readOnly={readOnly}
+                    />
                   </Box>
                 </Collapse>
               </Box>
@@ -274,14 +282,16 @@ export function SubmoduleList({
         </Box>
       )}
 
-      <Button
-        size="small"
-        startIcon={<IconWrapper icon="mdi:plus" size={16} />}
-        onClick={openAdd}
-        sx={{ mt: 1, color: "#6366f1", textTransform: "none", fontWeight: 600 }}
-      >
-        Add Submodule
-      </Button>
+      {!readOnly ? (
+        <Button
+          size="small"
+          startIcon={<IconWrapper icon="mdi:plus" size={16} />}
+          onClick={openAdd}
+          sx={{ mt: 1, color: "#6366f1", textTransform: "none", fontWeight: 600 }}
+        >
+          Add Submodule
+        </Button>
+      ) : null}
 
       {/* Add / Edit Dialog */}
       <Dialog open={dialogOpen} onClose={saving ? undefined : closeDialog} maxWidth="sm" fullWidth>

--- a/components/admin/manage-students/EnrollmentJobHistory.tsx
+++ b/components/admin/manage-students/EnrollmentJobHistory.tsx
@@ -20,6 +20,8 @@ import {
 import { useTranslation } from "react-i18next";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
 import {
   adminStudentEnrollmentService,
   StudentEnrollmentJob,
@@ -34,28 +36,36 @@ interface EnrollmentJobHistoryProps {
 export function EnrollmentJobHistory({ onJobSelect }: EnrollmentJobHistoryProps) {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
+  const { user, loading: authLoading } = useAuth();
   const [jobs, setJobs] = useState<StudentEnrollmentJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
 
-  // Load jobs function - can be called from multiple places
+  // Backend allows enrollment jobs list only for admin/superadmin — skip for course_manager etc.
   const loadJobs = useCallback(async () => {
+    if (!isClientOrgAdminRole(user?.role)) {
+      setJobs([]);
+      setLoading(false);
+      return;
+    }
     try {
       setLoading(true);
       const jobsData = await adminStudentEnrollmentService.listAllJobs();
       setJobs(jobsData);
-    } catch (error: any) {
-      showToast(error.message || t("adminManageStudents.failedToLoadJobHistory"), "error");
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : String(error ?? "");
+      showToast(message || t("adminManageStudents.failedToLoadJobHistory"), "error");
     } finally {
       setLoading(false);
     }
-  }, [t]);
+  }, [t, showToast, user?.role]);
 
-  // Load jobs on mount only - using loadJobs ref to avoid dependency issues
   useEffect(() => {
+    if (authLoading) return;
     loadJobs();
-  }, [loadJobs]); // Include loadJobs since it's memoized with useCallback
+  }, [authLoading, loadJobs]);
 
   const getStatusColor = (status: JobStatus): "default" | "primary" | "success" | "error" => {
     switch (status) {

--- a/components/admin/manage-students/StudentsFilters.tsx
+++ b/components/admin/manage-students/StudentsFilters.tsx
@@ -24,6 +24,8 @@ interface Course {
 interface StudentsFiltersProps {
   courses: Course[];
   selectedCourses: string[];
+  /** When true, empty multi-select shows "All courses" (course managers auto-load all scoped students). */
+  emptySelectionMeansAllCourses?: boolean;
   status: string;
   resumeFilter: "all" | "yes" | "no";
   searchTerm: string;
@@ -36,6 +38,7 @@ interface StudentsFiltersProps {
 export function StudentsFilters({
   courses,
   selectedCourses,
+  emptySelectionMeansAllCourses = false,
   status,
   resumeFilter,
   searchTerm,
@@ -87,7 +90,11 @@ export function StudentsFilters({
             input={<OutlinedInput label={t("adminManageStudents.filterByCourse")} />}
             renderValue={(selected) => {
               const selectedIds = selected as string[];
-              if (!selectedIds.length) return t("adminManageStudents.filterByCourse");
+              if (!selectedIds.length) {
+                return emptySelectionMeansAllCourses
+                  ? t("adminManageStudents.allCourses")
+                  : t("adminManageStudents.filterByCourse");
+              }
               const titleMap = new Map(courses.map((c) => [String(c.id), c.title]));
               return selectedIds
                 .map((id) => titleMap.get(id) || id)

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1259,6 +1259,7 @@
     "enrolled": "enrolled",
     "draft": "Draft",
     "manage": "Manage",
+    "viewCourse": "View course",
     "deleting": "Deleting...",
     "delete": "Delete",
     "failedToLoadCourseDetails": "Failed to load course details",


### PR DESCRIPTION
 scoped students, dashboard, read-only, course builder

- Course builder: read-only mode for course managers (no create/edit/publish/delete; edit redirect).
- Manage students: course managers auto-load all scoped students when no course selected; partial per-course failures use allSettled; admins keep strict Promise.all and empty filter.
- Hide enrollment job history and bulk enroll for non–org-admin; skip jobs API for course managers.
- StudentsFilters: All courses label only for course managers.
- Dashboard: suppress attendance analytics error toast only for course managers; restore for admins.
- Shared: apiErrorMessage (detail + error), CSV download guards, i18n for view course.

Made-with: Cursor