### PR TITLE
feat(assessment): device-type restrictions UI and API integration

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -430,7 +430,7 @@ export default function SignupPage() {
                       </Typography>
                     </Box>
                     <Switch
-                      checked={values.signup_as_instructor}
+                      checked={values.signup_as_instructor ?? false}
                       onChange={(e) =>
                         setFieldValue(
                           "signup_as_instructor",

--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
+import { useTranslation } from "react-i18next";
 import {
   Box,
   Typography,
@@ -243,6 +244,7 @@ function toISTForAPI(dateTimeString: string | null | undefined): string | undefi
 }
 
 export default function AssessmentEditPage() {
+  const { t } = useTranslation("common");
   const { showToast } = useToast();
   const router = useRouter();
   const params = useParams();
@@ -283,6 +285,9 @@ export default function AssessmentEditPage() {
   const [liveStreaming, setLiveStreaming] = useState(false);
   const [sendCommunication, setSendCommunication] = useState(false);
   const [showResult, setShowResult] = useState(true);
+  const [allowDesktop, setAllowDesktop] = useState(true);
+  const [allowMobile, setAllowMobile] = useState(true);
+  const [allowTablet, setAllowTablet] = useState(true);
 
   const [questionsPage, setQuestionsPage] = useState(1);
   const [questionsLimit, setQuestionsLimit] = useState(10);
@@ -347,6 +352,9 @@ export default function AssessmentEditPage() {
       setLiveStreaming((data as any).live_streaming ?? false);
       setSendCommunication((data as any).send_communication ?? false);
       setShowResult((data as any).show_result ?? true);
+      setAllowDesktop((data as any).allow_desktop ?? true);
+      setAllowMobile((data as any).allow_mobile ?? true);
+      setAllowTablet((data as any).allow_tablet ?? true);
     } catch (e: any) {
       showToast(e?.message || "Failed to load assessment", "error");
       setAssessment(null);
@@ -491,6 +499,10 @@ export default function AssessmentEditPage() {
       showToast("Please enter a valid price for paid assessment", "error");
       return;
     }
+    if (!allowDesktop && !allowMobile && !allowTablet) {
+      showToast(t("assessmentDevice.atLeastOne"), "error");
+      return;
+    }
     try {
       setSaving(true);
       const payload: Partial<CreateAssessmentPayload> = {
@@ -508,6 +520,9 @@ export default function AssessmentEditPage() {
         live_streaming: canConfigureLiveStreaming ? liveStreaming : false,
         send_communication: sendCommunication,
         show_result: showResult,
+        allow_desktop: allowDesktop,
+        allow_mobile: allowMobile,
+        allow_tablet: allowTablet,
         course_ids: courseIds,
         colleges: colleges.length ? colleges : undefined,
       };
@@ -1048,6 +1063,9 @@ export default function AssessmentEditPage() {
                   showLiveStreamingToggle={canConfigureLiveStreaming}
                   sendCommunication={sendCommunication}
                   showResult={showResult}
+                  allowDesktop={allowDesktop}
+                  allowMobile={allowMobile}
+                  allowTablet={allowTablet}
                   onDurationChange={setDurationMinutes}
                   onStartTimeChange={setStartTime}
                   onEndTimeChange={setEndTime}
@@ -1061,6 +1079,9 @@ export default function AssessmentEditPage() {
                   onLiveStreamingChange={setLiveStreaming}
                   onSendCommunicationChange={setSendCommunication}
                   onShowResultChange={setShowResult}
+                  onAllowDesktopChange={setAllowDesktop}
+                  onAllowMobileChange={setAllowMobile}
+                  onAllowTabletChange={setAllowTablet}
                   readOnly={readOnly}
                 />
                 {!readOnly && (

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
 import { useAuth } from "@/lib/auth/auth-context";
 import { isCourseManagerRole } from "@/lib/auth/auth-utils";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
@@ -41,6 +42,7 @@ type MCQInputMethod = "manual" | "existing" | "csv" | "ai";
 const steps = ["Assessment Details", "Add Questions", "Review & Create"];
 
 export default function CreateAssessmentPage() {
+  const { t } = useTranslation("common");
   const { showToast } = useToast();
   const router = useRouter();
   const { user, loading: authLoading } = useAuth();
@@ -75,6 +77,9 @@ export default function CreateAssessmentPage() {
   const [liveStreaming, setLiveStreaming] = useState(false);
   const [sendCommunication, setSendCommunication] = useState(false);
   const [showResult, setShowResult] = useState(true);
+  const [allowDesktop, setAllowDesktop] = useState(true);
+  const [allowMobile, setAllowMobile] = useState(true);
+  const [allowTablet, setAllowTablet] = useState(true);
 
   // Multiple sections
   const [sections, setSections] = useState<Section[]>([]);
@@ -494,6 +499,12 @@ export default function CreateAssessmentPage() {
     try {
       setCreating(true);
 
+      if (!allowDesktop && !allowMobile && !allowTablet) {
+        showToast(t("assessmentDevice.atLeastOne"), "error");
+        setCreating(false);
+        return;
+      }
+
       const quizSections = sections
         .filter((s) => s.type === "quiz")
         .sort((a, b) => a.order - b.order);
@@ -648,6 +659,9 @@ export default function CreateAssessmentPage() {
         live_streaming: canConfigureLiveStreaming ? liveStreaming : false,
         send_communication: sendCommunication,
         show_result: showResult,
+        allow_desktop: allowDesktop,
+        allow_mobile: allowMobile,
+        allow_tablet: allowTablet,
       };
 
       // Add course_ids if any courses are selected
@@ -795,6 +809,9 @@ export default function CreateAssessmentPage() {
               showLiveStreamingToggle={canConfigureLiveStreaming}
               sendCommunication={sendCommunication}
               showResult={showResult}
+              allowDesktop={allowDesktop}
+              allowMobile={allowMobile}
+              allowTablet={allowTablet}
               onDurationChange={setDurationMinutes}
               onStartTimeChange={setStartTime}
               onEndTimeChange={setEndTime}
@@ -808,6 +825,9 @@ export default function CreateAssessmentPage() {
               onLiveStreamingChange={setLiveStreaming}
               onSendCommunicationChange={setSendCommunication}
               onShowResultChange={setShowResult}
+              onAllowDesktopChange={setAllowDesktop}
+              onAllowMobileChange={setAllowMobile}
+              onAllowTabletChange={setAllowTablet}
             />
             <Divider />
             <MultipleSectionsSection

--- a/app/admin/course-builder/[id]/edit/page.tsx
+++ b/app/admin/course-builder/[id]/edit/page.tsx
@@ -237,7 +237,7 @@ export default function CourseEditPage() {
               <FormControlLabel
                 control={
                   <Switch
-                    checked={formData.is_free}
+                    checked={formData.is_free ?? true}
                     onChange={(e) => setFormData({ ...formData, is_free: e.target.checked })}
                     color="primary"
                   />

--- a/app/assessments/[slug]/device-check/page.tsx
+++ b/app/assessments/[slug]/device-check/page.tsx
@@ -17,7 +17,12 @@ import {
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { assessmentService } from "@/lib/services/assessment.service";
+import {
+  assessmentService,
+  type AssessmentDetail,
+} from "@/lib/services/assessment.service";
+import { isCurrentDeviceAllowedForAssessment } from "@/lib/utils/assessment-device";
+import { AssessmentDeviceStatusPanel } from "@/components/assessment/AssessmentDeviceStatusPanel";
 import { useProctoring } from "@/lib/hooks/useProctoring";
 import { CheckCircle, XCircle, Video, Mic, AlertCircle } from "lucide-react";
 
@@ -37,7 +42,9 @@ export default function DeviceCheckPage({
   const router = useRouter();
   const [loading, setLoading] = useState(false); // Start with false - don't block initial render
   const [checking, setChecking] = useState(false);
-  const [, setAssessment] = useState<any>(null);
+  const [deviceAccessDenied, setDeviceAccessDenied] = useState(false);
+  const [deniedAssessment, setDeniedAssessment] =
+    useState<AssessmentDetail | null>(null);
   const [deviceStatus, setDeviceStatus] = useState<DeviceStatus>({
     camera: false,
     microphone: false,
@@ -352,7 +359,12 @@ export default function DeviceCheckPage({
     const loadAssessment = async () => {
       try {
         const data = await assessmentService.getAssessmentDetail(slug);
-        setAssessment(data);
+
+        if (!isCurrentDeviceAllowedForAssessment(data)) {
+          setDeniedAssessment(data);
+          setDeviceAccessDenied(true);
+          return;
+        }
 
         // Check if assessment is already attempted
         if (data.is_attempted) {
@@ -377,7 +389,7 @@ export default function DeviceCheckPage({
     if (slug) {
       loadAssessment();
     }
-  }, [slug, router, showToast]);
+  }, [slug, router, showToast, t]);
 
   const handleStartAssessment = () => {
     if (!deviceStatus.camera || !deviceStatus.microphone) {
@@ -416,6 +428,77 @@ export default function DeviceCheckPage({
     deviceStatus.microphone &&
     deviceStatus.browserSupported &&
     faceValidationPassed;
+
+  if (deviceAccessDenied && deniedAssessment) {
+    return (
+      <MainLayout>
+        <Container maxWidth="md" sx={{ py: { xs: 3, sm: 5 }, px: 2 }}>
+          <Paper
+            elevation={0}
+            sx={{
+              p: { xs: 3, sm: 4 },
+              borderRadius: 3,
+              border: "1px solid #e5e7eb",
+              textAlign: "center",
+            }}
+          >
+            <Box
+              sx={{
+                width: 72,
+                height: 72,
+                borderRadius: "50%",
+                backgroundColor: "rgba(245, 158, 11, 0.15)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                mx: "auto",
+                mb: 2,
+              }}
+            >
+              <IconWrapper
+                icon="mdi:cellphone-off"
+                size={40}
+                color="#d97706"
+              />
+            </Box>
+            <Typography
+              variant="h5"
+              sx={{ fontWeight: 800, color: "#1f2937", mb: 1 }}
+            >
+              {t("assessmentDevice.deviceCheckBlockedTitle")}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ color: "#6b7280", mb: 3, maxWidth: 480, mx: "auto" }}
+            >
+              {t("assessmentDevice.deviceCheckBlockedSubtitle")}
+            </Typography>
+            <Box sx={{ textAlign: "left", mb: 3 }}>
+              <AssessmentDeviceStatusPanel
+                assessment={deniedAssessment}
+                sx={{ mb: 0 }}
+              />
+            </Box>
+            <Button
+              variant="contained"
+              size="large"
+              startIcon={<IconWrapper icon="mdi:arrow-left" size={20} />}
+              onClick={() => router.push(`/assessments/${slug}`)}
+              sx={{
+                textTransform: "none",
+                fontWeight: 600,
+                px: 3,
+                backgroundColor: "#6366f1",
+                "&:hover": { backgroundColor: "#4f46e5" },
+              }}
+            >
+              {t("assessmentDevice.backToAssessment")}
+            </Button>
+          </Paper>
+        </Container>
+      </MainLayout>
+    );
+  }
 
   // Don't show loading screen - render immediately for better UX
 

--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
   TextField,
   CircularProgress,
   LinearProgress,
+  Tooltip,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
@@ -24,6 +25,8 @@ import {
 } from "@/lib/services/assessment.service";
 import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { isCurrentDeviceAllowedForAssessment } from "@/lib/utils/assessment-device";
+import { AssessmentDeviceStatusPanel } from "@/components/assessment/AssessmentDeviceStatusPanel";
 
 export default function AssessmentDetailPage({
   params,
@@ -69,6 +72,10 @@ export default function AssessmentDetailPage({
   };
 
   const handleStart = () => {
+    if (assessment && !isCurrentDeviceAllowedForAssessment(assessment)) {
+      showToast(t("assessmentDevice.toastBlocked"), "warning");
+      return;
+    }
     // Skip device-check if proctoring is disabled
     if (assessment && assessment.proctoring_enabled === false) {
       router.push(`/assessments/${slug}/take`);
@@ -104,6 +111,8 @@ export default function AssessmentDetailPage({
       </MainLayout>
     );
   }
+
+  const deviceAllowed = isCurrentDeviceAllowedForAssessment(assessment);
 
   return (
     <MainLayout>
@@ -221,6 +230,9 @@ export default function AssessmentDetailPage({
             </Box>
           </Box>
         </Box>
+
+        <AssessmentDeviceStatusPanel assessment={assessment} />
+
         <Paper
           elevation={0}
           sx={{
@@ -464,29 +476,46 @@ export default function AssessmentDetailPage({
             </Box>
           )}
 
-          <Button
-            variant="contained"
-            size="large"
-            fullWidth
-            startIcon={<IconWrapper icon="mdi:play-circle-outline" size={24} />}
-            onClick={handleStart}
-            sx={{
-              backgroundColor: "#6366f1",
-              color: "#ffffff",
-              fontWeight: 600,
-              py: 1.5,
-              borderRadius: 2,
-              textTransform: "none",
-              fontSize: "1rem",
-              boxShadow: "0 4px 14px 0 rgba(99, 102, 241, 0.39)",
-              "&:hover": {
-                backgroundColor: "#4f46e5",
-                boxShadow: "0 6px 20px 0 rgba(99, 102, 241, 0.5)",
-              },
-            }}
+          <Tooltip
+            title={
+              !deviceAllowed ? t("assessmentDevice.startDisabledHint") : ""
+            }
+            placement="top"
+            arrow
           >
-            {t("assessments.startAssessment")}
-          </Button>
+            <span style={{ width: "100%", display: "block" }}>
+              <Button
+                variant="contained"
+                size="large"
+                fullWidth
+                disabled={!deviceAllowed}
+                startIcon={
+                  <IconWrapper icon="mdi:play-circle-outline" size={24} />
+                }
+                onClick={handleStart}
+                sx={{
+                  backgroundColor: "#6366f1",
+                  color: "#ffffff",
+                  fontWeight: 600,
+                  py: 1.5,
+                  borderRadius: 2,
+                  textTransform: "none",
+                  fontSize: "1rem",
+                  boxShadow: "0 4px 14px 0 rgba(99, 102, 241, 0.39)",
+                  "&:hover": {
+                    backgroundColor: "#4f46e5",
+                    boxShadow: "0 6px 20px 0 rgba(99, 102, 241, 0.5)",
+                  },
+                  "&.Mui-disabled": {
+                    backgroundColor: "#c7c9f5",
+                    color: "#f3f4f6",
+                  },
+                }}
+              >
+                {t("assessments.startAssessment")}
+              </Button>
+            </span>
+          </Tooltip>
         </Paper>
       </Box>
     </MainLayout>

--- a/components/admin/assessment/AssessmentSettingsSection.tsx
+++ b/components/admin/assessment/AssessmentSettingsSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslation } from "react-i18next";
 import {
   Box,
   Typography,
@@ -16,21 +17,29 @@ import {
   CircularProgress,
   Autocomplete,
   Chip,
+  Paper,
+  Stack,
 } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import { IconWrapper } from "@/components/common/IconWrapper";
 
 interface AssessmentSettingsSectionProps {
   durationMinutes: number;
   startTime: string;
   endTime: string;
-  isPaid: boolean;
+  /** Omitted or undefined is normalized via default params so MUI Switch stays controlled. */
+  isPaid?: boolean;
   price: string;
   currency: string;
-  isActive: boolean;
-  proctoringEnabled: boolean;
-  liveStreaming: boolean;
+  isActive?: boolean;
+  proctoringEnabled?: boolean;
+  liveStreaming?: boolean;
   showLiveStreamingToggle?: boolean;
-  sendCommunication: boolean;
-  showResult: boolean;
+  sendCommunication?: boolean;
+  showResult?: boolean;
+  allowDesktop?: boolean;
+  allowMobile?: boolean;
+  allowTablet?: boolean;
   courseIds: number[];
   courses: any[];
   loadingCourses: boolean;
@@ -46,6 +55,9 @@ interface AssessmentSettingsSectionProps {
   onLiveStreamingChange: (value: boolean) => void;
   onSendCommunicationChange: (value: boolean) => void;
   onShowResultChange: (value: boolean) => void;
+  onAllowDesktopChange: (value: boolean) => void;
+  onAllowMobileChange: (value: boolean) => void;
+  onAllowTabletChange: (value: boolean) => void;
   onCourseIdsChange: (value: number[]) => void;
   onCollegesChange: (value: string[]) => void;
   readOnly?: boolean;
@@ -55,15 +67,18 @@ export function AssessmentSettingsSection({
   durationMinutes,
   startTime,
   endTime,
-  isPaid,
+  isPaid = false,
   price,
   currency,
-  isActive,
-  proctoringEnabled,
-  liveStreaming,
+  isActive = true,
+  proctoringEnabled = true,
+  liveStreaming = false,
   showLiveStreamingToggle = false,
-  sendCommunication,
-  showResult,
+  sendCommunication = false,
+  showResult = true,
+  allowDesktop = true,
+  allowMobile = true,
+  allowTablet = true,
   courseIds,
   courses,
   loadingCourses,
@@ -79,10 +94,14 @@ export function AssessmentSettingsSection({
   onLiveStreamingChange,
   onSendCommunicationChange,
   onShowResultChange,
+  onAllowDesktopChange,
+  onAllowMobileChange,
+  onAllowTabletChange,
   onCourseIdsChange,
   onCollegesChange,
   readOnly = false,
 }: AssessmentSettingsSectionProps) {
+  const { t } = useTranslation("common");
   return (
     <Box>
       <Typography
@@ -279,7 +298,7 @@ export function AssessmentSettingsSection({
           <FormControlLabel
             control={
               <Switch
-                checked={proctoringEnabled ?? true}
+                checked={proctoringEnabled}
                 onChange={(e) => onProctoringEnabledChange(e.target.checked)}
                 disabled={readOnly}
               />
@@ -324,6 +343,150 @@ export function AssessmentSettingsSection({
           <Typography variant="caption" color="text.secondary" sx={{ ml: 4 }}>
             When enabled, students can view their score and detailed results after submission. When disabled, they will see an evaluation-in-progress message instead.
           </Typography>
+          <Paper
+            variant="outlined"
+            sx={{
+              p: 2,
+              mt: 2,
+              borderRadius: 2,
+              borderColor: "#e5e7eb",
+              backgroundColor: "#fafafa",
+            }}
+          >
+            <Stack direction="row" spacing={1.5} alignItems="flex-start" sx={{ mb: 2 }}>
+              <Box
+                sx={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 1.5,
+                  bgcolor: alpha("#6366f1", 0.12),
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                }}
+              >
+                <IconWrapper icon="mdi:devices" size={22} color="#6366f1" />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontWeight: 700, color: "#111827" }}
+                >
+                  {t("assessmentDevice.sectionTitle")}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", lineHeight: 1.5 }}
+                >
+                  {t("assessmentDevice.sectionIntro")}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mt: 0.75, fontWeight: 600 }}
+                >
+                  {t("assessmentDevice.sectionHint")}
+                </Typography>
+              </Box>
+            </Stack>
+            <Stack spacing={0}>
+              <Box
+                sx={{
+                  py: 1.25,
+                  borderBottom: "1px solid",
+                  borderColor: "#ececec",
+                }}
+              >
+                <Stack direction="row" alignItems="center" spacing={1.5}>
+                  <IconWrapper icon="mdi:monitor" size={22} color="#6366f1" />
+                  <FormControlLabel
+                    sx={{ flex: 1, m: 0 }}
+                    control={
+                      <Switch
+                        checked={allowDesktop}
+                        onChange={(e) => onAllowDesktopChange(e.target.checked)}
+                        disabled={readOnly}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2" fontWeight={600}>
+                        {t("assessmentDevice.allowDesktop")}
+                      </Typography>
+                    }
+                  />
+                </Stack>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mt: 0.5, ml: 5.5, lineHeight: 1.45 }}
+                >
+                  {t("assessmentDevice.allowDesktopHint")}
+                </Typography>
+              </Box>
+              <Box
+                sx={{
+                  py: 1.25,
+                  borderBottom: "1px solid",
+                  borderColor: "#ececec",
+                }}
+              >
+                <Stack direction="row" alignItems="center" spacing={1.5}>
+                  <IconWrapper icon="mdi:cellphone" size={22} color="#6366f1" />
+                  <FormControlLabel
+                    sx={{ flex: 1, m: 0 }}
+                    control={
+                      <Switch
+                        checked={allowMobile}
+                        onChange={(e) => onAllowMobileChange(e.target.checked)}
+                        disabled={readOnly}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2" fontWeight={600}>
+                        {t("assessmentDevice.allowMobile")}
+                      </Typography>
+                    }
+                  />
+                </Stack>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mt: 0.5, ml: 5.5, lineHeight: 1.45 }}
+                >
+                  {t("assessmentDevice.allowMobileHint")}
+                </Typography>
+              </Box>
+              <Box sx={{ py: 1.25 }}>
+                <Stack direction="row" alignItems="center" spacing={1.5}>
+                  <IconWrapper icon="mdi:tablet" size={22} color="#6366f1" />
+                  <FormControlLabel
+                    sx={{ flex: 1, m: 0 }}
+                    control={
+                      <Switch
+                        checked={allowTablet}
+                        onChange={(e) => onAllowTabletChange(e.target.checked)}
+                        disabled={readOnly}
+                      />
+                    }
+                    label={
+                      <Typography variant="body2" fontWeight={600}>
+                        {t("assessmentDevice.allowTablet")}
+                      </Typography>
+                    }
+                  />
+                </Stack>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ display: "block", mt: 0.5, ml: 5.5, lineHeight: 1.45 }}
+                >
+                  {t("assessmentDevice.allowTabletHint")}
+                </Typography>
+              </Box>
+            </Stack>
+          </Paper>
         </Box>
       </Box>
     </Box>

--- a/components/admin/content-management/ContentTable.tsx
+++ b/components/admin/content-management/ContentTable.tsx
@@ -178,9 +178,12 @@ export function ContentTable({
                         }
                       >
                         <Switch
-                          checked={content.is_verified}
+                          checked={content.is_verified ?? false}
                           onChange={() =>
-                            onToggleVerification(content.id, !content.is_verified)
+                            onToggleVerification(
+                              content.id,
+                              !(content.is_verified ?? false),
+                            )
                           }
                           disabled={isVerifying}
                           size="small"

--- a/components/admin/course-builder/CourseCard.tsx
+++ b/components/admin/course-builder/CourseCard.tsx
@@ -398,7 +398,7 @@ export function CourseCard({
             <FormControlLabel
               control={
                 <Switch
-                  checked={editData.is_free}
+                  checked={editData.is_free ?? true}
                   onChange={(e) => setEditData({ ...editData, is_free: e.target.checked })}
                   color="primary"
                   size="small"

--- a/components/admin/manage-students/AccountStatusCard.tsx
+++ b/components/admin/manage-students/AccountStatusCard.tsx
@@ -61,7 +61,7 @@ export function AccountStatusCard({
         >
           <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
             <Switch
-              checked={personal_info.is_active}
+              checked={personal_info.is_active ?? false}
               onChange={onToggle}
               disabled={saving}
               color="primary"

--- a/components/assessment/AssessmentDeviceStatusPanel.tsx
+++ b/components/assessment/AssessmentDeviceStatusPanel.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import {
+  Box,
+  Typography,
+  Chip,
+  Paper,
+  Stack,
+  alpha,
+  type SxProps,
+  type Theme,
+} from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  ASSESSMENT_DEVICE_CLASS_ICONS,
+  assessmentHasDeviceRestrictions,
+  getClientDeviceClass,
+  isCurrentDeviceAllowedForAssessment,
+  type AssessmentDeviceClass,
+} from "@/lib/utils/assessment-device";
+
+export type DevicePanelAssessment = {
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
+};
+
+function allowedClasses(assessment: DevicePanelAssessment): AssessmentDeviceClass[] {
+  const out: AssessmentDeviceClass[] = [];
+  if (assessment.allow_desktop !== false) out.push("desktop");
+  if (assessment.allow_mobile !== false) out.push("mobile");
+  if (assessment.allow_tablet !== false) out.push("tablet");
+  return out;
+}
+
+interface AssessmentDeviceStatusPanelProps {
+  assessment: DevicePanelAssessment;
+  /** Merged onto the root Paper (e.g. `{ mb: 0 }` when nested). */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Learner-facing summary: current device vs allowed types, with clear
+ * success / warning styling when restrictions apply.
+ */
+export function AssessmentDeviceStatusPanel({
+  assessment,
+  sx: sxProp,
+}: AssessmentDeviceStatusPanelProps) {
+  const { t } = useTranslation("common");
+  const current = getClientDeviceClass();
+  const allowed = isCurrentDeviceAllowedForAssessment(assessment);
+  const restricted = assessmentHasDeviceRestrictions(assessment);
+  const allowedList = allowedClasses(assessment);
+
+  const classLabel = (c: AssessmentDeviceClass) =>
+    t(`assessmentDevice.classNames.${c}`);
+
+  if (!restricted) {
+    return (
+      <Paper
+        elevation={0}
+        sx={[
+          {
+            p: 2,
+            mb: 3,
+            borderRadius: 2,
+            border: "1px solid",
+            borderColor: alpha("#10b981", 0.35),
+            background: alpha("#ecfdf5", 0.65),
+          },
+          ...(Array.isArray(sxProp) ? sxProp : sxProp != null ? [sxProp] : []),
+        ]}
+      >
+        <Stack direction="row" alignItems="center" gap={1.5} flexWrap="wrap">
+          <IconWrapper icon="mdi:check-decagram" size={26} color="#059669" />
+          <Box>
+            <Typography
+              variant="subtitle2"
+              sx={{ fontWeight: 700, color: "#047857", lineHeight: 1.3 }}
+            >
+              {t("assessmentDevice.panelTitleAllOk")}
+            </Typography>
+            <Typography variant="caption" sx={{ color: "#065f46" }}>
+              {t("assessmentDevice.panelSubtitleAllOk")}
+            </Typography>
+          </Box>
+        </Stack>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      sx={[
+        {
+          p: 2.5,
+          mb: 3,
+          borderRadius: 2,
+          border: "2px solid",
+          borderColor: allowed ? alpha("#6366f1", 0.45) : alpha("#f59e0b", 0.7),
+          backgroundColor: allowed
+            ? alpha("#eef2ff", 0.85)
+            : alpha("#fffbeb", 0.95),
+        },
+        ...(Array.isArray(sxProp) ? sxProp : sxProp != null ? [sxProp] : []),
+      ]}
+    >
+      <Stack spacing={2}>
+        <Stack direction="row" alignItems="flex-start" gap={1.5}>
+          <IconWrapper
+            icon={
+              allowed
+                ? "mdi:shield-check-outline"
+                : "mdi:cellphone-off"
+            }
+            size={28}
+            color={allowed ? "#4f46e5" : "#d97706"}
+          />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography
+              variant="subtitle1"
+              sx={{
+                fontWeight: 700,
+                color: allowed ? "#3730a3" : "#92400e",
+                mb: 0.5,
+              }}
+            >
+              {allowed
+                ? t("assessmentDevice.panelTitleAllowed")
+                : t("assessmentDevice.learnerAlertTitle")}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: allowed ? "#4338ca" : "#78350f",
+                lineHeight: 1.55,
+              }}
+            >
+              {allowed
+                ? t("assessmentDevice.panelBodyAllowed", {
+                    device: classLabel(current),
+                  })
+                : t("assessmentDevice.learnerAlertBody", {
+                    types: allowedList.map(classLabel).join(", "),
+                  })}
+            </Typography>
+          </Box>
+        </Stack>
+
+        <Box>
+          <Typography
+            variant="caption"
+            sx={{
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              color: "#6b7280",
+              display: "block",
+              mb: 1,
+            }}
+          >
+            {t("assessmentDevice.allowedDevicesHeading")}
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" gap={1}>
+            {allowedList.map((c) => (
+              <Chip
+                key={c}
+                icon={
+                  <IconWrapper
+                    icon={ASSESSMENT_DEVICE_CLASS_ICONS[c]}
+                    size={18}
+                  />
+                }
+                label={classLabel(c)}
+                size="small"
+                sx={{
+                  fontWeight: 600,
+                  backgroundColor: "#ffffff",
+                  border: "1px solid #e5e7eb",
+                }}
+              />
+            ))}
+          </Stack>
+        </Box>
+
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            flexWrap: "wrap",
+            pt: 0.5,
+            borderTop: "1px dashed",
+            borderColor: alpha("#000", 0.08),
+          }}
+        >
+          <Typography
+            variant="caption"
+            sx={{
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+              color: "#6b7280",
+            }}
+          >
+            {t("assessmentDevice.currentDeviceHeading")}
+          </Typography>
+          <Chip
+            icon={
+              <IconWrapper
+                icon={ASSESSMENT_DEVICE_CLASS_ICONS[current]}
+                size={18}
+              />
+            }
+            label={classLabel(current)}
+            size="small"
+            color={allowed ? "default" : "warning"}
+            variant={allowed ? "outlined" : "filled"}
+            sx={{
+              fontWeight: 700,
+              ...(allowed
+                ? {}
+                : {
+                    backgroundColor: alpha("#f59e0b", 0.2),
+                    color: "#92400e",
+                  }),
+            }}
+          />
+        </Box>
+      </Stack>
+    </Paper>
+  );
+}

--- a/components/profile/resume/SectionManager.tsx
+++ b/components/profile/resume/SectionManager.tsx
@@ -135,7 +135,7 @@ export function SectionManager({ sections, onSectionsChange }: SectionManagerPro
                 <FormControlLabel
                   control={
                     <Switch
-                      checked={section.enabled}
+                      checked={section.enabled ?? false}
                       onChange={(e) => toggleSection(section.id, e.target.checked)}
                       size="small"
                     />

--- a/lib/hooks/useAssessmentData.ts
+++ b/lib/hooks/useAssessmentData.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
 import { assessmentService } from "@/lib/services/assessment.service";
 import { useToast } from "@/components/common/Toast";
 
@@ -59,6 +60,7 @@ interface AssessmentResponse {
 
 export function useAssessmentData(slug: string) {
   const router = useRouter();
+  const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [assessment, setAssessment] = useState<AssessmentResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -79,6 +81,25 @@ export function useAssessmentData(slug: string) {
 
         setAssessment(data as any);
       } catch (error: any) {
+        const res = error?.response;
+        const body = res?.data;
+        if (
+          res?.status === 403 &&
+          body &&
+          typeof body === "object" &&
+          body.code === "device_not_allowed"
+        ) {
+          const fromApi =
+            typeof body.detail === "string" && body.detail.length > 0
+              ? body.detail
+              : t("assessmentDevice.toastBlocked");
+          showToast(
+            `${fromApi} ${t("assessmentDevice.takePageRedirectHint")}`.trim(),
+            "error",
+          );
+          router.push(`/assessments/${slug}`);
+          return;
+        }
         showToast("Failed to start assessment", "error");
         router.push(`/assessments/${slug}`);
       } finally {
@@ -89,7 +110,7 @@ export function useAssessmentData(slug: string) {
     if (slug) {
       loadAssessment();
     }
-  }, [slug, router, showToast]);
+  }, [slug, router, showToast, t]);
 
   return { assessment, loading };
 }

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -129,6 +129,9 @@ export interface CreateAssessmentPayload {
   send_communication?: boolean;
   /** Whether to show results to students after submission (default true) */
   show_result?: boolean;
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
   quiz_section?: QuizSection; // For backward compatibility
   quiz_sections?: Array<{
     title: string;
@@ -178,6 +181,9 @@ export interface Assessment {
   submissions_count?: number;
   courses?: Array<{ id: number; title: string }>;
   colleges?: string[];
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
 }
 
 export interface AssessmentDetail extends Assessment {
@@ -185,6 +191,9 @@ export interface AssessmentDetail extends Assessment {
   end_time?: string | null;
   proctoring_enabled?: boolean;
   live_streaming?: boolean;
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
   course_ids?: number[];
   currency?: string;
   quiz_sections?: Array<{

--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -5,6 +5,7 @@ import axios, {
 } from "axios";
 import Cookies from "js-cookie";
 import { config } from "../config";
+import { getClientDeviceClass } from "../utils/assessment-device";
 
 // Create axios instance
 const apiClient: AxiosInstance = axios.create({
@@ -24,6 +25,14 @@ apiClient.interceptors.request.use(
     // When sending FormData, remove Content-Type so the browser sets it with the correct boundary
     if (config.data instanceof FormData && config.headers) {
       delete config.headers["Content-Type"];
+    }
+    const path = `${config.baseURL ?? ""}${config.url ?? ""}`;
+    if (
+      typeof window !== "undefined" &&
+      path.includes("/assessment/api/client/") &&
+      config.headers
+    ) {
+      config.headers["X-Client-Device-Type"] = getClientDeviceClass();
     }
     return config;
   },

--- a/lib/services/assessment.service.ts
+++ b/lib/services/assessment.service.ts
@@ -21,12 +21,18 @@ export interface Assessment {
   proctoring_enabled?: boolean;
   /** "not_started" | "in_progress" | "submitted" | "completed" – when "submitted" or "completed", show results */
   status?: "not_started" | "in_progress" | "submitted" | "completed";
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
 }
 
 export interface AssessmentDetail extends Assessment {
   sections: any[];
   /** When false, hide "View Assessment Result" button on submission-success */
   show_result?: boolean;
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
 }
 
 export interface AssessmentSubmission {

--- a/lib/utils/assessment-device.ts
+++ b/lib/utils/assessment-device.ts
@@ -1,0 +1,88 @@
+export type AssessmentDeviceClass = "desktop" | "mobile" | "tablet";
+
+/** Iconify icon names for each device class (learner/admin UI). */
+export const ASSESSMENT_DEVICE_CLASS_ICONS: Record<
+  AssessmentDeviceClass,
+  string
+> = {
+  desktop: "mdi:monitor",
+  mobile: "mdi:cellphone",
+  tablet: "mdi:tablet",
+};
+
+/** True if the assessment limits at least one device type. */
+export function assessmentHasDeviceRestrictions(assessment: {
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
+}): boolean {
+  return (
+    assessment.allow_desktop === false ||
+    assessment.allow_mobile === false ||
+    assessment.allow_tablet === false
+  );
+}
+
+/**
+ * Coarse device class for assessment access rules. Aligns with backend
+ * X-Client-Device-Type and resolve_device_class heuristics.
+ */
+export function getClientDeviceClass(): AssessmentDeviceClass {
+  if (typeof window === "undefined") {
+    return "desktop";
+  }
+  const ua = navigator.userAgent || "";
+  const maxTouch = navigator.maxTouchPoints || 0;
+
+  // iPadOS 13+ reports as MacIntel with touch
+  if (/iPad/i.test(ua) || (navigator.platform === "MacIntel" && maxTouch > 1)) {
+    return "tablet";
+  }
+  if (/Android/i.test(ua) && !/Mobile/i.test(ua)) {
+    return "tablet";
+  }
+  if (/Tablet/i.test(ua)) {
+    return "tablet";
+  }
+
+  if (
+    /iPhone|iPod/i.test(ua) ||
+    /Android.*Mobile/i.test(ua) ||
+    /webOS|BlackBerry|IEMobile|Opera Mini/i.test(ua)
+  ) {
+    return "mobile";
+  }
+
+  const w = window.innerWidth;
+  if (maxTouch > 1 && w >= 768 && w <= 1280) {
+    return "tablet";
+  }
+
+  return "desktop";
+}
+
+export function isCurrentDeviceAllowedForAssessment(assessment: {
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
+}): boolean {
+  const d = getClientDeviceClass();
+  const ad = assessment.allow_desktop !== false;
+  const am = assessment.allow_mobile !== false;
+  const at = assessment.allow_tablet !== false;
+  if (d === "desktop") return ad;
+  if (d === "mobile") return am;
+  return at;
+}
+
+export function allowedDeviceLabels(assessment: {
+  allow_desktop?: boolean;
+  allow_mobile?: boolean;
+  allow_tablet?: boolean;
+}): string[] {
+  const out: string[] = [];
+  if (assessment.allow_desktop !== false) out.push("desktop");
+  if (assessment.allow_mobile !== false) out.push("mobile");
+  if (assessment.allow_tablet !== false) out.push("tablet");
+  return out;
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -525,6 +525,40 @@
       "noSections": "No sections are loaded for this assessment. Try refreshing the page."
     }
   },
+  "assessmentDevice": {
+    "sectionTitle": "Device access",
+    "sectionHint": "Choose which device types can take this assessment. At least one must stay enabled.",
+    "sectionIntro": "Control whether students can start this assessment from a computer, phone, or tablet. The app detects the device type automatically.",
+    "allowDesktop": "Desktop & laptop",
+    "allowMobile": "Phone",
+    "allowTablet": "Tablet",
+    "allowDesktopHint": "Web browsers on Mac, Windows, and Linux (typical laptops and desktops).",
+    "allowMobileHint": "Phones and small-screen mobile browsers.",
+    "allowTabletHint": "iPad, Android tablets, and similar.",
+    "atLeastOne": "At least one device type must be allowed.",
+    "labelDesktop": "desktop",
+    "labelMobile": "mobile",
+    "labelTablet": "tablet",
+    "classNames": {
+      "desktop": "Desktop / laptop",
+      "mobile": "Phone",
+      "tablet": "Tablet"
+    },
+    "panelTitleAllOk": "Any device allowed",
+    "panelSubtitleAllOk": "You can take this assessment on a computer, phone, or tablet.",
+    "panelTitleAllowed": "Your device is supported",
+    "panelBodyAllowed": "You’re on a {{device}}. You can start when you’re ready.",
+    "allowedDevicesHeading": "Allowed for this assessment",
+    "currentDeviceHeading": "This device",
+    "learnerAlertTitle": "This device can’t start the assessment",
+    "learnerAlertBody": "Allowed devices: {{types}}. Open this page on one of those devices to begin.",
+    "startDisabledHint": "Switch to an allowed device to enable Start.",
+    "toastBlocked": "This assessment can’t be started on this device.",
+    "deviceCheckBlockedTitle": "Wrong device type",
+    "deviceCheckBlockedSubtitle": "Use an allowed device before camera setup.",
+    "backToAssessment": "Back to assessment details",
+    "takePageRedirectHint": "Check device requirements on the assessment page."
+  },
   "mockInterview": {
     "title": "Mock Interview",
     "subtitle": "Practice with AI-powered mock interviews",


### PR DESCRIPTION
- Add device class helper, X-Client-Device-Type on assessment client routes
- Admin: toggles for desktop/mobile/tablet on create/edit; payload types
- Learner: status panel, detail page + device-check blocked state, take hook 403
- i18n for assessmentDevice strings
- Harden MUI Switch checked props (controlled) in shared components