### PR TITLE
Assessment UX: submit checklist, quiz navigator, coding completion

### DIFF
--- a/app/assessments/[slug]/take/page.tsx
+++ b/app/assessments/[slug]/take/page.tsx
@@ -41,6 +41,10 @@ import {
   mergeAssessmentSections,
   normalizeSubjectiveAnswer,
 } from "@/utils/assessment.utils";
+import {
+  getResponseForQuestion,
+  isAssessmentQuestionCompleted,
+} from "@/lib/utils/assessmentQuestionCompletion";
 import { stopAllMediaTracks } from "@/lib/utils/cameraUtils";
 import { getProctoringService } from "@/lib/services/proctoring.service";
 import { config } from "@/lib/config";
@@ -1310,34 +1314,13 @@ export default function TakeAssessmentPage({
       let answered = 0;
       sectionQuestions.forEach((question: any) => {
         const questionId = question.id;
-        const response = sectionResponses[questionId] ?? sectionResponses[String(questionId)];
-        
-        // For quiz: check if answer is selected
-        if (sectionType === "quiz") {
-          if (response !== undefined && response !== null && response !== "") {
-            answered++;
-          }
-        } 
-        // For coding: count as attempted if user has code, has run tests, or submitted
-        // (so "visited/attempted" matches what the student did, not only full pass)
-        else if (sectionType === "coding") {
-          if (response && typeof response === "object") {
-            const isSubmitted = response.submitted === true;
-            const totalCount = response.total_tc ?? response.total_test_cases ?? 0;
-            const hasCode = typeof response.code === "string" && response.code.trim().length > 0;
-            const hasRun = totalCount > 0;
-            if (isSubmitted || hasRun || hasCode) {
-              answered++;
-            }
-          }
-        } else if (sectionType === "subjective") {
-          const text =
-            typeof response === "string"
-              ? response
-              : normalizeSubjectiveAnswer(response);
-          if (text.trim().length > 0) {
-            answered++;
-          }
+        const response = getResponseForQuestion(
+          responses as Record<string, Record<string, unknown>>,
+          sectionType,
+          questionId,
+        );
+        if (isAssessmentQuestionCompleted(sectionType, response)) {
+          answered++;
         }
       });
       
@@ -1874,7 +1857,8 @@ export default function TakeAssessmentPage({
             {showSubmitDialog && (
               <SubmissionDialog
                 open={showSubmitDialog}
-                sections={sectionStatus}
+                sections={sections}
+                responses={responses}
                 totalQuestions={navigation.totalQuestions}
                 totalAnswered={totalAnswered}
                 onClose={handleCloseSubmitDialog}

--- a/components/assessment/AssessmentQuizLayout.tsx
+++ b/components/assessment/AssessmentQuizLayout.tsx
@@ -89,7 +89,7 @@ export const AssessmentQuizLayout = memo(
         {/* Left Sidebar - Question List */}
         <Box
           sx={{
-            width: { xs: "100%", md: "320px" },
+            width: { xs: "100%", md: "min(360px, 34vw)" },
             flexShrink: 0,
             display: "flex",
             flexDirection: "column",

--- a/components/assessment/AssessmentSubjectiveLayout.tsx
+++ b/components/assessment/AssessmentSubjectiveLayout.tsx
@@ -12,6 +12,7 @@ import {
   ButtonBase,
 } from "@mui/material";
 import { memo, useMemo, useRef, useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { QuizQuestionList } from "@/components/quiz";
 import { QuestionTitle } from "@/components/quiz/QuestionTitle";
 import { IconWrapper } from "@/components/common/IconWrapper";
@@ -84,6 +85,7 @@ export const AssessmentSubjectiveLayout = memo(
     onPreviousQuestion,
     onQuestionClick,
   }: AssessmentSubjectiveLayoutProps) {
+    const { t } = useTranslation("common");
     const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
     const isFirstQuestion = currentQuestionIndex === 0;
 
@@ -128,7 +130,7 @@ export const AssessmentSubjectiveLayout = memo(
       >
         <Box
           sx={{
-            width: { xs: "100%", md: "320px" },
+            width: { xs: "100%", md: "min(360px, 34vw)" },
             flexShrink: 0,
             display: "flex",
             flexDirection: "column",
@@ -140,8 +142,8 @@ export const AssessmentSubjectiveLayout = memo(
             questions={questions}
             currentQuestionId={currentQuestion.id}
             onQuestionClick={onQuestionClick}
-            listTitle="Written responses"
-            listSubtitle="Select a question to edit your answer. Your work is saved automatically."
+            listTitle={t("quiz.writtenListTitle")}
+            listSubtitle={t("quiz.writtenListSubtitle")}
             variant="subjective"
           />
         </Box>

--- a/components/assessment/SubmissionDialog.tsx
+++ b/components/assessment/SubmissionDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -12,20 +12,41 @@ import {
   Alert,
   Checkbox,
   FormControlLabel,
-  Divider,
+  LinearProgress,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Chip,
+  Stack,
+  ButtonGroup,
+  alpha,
+  useTheme,
 } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { useTranslation } from "react-i18next";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  formatChecklistQuestionLabel,
+  getResponseForQuestion,
+  isAssessmentQuestionCompleted,
+} from "@/lib/utils/assessmentQuestionCompletion";
 
-interface SectionStatus {
-  sectionName: string;
-  sectionType: string;
-  answered: number;
-  total: number;
-}
+export type SubmissionDialogSection = {
+  id?: number;
+  title?: string;
+  order?: number;
+  section_type?: string;
+  questions?: Array<Record<string, unknown> & { id: number | string }>;
+};
 
 interface SubmissionDialogProps {
   open: boolean;
-  sections: SectionStatus[];
+  sections: SubmissionDialogSection[];
+  responses: Record<string, Record<string, unknown>>;
   totalQuestions: number;
   totalAnswered: number;
   onClose: () => void;
@@ -33,130 +54,418 @@ interface SubmissionDialogProps {
   submitting?: boolean;
 }
 
+function sectionKey(section: SubmissionDialogSection, index: number): string {
+  if (section.id != null) return `s-${section.id}`;
+  return `s-idx-${section.order ?? index}`;
+}
+
+function sectionTypeLabel(
+  t: (k: string) => string,
+  sectionType: string | undefined,
+): string {
+  const st = sectionType || "quiz";
+  if (st === "coding") return t("assessments.submitChecklist.typeCoding");
+  if (st === "subjective") return t("assessments.submitChecklist.typeSubjective");
+  return t("assessments.submitChecklist.typeQuiz");
+}
+
 export function SubmissionDialog({
   open,
   sections,
+  responses,
   totalQuestions,
   totalAnswered,
   onClose,
   onConfirm,
   submitting = false,
 }: SubmissionDialogProps) {
-  const [confirmed, setConfirmed] = React.useState(false);
+  const { t } = useTranslation("common");
+  const theme = useTheme();
+  const [confirmed, setConfirmed] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  React.useEffect(() => {
+  const sortedSections = useMemo(
+    () =>
+      [...(sections || [])].sort(
+        (a, b) => (a.order ?? 0) - (b.order ?? 0),
+      ),
+    [sections],
+  );
+
+  const checklist = useMemo(() => {
+    return sortedSections.map((section, sIdx) => {
+      const sectionType = section.section_type || "quiz";
+      const questions = section.questions || [];
+      const rows = questions.map((q, qIdx) => {
+        const response = getResponseForQuestion(responses, sectionType, q.id);
+        const completed = isAssessmentQuestionCompleted(sectionType, response);
+        return {
+          id: q.id,
+          label: formatChecklistQuestionLabel(sectionType, q, qIdx),
+          completed,
+        };
+      });
+      const answered = rows.filter((r) => r.completed).length;
+      return {
+        key: sectionKey(section, sIdx),
+        title: section.title || sectionTypeLabel(t, sectionType),
+        sectionType,
+        rows,
+        answered,
+        total: rows.length,
+      };
+    });
+  }, [sortedSections, responses, t]);
+
+  useEffect(() => {
     if (!open) {
       setConfirmed(false);
+      setExpanded(new Set());
+      return;
     }
-  }, [open]);
+    setConfirmed(false);
+    setExpanded(
+      new Set(
+        sortedSections.map((section, i) => sectionKey(section, i)),
+      ),
+    );
+  }, [open, sortedSections]);
 
-  const unansweredCount = totalQuestions - totalAnswered;
-  const allAnswered = unansweredCount === 0;
+  const expandAll = useCallback(() => {
+    setExpanded(new Set(checklist.map((c) => c.key)));
+  }, [checklist]);
+
+  const collapseAll = useCallback(() => {
+    setExpanded(new Set());
+  }, []);
+
+  const unansweredCount = Math.max(0, totalQuestions - totalAnswered);
+  const allAnswered = totalQuestions > 0 && unansweredCount === 0;
+  const progress =
+    totalQuestions > 0
+      ? Math.min(100, Math.round((totalAnswered / totalQuestions) * 100))
+      : 0;
+
+  const doneColor = theme.palette.success.main;
+  const pendingColor = theme.palette.warning.main;
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <IconWrapper icon="mdi:file-check" size={24} />
-          <Typography variant="h6" fontWeight={600}>
-            Submit Assessment
-          </Typography>
-        </Box>
-      </DialogTitle>
-      <DialogContent>
-        {/* Completion Status */}
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="body1" fontWeight={600} gutterBottom>
-            Review Your Submission
-          </Typography>
+    <Dialog
+      open={open}
+      onClose={submitting ? undefined : onClose}
+      maxWidth="md"
+      fullWidth
+      scroll="paper"
+      PaperProps={{
+        sx: {
+          borderRadius: 2,
+          border: `1px solid ${theme.palette.divider}`,
+        },
+      }}
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        <Stack direction="row" spacing={1.5} alignItems="flex-start">
           <Box
             sx={{
-              mt: 2,
-              p: 2,
-              backgroundColor: allAnswered ? "#d1fae5" : "#fef3c7",
-              borderRadius: 1,
-              border: `1px solid ${allAnswered ? "#10b981" : "#f59e0b"}`,
+              width: 44,
+              height: 44,
+              borderRadius: 1.5,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              bgcolor: alpha(theme.palette.primary.main, 0.12),
+              color: "primary.main",
+              flexShrink: 0,
             }}
           >
-            <Typography variant="body2" fontWeight={600} gutterBottom>
-              Questions Visited: {totalAnswered} / {totalQuestions}
+            <IconWrapper icon="mdi:clipboard-text-outline" size={26} />
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="h6" fontWeight={700} component="div">
+              {t("assessments.submitChecklist.title")}
             </Typography>
-            {allAnswered ? (
-              <Typography variant="body2" sx={{ mt: 1, color: "#065f46", fontWeight: 500 }}>
-                All questions attempted. You can submit your assessment.
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {t("assessments.submitChecklist.subtitle")}
+            </Typography>
+          </Box>
+        </Stack>
+      </DialogTitle>
+
+      <DialogContent
+        dividers
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          px: 0,
+          py: 0,
+          minHeight: 0,
+          maxHeight: "min(78vh, 640px)",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflowY: "auto",
+            px: { xs: 2, sm: 3 },
+            pt: 2,
+            pb: 1,
+          }}
+        >
+          <Box
+            sx={{
+              p: 2,
+              mb: 2,
+              borderRadius: 2,
+              bgcolor: alpha(theme.palette.primary.main, 0.04),
+              border: `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+            }}
+          >
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              spacing={2}
+              sx={{ mb: 1 }}
+            >
+              <Typography variant="subtitle2" fontWeight={700}>
+                {t("assessments.submitChecklist.summaryTitle")}
               </Typography>
-            ) : (
-              <Typography variant="body2" color="warning.main" sx={{ mt: 1 }}>
-                You have {unansweredCount} unanswered question
-                {unansweredCount !== 1 ? "s" : ""}. Are you sure you want to
-                submit?
+              <Typography variant="caption" color="text.secondary" fontWeight={600}>
+                {t("assessments.submitChecklist.summaryLine", {
+                  answered: totalAnswered,
+                  total: totalQuestions,
+                })}
+              </Typography>
+            </Stack>
+            <LinearProgress
+              variant="determinate"
+              value={progress}
+              sx={{
+                height: 8,
+                borderRadius: 99,
+                bgcolor: alpha(theme.palette.primary.main, 0.12),
+                "& .MuiLinearProgress-bar": { borderRadius: 99 },
+              }}
+            />
+          </Box>
+
+          {allAnswered ? (
+            <Alert severity="success" sx={{ mb: 2, borderRadius: 2 }}>
+              {t("assessments.submitChecklist.allCompleteHint")}
+            </Alert>
+          ) : (
+            <Alert severity="warning" sx={{ mb: 2, borderRadius: 2 }}>
+              {t("assessments.submitChecklist.pendingHint", {
+                count: unansweredCount,
+              })}
+            </Alert>
+          )}
+
+          <Stack direction="row" justifyContent="flex-end" sx={{ mb: 1.5 }}>
+            <ButtonGroup size="small" variant="outlined">
+              <Button onClick={expandAll}>
+                {t("assessments.submitChecklist.expandAll")}
+              </Button>
+              <Button onClick={collapseAll}>
+                {t("assessments.submitChecklist.collapseAll")}
+              </Button>
+            </ButtonGroup>
+          </Stack>
+
+          <Stack spacing={1} sx={{ pb: 2 }}>
+            {checklist.length === 0 && (
+              <Typography variant="body2" color="text.secondary" sx={{ py: 2 }}>
+                {t("assessments.submitChecklist.noSections")}
               </Typography>
             )}
-          </Box>
+            {checklist.map((block) => {
+              const isExpanded = expanded.has(block.key);
+              const sectionComplete =
+                block.total === 0 || block.answered === block.total;
+              return (
+                <Accordion
+                  key={block.key}
+                  expanded={isExpanded}
+                  onChange={(_, isExpandedNext) => {
+                    setExpanded((prev) => {
+                      const next = new Set(prev);
+                      if (isExpandedNext) next.add(block.key);
+                      else next.delete(block.key);
+                      return next;
+                    });
+                  }}
+                  disableGutters
+                  elevation={0}
+                  sx={{
+                    border: `1px solid ${theme.palette.divider}`,
+                    borderRadius: "12px !important",
+                    overflow: "hidden",
+                    "&:before": { display: "none" },
+                  }}
+                >
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    sx={{
+                      px: 2,
+                      minHeight: 56,
+                      bgcolor: sectionComplete
+                        ? alpha(doneColor, 0.06)
+                        : alpha(pendingColor, 0.06),
+                    }}
+                  >
+                    <Stack
+                      direction="row"
+                      alignItems="center"
+                      spacing={1.5}
+                      sx={{ width: "100%", pr: 1 }}
+                    >
+                      <IconWrapper
+                        icon={
+                          sectionComplete
+                            ? "mdi:check-decagram"
+                            : "mdi:alert-decagram-outline"
+                        }
+                        size={22}
+                        style={{
+                          color: sectionComplete ? doneColor : pendingColor,
+                          flexShrink: 0,
+                        }}
+                      />
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
+                        <Typography variant="subtitle2" fontWeight={700} noWrap>
+                          {block.title}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {t("assessments.submitChecklist.sectionMeta", {
+                            answered: block.answered,
+                            total: block.total,
+                          })}
+                        </Typography>
+                      </Box>
+                      <Chip
+                        size="small"
+                        label={sectionTypeLabel(t, block.sectionType)}
+                        sx={{ fontWeight: 600, flexShrink: 0 }}
+                      />
+                    </Stack>
+                  </AccordionSummary>
+                  <AccordionDetails sx={{ px: 0, pt: 0, pb: 1 }}>
+                    <List dense disablePadding>
+                      {block.rows.map((row, idx) => (
+                        <ListItem
+                          key={`${block.key}-q-${row.id}`}
+                          sx={{
+                            px: 2,
+                            py: 0.75,
+                            borderTop: `1px solid ${theme.palette.divider}`,
+                          }}
+                        >
+                          <ListItemIcon sx={{ minWidth: 40 }}>
+                            <IconWrapper
+                              icon={
+                                row.completed
+                                  ? "mdi:check-circle"
+                                  : "mdi:circle-outline"
+                              }
+                              size={22}
+                              style={{
+                                color: row.completed
+                                  ? doneColor
+                                  : theme.palette.text.disabled,
+                              }}
+                            />
+                          </ListItemIcon>
+                          <ListItemText
+                            primaryTypographyProps={{ component: "div" }}
+                            secondaryTypographyProps={{ component: "div" }}
+                            primary={
+                              <Stack direction="row" alignItems="center" spacing={1}>
+                                <Chip
+                                  label={t("assessments.submitChecklist.questionNumber", {
+                                    n: idx + 1,
+                                  })}
+                                  size="small"
+                                  variant="outlined"
+                                  sx={{ height: 22, fontWeight: 600 }}
+                                />
+                                <Typography variant="body2" component="span">
+                                  {row.label}
+                                </Typography>
+                              </Stack>
+                            }
+                            secondary={
+                              <Chip
+                                size="small"
+                                sx={{
+                                  mt: 0.75,
+                                  height: 22,
+                                  fontWeight: 600,
+                                  bgcolor: row.completed
+                                    ? alpha(doneColor, 0.12)
+                                    : alpha(pendingColor, 0.12),
+                                  color: row.completed ? doneColor : pendingColor,
+                                }}
+                                label={
+                                  row.completed
+                                    ? t("assessments.submitChecklist.statusDone")
+                                    : t("assessments.submitChecklist.statusTodo")
+                                }
+                              />
+                            }
+                          />
+                        </ListItem>
+                      ))}
+                    </List>
+                  </AccordionDetails>
+                </Accordion>
+              );
+            })}
+          </Stack>
         </Box>
 
-        {/* Section Breakdown */}
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="body2" fontWeight={600} gutterBottom>
-            Section Breakdown:
-          </Typography>
-          {sections.map((section, index) => (
-            <Box
-              key={index}
-              sx={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                py: 1,
-                borderBottom:
-                  index < sections.length - 1 ? "1px solid #e5e7eb" : "none",
-              }}
-            >
-              <Typography variant="body2">{section.sectionName}</Typography>
-              <Typography variant="body2" fontWeight={600}>
-                {section.answered} / {section.total}
+        <Box
+          sx={{
+            flexShrink: 0,
+            px: { xs: 2, sm: 3 },
+            py: 1.5,
+            borderTop: `1px solid ${theme.palette.divider}`,
+            bgcolor: theme.palette.background.paper,
+            boxShadow: `0 -6px 16px ${alpha(theme.palette.common.black, 0.06)}`,
+          }}
+        >
+          <FormControlLabel
+            sx={{ alignItems: "flex-start", ml: 0, mr: 0 }}
+            control={
+              <Checkbox
+                checked={confirmed}
+                onChange={(e) => setConfirmed(e.target.checked)}
+                sx={{ pt: 0.25 }}
+              />
+            }
+            label={
+              <Typography variant="body2" color="text.secondary">
+                {t("assessments.submitChecklist.confirmCheckbox")}
               </Typography>
-            </Box>
-          ))}
+            }
+          />
         </Box>
-
-        {/* Violation Count */}
-
-        <Divider sx={{ my: 2 }} />
-
-        {/* Confirmation Checkbox */}
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={confirmed}
-              onChange={(e) => setConfirmed(e.target.checked)}
-            />
-          }
-          label={
-            <Typography variant="body2">
-              I confirm that I want to submit my assessment. I understand that I
-              cannot change my answers after submission.
-            </Typography>
-          }
-        />
       </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={submitting}>
-          Cancel
+
+      <DialogActions sx={{ px: 3, py: 2, gap: 1 }}>
+        <Button onClick={onClose} disabled={submitting} color="inherit">
+          {t("assessments.submitChecklist.cancel")}
         </Button>
         <Button
           onClick={onConfirm}
           variant="contained"
           disabled={!confirmed || submitting}
-          startIcon={<IconWrapper icon="mdi:check-circle" />}
-          sx={{
-            backgroundColor: "#374151",
-            "&:hover": {
-              backgroundColor: "#1f2937",
-            },
-          }}
+          startIcon={<IconWrapper icon="mdi:send-check" />}
         >
-          {submitting ? "Submitting..." : "Confirm Submit"}
+          {submitting
+            ? t("assessments.submitChecklist.submitting")
+            : t("assessments.submitChecklist.confirmSubmit")}
         </Button>
       </DialogActions>
     </Dialog>

--- a/components/quiz/QuizQuestionList.tsx
+++ b/components/quiz/QuizQuestionList.tsx
@@ -1,12 +1,63 @@
 "use client";
 
-import { Box, Paper, Typography, List, ListItem, ListItemButton, ListItemText } from "@mui/material";
-import { useState, memo } from "react";
+import {
+  Box,
+  Paper,
+  Typography,
+  List,
+  ListItem,
+  ListItemButton,
+  Chip,
+  Stack,
+  Tooltip,
+  Button,
+  LinearProgress,
+  alpha,
+  useTheme,
+  useMediaQuery,
+} from "@mui/material";
+import {
+  memo,
+  useMemo,
+  useState,
+  useRef,
+  useCallback,
+  useLayoutEffect,
+  type MouseEvent,
+} from "react";
+import { useTranslation } from "react-i18next";
 import { IconWrapper } from "@/components/common/IconWrapper";
 
-/** Check if string contains HTML tags so we can render with dangerouslySetInnerHTML */
 function hasHtml(str: unknown): str is string {
   return typeof str === "string" && /<[a-z][\s\S]*>/i.test(str);
+}
+
+function stripLeadingBracketTag(text: string): string {
+  return text.replace(/^\[[^\]\n]{1,48}\]\s*/, "").trim();
+}
+
+function plainTextFromQuestion(htmlOrText: string): string {
+  if (hasHtml(htmlOrText)) {
+    return stripLeadingBracketTag(
+      htmlOrText.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim(),
+    );
+  }
+  return stripLeadingBracketTag(htmlOrText);
+}
+
+function findNextUnansweredQuestionId(
+  questions: QuizQuestion[],
+  currentQuestionId: string | number,
+): string | number | null {
+  const cur = questions.findIndex((q) => q.id === currentQuestionId);
+  const start = cur >= 0 ? cur + 1 : 0;
+  for (let i = start; i < questions.length; i++) {
+    if (!questions[i]?.answered) return questions[i]!.id;
+  }
+  for (let i = 0; i < (cur >= 0 ? cur : questions.length); i++) {
+    if (!questions[i]?.answered) return questions[i]!.id;
+  }
+  return null;
 }
 
 interface QuizQuestion {
@@ -19,15 +70,11 @@ interface QuizQuestionListProps {
   questions: QuizQuestion[];
   currentQuestionId: string | number;
   onQuestionClick?: (questionId: string | number) => void;
-  /** Sidebar header (default: Quiz Questions List) */
   listTitle?: string;
-  /** Optional one-line hint under the title (e.g. subjective navigation) */
   listSubtitle?: string;
-  /** Visual accent for current row / icons */
   variant?: "quiz" | "subjective";
 }
 
-/** Colors from app/globals.css */
 const VARIANT_STYLES = {
   quiz: {
     currentBg: "var(--surface-indigo-light)",
@@ -51,15 +98,64 @@ const QuizQuestionListComponent = memo(function QuizQuestionList({
   questions,
   currentQuestionId,
   onQuestionClick,
-  listTitle = "Quiz Questions List",
+  listTitle,
   listSubtitle,
   variant = "quiz",
 }: QuizQuestionListProps) {
+  const { t } = useTranslation("common");
+  const theme = useTheme();
+  const isCoarsePointer = useMediaQuery("(pointer: coarse)");
   const c = VARIANT_STYLES[variant];
   const [expanded, setExpanded] = useState(true);
 
+  const resolvedTitle = listTitle ?? t("quiz.questionListTitle");
+  const itemElRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const isNarrow = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const answeredCount = useMemo(
+    () => questions.filter((q) => q.answered).length,
+    [questions],
+  );
+
+  const pendingCount = questions.length - answeredCount;
+  const progressPct =
+    questions.length > 0
+      ? Math.round((answeredCount / questions.length) * 100)
+      : 0;
+
+  const nextUnansweredId = useMemo(
+    () => findNextUnansweredQuestionId(questions, currentQuestionId),
+    [questions, currentQuestionId],
+  );
+
+  const setItemButtonRef = useCallback((id: string | number) => (el: HTMLElement | null) => {
+    const key = String(id);
+    if (el) itemElRefs.current.set(key, el);
+    else itemElRefs.current.delete(key);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!expanded) return;
+    const el = itemElRefs.current.get(String(currentQuestionId));
+    el?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [currentQuestionId, expanded, questions.length]);
+
+  const handleJumpNextUnanswered = useCallback(
+    (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const id = findNextUnansweredQuestionId(questions, currentQuestionId);
+      if (id != null) onQuestionClick?.(id);
+    },
+    [questions, currentQuestionId, onQuestionClick],
+  );
+
+  const rowMinHeight = isCoarsePointer ? 52 : 46;
+
   return (
     <Paper
+      component="nav"
+      aria-label={resolvedTitle}
       elevation={0}
       sx={{
         backgroundColor: "var(--card-bg)",
@@ -69,56 +165,115 @@ const QuizQuestionListComponent = memo(function QuizQuestionList({
         boxShadow:
           variant === "subjective"
             ? "0 1px 3px 0 var(--assessment-subjective-shadow)"
-            : "none",
+            : "0 1px 2px 0 color-mix(in srgb, var(--font-primary-dark) 6%, transparent)",
       }}
     >
-      {/* Header */}
       <Box
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-label={t("quiz.questionListToggle")}
         onClick={() => setExpanded(!expanded)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded((v) => !v);
+          }
+        }}
         sx={{
           p: 2,
           display: "flex",
           alignItems: "flex-start",
           justifyContent: "space-between",
-          gap: 1,
+          gap: 1.5,
           cursor: "pointer",
-          borderBottom: expanded ? "1px solid var(--border-default)" : "none",
+          borderBottom: "1px solid var(--border-default)",
           backgroundColor:
             variant === "subjective"
               ? "var(--assessment-subjective-header-strip-bg)"
-              : "transparent",
+              : alpha(theme.palette.primary.main, 0.03),
+          outline: "none",
           "&:hover": {
             backgroundColor:
               variant === "subjective"
                 ? "var(--assessment-subjective-surface-hover)"
-                : "var(--surface)",
+                : alpha(theme.palette.primary.main, 0.06),
+          },
+          "&:focus-visible": {
+            boxShadow: `inset 0 0 0 2px ${alpha(theme.palette.primary.main, 0.35)}`,
           },
         }}
       >
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography
-            variant="h6"
+            variant="subtitle1"
             sx={{
-              fontWeight: 600,
+              fontWeight: 700,
               color: "var(--font-primary-dark)",
               fontSize: "1rem",
               lineHeight: 1.3,
             }}
           >
-            {listTitle}
+            {resolvedTitle}
           </Typography>
+          <Stack direction="row" alignItems="center" flexWrap="wrap" gap={0.75} sx={{ mt: 1 }}>
+            <Chip
+              size="small"
+              label={t("quiz.answeredOf", {
+                answered: answeredCount,
+                total: questions.length,
+              })}
+              sx={{
+                height: 26,
+                fontWeight: 600,
+                fontSize: "0.72rem",
+                bgcolor: alpha(theme.palette.primary.main, 0.1),
+                color: "primary.main",
+                border: `1px solid ${alpha(theme.palette.primary.main, 0.22)}`,
+              }}
+            />
+            {pendingCount === 0 ? (
+              <Chip
+                size="small"
+                icon={<IconWrapper icon="mdi:check-all" size={16} color="inherit" />}
+                label={t("quiz.navAllDone")}
+                sx={{
+                  height: 26,
+                  fontWeight: 600,
+                  fontSize: "0.72rem",
+                  bgcolor: alpha(theme.palette.success.main, 0.12),
+                  color: "success.dark",
+                  border: `1px solid ${alpha(theme.palette.success.main, 0.28)}`,
+                  "& .MuiChip-icon": { ml: 0.5 },
+                }}
+              />
+            ) : (
+              <Chip
+                size="small"
+                label={t("quiz.navRemaining", { count: pendingCount })}
+                sx={{
+                  height: 26,
+                  fontWeight: 600,
+                  fontSize: "0.72rem",
+                  bgcolor: alpha(theme.palette.warning.main, 0.12),
+                  color: "warning.dark",
+                  border: `1px solid ${alpha(theme.palette.warning.main, 0.28)}`,
+                }}
+              />
+            )}
+          </Stack>
           {listSubtitle ? (
             <Typography
               variant="caption"
               sx={{
                 display: "block",
-                mt: 0.5,
+                mt: 1,
                 color:
                   variant === "subjective"
                     ? "var(--assessment-subjective-muted)"
                     : "var(--font-secondary)",
                 fontSize: "0.75rem",
-                lineHeight: 1.4,
+                lineHeight: 1.45,
               }}
             >
               {listSubtitle}
@@ -127,27 +282,78 @@ const QuizQuestionListComponent = memo(function QuizQuestionList({
         </Box>
         <IconWrapper
           icon={expanded ? "mdi:chevron-up" : "mdi:chevron-down"}
-          size={20}
+          size={22}
           color="var(--font-secondary)"
         />
       </Box>
 
-      {/* Question List */}
+      <Box
+        sx={{ px: 2, pt: 1.25, pb: 1.25, bgcolor: alpha(theme.palette.grey[500], 0.04) }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 0.75 }}>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ fontWeight: 600, letterSpacing: 0.02 }}
+          >
+            {t("quiz.navProgressLabel")}
+          </Typography>
+          <Typography variant="caption" color="text.secondary" fontWeight={700}>
+            {answeredCount}/{questions.length}
+          </Typography>
+        </Stack>
+        <LinearProgress
+          variant="determinate"
+          value={progressPct}
+          sx={{
+            height: 6,
+            borderRadius: 99,
+            bgcolor: alpha(theme.palette.primary.main, 0.1),
+            "& .MuiLinearProgress-bar": {
+              borderRadius: 99,
+              bgcolor:
+                pendingCount === 0 ? theme.palette.success.main : theme.palette.primary.main,
+            },
+          }}
+        />
+        {expanded && nextUnansweredId != null && onQuestionClick && (
+          <Button
+            fullWidth
+            size="small"
+            variant="outlined"
+            color="warning"
+            onClick={handleJumpNextUnanswered}
+            startIcon={<IconWrapper icon="mdi:arrow-right-bold-circle-outline" size={18} />}
+            sx={{
+              mt: 1.25,
+              textTransform: "none",
+              fontWeight: 700,
+              borderRadius: 1.5,
+              py: 0.75,
+            }}
+          >
+            {isNarrow
+              ? t("quiz.jumpToNextUnansweredShort")
+              : t("quiz.jumpToNextUnanswered")}
+          </Button>
+        )}
+      </Box>
+
       {expanded && (
-        <List 
-          sx={{ 
-            p: 0, 
-            maxHeight: { xs: "300px", md: "500px" }, 
+        <List
+          dense
+          sx={{
+            py: 0.75,
+            maxHeight: { xs: "min(50vh, 340px)", md: "min(58vh, 500px)" },
             overflowY: "auto",
-            "&::-webkit-scrollbar": {
-              width: "6px",
-            },
-            "&::-webkit-scrollbar-track": {
-              background: "var(--surface)",
-            },
+            scrollBehavior: "smooth",
+            scrollPaddingBlock: "12px",
+            "&::-webkit-scrollbar": { width: "8px" },
+            "&::-webkit-scrollbar-track": { background: "var(--surface)" },
             "&::-webkit-scrollbar-thumb": {
               background: "var(--border-light)",
-              borderRadius: "3px",
+              borderRadius: "4px",
             },
             "&::-webkit-scrollbar-thumb:hover": {
               background: "var(--font-tertiary)",
@@ -156,105 +362,177 @@ const QuizQuestionListComponent = memo(function QuizQuestionList({
         >
           {questions.map((question, index) => {
             const isCurrent = question.id === currentQuestionId;
-            const isAnswered = question.answered;
+            const isAnswered = Boolean(question.answered);
+            const preview = hasHtml(question.question)
+              ? plainTextFromQuestion(question.question)
+              : plainTextFromQuestion(question.question || "");
+            const displayLine =
+              preview ||
+              t("quiz.questionOf", {
+                current: index + 1,
+                total: questions.length,
+              });
+            const truncated =
+              displayLine.length > 72
+                ? `${displayLine.slice(0, 69)}…`
+                : displayLine;
+
+            const statusLabel = isCurrent
+              ? t("quiz.questionStatusCurrent")
+              : isAnswered
+                ? t("quiz.questionStatusAnswered")
+                : t("quiz.questionStatusPending");
 
             return (
               <ListItem
                 key={question.id}
                 disablePadding
-                sx={{
-                  borderBottom:
-                    index < questions.length - 1
-                      ? "1px solid var(--border-default)"
-                      : "none",
-                }}
+                sx={{ px: 0.75, py: 0.35 }}
               >
                 <ListItemButton
-                  onClick={() => onQuestionClick && onQuestionClick(question.id)}
+                  ref={setItemButtonRef(question.id)}
+                  onClick={() => onQuestionClick?.(question.id)}
+                  aria-current={isCurrent ? "true" : undefined}
+                  aria-label={`${t("quiz.questionNumber", { n: index + 1 })}. ${statusLabel}. ${displayLine}`}
                   sx={{
-                    py: 1.5,
-                    px: 2,
+                    minHeight: rowMinHeight,
+                    py: 1,
+                    px: 1.25,
+                    borderRadius: 2,
+                    mx: 0.25,
+                    borderLeft: isCurrent ? `4px solid ${c.accent}` : "4px solid transparent",
                     backgroundColor: isCurrent ? c.currentBg : "transparent",
-                    borderLeft: isCurrent ? `3px solid ${c.accent}` : "3px solid transparent",
+                    boxShadow: isCurrent
+                      ? `0 0 0 1px ${alpha(theme.palette.primary.main, 0.14)}, 0 2px 10px ${alpha(theme.palette.common.black, 0.07)}`
+                      : "none",
+                    transition:
+                      "background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease",
                     "&:hover": {
-                      backgroundColor: isCurrent ? c.currentHover : "#f9fafb",
+                      backgroundColor: isCurrent ? c.currentHover : "var(--surface)",
+                      transform: "translateY(-1px)",
                     },
-                    transition: "all 0.2s ease-in-out",
+                    "&:active": {
+                      transform: "translateY(0)",
+                    },
+                    "&:focus-visible": {
+                      outline: `2px solid ${alpha(theme.palette.primary.main, 0.45)}`,
+                      outlineOffset: 2,
+                    },
                   }}
                 >
-                  <ListItemText
-                    primary={
-                      <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 1.5,
-                        }}
-                      >
-                        {isAnswered ? (
-                          <IconWrapper
-                            icon="mdi:check-circle"
-                            size={20}
-                            color={isCurrent ? c.accent : c.answered}
-                          />
-                        ) : (
-                          <IconWrapper
-                            icon="mdi:circle-outline"
-                            size={20}
-                            color={isCurrent ? c.accent : "var(--border-light)"}
-                          />
-                        )}
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={1.25}
+                    sx={{ width: "100%", minWidth: 0 }}
+                  >
+                    <Box
+                      sx={{
+                        flexShrink: 0,
+                        width: 30,
+                        display: "flex",
+                        justifyContent: "center",
+                      }}
+                    >
+                      {isAnswered ? (
+                        <IconWrapper
+                          icon="mdi:check-decagram"
+                          size={24}
+                          color={isCurrent ? c.accent : c.answered}
+                        />
+                      ) : (
+                        <IconWrapper
+                          icon="mdi:circle-outline"
+                          size={24}
+                          color={isCurrent ? c.accent : "var(--border-light)"}
+                        />
+                      )}
+                    </Box>
+
+                    <Chip
+                      label={t("quiz.questionNumber", { n: index + 1 })}
+                      size="small"
+                      sx={{
+                        height: 26,
+                        minWidth: 44,
+                        fontWeight: 800,
+                        flexShrink: 0,
+                        fontSize: "0.72rem",
+                        bgcolor: isCurrent
+                          ? alpha(theme.palette.primary.main, 0.22)
+                          : alpha(theme.palette.grey[500], 0.1),
+                        color: isCurrent ? c.currentText : "var(--font-secondary)",
+                        border: `1px solid ${
+                          isCurrent
+                            ? alpha(theme.palette.primary.main, 0.4)
+                            : "var(--border-default)"
+                        }`,
+                      }}
+                    />
+
+                    <Tooltip
+                      title={displayLine}
+                      placement="left"
+                      enterDelay={350}
+                      slotProps={{
+                        tooltip: { sx: { maxWidth: 360 } },
+                        popper: { modifiers: [{ name: "offset", options: { offset: [0, -6] } }] },
+                      }}
+                    >
+                      <Box sx={{ flex: 1, minWidth: 0 }}>
                         {hasHtml(question.question) ? (
                           <Box
                             component="span"
                             sx={{
                               fontWeight: isCurrent ? 700 : 500,
                               color: isCurrent ? c.currentText : c.muted,
-                              fontSize: "0.875rem",
+                              fontSize: "0.8125rem",
                               overflow: "hidden",
                               textOverflow: "ellipsis",
                               whiteSpace: "nowrap",
-                              flex: 1,
+                              display: "block",
                               lineHeight: 1.5,
                               "& p": { margin: 0, display: "inline" },
                               "& br": { display: "none" },
                             }}
                             dangerouslySetInnerHTML={{
-                              __html: question.question || `Quiz question ${index + 1}`,
+                              __html: question.question || "",
                             }}
                           />
                         ) : (
                           <Typography
+                            component="span"
                             sx={{
                               fontWeight: isCurrent ? 700 : 500,
-                              color: isCurrent
-                                ? c.currentText
-                                : c.muted,
-                              fontSize: "0.875rem",
+                              color: isCurrent ? c.currentText : c.muted,
+                              fontSize: "0.8125rem",
                               overflow: "hidden",
                               textOverflow: "ellipsis",
                               whiteSpace: "nowrap",
-                              flex: 1,
+                              display: "block",
                               lineHeight: 1.5,
                             }}
                           >
-                            {question.question || `Quiz question ${index + 1}`}
+                            {truncated}
                           </Typography>
                         )}
-                        {isCurrent && (
-                          <Box
-                            sx={{
-                              width: 6,
-                              height: 6,
-                              borderRadius: "50%",
-                              backgroundColor: c.accent,
-                              ml: 0.5,
-                            }}
-                          />
-                        )}
                       </Box>
-                    }
-                  />
+                    </Tooltip>
+
+                    {isCurrent && (
+                      <Box
+                        aria-hidden
+                        sx={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: "50%",
+                          bgcolor: c.accent,
+                          flexShrink: 0,
+                          boxShadow: `0 0 0 3px ${alpha(theme.palette.primary.main, 0.22)}`,
+                        }}
+                      />
+                    )}
+                  </Stack>
                 </ListItemButton>
               </ListItem>
             );
@@ -264,31 +542,30 @@ const QuizQuestionListComponent = memo(function QuizQuestionList({
     </Paper>
   );
 }, (prevProps, nextProps) => {
-  // If current question changed, we MUST re-render (navigation)
   if (prevProps.currentQuestionId !== nextProps.currentQuestionId) return false;
   if (prevProps.listTitle !== nextProps.listTitle) return false;
   if (prevProps.listSubtitle !== nextProps.listSubtitle) return false;
   if (prevProps.variant !== nextProps.variant) return false;
-
-  // If questions array length changed, re-render
   if (prevProps.questions.length !== nextProps.questions.length) return false;
-  
-  // Only check if the current question's answered status changed (optimized)
-  const prevCurrent = prevProps.questions.find(q => q.id === prevProps.currentQuestionId);
-  const nextCurrent = nextProps.questions.find(q => q.id === nextProps.currentQuestionId);
+
+  const prevCurrent = prevProps.questions.find(
+    (q) => q.id === prevProps.currentQuestionId,
+  );
+  const nextCurrent = nextProps.questions.find(
+    (q) => q.id === nextProps.currentQuestionId,
+  );
   if (prevCurrent?.answered !== nextCurrent?.answered) return false;
-  
-  // Check if any question's answered status changed (but only for visible questions)
-  // This is a lighter check than filtering all questions
-  for (let i = 0; i < Math.min(prevProps.questions.length, nextProps.questions.length); i++) {
+
+  for (let i = 0; i < prevProps.questions.length; i++) {
     if (prevProps.questions[i]?.answered !== nextProps.questions[i]?.answered) {
-      return false; // Re-render if answered status changed
+      return false;
+    }
+    if (prevProps.questions[i]?.question !== nextProps.questions[i]?.question) {
+      return false;
     }
   }
-  
-  return true; // Skip re-render
+
+  return true;
 });
 
-// Export as named export for barrel file compatibility
 export { QuizQuestionListComponent as QuizQuestionList };
-

--- a/lib/utils/assessmentQuestionCompletion.ts
+++ b/lib/utils/assessmentQuestionCompletion.ts
@@ -1,0 +1,75 @@
+import { normalizeSubjectiveAnswer } from "@/utils/assessment.utils";
+
+/**
+ * Whether a single question counts as "addressed" for pre-submit checklist
+ * (aligned with take page / submission UX).
+ */
+export function isAssessmentQuestionCompleted(
+  sectionType: string,
+  response: unknown,
+): boolean {
+  if (sectionType === "quiz") {
+    return response !== undefined && response !== null && response !== "";
+  }
+  if (sectionType === "coding") {
+    if (!response || typeof response !== "object") return false;
+    const r = response as Record<string, unknown>;
+    const isSubmitted = r.submitted === true;
+    const totalCount = Number(r.total_tc ?? r.total_test_cases ?? 0) || 0;
+    const passedCount = Number(r.tc_passed ?? r.passed ?? 0) || 0;
+    // Align with coding sidebar (take page): starter/template code alone is not "done".
+    // Count as addressed only after explicit submit, or after a run with ≥1 passing test.
+    if (isSubmitted) return true;
+    if (totalCount > 0 && passedCount > 0) return true;
+    return false;
+  }
+  if (sectionType === "subjective") {
+    const text =
+      typeof response === "string"
+        ? response
+        : normalizeSubjectiveAnswer(response);
+    return text.trim().length > 0;
+  }
+  return false;
+}
+
+export function getResponseForQuestion(
+  responses: Record<string, Record<string, unknown>>,
+  sectionType: string,
+  questionId: string | number,
+): unknown {
+  const bucket = responses[sectionType] || {};
+  return bucket[questionId] ?? bucket[String(questionId)];
+}
+
+export function formatChecklistQuestionLabel(
+  sectionType: string,
+  question: Record<string, unknown>,
+  index: number,
+): string {
+  if (sectionType === "quiz") {
+    const raw =
+      (typeof question.question === "string" && question.question) ||
+      (typeof question.question_text === "string" && question.question_text) ||
+      "";
+    const oneLine = raw.replace(/\s+/g, " ").trim();
+    if (!oneLine) return `Question ${index + 1}`;
+    return oneLine.length > 100 ? `${oneLine.slice(0, 97)}…` : oneLine;
+  }
+  if (sectionType === "coding") {
+    const t =
+      (typeof question.title === "string" && question.title) ||
+      (typeof question.name === "string" && question.name) ||
+      "";
+    return t.trim() || `Problem ${index + 1}`;
+  }
+  if (sectionType === "subjective") {
+    const raw =
+      (typeof question.question_text === "string" && question.question_text) ||
+      "";
+    const oneLine = raw.replace(/\s+/g, " ").trim();
+    if (!oneLine) return `Written ${index + 1}`;
+    return oneLine.length > 120 ? `${oneLine.slice(0, 117)}…` : oneLine;
+  }
+  return `Item ${index + 1}`;
+}

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -423,7 +423,20 @@
     "submitting": "جاري الإرسال...",
     "back": "رجوع",
     "answeredOf": "{{answered}} من {{total}} تمت الإجابة عليها",
-    "questionOf": "سؤال {{current}} من {{total}}"
+    "questionOf": "سؤال {{current}} من {{total}}",
+    "questionListTitle": "التنقل بين الأسئلة",
+    "questionListToggle": "إظهار أو إخفاء قائمة الأسئلة",
+    "questionNumber": "س{{n}}",
+    "questionStatusAnswered": "تمت الإجابة",
+    "questionStatusPending": "بدون إجابة",
+    "questionStatusCurrent": "السؤال الحالي",
+    "writtenListTitle": "إجابات كتابية",
+    "writtenListSubtitle": "اختر سؤالًا لتعديل إجابتك. يُحفظ عملك تلقائيًا.",
+    "navProgressLabel": "الإنجاز",
+    "navAllDone": "اكتمل الكل",
+    "navRemaining": "{{count}} متبقية",
+    "jumpToNextUnanswered": "التالي بدون إجابة",
+    "jumpToNextUnansweredShort": "التالي الفارغ"
   },
   "tools": {
     "calculator": "آلة حاسبة علمية",
@@ -487,6 +500,28 @@
       "title": "فحص الجهاز",
       "noFaceDetected": "لم يتم اكتشاف وجه. يرجى وضع نفسك أمام الكاميرا.",
       "multipleFaces": "تم اكتشاف {{count}} وجوه. يجب أن يكون شخص واحد فقط مرئياً."
+    },
+    "submitChecklist": {
+      "title": "مراجعة قبل الإرسال",
+      "subtitle": "راجع كل قسم وكل سؤال. الأخضر يعني وجود إجابة أو محاولة؛ الكهرماني يحتاج إلى اهتمامك.",
+      "summaryTitle": "التقدم الإجمالي",
+      "summaryLine": "{{answered}} من {{total}} أسئلة تمت معالجتها",
+      "allCompleteHint": "يبدو أن كل شيء مكتمل. يمكنك مراجعة القائمة ثم التأكيد.",
+      "pendingHint": "لا يزال لديك {{count}} سؤالًا بلا رد واضح. يمكنك الإرسال بعد التأكيد أدناه.",
+      "sectionMeta": "{{answered}} / {{total}} في هذا القسم",
+      "expandAll": "توسيع الكل",
+      "collapseAll": "طي الكل",
+      "statusDone": "تم",
+      "statusTodo": "معلق",
+      "typeQuiz": "اختيار من متعدد",
+      "typeCoding": "برمجة",
+      "typeSubjective": "كتابي",
+      "questionNumber": "س{{n}}",
+      "confirmCheckbox": "أفهم أن إجاباتي ستُعتمد نهائيًا ولن أتمكن من تعديلها بعد الإرسال.",
+      "cancel": "رجوع",
+      "confirmSubmit": "إرسال التقييم",
+      "submitting": "جاري الإرسال…",
+      "noSections": "لم تُحمّل أقسام لهذا التقييم. جرّب تحديث الصفحة."
     }
   },
   "mockInterview": {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -423,7 +423,20 @@
     "submitting": "Submitting...",
     "back": "Back",
     "answeredOf": "{{answered}} of {{total}} answered",
-    "questionOf": "Question {{current}} of {{total}}"
+    "questionOf": "Question {{current}} of {{total}}",
+    "questionListTitle": "Question navigator",
+    "questionListToggle": "Show or hide the question list",
+    "questionNumber": "Q{{n}}",
+    "questionStatusAnswered": "Answered",
+    "questionStatusPending": "Not answered",
+    "questionStatusCurrent": "Current question",
+    "writtenListTitle": "Written responses",
+    "writtenListSubtitle": "Select a question to edit your answer. Your work is saved automatically.",
+    "navProgressLabel": "Completion",
+    "navAllDone": "All done",
+    "navRemaining": "{{count}} left",
+    "jumpToNextUnanswered": "Next unanswered",
+    "jumpToNextUnansweredShort": "Next gap"
   },
   "tools": {
     "calculator": "Scientific calculator",
@@ -487,6 +500,28 @@
       "title": "Device check",
       "noFaceDetected": "No face detected. Please position yourself in front of the camera.",
       "multipleFaces": "{{count}} faces detected. Only one person should be visible."
+    },
+    "submitChecklist": {
+      "title": "Review before you submit",
+      "subtitle": "Go through each section and question. Green means we detected an answer or attempt; amber still needs your attention.",
+      "summaryTitle": "Overall progress",
+      "summaryLine": "{{answered}} of {{total}} questions addressed",
+      "allCompleteHint": "Everything looks answered. You can still review the list below, then confirm.",
+      "pendingHint": "You still have {{count}} question(s) without a clear response. You may submit anyway after confirming below.",
+      "sectionMeta": "{{answered}} / {{total}} in this section",
+      "expandAll": "Expand all",
+      "collapseAll": "Collapse all",
+      "statusDone": "Done",
+      "statusTodo": "Pending",
+      "typeQuiz": "Multiple choice",
+      "typeCoding": "Coding",
+      "typeSubjective": "Written",
+      "questionNumber": "Q{{n}}",
+      "confirmCheckbox": "I understand my responses will be finalized and I cannot change them after submission.",
+      "cancel": "Go back",
+      "confirmSubmit": "Submit assessment",
+      "submitting": "Submitting…",
+      "noSections": "No sections are loaded for this assessment. Try refreshing the page."
     }
   },
   "mockInterview": {


### PR DESCRIPTION
Add pre-submit modal with per-section question checklist, progress, and pinned confirmation checkbox; fix ListItemText invalid nesting. Improve quiz navigator with progress bar, next-unanswered shortcut, auto-scroll, and i18n. Align coding "completed" with sidebar (submit or pass ≥1 test, not template code). Share completion logic via assessmentQuestionCompletion; widen quiz/ subjective side columns slightly.