### PR TITLE
feat(assessment): add live streaming configuration to assessment creation and editing

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -50,6 +50,7 @@ import { PaginationControls } from "@/components/admin/assessment/PaginationCont
 import { ProblemDescription } from "@/components/coding/ProblemDescription";
 import { useAuth } from "@/lib/auth/auth-context";
 import { isCourseManagerRole } from "@/lib/auth/auth-utils";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { generateAssessmentResultPdfVector } from "@/lib/utils/assessment-result-pdf.utils";
 import {
   mapSubmissionsExportRowToAssessmentResult,
@@ -232,6 +233,9 @@ export default function AssessmentEditPage() {
   const params = useParams();
   const searchParams = useSearchParams();
   const { user, loading: authLoading } = useAuth();
+  const { clientInfo } = useClientInfo();
+  const canConfigureLiveStreaming =
+    clientInfo?.live_proctoring_enabled === true;
   const hideAdminQuestions = isCourseManagerRole(user?.role);
   const readOnly =
     hideAdminQuestions || searchParams.get("readonly") === "1";
@@ -261,6 +265,7 @@ export default function AssessmentEditPage() {
   const [courseIds, setCourseIds] = useState<number[]>([]);
   const [colleges, setColleges] = useState<string[]>([]);
   const [proctoringEnabled, setProctoringEnabled] = useState(true);
+  const [liveStreaming, setLiveStreaming] = useState(false);
   const [sendCommunication, setSendCommunication] = useState(false);
   const [showResult, setShowResult] = useState(true);
 
@@ -312,6 +317,7 @@ export default function AssessmentEditPage() {
       setCourseIds(loadedCourseIds);
       setColleges(Array.isArray((data as any).colleges) ? (data as any).colleges : []);
       setProctoringEnabled((data as any).proctoring_enabled ?? true);
+      setLiveStreaming((data as any).live_streaming ?? false);
       setSendCommunication((data as any).send_communication ?? false);
       setShowResult((data as any).show_result ?? true);
     } catch (e: any) {
@@ -441,6 +447,7 @@ export default function AssessmentEditPage() {
         currency: isPaid ? currency : undefined,
         is_active: isActive,
         proctoring_enabled: proctoringEnabled,
+        live_streaming: canConfigureLiveStreaming ? liveStreaming : false,
         send_communication: sendCommunication,
         show_result: showResult,
         course_ids: courseIds,
@@ -884,6 +891,8 @@ export default function AssessmentEditPage() {
                   loadingCourses={loadingCourses}
                   colleges={colleges}
                   proctoringEnabled={proctoringEnabled}
+                  liveStreaming={liveStreaming}
+                  showLiveStreamingToggle={canConfigureLiveStreaming}
                   sendCommunication={sendCommunication}
                   showResult={showResult}
                   onDurationChange={setDurationMinutes}
@@ -896,6 +905,7 @@ export default function AssessmentEditPage() {
                   onCourseIdsChange={setCourseIds}
                   onCollegesChange={setColleges}
                   onProctoringEnabledChange={setProctoringEnabled}
+                  onLiveStreamingChange={setLiveStreaming}
                   onSendCommunicationChange={setSendCommunication}
                   onShowResultChange={setShowResult}
                   readOnly={readOnly}

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/auth-context";
 import { isCourseManagerRole } from "@/lib/auth/auth-utils";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import {
   Box,
   Typography,
@@ -43,6 +44,9 @@ export default function CreateAssessmentPage() {
   const { showToast } = useToast();
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
+  const { clientInfo } = useClientInfo();
+  const canConfigureLiveStreaming =
+    clientInfo?.live_proctoring_enabled === true;
 
   useEffect(() => {
     if (authLoading) return;
@@ -68,6 +72,7 @@ export default function CreateAssessmentPage() {
   const [courseIds, setCourseIds] = useState<number[]>([]);
   const [colleges, setColleges] = useState<string[]>([]);
   const [proctoringEnabled, setProctoringEnabled] = useState(true);
+  const [liveStreaming, setLiveStreaming] = useState(false);
   const [sendCommunication, setSendCommunication] = useState(false);
   const [showResult, setShowResult] = useState(true);
 
@@ -640,6 +645,7 @@ export default function CreateAssessmentPage() {
         currency: isPaid ? currency : undefined,
         is_active: isActive,
         proctoring_enabled: proctoringEnabled,
+        live_streaming: canConfigureLiveStreaming ? liveStreaming : false,
         send_communication: sendCommunication,
         show_result: showResult,
       };
@@ -785,6 +791,8 @@ export default function CreateAssessmentPage() {
               loadingCourses={loadingCourses}
               colleges={colleges}
               proctoringEnabled={proctoringEnabled}
+              liveStreaming={liveStreaming}
+              showLiveStreamingToggle={canConfigureLiveStreaming}
               sendCommunication={sendCommunication}
               showResult={showResult}
               onDurationChange={setDurationMinutes}
@@ -797,6 +805,7 @@ export default function CreateAssessmentPage() {
               onCourseIdsChange={setCourseIds}
               onCollegesChange={setColleges}
               onProctoringEnabledChange={setProctoringEnabled}
+              onLiveStreamingChange={setLiveStreaming}
               onSendCommunicationChange={setSendCommunication}
               onShowResultChange={setShowResult}
             />

--- a/components/admin/assessment/AssessmentSettingsSection.tsx
+++ b/components/admin/assessment/AssessmentSettingsSection.tsx
@@ -27,6 +27,8 @@ interface AssessmentSettingsSectionProps {
   currency: string;
   isActive: boolean;
   proctoringEnabled: boolean;
+  liveStreaming: boolean;
+  showLiveStreamingToggle?: boolean;
   sendCommunication: boolean;
   showResult: boolean;
   courseIds: number[];
@@ -41,6 +43,7 @@ interface AssessmentSettingsSectionProps {
   onCurrencyChange: (value: string) => void;
   onActiveChange: (value: boolean) => void;
   onProctoringEnabledChange: (value: boolean) => void;
+  onLiveStreamingChange: (value: boolean) => void;
   onSendCommunicationChange: (value: boolean) => void;
   onShowResultChange: (value: boolean) => void;
   onCourseIdsChange: (value: number[]) => void;
@@ -57,6 +60,8 @@ export function AssessmentSettingsSection({
   currency,
   isActive,
   proctoringEnabled,
+  liveStreaming,
+  showLiveStreamingToggle = false,
   sendCommunication,
   showResult,
   courseIds,
@@ -71,6 +76,7 @@ export function AssessmentSettingsSection({
   onCurrencyChange,
   onActiveChange,
   onProctoringEnabledChange,
+  onLiveStreamingChange,
   onSendCommunicationChange,
   onShowResultChange,
   onCourseIdsChange,
@@ -280,6 +286,18 @@ export function AssessmentSettingsSection({
             }
             label="Proctoring Enabled"
           />
+          {showLiveStreamingToggle && (
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={liveStreaming}
+                  onChange={(e) => onLiveStreamingChange(e.target.checked)}
+                  disabled={readOnly}
+                />
+              }
+              label="Live Streaming"
+            />
+          )}
           <FormControlLabel
             control={
               <Switch

--- a/components/admin/assessment/AssessmentTable.tsx
+++ b/components/admin/assessment/AssessmentTable.tsx
@@ -134,6 +134,11 @@ export function AssessmentTable({
     return { display, full };
   };
 
+  const canAccessLiveMonitor = (assessment: Assessment): boolean =>
+    liveProctoringEnabled &&
+    assessment.live_streaming === true &&
+    isProctoredAssessmentInLiveWindow(assessment);
+
   // Mobile Card View
   if (isMobile) {
     return (
@@ -214,8 +219,7 @@ export function AssessmentTable({
                         }}
                       />
                     )}
-                    {liveProctoringEnabled &&
-                      isProctoredAssessmentInLiveWindow(assessment) && (
+                    {canAccessLiveMonitor(assessment) && (
                       <Chip
                         component={Link}
                         href={`/admin/assessment/${assessment.id}/live-monitor`}
@@ -233,7 +237,7 @@ export function AssessmentTable({
                           textDecoration: "none",
                         }}
                       />
-                      )}
+                    )}
                     <Chip
                       label={assessment.is_active ? "Active" : "Inactive"}
                       size="small"
@@ -454,8 +458,7 @@ export function AssessmentTable({
                       <ListItemText>{actionsReadOnly ? "View" : "View / Edit"}</ListItemText>
                     </MenuItem>
                   )}
-                  {liveProctoringEnabled &&
-                    isProctoredAssessmentInLiveWindow(assessment) && (
+                  {canAccessLiveMonitor(assessment) && (
                     <MenuItem
                       component={Link}
                       href={`/admin/assessment/${assessment.id}/live-monitor`}
@@ -836,8 +839,7 @@ export function AssessmentTable({
                           }}
                         />
                       )}
-                      {liveProctoringEnabled &&
-                        isProctoredAssessmentInLiveWindow(assessment) && (
+                      {canAccessLiveMonitor(assessment) && (
                         <Chip
                           component={Link}
                           href={`/admin/assessment/${assessment.id}/live-monitor`}
@@ -856,7 +858,7 @@ export function AssessmentTable({
                             textDecoration: "none",
                           }}
                         />
-                        )}
+                      )}
                     </Stack>
 
                     {/* Time Information */}
@@ -1127,8 +1129,7 @@ export function AssessmentTable({
                           <ListItemText>{actionsReadOnly ? "View" : "View / Edit"}</ListItemText>
                         </MenuItem>
                       )}
-                      {liveProctoringEnabled &&
-                        isProctoredAssessmentInLiveWindow(assessment) && (
+                      {canAccessLiveMonitor(assessment) && (
                         <MenuItem
                           component={Link}
                           href={`/admin/assessment/${assessment.id}/live-monitor`}

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -124,6 +124,7 @@ export interface CreateAssessmentPayload {
   currency?: string;
   is_active?: boolean;
   proctoring_enabled?: boolean;
+  live_streaming?: boolean;
   /** Whether to send notification email to students */
   send_communication?: boolean;
   /** Whether to show results to students after submission (default true) */
@@ -167,6 +168,7 @@ export interface Assessment {
   price: string | number | null;
   is_active: boolean;
   proctoring_enabled?: boolean;
+  live_streaming?: boolean;
   start_time?: string | null;
   end_time?: string | null;
   created_at: string;
@@ -182,6 +184,7 @@ export interface AssessmentDetail extends Assessment {
   start_time?: string | null;
   end_time?: string | null;
   proctoring_enabled?: boolean;
+  live_streaming?: boolean;
   course_ids?: number[];
   currency?: string;
   quiz_sections?: Array<{


### PR DESCRIPTION


- Integrated live streaming options in both CreateAssessmentPage and AssessmentEditPage.
- Updated AssessmentSettingsSection to include a toggle for live streaming, conditionally displayed based on user permissions.
- Enhanced AssessmentTable to manage live streaming visibility and access during assessments.
- Modified assessment service interfaces to support live streaming data in payloads.