### PR TITLE
feat(auth): client 28 branded layout, teal theme, and shared auth shell

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -28,7 +28,8 @@ import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const primaryBtnSx = {
   py: 1.25,
-  background: "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+  background:
+    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
   color: "white",
   fontWeight: 600,
   fontSize: "0.9375rem",
@@ -36,11 +37,13 @@ const primaryBtnSx = {
   boxShadow: "none",
   "&:hover": {
     background:
-      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-700) 100%)",
-    boxShadow: "0 4px 12px rgba(37, 92, 121, 0.4)",
+      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
+    boxShadow:
+      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
   },
   "&:disabled": {
-    background: "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+    background:
+      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
     opacity: 0.6,
   },
 } as const;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -287,20 +287,21 @@ export default function LoginPage() {
                   py: 1.25,
                   mb: 2,
                   background:
-                    "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+                    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
                   color: "white",
                   fontWeight: 600,
                   fontSize: "0.9375rem",
                   textTransform: "none",
                   boxShadow: "none",
                   "&:hover": {
-                        background:
-                          "linear-gradient(135deg, #255c79 0%, #1e4a63 100%)",
-                    boxShadow: "0 4px 12px rgba(37, 92, 121, 0.4)",
+                    background:
+                      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
+                    boxShadow:
+                      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
                   },
                   "&:disabled": {
                     background:
-                      "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+                      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
                     opacity: 0.6,
                   },
                 }}

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -419,7 +419,7 @@ export default function SignupPage() {
                   justifyContent: "center",
                   gap: 1.25,
                   background:
-                    "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+                    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
                   color: "white",
                   fontWeight: 600,
                   fontSize: "0.9375rem",
@@ -427,12 +427,13 @@ export default function SignupPage() {
                   boxShadow: "none",
                   "&:hover": {
                     background:
-                      "linear-gradient(135deg, #255c79 0%, #1e4a63 100%)",
-                    boxShadow: "0 4px 12px rgba(37, 92, 121, 0.4)",
+                      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
+                    boxShadow:
+                      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
                   },
                   "&:disabled": {
                     background:
-                      "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+                      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
                     opacity: 0.6,
                     color: "white",
                   },

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -161,7 +161,7 @@ export default function VerifyEmailPage() {
                   py: 1.25,
                   mb: 1.5,
                   background:
-                    "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+                    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
                   color: "white",
                   fontWeight: 600,
                   fontSize: "0.9375rem",
@@ -169,12 +169,13 @@ export default function VerifyEmailPage() {
                   boxShadow: "none",
                   "&:hover": {
                     background:
-                      "linear-gradient(135deg, #255c79 0%, #1e4a63 100%)",
-                    boxShadow: "0 4px 12px rgba(37, 92, 121, 0.4)",
+                      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
+                    boxShadow:
+                      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
                   },
                   "&:disabled": {
                     background:
-                      "linear-gradient(135deg, #2a8cb0 0%,#1e4a63 100%)",
+                      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
                     opacity: 0.6,
                   },
                 }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "@/lib/auth/auth-context";
 import { ToastProvider } from "@/components/common/Toast";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
 import { EmotionCacheProvider } from "@/lib/emotion-cache";
+import { config } from "@/lib/config";
 import { getClientInfo } from "@/lib/utils/clientInfo";
 import { headers } from "next/headers";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
@@ -81,7 +82,13 @@ export default async function RootLayout({
           <ErrorBoundary>
             <I18nProvider clientId={client?.id}>
               <EmotionCacheProvider>
-                <ThemeProvider>
+                <ThemeProvider
+                  initialClientId={
+                    typeof client?.id === "number"
+                      ? client.id
+                      : Number(config.clientId)
+                  }
+                >
                   <DirectionSync />
                   <ReduxProvider>
                     <ThemeModeProvider>

--- a/components/auth/AuthLayout.tsx
+++ b/components/auth/AuthLayout.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { Box, Typography, Skeleton } from "@mui/material";
 import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import Image from "next/image";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import { resolveAuthLayoutVariant } from "@/lib/auth/auth-layout-variants";
+import { AuthLayoutShell } from "./layout/AuthLayoutShell";
+import { AuthLeftPanel } from "./layout/AuthLeftPanel";
+import { AuthRightPanelDefault } from "./layout/AuthRightPanelDefault";
+import { AuthRightPanelClient28 } from "./layout/AuthRightPanelClient28";
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -15,6 +18,7 @@ export function AuthLayout({ children, slogan }: AuthLayoutProps) {
   const { t } = useTranslation("common");
   const { clientInfo, loading: clientInfoLoading } = useClientInfo();
   const sloganText = slogan ?? t("auth.slogan");
+  const variant = resolveAuthLayoutVariant();
 
   const brandName = clientInfo?.name?.trim() || "";
   const logoUrl =
@@ -22,297 +26,23 @@ export function AuthLayout({ children, slogan }: AuthLayoutProps) {
     clientInfo?.app_logo_url?.trim() ||
     "";
 
-  /** Same gradient highlight as slogan words “the” / “world” */
-  const brandWordHighlightSx = {
-    position: "relative" as const,
-    display: "inline-block" as const,
-    "&::after": {
-      content: '""',
-      position: "absolute",
-      top: "50%",
-      left: 0,
-      right: 0,
-      height: "40%",
-      background: "linear-gradient(135deg, #f97316 0%, #ec4899 100%)",
-      borderRadius: "20px",
-      opacity: 0.3,
-      zIndex: -1,
-    },
+  const rightPanelProps = {
+    clientInfoLoading,
+    sloganText,
+    logoUrl,
+    brandName,
   };
 
   return (
-    <Box
-      sx={{
-        height: "100vh",
-        maxHeight: "100vh",
-        overflow: "hidden",
-        display: "flex",
-        flexDirection: { xs: "column", md: "row" },
-      }}
-    >
-      {/* Left Section - Form */}
-      <Box
-        sx={{
-          flex: { xs: 1, md: "0 0 50%" },
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          px: { xs: 3, sm: 4, md: 6 },
-          py: { xs: 4, md: 0 },
-          backgroundColor: "background.default",
-          overflow: "auto",
-        }}
-      >
-        {children}
-      </Box>
-
-      {/* Right Section - Branding */}
-      <Box
-        sx={{
-          flex: { xs: 0, md: "0 0 50%" },
-          display: { xs: "none", md: "flex" },
-          alignItems: "center",
-          justifyContent: "center",
-          position: "relative",
-          backgroundColor: "#f8fafc",
-          overflow: "hidden",
-          height: "100vh",
-        }}
-      >
-        {/* Abstract Shapes */}
-        <Box
-          sx={{
-            position: "absolute",
-            width: "100%",
-            height: "100%",
-            zIndex: 0,
-          }}
-        >
-          {/* Top-center primary gradient */}
-          <Box
-            sx={{
-              position: "absolute",
-              top: -100,
-              right: "20%",
-              width: 400,
-              height: 400,
-              borderRadius: "50%",
-              background:
-                "linear-gradient(135deg, var(--primary-300) 0%, var(--primary-500) 100%)",
-              opacity: 0.3,
-              filter: "blur(80px)",
-            }}
-          />
-          {/* Top-right orange */}
-          <Box
-            sx={{
-              position: "absolute",
-              top: -50,
-              right: -50,
-              width: 350,
-              height: 350,
-              borderRadius: "50%",
-              background: "linear-gradient(135deg, #f97316 0%, #fb923c 100%)",
-              opacity: 0.25,
-              filter: "blur(70px)",
-            }}
-          />
-          {/* Bottom-left pink-red gradient */}
-          <Box
-            sx={{
-              position: "absolute",
-              bottom: -100,
-              left: -100,
-              width: 500,
-              height: 500,
-              borderRadius: "50%",
-              background: "linear-gradient(135deg, #ec4899 0%, #ef4444 100%)",
-              opacity: 0.2,
-              filter: "blur(100px)",
-            }}
-          />
-          {/* Bottom-center light blue */}
-          <Box
-            sx={{
-              position: "absolute",
-              bottom: 100,
-              left: "30%",
-              width: 300,
-              height: 300,
-              borderRadius: "50%",
-              background: "linear-gradient(135deg, #60a5fa 0%, #93c5fd 100%)",
-              opacity: 0.25,
-              filter: "blur(60px)",
-            }}
-          />
-          {/* Bottom-right light purple */}
-          <Box
-            sx={{
-              position: "absolute",
-              bottom: 50,
-              right: 50,
-              width: 200,
-              height: 200,
-              borderRadius: "30%",
-              background: "linear-gradient(135deg, #c084fc 0%, #d8b4fe 100%)",
-              opacity: 0.3,
-              filter: "blur(50px)",
-            }}
-          />
-        </Box>
-
-        {/* Brand + slogan */}
-        <Box
-          sx={{
-            position: "relative",
-            zIndex: 1,
-            px: 6,
-            textAlign: "center",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            gap: 3,
-          }}
-        >
-          {clientInfoLoading ? (
-            <Box
-              sx={{
-                width: "100%",
-                maxWidth: 320,
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                textAlign: "center",
-                gap: 1.5,
-                mx: "auto",
-              }}
-            >
-              <Skeleton variant="rounded" width={200} height={56} sx={{ borderRadius: 1 }} />
-              <Skeleton variant="text" width={280} height={52} />
-            </Box>
-          ) : (
-            (logoUrl || brandName) && (
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  textAlign: "center",
-                  width: "100%",
-                  gap: 1.5,
-                  maxWidth: 600,
-                  mx: "auto",
-                }}
-              >
-                {logoUrl ? (
-                  <Box
-                    sx={{
-                      position: "relative",
-                      width: "100%",
-                      maxWidth: 280,
-                      height: { xs: 56, md: 72 },
-                      mx: "auto",
-                      alignSelf: "center",
-                    }}
-                  >
-                    <Image
-                      src={logoUrl}
-                      alt={brandName || "Logo"}
-                      fill
-                      sizes="280px"
-                      style={{ objectFit: "contain" }}
-                      priority
-                    />
-                  </Box>
-                ) : null}
-                {brandName ? (
-                  <Typography
-                    component="p"
-                    sx={{
-                      fontSize: { md: "2.75rem", lg: "3.25rem" },
-                      fontWeight: 800,
-                      lineHeight: 1.15,
-                      letterSpacing: "-0.02em",
-                      wordSpacing: "normal",
-                      color: "#1e293b",
-                      maxWidth: 720,
-                      width: "100%",
-                      m: 0,
-                      mt: logoUrl ? 0.5 : 0,
-                      mx: "auto",
-                      textAlign: "center",
-                      alignSelf: "center",
-                    }}
-                  >
-                    {brandName
-                      .split(/\s+/)
-                      .filter(Boolean)
-                      .map((word, index, words) => (
-                        <Box
-                          key={`${word}-${index}`}
-                          component="span"
-                          sx={{
-                            ...brandWordHighlightSx,
-                            marginRight:
-                              index < words.length - 1 ? "0.35em" : 0,
-                          }}
-                        >
-                          {word}
-                        </Box>
-                      ))}
-                  </Typography>
-                ) : null}
-              </Box>
-            )
-          )}
-
-          <Typography
-            variant="h2"
-            component="div"
-            sx={{
-              fontSize: { md: "3rem", lg: "4rem" },
-              fontWeight: 700,
-              lineHeight: 1.2,
-              color: "#1e293b",
-              position: "relative",
-              zIndex: 2,
-            }}
-          >
-            {sloganText.split(" ").map((word, index) => {
-              if (word === "the" || word === "world") {
-                return (
-                  <Box
-                    key={index}
-                    component="span"
-                    sx={{
-                      position: "relative",
-                      display: "inline-block",
-                      "&::after": {
-                        content: '""',
-                        position: "absolute",
-                        top: "50%",
-                        left: 0,
-                        right: 0,
-                        height: "40%",
-                        background:
-                          "linear-gradient(135deg, #f97316 0%, #ec4899 100%)",
-                        borderRadius: "20px",
-                        opacity: 0.3,
-                        zIndex: -1,
-                      },
-                    }}
-                  >
-                    {word}{" "}
-                  </Box>
-                );
-              }
-              return <span key={index}>{word} </span>;
-            })}
-          </Typography>
-        </Box>
-      </Box>
-    </Box>
+    <AuthLayoutShell
+      left={<AuthLeftPanel variant={variant}>{children}</AuthLeftPanel>}
+      right={
+        variant === "client28" ? (
+          <AuthRightPanelClient28 {...rightPanelProps} />
+        ) : (
+          <AuthRightPanelDefault {...rightPanelProps} />
+        )
+      }
+    />
   );
 }

--- a/components/auth/layout/AuthLayoutShell.tsx
+++ b/components/auth/layout/AuthLayoutShell.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Box } from "@mui/material";
+import { ReactNode } from "react";
+
+interface AuthLayoutShellProps {
+  left: ReactNode;
+  right: ReactNode;
+}
+
+export function AuthLayoutShell({ left, right }: AuthLayoutShellProps) {
+  return (
+    <Box
+      sx={{
+        height: "100vh",
+        maxHeight: "100vh",
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: { xs: "column", md: "row" },
+      }}
+    >
+      {left}
+      {right}
+    </Box>
+  );
+}

--- a/components/auth/layout/AuthLeftPanel.tsx
+++ b/components/auth/layout/AuthLeftPanel.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Box } from "@mui/material";
+import { ReactNode } from "react";
+import type { AuthLayoutVariantId } from "@/lib/auth/auth-layout-variants";
+
+interface AuthLeftPanelProps {
+  variant: AuthLayoutVariantId;
+  children: ReactNode;
+}
+
+export function AuthLeftPanel({ variant, children }: AuthLeftPanelProps) {
+  if (variant === "client28") {
+    return (
+      <Box
+        sx={{
+          flex: { xs: 1, md: "0 0 50%" },
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          px: { xs: 3, sm: 4, md: 6 },
+          py: { xs: 4, md: 0 },
+          overflow: "auto",
+          background:
+            "linear-gradient(180deg, #f8fffc 0%, #ecfdf5 35%, #f1f5f9 100%)",
+        }}
+      >
+        <Box
+          sx={{
+            width: "100%",
+            maxWidth: 440,
+            borderRadius: 2,
+            px: { xs: 2.5, sm: 3.5 },
+            py: { xs: 3, sm: 3.5 },
+            backgroundColor: "rgba(255,255,255,0.72)",
+            backdropFilter: "blur(12px)",
+            border: "1px solid rgba(15, 23, 42, 0.06)",
+            boxShadow: "0 4px 24px rgba(15, 23, 42, 0.06)",
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        flex: { xs: 1, md: "0 0 50%" },
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        px: { xs: 3, sm: 4, md: 6 },
+        py: { xs: 4, md: 0 },
+        backgroundColor: "background.default",
+        overflow: "auto",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/components/auth/layout/AuthRightPanelClient28.tsx
+++ b/components/auth/layout/AuthRightPanelClient28.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { Box, Typography, Skeleton } from "@mui/material";
+import Image from "next/image";
+import { Noto_Sans_Arabic } from "next/font/google";
+import { TextHoverEffect } from "@/components/ui/text-hover-effect";
+import { authLayoutClient28Tokens } from "@/lib/auth/auth-layout-variants";
+import { brandWordHighlightSx } from "./authBrandStyles";
+
+const notoArabic = Noto_Sans_Arabic({
+  subsets: ["arabic"],
+  weight: ["600", "700"],
+  display: "swap",
+});
+
+interface AuthRightPanelClient28Props {
+  clientInfoLoading: boolean;
+  sloganText: string;
+  logoUrl: string;
+  brandName: string;
+}
+
+export function AuthRightPanelClient28({
+  clientInfoLoading,
+  sloganText,
+  logoUrl,
+  brandName,
+}: AuthRightPanelClient28Props) {
+  const arabicFont = `${notoArabic.style.fontFamily}, "Noto Sans Arabic", sans-serif`;
+
+  return (
+    <Box
+      sx={{
+        flex: { xs: 0, md: "0 0 50%" },
+        display: { xs: "none", md: "flex" },
+        flexDirection: "column",
+        alignItems: "center",
+        position: "relative",
+        overflow: "hidden",
+        height: "100vh",
+        background:
+          "linear-gradient(165deg, #0f172a 0%, #134e4a 42%, #0f172a 100%)",
+      }}
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          zIndex: 0,
+          pointerEvents: "none",
+        }}
+      >
+        <Box
+          sx={{
+            position: "absolute",
+            top: "8%",
+            right: "12%",
+            width: 320,
+            height: 320,
+            borderRadius: "50%",
+            background: "radial-gradient(circle, rgba(45,212,191,0.18) 0%, transparent 70%)",
+            filter: "blur(40px)",
+          }}
+        />
+        <Box
+          sx={{
+            position: "absolute",
+            bottom: "5%",
+            left: "8%",
+            width: 380,
+            height: 380,
+            borderRadius: "50%",
+            background: "radial-gradient(circle, rgba(94,234,212,0.12) 0%, transparent 72%)",
+            filter: "blur(50px)",
+          }}
+        />
+      </Box>
+
+      {/* Top: Arabic INUN + Arabic LMS hover effects */}
+      <Box
+        className={notoArabic.className}
+        sx={{
+          position: "relative",
+          zIndex: 2,
+          flexShrink: 0,
+          width: "100%",
+          maxWidth: 720,
+          px: 3,
+          pt: 3,
+          pb: 1,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 2,
+        }}
+      >
+        <Box sx={{ width: "100%", height: 118, maxWidth: 560 }}>
+          <TextHoverEffect
+            text={authLayoutClient28Tokens.hoverBrandArabic}
+            duration={0.3}
+            fontSize={56}
+            viewBox="0 0 520 120"
+            fontFamily={arabicFont}
+            direction="rtl"
+            colorMode="onDark"
+            className="w-full h-full"
+          />
+        </Box>
+        <Box sx={{ width: "100%", height: 100, maxWidth: 680 }}>
+          <TextHoverEffect
+            text={authLayoutClient28Tokens.hoverLmsArabic}
+            duration={0.35}
+            fontSize={38}
+            viewBox="0 0 960 130"
+            fontFamily={arabicFont}
+            direction="rtl"
+            colorMode="onDark"
+            className="w-full h-full"
+          />
+        </Box>
+      </Box>
+
+      {/* Center: logo, title, slogan — slightly above vertical center */}
+      <Box
+        sx={{
+          position: "relative",
+          zIndex: 2,
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          width: "100%",
+          maxWidth: 560,
+          px: 4,
+          gap: 2,
+          textAlign: "center",
+          minHeight: 0,
+          transform: "translateY(clamp(-72px, -7vh, -32px))",
+        }}
+      >
+        {clientInfoLoading ? (
+          <Box
+            sx={{
+              width: "100%",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 2,
+            }}
+          >
+            <Skeleton
+              variant="rounded"
+              sx={{
+                bgcolor: "rgba(148,163,184,0.2)",
+                width: authLayoutClient28Tokens.logoMaxWidthPx,
+                height: authLayoutClient28Tokens.logoHeightMdPx,
+                borderRadius: 2,
+              }}
+            />
+            <Skeleton
+              variant="text"
+              sx={{ bgcolor: "rgba(148,163,184,0.2)", width: "85%", height: 48 }}
+            />
+            <Skeleton
+              variant="text"
+              sx={{ bgcolor: "rgba(148,163,184,0.15)", width: "70%", height: 22 }}
+            />
+          </Box>
+        ) : (
+          (logoUrl || brandName) && (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 1.25,
+                width: "100%",
+              }}
+            >
+              {logoUrl ? (
+                <Box
+                  sx={{
+                    position: "relative",
+                    width: "100%",
+                    maxWidth: authLayoutClient28Tokens.logoMaxWidthPx,
+                    height: { xs: 72, md: authLayoutClient28Tokens.logoHeightMdPx },
+                    mx: "auto",
+                  }}
+                >
+                  <Image
+                    src={logoUrl}
+                    alt={brandName || "Logo"}
+                    fill
+                    sizes={`${authLayoutClient28Tokens.logoMaxWidthPx}px`}
+                    style={{ objectFit: "contain" }}
+                    priority
+                  />
+                </Box>
+              ) : null}
+              {brandName ? (
+                <Typography
+                  component="p"
+                  sx={{
+                    m: 0,
+                    fontSize: { md: "3.25rem", lg: "3.75rem" },
+                    fontWeight: 800,
+                    lineHeight: 1.12,
+                    letterSpacing: "-0.02em",
+                    color: "#f8fafc",
+                  }}
+                >
+                  {brandName
+                    .split(/\s+/)
+                    .filter(Boolean)
+                    .map((word, index, words) => (
+                      <Box
+                        key={`${word}-${index}`}
+                        component="span"
+                        sx={{
+                          ...brandWordHighlightSx,
+                          marginRight: index < words.length - 1 ? "0.35em" : 0,
+                        }}
+                      >
+                        {word}
+                      </Box>
+                    ))}
+                </Typography>
+              ) : null}
+            </Box>
+          )
+        )}
+
+        <Typography
+          variant="h2"
+          component="div"
+          sx={{
+            fontSize: {
+              md: authLayoutClient28Tokens.sloganFontSizeMd,
+              lg: authLayoutClient28Tokens.sloganFontSizeLg,
+            },
+            fontWeight: 700,
+            lineHeight: 1.45,
+            color: "#e2e8f0",
+            position: "relative",
+            zIndex: 2,
+            maxWidth: 440,
+          }}
+        >
+          {sloganText.split(" ").map((word, index) => {
+            if (word === "the" || word === "world") {
+              return (
+                <Box
+                  key={index}
+                  component="span"
+                  sx={{
+                    position: "relative",
+                    display: "inline-block",
+                    "&::after": {
+                      content: '""',
+                      position: "absolute",
+                      top: "50%",
+                      left: 0,
+                      right: 0,
+                      height: "40%",
+                      background:
+                        "linear-gradient(135deg, #f97316 0%, #ec4899 100%)",
+                      borderRadius: "20px",
+                      opacity: 0.3,
+                      zIndex: -1,
+                    },
+                  }}
+                >
+                  {word}{" "}
+                </Box>
+              );
+            }
+            return <span key={index}>{word} </span>;
+          })}
+        </Typography>
+      </Box>
+
+      {/* Bottom: INUN — large type, anchored to viewport bottom */}
+      <Box
+        sx={{
+          position: "relative",
+          zIndex: 2,
+          flexShrink: 0,
+          width: "100%",
+          maxWidth: 720,
+          px: 3,
+          pt: 0,
+          pb: "max(0px, env(safe-area-inset-bottom, 0px))",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "flex-end",
+          minHeight: { md: "min(34vh, 300px)" },
+          height: { md: "min(34vh, 300px)" },
+        }}
+      >
+        <Box
+          sx={{
+            width: "100%",
+            height: "100%",
+            maxWidth: 640,
+            display: "flex",
+            alignItems: "flex-end",
+            justifyContent: "center",
+          }}
+        >
+          <TextHoverEffect
+            text={authLayoutClient28Tokens.hoverBrandText}
+            duration={0.3}
+            fontSize={112}
+            viewBox="0 0 520 200"
+            textYPercent="76%"
+            preserveAspectRatioProp="xMidYMax meet"
+            colorMode="onDark"
+            omitGhostLayer
+            className="w-full h-full"
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/components/auth/layout/AuthRightPanelDefault.tsx
+++ b/components/auth/layout/AuthRightPanelDefault.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { Box, Typography, Skeleton } from "@mui/material";
+import Image from "next/image";
+import { brandWordHighlightSx } from "./authBrandStyles";
+
+interface AuthRightPanelDefaultProps {
+  clientInfoLoading: boolean;
+  sloganText: string;
+  logoUrl: string;
+  brandName: string;
+}
+
+export function AuthRightPanelDefault({
+  clientInfoLoading,
+  sloganText,
+  logoUrl,
+  brandName,
+}: AuthRightPanelDefaultProps) {
+  return (
+    <Box
+      sx={{
+        flex: { xs: 0, md: "0 0 50%" },
+        display: { xs: "none", md: "flex" },
+        alignItems: "center",
+        justifyContent: "center",
+        position: "relative",
+        backgroundColor: "#f8fafc",
+        overflow: "hidden",
+        height: "100vh",
+      }}
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          width: "100%",
+          height: "100%",
+          zIndex: 0,
+        }}
+      >
+        <Box
+          sx={{
+            position: "absolute",
+            top: -100,
+            right: "20%",
+            width: 400,
+            height: 400,
+            borderRadius: "50%",
+            background:
+              "linear-gradient(135deg, var(--primary-300) 0%, var(--primary-500) 100%)",
+            opacity: 0.3,
+            filter: "blur(80px)",
+          }}
+        />
+        <Box
+          sx={{
+            position: "absolute",
+            top: -50,
+            right: -50,
+            width: 350,
+            height: 350,
+            borderRadius: "50%",
+            background: "linear-gradient(135deg, #f97316 0%, #fb923c 100%)",
+            opacity: 0.25,
+            filter: "blur(70px)",
+          }}
+        />
+        <Box
+          sx={{
+            position: "absolute",
+            bottom: -100,
+            left: -100,
+            width: 500,
+            height: 500,
+            borderRadius: "50%",
+            background: "linear-gradient(135deg, #ec4899 0%, #ef4444 100%)",
+            opacity: 0.2,
+            filter: "blur(100px)",
+          }}
+        />
+        <Box
+          sx={{
+            position: "absolute",
+            bottom: 100,
+            left: "30%",
+            width: 300,
+            height: 300,
+            borderRadius: "50%",
+            background: "linear-gradient(135deg, #60a5fa 0%, #93c5fd 100%)",
+            opacity: 0.25,
+            filter: "blur(60px)",
+          }}
+        />
+        <Box
+          sx={{
+            position: "absolute",
+            bottom: 50,
+            right: 50,
+            width: 200,
+            height: 200,
+            borderRadius: "30%",
+            background: "linear-gradient(135deg, #c084fc 0%, #d8b4fe 100%)",
+            opacity: 0.3,
+            filter: "blur(50px)",
+          }}
+        />
+      </Box>
+
+      <Box
+        sx={{
+          position: "relative",
+          zIndex: 1,
+          px: 6,
+          textAlign: "center",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 3,
+        }}
+      >
+        {clientInfoLoading ? (
+          <Box
+            sx={{
+              width: "100%",
+              maxWidth: 320,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              textAlign: "center",
+              gap: 1.5,
+              mx: "auto",
+            }}
+          >
+            <Skeleton variant="rounded" width={200} height={56} sx={{ borderRadius: 1 }} />
+            <Skeleton variant="text" width={280} height={52} />
+          </Box>
+        ) : (
+          (logoUrl || brandName) && (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                textAlign: "center",
+                width: "100%",
+                gap: 1.5,
+                maxWidth: 600,
+                mx: "auto",
+              }}
+            >
+              {logoUrl ? (
+                <Box
+                  sx={{
+                    position: "relative",
+                    width: "100%",
+                    maxWidth: 280,
+                    height: { xs: 56, md: 72 },
+                    mx: "auto",
+                    alignSelf: "center",
+                  }}
+                >
+                  <Image
+                    src={logoUrl}
+                    alt={brandName || "Logo"}
+                    fill
+                    sizes="280px"
+                    style={{ objectFit: "contain" }}
+                    priority
+                  />
+                </Box>
+              ) : null}
+              {brandName ? (
+                <Typography
+                  component="p"
+                  sx={{
+                    fontSize: { md: "2.75rem", lg: "3.25rem" },
+                    fontWeight: 800,
+                    lineHeight: 1.15,
+                    letterSpacing: "-0.02em",
+                    wordSpacing: "normal",
+                    color: "#1e293b",
+                    maxWidth: 720,
+                    width: "100%",
+                    m: 0,
+                    mt: logoUrl ? 0.5 : 0,
+                    mx: "auto",
+                    textAlign: "center",
+                    alignSelf: "center",
+                  }}
+                >
+                  {brandName
+                    .split(/\s+/)
+                    .filter(Boolean)
+                    .map((word, index, words) => (
+                      <Box
+                        key={`${word}-${index}`}
+                        component="span"
+                        sx={{
+                          ...brandWordHighlightSx,
+                          marginRight: index < words.length - 1 ? "0.35em" : 0,
+                        }}
+                      >
+                        {word}
+                      </Box>
+                    ))}
+                </Typography>
+              ) : null}
+            </Box>
+          )
+        )}
+
+        <Typography
+          variant="h2"
+          component="div"
+          sx={{
+            fontSize: { md: "3rem", lg: "4rem" },
+            fontWeight: 700,
+            lineHeight: 1.2,
+            color: "#1e293b",
+            position: "relative",
+            zIndex: 2,
+          }}
+        >
+          {sloganText.split(" ").map((word, index) => {
+            if (word === "the" || word === "world") {
+              return (
+                <Box
+                  key={index}
+                  component="span"
+                  sx={{
+                    position: "relative",
+                    display: "inline-block",
+                    "&::after": {
+                      content: '""',
+                      position: "absolute",
+                      top: "50%",
+                      left: 0,
+                      right: 0,
+                      height: "40%",
+                      background:
+                        "linear-gradient(135deg, #f97316 0%, #ec4899 100%)",
+                      borderRadius: "20px",
+                      opacity: 0.3,
+                      zIndex: -1,
+                    },
+                  }}
+                >
+                  {word}{" "}
+                </Box>
+              );
+            }
+            return <span key={index}>{word} </span>;
+          })}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/components/auth/layout/authBrandStyles.ts
+++ b/components/auth/layout/authBrandStyles.ts
@@ -1,0 +1,17 @@
+/** Shared word-highlight style for default auth right panel (brand + slogan). */
+export const brandWordHighlightSx = {
+  position: "relative" as const,
+  display: "inline-block" as const,
+  "&::after": {
+    content: '""',
+    position: "absolute",
+    top: "50%",
+    left: 0,
+    right: 0,
+    height: "40%",
+    background: "linear-gradient(135deg, #f97316 0%, #ec4899 100%)",
+    borderRadius: "20px",
+    opacity: 0.3,
+    zIndex: -1,
+  },
+};

--- a/components/providers/ClientThemeProvider.tsx
+++ b/components/providers/ClientThemeProvider.tsx
@@ -1,12 +1,38 @@
 "use client";
 
 import { useEffect } from "react";
+import { config } from "@/lib/config";
+import {
+  CLIENT_28_EXTRA_CSS_VARS,
+  isClient28Theme,
+  mergeClient28ThemeSettings,
+} from "@/lib/theme/client28-theme";
+
+function resolveClientId(client: { id?: number } | null | undefined): number {
+  const fromApi = client?.id;
+  if (typeof fromApi === "number" && Number.isFinite(fromApi)) return fromApi;
+  const fromEnv = Number(config.clientId);
+  return Number.isFinite(fromEnv) ? fromEnv : NaN;
+}
 
 /** Default export so `next/dynamic` can load this module without Turbopack SSR factory issues. */
 export default function ClientThemeProvider({ client }: { client: any }) {
   useEffect(() => {
-    if (!client?.theme_settings) return;
-    const themeSettings = client.theme_settings;
+    const resolvedId = resolveClientId(client);
+    const api = client?.theme_settings;
+    const apiIsEmpty =
+      !api || (typeof api === "object" && Object.keys(api).length === 0);
+
+    let themeSettings: Record<string, string> | null = null;
+    if (isClient28Theme(resolvedId)) {
+      themeSettings = mergeClient28ThemeSettings(
+        apiIsEmpty ? undefined : api
+      );
+    } else if (!apiIsEmpty) {
+      themeSettings = api;
+    }
+
+    if (!themeSettings) return;
 
     document.body.style.setProperty("--primary-50", themeSettings.primary50);
     document.body.style.setProperty("--primary-100", themeSettings.primary100);
@@ -121,6 +147,12 @@ export default function ClientThemeProvider({ client }: { client: any }) {
     document.body.style.setProperty("--font-dark", themeSettings.fontDark);
     document.body.style.setProperty("--background", "#ffffff");
     document.body.style.setProperty("--foreground", "#171717");
+
+    if (isClient28Theme(resolvedId)) {
+      for (const [cssVar, value] of Object.entries(CLIENT_28_EXTRA_CSS_VARS)) {
+        document.body.style.setProperty(cssVar, value);
+      }
+    }
   }, [client]);
 
   return null;

--- a/components/providers/ThemeProvider.tsx
+++ b/components/providers/ThemeProvider.tsx
@@ -7,20 +7,35 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { createTheme } from "@mui/material/styles";
 import { theme as baseTheme } from "@/lib/theme";
 import { isRtl } from "@/lib/i18n";
+import { client28MuiPrimary, isClient28Theme } from "@/lib/theme/client28-theme";
 
 interface ThemeProviderProps {
   children: React.ReactNode;
+  /** From server `getClientInfo` so MUI matches CSS vars before client fetch completes. */
+  initialClientId?: number;
 }
 
-export function ThemeProvider({ children }: ThemeProviderProps) {
+export function ThemeProvider({
+  children,
+  initialClientId,
+}: ThemeProviderProps) {
   const { i18n } = useTranslation();
   const lng = i18n.language || "en";
   const direction = isRtl(lng) ? "rtl" : "ltr";
 
-  const theme = useMemo(
-    () => createTheme({ ...baseTheme, direction }),
-    [direction]
-  );
+  const theme = useMemo(() => {
+    const palette = isClient28Theme(initialClientId)
+      ? {
+          ...baseTheme.palette,
+          primary: { ...baseTheme.palette.primary, ...client28MuiPrimary },
+        }
+      : baseTheme.palette;
+    return createTheme({
+      ...baseTheme,
+      direction,
+      palette,
+    });
+  }, [direction, initialClientId]);
 
   return (
     <MuiThemeProvider theme={theme}>

--- a/components/ui/text-hover-effect.tsx
+++ b/components/ui/text-hover-effect.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import React, { useEffect, useId, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Aceternity-style SVG text hover (gradient reveal + stroke).
+ * Vendored for Next 16 + Tailwind v4 without shadcn CLI.
+ */
+export function TextHoverEffect({
+  text,
+  duration = 0.25,
+  className,
+  fontSize = 56,
+  viewBox = "0 0 320 100",
+  fontFamily = "system-ui, sans-serif",
+  direction = "ltr",
+  colorMode = "default",
+  /** Vertical position of text in viewBox (SVG %), e.g. "72%" to sit lower */
+  textYPercent = "58%",
+  /** e.g. xMidYMax meet anchors content to bottom of the SVG viewport */
+  preserveAspectRatioProp = "xMidYMid meet",
+  /** Single clean face: skip faint ghost layer (fixes “double font” on large Latin glyphs) */
+  omitGhostLayer = false,
+}: {
+  text: string;
+  duration?: number;
+  className?: string;
+  /** SVG text font size (px) */
+  fontSize?: number;
+  /** e.g. "0 0 900 120" for longer Arabic phrases */
+  viewBox?: string;
+  fontFamily?: string;
+  direction?: "ltr" | "rtl";
+  /** Higher-contrast strokes on dark backgrounds */
+  colorMode?: "default" | "onDark";
+  textYPercent?: string;
+  preserveAspectRatioProp?: string;
+  omitGhostLayer?: boolean;
+}) {
+  const uid = useId().replace(/:/g, "");
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [cursor, setCursor] = useState({ x: 0, y: 0 });
+  const [hovered, setHovered] = useState(false);
+  const [maskPosition, setMaskPosition] = useState({ cx: "50%", cy: "50%" });
+
+  const gid = `th-${uid}`;
+  const strokeDash = Math.max(1400, text.length * 160);
+
+  const strokeGhost =
+    colorMode === "onDark"
+      ? "rgba(148, 163, 184, 0.45)"
+      : "rgba(148, 163, 184, 0.35)";
+  const strokeMotion =
+    colorMode === "onDark"
+      ? "rgba(226, 232, 240, 0.45)"
+      : "rgba(51, 65, 85, 0.85)";
+
+  useEffect(() => {
+    if (!svgRef.current) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const w = rect.width || 1;
+    const h = rect.height || 1;
+    const cx = ((cursor.x - rect.left) / w) * 100;
+    const cy = ((cursor.y - rect.top) / h) * 100;
+    setMaskPosition({ cx: `${cx}%`, cy: `${cy}%` });
+  }, [cursor]);
+
+  const textStyle: React.CSSProperties = {
+    fontSize,
+    fontWeight: 700,
+    fontFamily,
+    direction,
+    unicodeBidi: direction === "rtl" ? "embed" : "normal",
+    /** Keeps stacked strokes aligned to the same glyph outline */
+    paintOrder: "stroke fill",
+  };
+
+  const strokeW = Math.max(0.9, fontSize / 48);
+
+  return (
+    <svg
+      ref={svgRef}
+      width="100%"
+      height="100%"
+      viewBox={viewBox}
+      preserveAspectRatio={preserveAspectRatioProp}
+      xmlns="http://www.w3.org/2000/svg"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onMouseMove={(e) => setCursor({ x: e.clientX, y: e.clientY })}
+      className={cn("select-none", className)}
+      aria-hidden
+    >
+      <defs>
+        <radialGradient
+          id={`${gid}-radial`}
+          gradientUnits="userSpaceOnUse"
+          r="32%"
+          cx={maskPosition.cx}
+          cy={maskPosition.cy}
+        >
+          <stop offset="0%" stopColor="white" />
+          <stop offset="100%" stopColor="black" />
+        </radialGradient>
+        <linearGradient id={`${gid}-line`} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#99f6e4" />
+          <stop offset="45%" stopColor="#2dd4bf" />
+          <stop offset="100%" stopColor="#0f766e" />
+        </linearGradient>
+        <mask id={`${gid}-mask`}>
+          <rect
+            x="0"
+            y="0"
+            width="100%"
+            height="100%"
+            fill={`url(#${gid}-radial)`}
+          />
+        </mask>
+      </defs>
+      {!omitGhostLayer ? (
+        <text
+          x="50%"
+          y={textYPercent}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          strokeWidth={strokeW}
+          fill="transparent"
+          stroke={strokeGhost}
+          style={{
+            ...textStyle,
+            opacity: hovered ? 0.6 : colorMode === "onDark" ? 0.3 : 0.22,
+          }}
+        >
+          {text}
+        </text>
+      ) : null}
+      <text
+        x="50%"
+        y={textYPercent}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        strokeWidth={strokeW}
+        fill="transparent"
+        stroke={strokeMotion}
+        style={{
+          strokeDasharray: strokeDash,
+          strokeDashoffset: hovered ? 0 : strokeDash,
+          ...textStyle,
+          transition: `stroke-dashoffset ${duration}s ease-in-out`,
+        }}
+      >
+        {text}
+      </text>
+      <text
+        x="50%"
+        y={textYPercent}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        strokeWidth={strokeW}
+        fill="transparent"
+        stroke={`url(#${gid}-line)`}
+        mask={`url(#${gid}-mask)`}
+        style={textStyle}
+      >
+        {text}
+      </text>
+    </svg>
+  );
+}

--- a/lib/auth/auth-layout-variants.ts
+++ b/lib/auth/auth-layout-variants.ts
@@ -1,0 +1,29 @@
+import { config } from "@/lib/config";
+import { CLIENT_28_ID } from "@/lib/theme/client28-theme";
+
+export type AuthLayoutVariantId = "default" | "client28";
+
+/**
+ * Resolves auth landing layout variant from deployment client id (env).
+ * Add new branches here as more clients get custom auth shells.
+ */
+export function resolveAuthLayoutVariant(): AuthLayoutVariantId {
+  const id = Number(config.clientId);
+  if (!Number.isFinite(id)) return "default";
+  if (id === CLIENT_28_ID) return "client28";
+  return "default";
+}
+
+export const authLayoutClient28Tokens = {
+  logoMaxWidthPx: 520,
+  logoHeightMdPx: 132,
+  /** Smaller than default landing slogan (3rem / 4rem) */
+  sloganFontSizeMd: "0.875rem",
+  sloganFontSizeLg: "0.9375rem",
+  /** Latin hover effect (large, bottom panel) */
+  hoverBrandText: "INUN",
+  /** Arabic transliteration for INUN (phonetic) */
+  hoverBrandArabic: "إينون",
+  /** Learning management system in Arabic */
+  hoverLmsArabic: "نظام إدارة التعلم",
+} as const;

--- a/lib/theme/client28-theme.ts
+++ b/lib/theme/client28-theme.ts
@@ -1,0 +1,137 @@
+/**
+ * Client 28 (INUN): teal / emerald CSS variables and MUI palette so the app
+ * matches the auth landing gradient instead of default blue primaries.
+ */
+
+export const CLIENT_28_ID = 28;
+
+/** Keys we always re-apply after API theme so blues cannot win. */
+const CLIENT_28_STICKY_KEYS = [
+  "primary50",
+  "primary100",
+  "primary200",
+  "primary300",
+  "primary400",
+  "primary500",
+  "primary600",
+  "primary700",
+  "primary800",
+  "primary900",
+  "navBackground",
+  "fontDarkNav",
+  "secondary400",
+  "secondary500",
+  "navSelected",
+  "secondary600",
+  "secondary700",
+  "accentBlue",
+  "accentTeal",
+  "courseCta",
+  "defaultPrimary",
+] as const;
+
+type StickyKey = (typeof CLIENT_28_STICKY_KEYS)[number];
+
+/** Full baseline when API omits fields; aligns with globals.css non-blue tokens. */
+export const CLIENT_28_THEME_COMPLETE: Record<string, string> = {
+  primary50: "#ecfdf5",
+  primary100: "#d1fae5",
+  primary200: "#a7f3d0",
+  primary300: "#6ee7b7",
+  primary400: "#34d399",
+  primary500: "#10b981",
+  primary600: "#059669",
+  primary700: "#047857",
+  primary800: "#065f46",
+  primary900: "#064e3b",
+
+  secondary50: "#ecfdf5",
+  secondary100: "#ccfbf1",
+  secondary200: "#5eead4",
+  secondary300: "#ae0606",
+  secondary400: "#0d9488",
+  secondary500: "#134e4a",
+  navSelected: "#115e59",
+  secondary600: "#0f766e",
+  secondary700: "#134e4a",
+
+  navBackground: "#d1fae5",
+  fontDarkNav: "#064e3b",
+  fontLightNav: "#ffffff",
+
+  accentYellow: "#facc15",
+  accentBlue: "#14b8a6",
+  accentGreen: "#38a169",
+  accentRed: "#e53e3e",
+  accentOrange: "#dd6b20",
+  accentTeal: "#0d9488",
+  accentPurple: "#805ad5",
+  accentPink: "#d53f8c",
+
+  neutral50: "#f8f9fa",
+  neutral100: "#e9ecef",
+  neutral200: "#dde2e6",
+  neutral300: "#6c757d",
+  neutral400: "#495057",
+  neutral500: "#343a40",
+  neutral600: "#2d3748",
+  neutral700: "#1e1e1e",
+  neutral800: "#1a1a1a",
+
+  success50: "#ecfdf5",
+  success100: "#a7f3d0",
+  success500: "#059669",
+
+  warning100: "#fff8e6",
+  warning500: "#ffb800",
+
+  error100: "#ffe6e6",
+  error500: "#ea4335",
+  error600: "#ae0606",
+
+  fontLight: "#ffffff",
+  courseCta: "#10b981",
+  defaultPrimary: "#0f766e",
+  fontDark: "#000000",
+};
+
+function pickSticky(
+  source: Record<string, string>
+): Record<StickyKey, string> {
+  const out = {} as Record<StickyKey, string>;
+  for (const k of CLIENT_28_STICKY_KEYS) {
+    out[k] = source[k];
+  }
+  return out;
+}
+
+/**
+ * Merge API theme with client-28 teal palette; sticky keys override API blues.
+ */
+export function mergeClient28ThemeSettings(
+  api: Record<string, string> | null | undefined
+): Record<string, string> {
+  const base = { ...CLIENT_28_THEME_COMPLETE, ...(api || {}) };
+  return { ...base, ...pickSticky(CLIENT_28_THEME_COMPLETE) };
+}
+
+export function isClient28Theme(clientId: unknown): boolean {
+  return Number(clientId) === CLIENT_28_ID;
+}
+
+/** Extra body CSS vars not driven by theme_settings today (blue-tinted defaults in globals). */
+export const CLIENT_28_EXTRA_CSS_VARS: Record<string, string> = {
+  "--accent-blue-light": "#14b8a6",
+  "--surface-blue-light": "#ccfbf1",
+  "--accent-indigo": "#0d9488",
+  "--accent-indigo-dark": "#0f766e",
+  "--surface-indigo-light": "#ecfdf5",
+  "--chart-articles": "#134e4a",
+};
+
+export const client28MuiPrimary = {
+  main: "#0d9488",
+  light: "#2dd4bf",
+  dark: "#0f766e",
+  contrastText: "#ffffff",
+} as const;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Minimal className merge (no tailwind-merge) for UI primitives.
+ * Prefer explicit classes; expand later with clsx + tailwind-merge if needed.
+ */
+export function cn(...inputs: Array<string | undefined | null | false>): string {
+  return inputs.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
- Add auth layout variants (default vs client 28) via env client id
- Client 28 right panel: Arabic/Latin TextHoverEffect, logo block, mint gradient
- Client 28 left panel: glass card on soft green-tinted background
- Vendored TextHoverEffect: omitGhostLayer and stroke tweaks for crisp INUN type
- Client 28 theme: merge teal CSS variables over API settings; MUI primary teal
- Map accent-blue-light, indigo surfaces, and chart-articles to teal for client 28
- Auth primary buttons use var(--primary-*) gradients for theme-aware CTAs
- Root layout passes initialClientId for MUI; ClientThemeProvider resolves id from env fallback