### PR TITLE
feat(jobs-v2): passout year display, admin form rules, location UX

### DIFF
--- a/app/admin/jobs-v2/[id]/page.tsx
+++ b/app/admin/jobs-v2/[id]/page.tsx
@@ -21,9 +21,10 @@ import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { adminJobsV2Service } from "@/lib/services/admin/admin-jobs-v2.service";
 import type { JobV2 } from "@/lib/services/jobs-v2.service";
+import { formatJobPassoutYear } from "@/lib/services/jobs-v2.service";
 import { config } from "@/lib/config";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
-import { MapPin, Briefcase, Tag, Calendar, Clock, ExternalLink, Users, FileText, Heart } from "lucide-react";
+import { MapPin, Briefcase, Tag, Calendar, Clock, ExternalLink, Users, FileText, Heart, GraduationCap } from "lucide-react";
 const JOB_STATUS_STYLES: Record<string, { bg: string; color: string }> = {
   active: { bg: "rgba(34, 197, 94, 0.12)", color: "#16a34a" },
   inactive: { bg: "rgba(99, 102, 241, 0.12)", color: "#6366f1" },
@@ -99,10 +100,13 @@ const InfoPill = ({
   icon,
   label,
   value,
+  multiline = false,
 }: {
   icon: React.ReactNode;
   label: string;
   value: string;
+  /** Full-width row with wrapped text (e.g. long addresses). */
+  multiline?: boolean;
 }) => (
   <Box
     sx={{
@@ -114,9 +118,10 @@ const InfoPill = ({
       borderRadius: 2,
       backgroundColor: "#fff",
       border: "1px solid",
-      borderColor: "rgba(0,0,0,0.06)",
-      flex: "1 1 160px",
-      minWidth: 0,
+      borderColor: multiline ? "rgba(99, 102, 241, 0.18)" : "rgba(0,0,0,0.06)",
+      flex: multiline ? "1 1 100%" : "1 1 160px",
+      minWidth: multiline ? "100%" : 0,
+      maxWidth: multiline ? "100%" : undefined,
       transition: "all 0.2s ease",
       "&:hover": {
         borderColor: "rgba(99, 102, 241, 0.2)",
@@ -125,11 +130,41 @@ const InfoPill = ({
     }}
   >
     <Box sx={{ color: "#6366f1", flexShrink: 0, mt: 0.25 }}>{icon}</Box>
-    <Box sx={{ minWidth: 0 }}>
-      <Typography variant="caption" color="text.secondary" sx={{ display: "block", lineHeight: 1.3, fontWeight: 500, textTransform: "uppercase", letterSpacing: "0.04em", fontSize: "0.7rem" }}>
+    <Box sx={{ minWidth: 0, flex: multiline ? 1 : undefined }}>
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{
+          display: "block",
+          lineHeight: 1.3,
+          fontWeight: 500,
+          textTransform: "uppercase",
+          letterSpacing: "0.04em",
+          fontSize: "0.7rem",
+        }}
+      >
         {label}
       </Typography>
-      <Typography variant="body2" sx={{ fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: "#0f172a", mt: 0.25 }}>
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: 600,
+          color: "#0f172a",
+          mt: 0.25,
+          ...(multiline
+            ? {
+                whiteSpace: "normal",
+                wordBreak: "break-word",
+                overflowWrap: "anywhere",
+                lineHeight: 1.55,
+              }
+            : {
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }),
+        }}
+      >
         {value}
       </Typography>
     </Box>
@@ -222,6 +257,7 @@ export default function JobDetailPage() {
   const skills = [...(job.mandatory_skills ?? []), ...(job.key_skills ?? [])].filter(Boolean);
   const courses = job.courses ?? [];
   const collegeMappings = job.college_mappings ?? [];
+  const passoutYearDisplay = formatJobPassoutYear(job.applicable_passout_year);
 
   return (
     <MainLayout>
@@ -243,7 +279,20 @@ export default function JobDetailPage() {
             Jobs
           </Button>
           <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 400 }}>/</Typography>
-          <Typography variant="body2" sx={{ fontWeight: 600, color: "#0f172a", maxWidth: 280, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontWeight: 600,
+              color: "#0f172a",
+              flex: 1,
+              minWidth: 0,
+              lineHeight: 1.35,
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
             {job.job_title}
           </Typography>
         </Box>
@@ -439,16 +488,24 @@ export default function JobDetailPage() {
           </Box>
         </Paper>
 
-        {/* Quick info pills */}
+        {/* Quick info: location on its own full-width row so long addresses are readable */}
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, mb: 3 }}>
           {job.location && (
-            <InfoPill icon={<MapPin size={18} />} label="Location" value={job.location} />
+            <InfoPill
+              multiline
+              icon={<MapPin size={18} />}
+              label="Location"
+              value={job.location}
+            />
           )}
           {job.years_of_experience && (
             <InfoPill icon={<Briefcase size={18} />} label="Experience" value={job.years_of_experience} />
           )}
           {job.salary && (
             <InfoPill icon={<Tag size={18} />} label="Salary" value={job.salary} />
+          )}
+          {passoutYearDisplay && (
+            <InfoPill icon={<GraduationCap size={18} />} label="Passout year" value={passoutYearDisplay} />
           )}
           {job.number_of_openings != null && (
             <InfoPill icon={<Users size={18} />} label="Openings" value={String(job.number_of_openings)} />
@@ -614,6 +671,11 @@ export default function JobDetailPage() {
               {job.education && (
                 <SectionCard title="Education" icon="mdi:school-outline">
                   <Typography variant="body2" sx={{ color: "#475569", fontWeight: 500 }}>{job.education}</Typography>
+                </SectionCard>
+              )}
+              {passoutYearDisplay && (
+                <SectionCard title="Applicable passout year" icon="mdi:calendar-outline">
+                  <Typography variant="body2" sx={{ color: "#475569", fontWeight: 500 }}>{passoutYearDisplay}</Typography>
                 </SectionCard>
               )}
               {job.role_category && (

--- a/app/jobs-v2/[id]/page.tsx
+++ b/app/jobs-v2/[id]/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mui/material";
 import { ArrowLeft, ExternalLink, MapPin, Briefcase, Calendar, Heart, Banknote, FileText, Building2, Users, GraduationCap } from "lucide-react";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { jobsV2Service, JobV2 } from "@/lib/services/jobs-v2.service";
+import { jobsV2Service, JobV2, formatJobPassoutYear } from "@/lib/services/jobs-v2.service";
 import { useToast } from "@/components/common/Toast";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useAdminMode } from "@/lib/contexts/AdminModeContext";
@@ -213,6 +213,8 @@ export default function JobDetailPage() {
     ...(job.key_skills ?? []),
   ].filter(Boolean);
 
+  const passoutYearDisplay = formatJobPassoutYear(job.applicable_passout_year);
+
   return (
     <MainLayout>
       <Box sx={{ minHeight: "calc(100vh - 64px)", backgroundColor: "#f8fafc" }}>
@@ -357,6 +359,12 @@ export default function JobDetailPage() {
                       <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                         <Briefcase size={16} />
                         <Typography variant="body2">{job.years_of_experience}</Typography>
+                      </Box>
+                    )}
+                    {passoutYearDisplay && (
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                        <GraduationCap size={16} />
+                        <Typography variant="body2">Passout {passoutYearDisplay}</Typography>
                       </Box>
                     )}
                     {job.salary && (
@@ -752,6 +760,28 @@ export default function JobDetailPage() {
                     </Box>
                   </Box>
                 )}
+                {passoutYearDisplay && (
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: 1.5,
+                      py: 1.5,
+                      borderBottom: "1px solid",
+                      borderColor: "rgba(0,0,0,0.06)",
+                    }}
+                  >
+                    <Box sx={{ color: "#6366f1", flexShrink: 0, mt: 0.25 }}>
+                      <GraduationCap size={18} />
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant="caption" sx={{ color: "#64748b", fontWeight: 500, display: "block" }}>
+                        Applicable passout year
+                      </Typography>
+                      <Typography variant="body2" sx={{ color: "#0f172a", fontWeight: 500 }}>{passoutYearDisplay}</Typography>
+                    </Box>
+                  </Box>
+                )}
                 {job.ug_requirements && (
                   <Box
                     sx={{
@@ -838,7 +868,7 @@ export default function JobDetailPage() {
                     </Box>
                   </Box>
                 )}
-                {!job.industry_type && !job.department && !job.employment_type && !job.role_category && !job.education && !job.ug_requirements && !job.pg_requirements && !job.application_deadline && (job.number_of_openings == null || job.number_of_openings === 0) && (
+                {!job.industry_type && !job.department && !job.employment_type && !job.role_category && !job.education && !passoutYearDisplay && !job.ug_requirements && !job.pg_requirements && !job.application_deadline && (job.number_of_openings == null || job.number_of_openings === 0) && (
                   <Box sx={{ py: 2, textAlign: "center" }}>
                     <Typography variant="body2" color="text.secondary">No additional details</Typography>
                   </Box>

--- a/components/admin/jobs-v2/JobCreateEditPage.tsx
+++ b/components/admin/jobs-v2/JobCreateEditPage.tsx
@@ -28,6 +28,7 @@ import type {
 } from "@/lib/services/admin/admin-jobs-v2.service";
 import { adminJobsV2Service } from "@/lib/services/admin/admin-jobs-v2.service";
 import type { JobV2 } from "@/lib/services/jobs-v2.service";
+import { formatJobPassoutYear } from "@/lib/services/jobs-v2.service";
 import { CreateJobIllustration } from "@/components/jobs-v2/illustrations";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { ApplicationQuestionsModal } from "./ApplicationQuestionsModal";
@@ -391,7 +392,9 @@ export function JobCreateEditPage({
           ? formData.application_deadline.trim()
           : null,
         number_of_openings: parseNumberOfOpeningsInput(formData.number_of_openings),
-        applicable_passout_year: formData.applicable_passout_year?.trim() || null,
+        applicable_passout_year: formatJobPassoutYear(
+          formData.applicable_passout_year
+        ),
         min_10th_percentage: formData.min_10th_percentage ?? null,
         min_12th_percentage: formData.min_12th_percentage ?? null,
         min_graduation_percentage: formData.min_graduation_percentage ?? null,

--- a/components/admin/jobs-v2/JobCreateEditPage.tsx
+++ b/components/admin/jobs-v2/JobCreateEditPage.tsx
@@ -88,6 +88,20 @@ const emptyPayload: JobCreateUpdatePayload = {
   question_ids: [],
 };
 
+/** Positive integer or null — coerces API values; never keeps a string in state. */
+function parseNumberOfOpeningsInput(v: unknown): number | null {
+  if (v == null || v === "") return null;
+  if (typeof v === "number") {
+    if (!Number.isFinite(v) || !Number.isInteger(v) || v < 1) return null;
+    return v;
+  }
+  const digits = String(v).replace(/\D/g, "");
+  if (!digits) return null;
+  const n = parseInt(digits, 10);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return n;
+}
+
 const STEPS = [
   "Basic Info",
   "Description & Skills",
@@ -213,7 +227,7 @@ export function JobCreateEditPage({
           : "";
       const init = initialData as {
         status?: "active" | "inactive" | "closed" | "completed";
-        number_of_openings?: number | null;
+        number_of_openings?: number | string | null;
         applicable_passout_year?: string | null;
         min_10th_percentage?: number | null;
         min_12th_percentage?: number | null;
@@ -243,7 +257,7 @@ export function JobCreateEditPage({
         is_published: initialData.is_published ?? false,
         status: init.status ?? "active",
         application_deadline: formattedDeadline,
-        number_of_openings: init.number_of_openings ?? null,
+        number_of_openings: parseNumberOfOpeningsInput(init.number_of_openings),
         applicable_passout_year: init.applicable_passout_year ?? null,
         min_10th_percentage: init.min_10th_percentage ?? null,
         min_12th_percentage: init.min_12th_percentage ?? null,
@@ -356,11 +370,18 @@ export function JobCreateEditPage({
   }, []);
 
   const handleSubmit = useCallback(async () => {
-    if (!formData.job_title.trim() || !formData.company_name.trim()) return;
+    if (
+      !formData.job_title.trim() ||
+      !formData.company_name.trim() ||
+      !formData.company_logo?.trim()
+    ) {
+      return;
+    }
     try {
       setSubmitting(true);
       const payload: JobCreateUpdatePayload | Partial<JobCreateUpdatePayload> = {
         ...formData,
+        company_logo: formData.company_logo.trim(),
         mandatory_skills: formData.key_skills ?? [],
         course_ids: formData.course_ids ?? [],
         question_ids: formData.question_ids ?? [],
@@ -369,7 +390,7 @@ export function JobCreateEditPage({
         application_deadline: formData.application_deadline?.trim()
           ? formData.application_deadline.trim()
           : null,
-        number_of_openings: formData.number_of_openings ?? null,
+        number_of_openings: parseNumberOfOpeningsInput(formData.number_of_openings),
         applicable_passout_year: formData.applicable_passout_year?.trim() || null,
         min_10th_percentage: formData.min_10th_percentage ?? null,
         min_12th_percentage: formData.min_12th_percentage ?? null,
@@ -384,7 +405,10 @@ export function JobCreateEditPage({
     }
   }, [formData, jdFile, onSubmit, onCancel]);
 
-  const canProceedStep0 = formData.job_title.trim() && formData.company_name.trim();
+  const canProceedStep0 =
+    Boolean(formData.job_title.trim()) &&
+    Boolean(formData.company_name.trim()) &&
+    Boolean(formData.company_logo?.trim());
   const isLastStep = activeStep === STEPS.length - 1;
 
   const renderStepContent = () => {
@@ -452,9 +476,11 @@ export function JobCreateEditPage({
                 label="Company Logo URL"
                 value={formData.company_logo}
                 onChange={(e) => handleChange("company_logo", e.target.value)}
+                required
                 fullWidth
                 size="small"
                 placeholder="https://example.com/logo.png"
+                helperText="Required — public image URL shown on job cards and detail pages"
                 sx={inputSx}
               />
               <TextField
@@ -474,18 +500,30 @@ export function JobCreateEditPage({
               <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 2 }}>
                 <TextField
                   label="Number of Openings"
-                  type="number"
-                  value={formData.number_of_openings ?? ""}
-                  onChange={(e) =>
-                    handleChange(
-                      "number_of_openings",
-                      e.target.value === "" ? null : Number(e.target.value)
-                    )
+                  type="text"
+                  value={
+                    formData.number_of_openings == null
+                      ? ""
+                      : String(formData.number_of_openings)
                   }
+                  onChange={(e) => {
+                    const digits = e.target.value.replace(/\D/g, "");
+                    if (digits === "") {
+                      handleChange("number_of_openings", null);
+                      return;
+                    }
+                    const n = parseInt(digits, 10);
+                    handleChange("number_of_openings", n >= 1 ? n : null);
+                  }}
                   fullWidth
                   size="small"
                   placeholder="e.g. 5"
-                  inputProps={{ min: 1 }}
+                  helperText="Whole number only (minimum 1)"
+                  inputProps={{
+                    inputMode: "numeric",
+                    pattern: "[0-9]*",
+                    autoComplete: "off",
+                  }}
                   sx={inputSx}
                 />
                 <TextField
@@ -1486,7 +1524,12 @@ export function JobCreateEditPage({
               <Button
                 variant="contained"
                 onClick={handleSubmit}
-                disabled={submitting || !formData.job_title.trim() || !formData.company_name.trim()}
+                disabled={
+                  submitting ||
+                  !formData.job_title.trim() ||
+                  !formData.company_name.trim() ||
+                  !formData.company_logo?.trim()
+                }
                 startIcon={<IconWrapper icon="mdi:content-save" size={18} />}
                 sx={{
                   textTransform: "none",

--- a/components/admin/jobs-v2/JobDetailModal.tsx
+++ b/components/admin/jobs-v2/JobDetailModal.tsx
@@ -13,10 +13,11 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import { MapPin, Briefcase, Tag, Calendar, Clock, ExternalLink } from "lucide-react";
+import { MapPin, Briefcase, Tag, Calendar, Clock, ExternalLink, GraduationCap } from "lucide-react";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { JobDetailIllustration } from "@/components/jobs-v2/illustrations";
 import type { JobV2 } from "@/lib/services/jobs-v2.service";
+import { formatJobPassoutYear } from "@/lib/services/jobs-v2.service";
 
 interface JobDetailModalProps {
   open: boolean;
@@ -142,6 +143,7 @@ export function JobDetailModal({
   ].filter(Boolean);
   const courses = job.courses ?? [];
   const collegeMappings = job.college_mappings ?? [];
+  const passoutYearDisplay = formatJobPassoutYear(job.applicable_passout_year);
 
   return (
     <Dialog
@@ -273,6 +275,13 @@ export function JobDetailModal({
           )}
           {job.salary && (
             <InfoPill icon={<Tag size={18} />} label="Salary" value={job.salary} />
+          )}
+          {passoutYearDisplay && (
+            <InfoPill
+              icon={<GraduationCap size={18} />}
+              label="Passout year"
+              value={passoutYearDisplay}
+            />
           )}
           <InfoPill icon={<Calendar size={18} />} label="Created" value={formatDate(job.created_at)} />
           {job.application_deadline && (

--- a/components/jobs-v2/JobCardV2.tsx
+++ b/components/jobs-v2/JobCardV2.tsx
@@ -12,7 +12,7 @@ import {
   Avatar,
   Tooltip,
 } from "@mui/material";
-import { JobV2 } from "@/lib/services/jobs-v2.service";
+import { JobV2, formatJobPassoutYear } from "@/lib/services/jobs-v2.service";
 import { formatDistanceToNow } from "@/lib/utils/date-utils";
 import { jobsV2Service } from "@/lib/services/jobs-v2.service";
 import { useToast } from "@/components/common/Toast";
@@ -24,6 +24,7 @@ import {
   Briefcase,
   ChevronRight,
   Banknote,
+  GraduationCap,
 } from "lucide-react";
 
 interface JobCardV2Props {
@@ -79,6 +80,7 @@ const JobCardV2Component = ({ job, onFavoriteChange }: JobCardV2Props) => {
 
   const tags = job.tags ?? [];
   const skillsDisplay = [...(job.mandatory_skills ?? []), ...(job.key_skills ?? [])].slice(0, 5);
+  const passoutYear = formatJobPassoutYear(job.applicable_passout_year);
 
   return (
     <Paper
@@ -209,6 +211,17 @@ const JobCardV2Component = ({ job, onFavoriteChange }: JobCardV2Props) => {
                 </Typography>
               </Box>
             )}
+            {passoutYear && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                <GraduationCap size={14} style={{ color: "#6b7280" }} />
+                <Typography
+                  variant="body2"
+                  sx={{ fontSize: "0.875rem", color: "text.secondary" }}
+                >
+                  Passout {passoutYear}
+                </Typography>
+              </Box>
+            )}
             {job.salary && (
               <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                 <Banknote size={14} style={{ color: "#6b7280" }} />
@@ -321,6 +334,10 @@ const JobCardV2Component = ({ job, onFavoriteChange }: JobCardV2Props) => {
 };
 
 export const JobCardV2 = memo(JobCardV2Component, (prevProps, nextProps) => {
-  return prevProps.job.id === nextProps.job.id;
+  return (
+    prevProps.job.id === nextProps.job.id &&
+    prevProps.job.is_favourited === nextProps.job.is_favourited &&
+    prevProps.job.applicable_passout_year === nextProps.job.applicable_passout_year
+  );
 });
 JobCardV2.displayName = "JobCardV2";

--- a/lib/services/admin/admin-jobs-v2.service.ts
+++ b/lib/services/admin/admin-jobs-v2.service.ts
@@ -36,7 +36,7 @@ export interface JobCreateUpdatePayload {
   status?: "active" | "inactive" | "closed" | "completed" | "on_hold";
   application_deadline?: string | null;
   number_of_openings?: number | null;
-  applicable_passout_year?: string | null;
+  applicable_passout_year?: string | number | null;
   min_10th_percentage?: number | null;
   min_12th_percentage?: number | null;
   min_graduation_percentage?: number | null;

--- a/lib/services/jobs-v2.service.ts
+++ b/lib/services/jobs-v2.service.ts
@@ -28,7 +28,7 @@ export interface JobV2 {
   application_deadline?: string;
   jd_file_url?: string;
   number_of_openings?: number | null;
-  applicable_passout_year?: string | null;
+  applicable_passout_year?: string | number | null;
   min_10th_percentage?: number | null;
   min_12th_percentage?: number | null;
   min_graduation_percentage?: number | null;
@@ -51,6 +51,15 @@ export interface JobV2 {
     options?: string[];
   }>;
   question_ids?: number[];
+}
+
+/** Normalizes API `applicable_passout_year` for UI (string or number from JSON). */
+export function formatJobPassoutYear(
+  value: JobV2["applicable_passout_year"]
+): string | null {
+  if (value == null) return null;
+  const s = String(value).trim();
+  return s.length > 0 ? s : null;
 }
 
 export interface JobV2Filters {


### PR DESCRIPTION
- Surface applicable_passout_year on student cards/detail and admin views
- Add formatJobPassoutYear helper; widen API type for string or number
- Require company logo URL on admin create/edit; coerce openings to positive int
- Admin job detail: full-width multiline location pill; breadcrumb title two-line clamp