### PR TITLE
feat(proctoring): enable tab switch detection during assessments

### DIFF
--- a/app/assessments/[slug]/take/page.tsx
+++ b/app/assessments/[slug]/take/page.tsx
@@ -248,6 +248,8 @@ export default function TakeAssessmentPage({
     maxViolations: MAX_VIOLATIONS,
     onViolationThresholdReached: handleViolationThresholdReached,
     autoStart: false,
+    tabSwitchDetectionEnabled:
+      assessmentStarted && assessment?.proctoring_enabled !== false,
   });
 
   totalViolationCountRef.current = totalViolationCount;

--- a/components/assessment/FullscreenExitConfirmDialog.tsx
+++ b/components/assessment/FullscreenExitConfirmDialog.tsx
@@ -72,11 +72,7 @@ export function FullscreenExitConfirmDialog({
           to fullscreen if your browser already left it).{" "}
           <strong>Submit assessment</strong> hands in all your answers now.
         </Typography>
-        <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1.5 }}>
-          In Firefox and Safari, Escape usually leaves fullscreen first (browser
-          rule), then this dialog appears. In Chrome, Edge, Brave, and Opera it
-          can appear without leaving fullscreen when the browser allows it.
-        </Typography>
+     
       </DialogContent>
       <DialogActions sx={{ flexWrap: "wrap", gap: 1, px: 3, pb: 2 }}>
         <Button variant="contained" onClick={onCancel} fullWidth sx={{ py: 1.25 }}>

--- a/lib/hooks/useAssessmentProctoring.ts
+++ b/lib/hooks/useAssessmentProctoring.ts
@@ -58,6 +58,11 @@ interface UseAssessmentProctoringOptions {
   autoStart?: boolean;
   /** When false, trackpad swipe detection is disabled (no warnings, no blocking). Default true. */
   trackpadSwipeDetection?: boolean;
+  /**
+   * When false, tab/window visibility listeners are off (no tab-switch violations).
+   * Default true. Prefer enabling only during an active proctored session.
+   */
+  tabSwitchDetectionEnabled?: boolean;
 }
 
 interface UseAssessmentProctoringReturn {
@@ -106,6 +111,7 @@ export function useAssessmentProctoring(
     onViolationThresholdReached,
     autoStart = false,
     trackpadSwipeDetection = true,
+    tabSwitchDetectionEnabled = true,
   } = options;
 
   const startedAtRef = useRef<string>(new Date().toISOString());
@@ -174,7 +180,7 @@ export function useAssessmentProctoring(
     tabSwitchCount,
     violations: tabSwitchViolations,
     clearViolations: clearTabSwitchViolations,
-  } = useTabSwitchDetector();
+  } = useTabSwitchDetector({ enabled: tabSwitchDetectionEnabled });
 
   // Trackpad swipe detection (horizontal swipes only; mouse wheel unaffected). Can be turned off via trackpadSwipeDetection.
   const {

--- a/lib/hooks/useTabSwitchDetector.ts
+++ b/lib/hooks/useTabSwitchDetector.ts
@@ -7,6 +7,14 @@ export interface TabSwitchViolation {
   duration_seconds: number;
 }
 
+interface UseTabSwitchDetectorOptions {
+  /**
+   * When false, listeners are detached (no tab-switch state updates).
+   * Use while the proctored session is inactive to avoid noise (e.g. editors).
+   */
+  enabled?: boolean;
+}
+
 interface UseTabSwitchDetectorReturn {
   isVisible: boolean;
   tabSwitchCount: number;
@@ -14,16 +22,32 @@ interface UseTabSwitchDetectorReturn {
   clearViolations: () => void;
 }
 
+/** Cross-browser hidden check (Safari/WebKit legacy + Gecko prefixes). */
+function isPageHidden(doc: Document): boolean {
+  if (doc.visibilityState === "hidden") return true;
+  const d = doc as Document & {
+    hidden?: boolean;
+    webkitHidden?: boolean;
+    mozHidden?: boolean;
+  };
+  return d.hidden === true || d.webkitHidden === true || d.mozHidden === true;
+}
+
 /**
- * Hook to detect tab switches and window visibility changes
+ * Detects leaving / returning to the assessment tab (or minimizing the window).
+ * Uses visibility + prefixed visibility events and delayed reconcile on
+ * window blur/focus so Firefox / Safari match Chromium when the API updates late.
  */
-export function useTabSwitchDetector(): UseTabSwitchDetectorReturn {
+export function useTabSwitchDetector(
+  options: UseTabSwitchDetectorOptions = {}
+): UseTabSwitchDetectorReturn {
+  const { enabled = true } = options;
   const [isVisible, setIsVisible] = useState(true);
   const [tabSwitchCount, setTabSwitchCount] = useState(0);
   const [violations, setViolations] = useState<TabSwitchViolation[]>([]);
   const hiddenTimestampRef = useRef<number | null>(null);
+  const reconcileTimerIdsRef = useRef<number[]>([]);
 
-  // Clear violations
   const clearViolations = useCallback(() => {
     setViolations([]);
     setTabSwitchCount(0);
@@ -31,45 +55,79 @@ export function useTabSwitchDetector(): UseTabSwitchDetectorReturn {
   }, []);
 
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      const isHidden = document.hidden;
+    if (!enabled) {
+      reconcileTimerIdsRef.current.forEach((id) => clearTimeout(id));
+      reconcileTimerIdsRef.current = [];
+      return;
+    }
 
-      if (isHidden) {
-        // Tab was switched or window was minimized
+    const clearScheduledReconciles = () => {
+      reconcileTimerIdsRef.current.forEach((id) => clearTimeout(id));
+      reconcileTimerIdsRef.current = [];
+    };
+
+    const applyVisibilityTransition = () => {
+      const hidden = isPageHidden(document);
+
+      if (hidden) {
         setIsVisible(false);
-        hiddenTimestampRef.current = Date.now();
-      } else {
-        // Tab/window is visible again
-        setIsVisible(true);
-
-        if (hiddenTimestampRef.current !== null) {
-          // Calculate duration
-          const duration = (Date.now() - hiddenTimestampRef.current) / 1000;
-          hiddenTimestampRef.current = null;
-
-          // Increment counter and add violation
-          setTabSwitchCount((prev) => prev + 1);
-          setViolations((prev) => [
-            ...prev,
-            {
-              timestamp: new Date().toISOString(),
-              duration_seconds: duration,
-            },
-          ]);
+        if (hiddenTimestampRef.current === null) {
+          hiddenTimestampRef.current = Date.now();
         }
+        return;
+      }
+
+      setIsVisible(true);
+      if (hiddenTimestampRef.current !== null) {
+        const duration = (Date.now() - hiddenTimestampRef.current) / 1000;
+        hiddenTimestampRef.current = null;
+        setTabSwitchCount((prev) => prev + 1);
+        setViolations((prev) => [
+          ...prev,
+          {
+            timestamp: new Date().toISOString(),
+            duration_seconds: duration,
+          },
+        ]);
       }
     };
 
-    // Listen to visibility changes
-    document.addEventListener("visibilitychange", handleVisibilityChange);
+    const onVisibilityEvent = () => {
+      applyVisibilityTransition();
+    };
 
-    // Don't add blur/focus listeners - they cause infinite loops with Monaco editor
-    // The visibilitychange event is sufficient for tab switch detection
+    const scheduleReconcile = () => {
+      clearScheduledReconciles();
+      const delays = [0, 50, 120, 250];
+      delays.forEach((ms) => {
+        const id = window.setTimeout(() => {
+          applyVisibilityTransition();
+        }, ms);
+        reconcileTimerIdsRef.current.push(id);
+      });
+    };
+
+    // WebKit (Safari) older builds used webkitvisibilitychange; Gecko/Chromium use visibilitychange.
+    const docEvents = ["visibilitychange", "webkitvisibilitychange"] as const;
+
+    docEvents.forEach((evt) => {
+      document.addEventListener(evt, onVisibilityEvent);
+    });
+
+    window.addEventListener("blur", scheduleReconcile);
+    window.addEventListener("focus", scheduleReconcile);
+
+    applyVisibilityTransition();
 
     return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      clearScheduledReconciles();
+      docEvents.forEach((evt) => {
+        document.removeEventListener(evt, onVisibilityEvent);
+      });
+      window.removeEventListener("blur", scheduleReconcile);
+      window.removeEventListener("focus", scheduleReconcile);
     };
-  }, []);
+  }, [enabled]);
 
   return {
     isVisible,
@@ -78,4 +136,3 @@ export function useTabSwitchDetector(): UseTabSwitchDetectorReturn {
     clearViolations,
   };
 }
-


### PR DESCRIPTION
- Introduced a new option for tab switch detection in the proctoring hooks, allowing for better management of tab/window visibility during assessments.
- Updated the TakeAssessmentPage to conditionally enable tab switch detection based on the assessment state.
- Enhanced the useTabSwitchDetector hook to support enabling/disabling listeners based on the new option, improving performance and reducing noise during inactive sessions.