### PR TITLE
feat(admin): assessment question exports as PDF/CSV with subjective

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   Paper,
   Button,
+  Stack,
   Tabs,
   Tab,
   Alert,
@@ -39,8 +40,10 @@ import {
   CreateAssessmentPayload,
   isMCQQuestion,
   isCodingQuestion,
+  isSubjectiveQuestion,
   QuestionsExportMCQQuestion,
   QuestionsExportCodingQuestion,
+  QuestionsExportSubjectiveQuestion,
   type AssessmentAnalyticsResponse,
   clampAssessmentAnalyticsTopPerformers,
 } from "@/lib/services/admin/admin-assessment.service";
@@ -62,9 +65,14 @@ import {
   mapSubmissionsExportRowToAssessmentResult,
   safeAssessmentPdfFileName,
 } from "@/lib/utils/admin-submission-export-to-assessment-result.utils";
+import {
+  saveAssessmentMcqQuestionsPdf,
+  saveAssessmentCodingQuestionsPdf,
+  saveAssessmentSubjectiveQuestionsPdf,
+} from "@/lib/utils/assessment-questions-export-pdf.utils";
 
 type TabValue = "details" | "questions" | "submissions" | "analytics";
-type QuestionsSubTab = "mcq" | "coding";
+type QuestionsSubTab = "mcq" | "coding" | "subjective";
 
 function escapeCsv(val: unknown): string {
   if (val == null || val === undefined) return "";
@@ -352,6 +360,8 @@ export default function AssessmentEditPage() {
   const [questionsLimit, setQuestionsLimit] = useState(10);
   const [codingQuestionsPage, setCodingQuestionsPage] = useState(1);
   const [codingQuestionsLimit, setCodingQuestionsLimit] = useState(10);
+  const [subjectiveQuestionsPage, setSubjectiveQuestionsPage] = useState(1);
+  const [subjectiveQuestionsLimit, setSubjectiveQuestionsLimit] = useState(10);
   const [submissionsPage, setSubmissionsPage] = useState(1);
   const [submissionsLimit, setSubmissionsLimit] = useState(10);
   const [downloadingAllSubmissionPdfs, setDownloadingAllSubmissionPdfs] =
@@ -592,6 +602,14 @@ export default function AssessmentEditPage() {
       return;
     }
     if (passBandFieldErrors.lower || passBandFieldErrors.upper) {
+      showToast(
+        [passBandFieldErrors.lower, passBandFieldErrors.upper]
+          .filter(Boolean)
+          .join(" ") || "Invalid pass band",
+        "error",
+      );
+      return;
+    }
     if (!allowDesktop && !allowMobile && !allowTablet) {
       showToast(t("assessmentDevice.atLeastOne"), "error");
       return;
@@ -647,7 +665,6 @@ export default function AssessmentEditPage() {
       setSaving(false);
     }
   };
-}
 
   const handleDownloadMCQQuestions = () => {
     if (!questionsData) return;
@@ -745,6 +762,89 @@ export default function AssessmentEditPage() {
     const csv = jsonToCsvRows(flat, columns);
     downloadCsv(csv, `assessment-${questionsData.assessment.slug || assessmentId}-coding-questions.csv`);
     showToast("Coding questions exported", "success");
+  };
+
+  const handleDownloadMCQQuestionsPdf = () => {
+    if (!questionsData) return;
+    const flat: Record<string, unknown>[] = [];
+    for (const sec of quizSections) {
+      for (const q of sec.questions) {
+        if (isMCQQuestion(q)) {
+          flat.push({
+            section_id: sec.section_id,
+            section_title: sec.section_title,
+            section_order: sec.order,
+            id: q.id,
+            question_text: q.question_text,
+            option_a: q.option_a,
+            option_b: q.option_b,
+            option_c: q.option_c,
+            option_d: q.option_d,
+            correct_option: q.correct_option,
+            explanation: q.explanation ?? "",
+            difficulty_level: q.difficulty_level ?? "",
+            topic: q.topic ?? "",
+            skills: q.skills ?? "",
+          });
+        }
+      }
+    }
+    if (flat.length === 0) {
+      showToast("No MCQ questions to export", "info");
+      return;
+    }
+    saveAssessmentMcqQuestionsPdf(
+      {
+        assessmentTitle: questionsData.assessment.title ?? "",
+        baseSlug: questionsData.assessment.slug || String(assessmentId),
+      },
+      flat,
+    );
+    showToast("MCQ questions exported as PDF", "success");
+  };
+
+  const handleDownloadCodingQuestionsPdf = () => {
+    if (!questionsData) return;
+    const flat: Record<string, unknown>[] = [];
+    for (const sec of codingSections) {
+      for (const q of sec.questions) {
+        if (isCodingQuestion(q)) {
+          const ps = typeof q.problem_statement === "string" ? q.problem_statement : "";
+          const inp = typeof q.input_format === "string" ? q.input_format : "";
+          const out = typeof q.output_format === "string" ? q.output_format : "";
+          const con = typeof q.constraints === "string" ? q.constraints : "";
+          flat.push({
+            section_id: sec.section_id,
+            section_title: sec.section_title,
+            section_order: sec.order,
+            id: q.id,
+            title: q.title ?? "",
+            problem_statement: htmlToPlainText(ps),
+            input_format: htmlToPlainText(inp),
+            output_format: htmlToPlainText(out),
+            sample_input: q.sample_input ?? "",
+            sample_output: q.sample_output ?? "",
+            constraints: htmlToPlainText(con),
+            difficulty_level: q.difficulty_level ?? "",
+            tags: q.tags ?? "",
+            time_limit: q.time_limit ?? "",
+            memory_limit: q.memory_limit ?? "",
+          });
+        }
+      }
+    }
+    if (flat.length === 0) {
+      showToast("No coding questions to export", "info");
+      return;
+    }
+    saveAssessmentCodingQuestionsPdf(
+      {
+        assessmentTitle: questionsData.assessment.title ?? "",
+        baseSlug: questionsData.assessment.slug || String(assessmentId),
+      },
+      flat,
+    );
+    showToast("Coding questions exported as PDF", "success");
   };
 
   function downloadCsv(csv: string, filename: string) {
@@ -857,6 +957,13 @@ export default function AssessmentEditPage() {
     );
   }, [questionsData]);
 
+  const subjectiveSections = useMemo(() => {
+    if (!questionsData?.sections) return [];
+    return questionsData.sections.filter(
+      (s) => (s.section_type ?? "").toLowerCase() === "subjective"
+    );
+  }, [questionsData]);
+
   const allQuizItems = useMemo(() => {
     return quizSections.flatMap((sec) =>
       sec.questions
@@ -873,6 +980,14 @@ export default function AssessmentEditPage() {
     );
   }, [codingSections]);
 
+  const allSubjectiveItems = useMemo(() => {
+    return subjectiveSections.flatMap((sec) =>
+      sec.questions
+        .filter((q): q is QuestionsExportSubjectiveQuestion => isSubjectiveQuestion(q))
+        .map((q) => ({ section: sec, question: q }))
+    );
+  }, [subjectiveSections]);
+
   const paginatedQuizQuestions = useMemo(() => {
     const start = (questionsPage - 1) * questionsLimit;
     return allQuizItems.slice(start, start + questionsLimit);
@@ -883,9 +998,86 @@ export default function AssessmentEditPage() {
     return allCodingItems.slice(start, start + codingQuestionsLimit);
   }, [allCodingItems, codingQuestionsPage, codingQuestionsLimit]);
 
+  const paginatedSubjectiveQuestions = useMemo(() => {
+    const start = (subjectiveQuestionsPage - 1) * subjectiveQuestionsLimit;
+    return allSubjectiveItems.slice(start, start + subjectiveQuestionsLimit);
+  }, [allSubjectiveItems, subjectiveQuestionsPage, subjectiveQuestionsLimit]);
+
   const totalQuizQuestions = allQuizItems.length;
   const totalCodingQuestions = allCodingItems.length;
-  const totalQuestions = totalQuizQuestions + totalCodingQuestions;
+  const totalSubjectiveQuestions = allSubjectiveItems.length;
+  const totalQuestions = totalQuizQuestions + totalCodingQuestions + totalSubjectiveQuestions;
+
+  const handleDownloadSubjectiveQuestions = () => {
+    if (!questionsData) return;
+    const flat: Record<string, unknown>[] = [];
+    for (const sec of subjectiveSections) {
+      for (const q of sec.questions) {
+        if (isSubjectiveQuestion(q)) {
+          flat.push({
+            section_id: sec.section_id,
+            section_title: sec.section_title,
+            section_order: sec.order,
+            id: q.id,
+            question_text: q.question_text,
+            evaluation_prompt: htmlToPlainText(q.evaluation_prompt),
+            max_marks: q.max_marks ?? "",
+            question_type: q.question_type ?? "",
+          });
+        }
+      }
+    }
+    if (flat.length === 0) {
+      showToast("No subjective questions to export", "info");
+      return;
+    }
+    const columns: { key: string; header: string }[] = [
+      { key: "section_id", header: "Section ID" },
+      { key: "section_title", header: "Section Title" },
+      { key: "section_order", header: "Section Order" },
+      { key: "id", header: "Question ID" },
+      { key: "question_text", header: "Question Text" },
+      { key: "evaluation_prompt", header: "Evaluation Prompt" },
+      { key: "max_marks", header: "Max Marks" },
+      { key: "question_type", header: "Question Type" },
+    ];
+    const csv = jsonToCsvRows(flat, columns);
+    downloadCsv(csv, `assessment-${questionsData.assessment.slug || assessmentId}-subjective-questions.csv`);
+    showToast("Subjective questions exported", "success");
+  };
+
+  const handleDownloadSubjectiveQuestionsPdf = () => {
+    if (!questionsData) return;
+    const flat: Record<string, unknown>[] = [];
+    for (const sec of subjectiveSections) {
+      for (const q of sec.questions) {
+        if (isSubjectiveQuestion(q)) {
+          flat.push({
+            section_id: sec.section_id,
+            section_title: sec.section_title,
+            section_order: sec.order,
+            id: q.id,
+            question_text: q.question_text,
+            evaluation_prompt: htmlToPlainText(q.evaluation_prompt),
+            max_marks: q.max_marks ?? "",
+            question_type: q.question_type ?? "",
+          });
+        }
+      }
+    }
+    if (flat.length === 0) {
+      showToast("No subjective questions to export", "info");
+      return;
+    }
+    saveAssessmentSubjectiveQuestionsPdf(
+      {
+        assessmentTitle: questionsData.assessment.title ?? "",
+        baseSlug: questionsData.assessment.slug || String(assessmentId),
+      },
+      flat,
+    );
+    showToast("Subjective questions exported as PDF", "success");
+  };
 
   const paginatedSubmissions = useMemo(() => {
     if (!submissionsData?.submissions) return [];
@@ -1025,17 +1217,30 @@ export default function AssessmentEditPage() {
   useEffect(() => {
     setQuestionsPage(1);
     setCodingQuestionsPage(1);
+    setSubjectiveQuestionsPage(1);
     setSubmissionsPage(1);
   }, [tab]);
 
   useEffect(() => {
     if (tab !== "questions" || !questionsData) return;
-    if (questionsSubTab === "mcq" && totalQuizQuestions === 0 && totalCodingQuestions > 0) {
-      setQuestionsSubTab("coding");
-    } else if (questionsSubTab === "coding" && totalCodingQuestions === 0 && totalQuizQuestions > 0) {
-      setQuestionsSubTab("mcq");
+    if (questionsSubTab === "mcq" && totalQuizQuestions === 0) {
+      if (totalCodingQuestions > 0) setQuestionsSubTab("coding");
+      else if (totalSubjectiveQuestions > 0) setQuestionsSubTab("subjective");
+    } else if (questionsSubTab === "coding" && totalCodingQuestions === 0) {
+      if (totalQuizQuestions > 0) setQuestionsSubTab("mcq");
+      else if (totalSubjectiveQuestions > 0) setQuestionsSubTab("subjective");
+    } else if (questionsSubTab === "subjective" && totalSubjectiveQuestions === 0) {
+      if (totalQuizQuestions > 0) setQuestionsSubTab("mcq");
+      else if (totalCodingQuestions > 0) setQuestionsSubTab("coding");
     }
-  }, [tab, questionsData, questionsSubTab, totalQuizQuestions, totalCodingQuestions]);
+  }, [
+    tab,
+    questionsData,
+    questionsSubTab,
+    totalQuizQuestions,
+    totalCodingQuestions,
+    totalSubjectiveQuestions,
+  ]);
 
   const codingProblemDataForPreview = (q: QuestionsExportCodingQuestion) => ({
     content_title: q.title,
@@ -1287,6 +1492,26 @@ export default function AssessmentEditPage() {
                           </Box>
                         }
                       />
+                      <Tab
+                        value="subjective"
+                        label={
+                          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                            Subjective
+                            {totalSubjectiveQuestions > 0 && (
+                              <Chip
+                                label={totalSubjectiveQuestions}
+                                size="small"
+                                sx={{
+                                  height: 20,
+                                  fontSize: "0.75rem",
+                                  bgcolor: questionsSubTab === "subjective" ? "primary.main" : "action.hover",
+                                  color: questionsSubTab === "subjective" ? "primary.contrastText" : "text.secondary",
+                                }}
+                              />
+                            )}
+                          </Box>
+                        }
+                      />
                     </Tabs>
 
                     {questionsSubTab === "mcq" && (
@@ -1315,16 +1540,28 @@ export default function AssessmentEditPage() {
                           <Typography variant="body2" color="text.secondary">
                             {totalQuizQuestions} MCQ question{totalQuizQuestions !== 1 ? "s" : ""}
                           </Typography>
-                          <Button
-                            variant="contained"
-                            size="small"
-                            startIcon={<IconWrapper icon="mdi:download" size={18} />}
-                            onClick={handleDownloadMCQQuestions}
-                            disabled={readOnly || totalQuizQuestions === 0}
-                            sx={{ bgcolor: "#6366f1", "&:hover": { bgcolor: "#4f46e5" } }}
-                          >
-                            Download MCQ CSV
-                          </Button>
+                          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                            <Button
+                              variant="contained"
+                              size="small"
+                              startIcon={<IconWrapper icon="mdi:file-delimited-outline" size={18} />}
+                              onClick={handleDownloadMCQQuestions}
+                              disabled={readOnly || totalQuizQuestions === 0}
+                              sx={{ bgcolor: "#6366f1", "&:hover": { bgcolor: "#4f46e5" } }}
+                            >
+                              Download MCQ CSV
+                            </Button>
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              startIcon={<IconWrapper icon="mdi:file-pdf-box" size={18} />}
+                              onClick={handleDownloadMCQQuestionsPdf}
+                              disabled={readOnly || totalQuizQuestions === 0}
+                              color="primary"
+                            >
+                              Download MCQ PDF
+                            </Button>
+                          </Stack>
                         </Box>
                         {totalQuizQuestions === 0 ? (
                           <Box sx={{ py: 6, textAlign: "center" }}>
@@ -1422,16 +1659,28 @@ export default function AssessmentEditPage() {
                           <Typography variant="body2" color="text.secondary">
                             {totalCodingQuestions} coding question{totalCodingQuestions !== 1 ? "s" : ""}
                           </Typography>
-                          <Button
-                            variant="contained"
-                            size="small"
-                            startIcon={<IconWrapper icon="mdi:download" size={18} />}
-                            onClick={handleDownloadCodingQuestions}
-                            disabled={readOnly || totalCodingQuestions === 0}
-                            sx={{ bgcolor: "#6366f1", "&:hover": { bgcolor: "#4f46e5" } }}
-                          >
-                            Download Coding CSV
-                          </Button>
+                          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                            <Button
+                              variant="contained"
+                              size="small"
+                              startIcon={<IconWrapper icon="mdi:file-delimited-outline" size={18} />}
+                              onClick={handleDownloadCodingQuestions}
+                              disabled={readOnly || totalCodingQuestions === 0}
+                              sx={{ bgcolor: "#6366f1", "&:hover": { bgcolor: "#4f46e5" } }}
+                            >
+                              Download Coding CSV
+                            </Button>
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              startIcon={<IconWrapper icon="mdi:file-pdf-box" size={18} />}
+                              onClick={handleDownloadCodingQuestionsPdf}
+                              disabled={readOnly || totalCodingQuestions === 0}
+                              color="primary"
+                            >
+                              Download Coding PDF
+                            </Button>
+                          </Stack>
                         </Box>
                         {totalCodingQuestions === 0 ? (
                           <Box sx={{ py: 6, textAlign: "center" }}>
@@ -1522,6 +1771,114 @@ export default function AssessmentEditPage() {
                               limit={codingQuestionsLimit}
                               onPageChange={setCodingQuestionsPage}
                               onLimitChange={(l) => { setCodingQuestionsLimit(l); setCodingQuestionsPage(1); }}
+                              itemLabel="questions"
+                            />
+                          </>
+                        )}
+                      </Paper>
+                    )}
+
+                    {questionsSubTab === "subjective" && (
+                      <Paper
+                        variant="outlined"
+                        sx={{
+                          borderRadius: 2,
+                          overflow: "hidden",
+                          borderColor: "#e5e7eb",
+                          bgcolor: "#fafafa",
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            px: 2,
+                            py: 1.5,
+                            borderBottom: "1px solid #e5e7eb",
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            flexWrap: "wrap",
+                            gap: 1,
+                            bgcolor: "#fff",
+                          }}
+                        >
+                          <Typography variant="body2" color="text.secondary">
+                            {totalSubjectiveQuestions} subjective question{totalSubjectiveQuestions !== 1 ? "s" : ""}
+                          </Typography>
+                          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                            <Button
+                              variant="contained"
+                              size="small"
+                              startIcon={<IconWrapper icon="mdi:file-delimited-outline" size={18} />}
+                              onClick={handleDownloadSubjectiveQuestions}
+                              disabled={readOnly || totalSubjectiveQuestions === 0}
+                              sx={{ bgcolor: "#7c3aed", "&:hover": { bgcolor: "#6d28d9" } }}
+                            >
+                              Download Subjective CSV
+                            </Button>
+                            <Button
+                              variant="outlined"
+                              size="small"
+                              startIcon={<IconWrapper icon="mdi:file-pdf-box" size={18} />}
+                              onClick={handleDownloadSubjectiveQuestionsPdf}
+                              disabled={readOnly || totalSubjectiveQuestions === 0}
+                              color="secondary"
+                            >
+                              Download Subjective PDF
+                            </Button>
+                          </Stack>
+                        </Box>
+                        {totalSubjectiveQuestions === 0 ? (
+                          <Box sx={{ py: 6, textAlign: "center" }}>
+                            <Typography color="text.secondary">No subjective questions.</Typography>
+                          </Box>
+                        ) : (
+                          <>
+                            <TableContainer sx={{ maxHeight: 440 }}>
+                              <Table size="small" stickyHeader>
+                                <TableHead>
+                                  <TableRow sx={{ bgcolor: "#f3f4f6" }}>
+                                    <TableCell sx={{ fontWeight: 700, py: 1.5, fontSize: "0.8rem" }}>Section</TableCell>
+                                    <TableCell sx={{ fontWeight: 700, py: 1.5, fontSize: "0.8rem" }}>Order</TableCell>
+                                    <TableCell sx={{ fontWeight: 700, py: 1.5, fontSize: "0.8rem" }}>ID</TableCell>
+                                    <TableCell sx={{ fontWeight: 700, py: 1.5, fontSize: "0.8rem", minWidth: 220 }}>Question</TableCell>
+                                    <TableCell sx={{ fontWeight: 700, py: 1.5, fontSize: "0.8rem" }}>Max marks</TableCell>
+                                    <TableCell sx={{ fontWeight: 700, py: 1.5, fontSize: "0.8rem" }}>Type</TableCell>
+                                  </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                  {paginatedSubjectiveQuestions.map(({ section: sec, question: q }) => (
+                                    <TableRow key={`subjective-${q.id}`} hover sx={{ "&:hover": { bgcolor: "#f9fafb" } }}>
+                                      <TableCell sx={{ py: 1.5 }}>{sec.section_title}</TableCell>
+                                      <TableCell sx={{ py: 1.5 }}>{sec.order}</TableCell>
+                                      <TableCell sx={{ py: 1.5, fontFamily: "monospace" }}>{q.id}</TableCell>
+                                      <TableCell sx={{ py: 1.5, maxWidth: 300 }}>
+                                        <Typography
+                                          variant="body2"
+                                          sx={{
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
+                                            display: "-webkit-box",
+                                            WebkitLineClamp: 2,
+                                            WebkitBoxOrient: "vertical",
+                                          }}
+                                          title={q.question_text}
+                                        >
+                                          {q.question_text}
+                                        </Typography>
+                                      </TableCell>
+                                      <TableCell sx={{ py: 1.5 }}>{q.max_marks ?? "—"}</TableCell>
+                                      <TableCell sx={{ py: 1.5 }}>{q.question_type?.trim() ? q.question_type : "—"}</TableCell>
+                                    </TableRow>
+                                  ))}
+                                </TableBody>
+                              </Table>
+                            </TableContainer>
+                            <PaginationControls
+                              totalItems={totalSubjectiveQuestions}
+                              page={subjectiveQuestionsPage}
+                              limit={subjectiveQuestionsLimit}
+                              onPageChange={setSubjectiveQuestionsPage}
+                              onLimitChange={(l) => { setSubjectiveQuestionsLimit(l); setSubjectiveQuestionsPage(1); }}
                               itemLabel="questions"
                             />
                           </>

--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -32,7 +32,10 @@ import {
   Assessment,
   isMCQQuestion,
   isCodingQuestion,
+  isSubjectiveQuestion,
+  type QuestionsExportResponse,
 } from "@/lib/services/admin/admin-assessment.service";
+import { saveAssessmentQuestionsPdfs } from "@/lib/utils/assessment-questions-export-pdf.utils";
 import { useAuth } from "@/lib/auth/auth-context";
 import { isCourseManagerRole } from "@/lib/auth/auth-utils";
 import {
@@ -284,7 +287,82 @@ export default function AssessmentPage() {
     }
   };
 
-  const handleExportQuestions = async (assessment: Assessment) => {
+  const buildQuestionExportRows = (
+    data: QuestionsExportResponse,
+    assessmentId: number
+  ) => {
+    const baseSlug = data.assessment.slug || String(assessmentId);
+    const mcqFlat: Record<string, unknown>[] = [];
+    const codingFlat: Record<string, unknown>[] = [];
+    const subjectiveFlat: Record<string, unknown>[] = [];
+    for (const sec of data.sections) {
+      for (const q of sec.questions) {
+        if (isMCQQuestion(q)) {
+          mcqFlat.push({
+            section_id: sec.section_id,
+            section_title: sec.section_title,
+            section_order: sec.order,
+            id: q.id,
+            question_text: q.question_text,
+            option_a: q.option_a,
+            option_b: q.option_b,
+            option_c: q.option_c,
+            option_d: q.option_d,
+            correct_option: q.correct_option,
+            explanation: q.explanation ?? "",
+            difficulty_level: q.difficulty_level ?? "",
+            topic: q.topic ?? "",
+            skills: q.skills ?? "",
+          });
+        } else if (isCodingQuestion(q)) {
+          const ps = typeof q.problem_statement === "string" ? q.problem_statement : "";
+          const inp = typeof q.input_format === "string" ? q.input_format : "";
+          const out = typeof q.output_format === "string" ? q.output_format : "";
+          const con = typeof q.constraints === "string" ? q.constraints : "";
+          codingFlat.push({
+            section_id: sec.section_id,
+            section_title: sec.section_title,
+            section_order: sec.order,
+            id: q.id,
+            title: q.title ?? "",
+            problem_statement: htmlToPlainText(ps),
+            input_format: htmlToPlainText(inp),
+            output_format: htmlToPlainText(out),
+            sample_input: q.sample_input ?? "",
+            sample_output: q.sample_output ?? "",
+            constraints: htmlToPlainText(con),
+            difficulty_level: q.difficulty_level ?? "",
+            tags: q.tags ?? "",
+            time_limit: q.time_limit ?? "",
+            memory_limit: q.memory_limit ?? "",
+          });
+        } else if (isSubjectiveQuestion(q)) {
+          subjectiveFlat.push({
+            section_id: sec.section_id,
+            section_title: sec.section_title,
+            section_order: sec.order,
+            id: q.id,
+            question_text: q.question_text,
+            evaluation_prompt: htmlToPlainText(q.evaluation_prompt),
+            max_marks: q.max_marks ?? "",
+            question_type: q.question_type ?? "",
+          });
+        }
+      }
+    }
+    return {
+      mcqFlat,
+      codingFlat,
+      subjectiveFlat,
+      baseSlug,
+      assessmentTitle: data.assessment.title ?? "",
+    };
+  };
+
+  const handleExportQuestions = async (
+    assessment: Assessment,
+    format: "csv" | "pdf" = "csv"
+  ) => {
     try {
       setExportingQuestionsId(assessment.id);
       const data = await adminAssessmentService.getQuestionsExportJson(
@@ -292,54 +370,29 @@ export default function AssessmentPage() {
         assessment.id
       );
 
-      const baseSlug = data.assessment.slug || String(assessment.id);
+      const { mcqFlat, codingFlat, subjectiveFlat, baseSlug, assessmentTitle } =
+        buildQuestionExportRows(data, assessment.id);
 
-      // MCQ rows (same format as edit page)
-      const mcqFlat: Record<string, unknown>[] = [];
-      const codingFlat: Record<string, unknown>[] = [];
-      for (const sec of data.sections) {
-        for (const q of sec.questions) {
-          if (isMCQQuestion(q)) {
-            mcqFlat.push({
-              section_id: sec.section_id,
-              section_title: sec.section_title,
-              section_order: sec.order,
-              id: q.id,
-              question_text: q.question_text,
-              option_a: q.option_a,
-              option_b: q.option_b,
-              option_c: q.option_c,
-              option_d: q.option_d,
-              correct_option: q.correct_option,
-              explanation: q.explanation ?? "",
-              difficulty_level: q.difficulty_level ?? "",
-              topic: q.topic ?? "",
-              skills: q.skills ?? "",
-            });
-          } else if (isCodingQuestion(q)) {
-            const ps = typeof q.problem_statement === "string" ? q.problem_statement : "";
-            const inp = typeof q.input_format === "string" ? q.input_format : "";
-            const out = typeof q.output_format === "string" ? q.output_format : "";
-            const con = typeof q.constraints === "string" ? q.constraints : "";
-            codingFlat.push({
-              section_id: sec.section_id,
-              section_title: sec.section_title,
-              section_order: sec.order,
-              id: q.id,
-              title: q.title ?? "",
-              problem_statement: htmlToPlainText(ps),
-              input_format: htmlToPlainText(inp),
-              output_format: htmlToPlainText(out),
-              sample_input: q.sample_input ?? "",
-              sample_output: q.sample_output ?? "",
-              constraints: htmlToPlainText(con),
-              difficulty_level: q.difficulty_level ?? "",
-              tags: q.tags ?? "",
-              time_limit: q.time_limit ?? "",
-              memory_limit: q.memory_limit ?? "",
-            });
-          }
-        }
+      if (format === "pdf") {
+        const { fileCount } = saveAssessmentQuestionsPdfs(
+          { assessmentTitle, baseSlug },
+          mcqFlat,
+          codingFlat,
+          subjectiveFlat
+        );
+        const pdfParts: string[] = [];
+        if (mcqFlat.length) pdfParts.push("MCQ");
+        if (codingFlat.length) pdfParts.push("coding");
+        if (subjectiveFlat.length) pdfParts.push("subjective");
+        showToast(
+          fileCount === 0
+            ? "No questions to export"
+            : pdfParts.length
+              ? `${pdfParts.join(", ")} exported as PDF (${fileCount} file${fileCount !== 1 ? "s" : ""})`
+              : "Questions exported as PDF successfully",
+          fileCount > 0 ? "success" : "info"
+        );
+        return;
       }
 
       const mcqColumns: { key: string; header: string }[] = [
@@ -375,6 +428,16 @@ export default function AssessmentPage() {
         { key: "time_limit", header: "Time Limit (sec)" },
         { key: "memory_limit", header: "Memory Limit (MB)" },
       ];
+      const subjectiveColumns: { key: string; header: string }[] = [
+        { key: "section_id", header: "Section ID" },
+        { key: "section_title", header: "Section Title" },
+        { key: "section_order", header: "Section Order" },
+        { key: "id", header: "Question ID" },
+        { key: "question_text", header: "Question Text" },
+        { key: "evaluation_prompt", header: "Evaluation Prompt" },
+        { key: "max_marks", header: "Max Marks" },
+        { key: "question_type", header: "Question Type" },
+      ];
 
       const downloads: Array<() => void> = [];
       if (mcqFlat.length > 0) {
@@ -393,18 +456,29 @@ export default function AssessmentPage() {
           )
         );
       }
-      downloads[0]?.();
-      if (downloads.length > 1) {
-        setTimeout(() => downloads[1](), 100);
+      if (subjectiveFlat.length > 0) {
+        downloads.push(() =>
+          downloadCsv(
+            jsonToCsvRows(subjectiveFlat, subjectiveColumns),
+            `assessment-${baseSlug}-subjective-questions.csv`
+          )
+        );
       }
+      downloads.forEach((fn, i) => {
+        setTimeout(() => fn(), i * 100);
+      });
 
       const fileCount = downloads.length;
+      const csvParts: string[] = [];
+      if (mcqFlat.length) csvParts.push("MCQ");
+      if (codingFlat.length) csvParts.push("coding");
+      if (subjectiveFlat.length) csvParts.push("subjective");
       showToast(
-        fileCount === 2
-          ? "MCQ and coding questions exported (2 files)"
-          : fileCount === 1
-            ? "Questions exported successfully"
-            : "No questions to export",
+        fileCount === 0
+          ? "No questions to export"
+          : csvParts.length
+            ? `${csvParts.join(", ")} exported (${fileCount} file${fileCount !== 1 ? "s" : ""})`
+            : "Questions exported successfully",
         fileCount > 0 ? "success" : "info"
       );
     } catch (error: any) {

--- a/components/admin/assessment/AssessmentTable.tsx
+++ b/components/admin/assessment/AssessmentTable.tsx
@@ -43,7 +43,10 @@ interface AssessmentTableProps {
   onDelete?: (assessment: Assessment) => void;
   onTriggerEmailJob?: (assessment: Assessment) => Promise<void>;
   onExportSubmissions: (assessment: Assessment) => Promise<void>;
-  onExportQuestions: (assessment: Assessment) => Promise<void>;
+  onExportQuestions: (
+    assessment: Assessment,
+    format?: "csv" | "pdf"
+  ) => Promise<void>;
   onDuplicate?: (assessment: Assessment) => Promise<void>;
   exportingSubmissionsId?: number | null;
   exportingQuestionsId?: number | null;
@@ -523,24 +526,48 @@ export function AssessmentTable({
                     );
                   })()}
                   {!actionsReadOnly && (
-                    <MenuItem
-                      onClick={() => {
-                        handleMenuClose(assessment.id);
-                        onExportQuestions(assessment);
-                      }}
-                      disabled={exportingQuestionsId === assessment.id}
-                    >
-                      <ListItemIcon>
-                        {exportingQuestionsId === assessment.id ? (
-                          <CircularProgress size={18} />
-                        ) : (
-                          <IconWrapper icon="mdi:help-circle-outline" size={18} color="#6366f1" />
-                        )}
-                      </ListItemIcon>
-                      <ListItemText>
-                        {exportingQuestionsId === assessment.id ? "Exporting..." : "Download Questions"}
-                      </ListItemText>
-                    </MenuItem>
+                    <>
+                      <MenuItem
+                        onClick={() => {
+                          handleMenuClose(assessment.id);
+                          void onExportQuestions(assessment, "csv");
+                        }}
+                        disabled={exportingQuestionsId === assessment.id}
+                      >
+                        <ListItemIcon>
+                          {exportingQuestionsId === assessment.id ? (
+                            <CircularProgress size={18} />
+                          ) : (
+                            <IconWrapper icon="mdi:file-delimited-outline" size={18} color="#6366f1" />
+                          )}
+                        </ListItemIcon>
+                        <ListItemText>
+                          {exportingQuestionsId === assessment.id
+                            ? "Exporting..."
+                            : "Download questions (CSV)"}
+                        </ListItemText>
+                      </MenuItem>
+                      <MenuItem
+                        onClick={() => {
+                          handleMenuClose(assessment.id);
+                          void onExportQuestions(assessment, "pdf");
+                        }}
+                        disabled={exportingQuestionsId === assessment.id}
+                      >
+                        <ListItemIcon>
+                          {exportingQuestionsId === assessment.id ? (
+                            <CircularProgress size={18} />
+                          ) : (
+                            <IconWrapper icon="mdi:file-pdf-box" size={18} color="#b91c1c" />
+                          )}
+                        </ListItemIcon>
+                        <ListItemText>
+                          {exportingQuestionsId === assessment.id
+                            ? "Exporting..."
+                            : "Download questions (PDF)"}
+                        </ListItemText>
+                      </MenuItem>
+                    </>
                   )}
                   <MenuItem
                     onClick={() => {
@@ -1194,24 +1221,48 @@ export function AssessmentTable({
                         );
                       })()}
                       {!actionsReadOnly && (
-                        <MenuItem
-                          onClick={() => {
-                            handleMenuClose(assessment.id);
-                            onExportQuestions(assessment);
-                          }}
-                          disabled={exportingQuestionsId === assessment.id}
-                        >
-                          <ListItemIcon>
-                            {exportingQuestionsId === assessment.id ? (
-                              <CircularProgress size={18} />
-                            ) : (
-                              <IconWrapper icon="mdi:help-circle-outline" size={18} color="#6366f1" />
-                            )}
-                          </ListItemIcon>
-                          <ListItemText>
-                            {exportingQuestionsId === assessment.id ? "Exporting..." : "Download Questions"}
-                          </ListItemText>
-                        </MenuItem>
+                        <>
+                          <MenuItem
+                            onClick={() => {
+                              handleMenuClose(assessment.id);
+                              void onExportQuestions(assessment, "csv");
+                            }}
+                            disabled={exportingQuestionsId === assessment.id}
+                          >
+                            <ListItemIcon>
+                              {exportingQuestionsId === assessment.id ? (
+                                <CircularProgress size={18} />
+                              ) : (
+                                <IconWrapper icon="mdi:file-delimited-outline" size={18} color="#6366f1" />
+                              )}
+                            </ListItemIcon>
+                            <ListItemText>
+                              {exportingQuestionsId === assessment.id
+                                ? "Exporting..."
+                                : "Download questions (CSV)"}
+                            </ListItemText>
+                          </MenuItem>
+                          <MenuItem
+                            onClick={() => {
+                              handleMenuClose(assessment.id);
+                              void onExportQuestions(assessment, "pdf");
+                            }}
+                            disabled={exportingQuestionsId === assessment.id}
+                          >
+                            <ListItemIcon>
+                              {exportingQuestionsId === assessment.id ? (
+                                <CircularProgress size={18} />
+                              ) : (
+                                <IconWrapper icon="mdi:file-pdf-box" size={18} color="#b91c1c" />
+                              )}
+                            </ListItemIcon>
+                            <ListItemText>
+                              {exportingQuestionsId === assessment.id
+                                ? "Exporting..."
+                                : "Download questions (PDF)"}
+                            </ListItemText>
+                          </MenuItem>
+                        </>
                       )}
                       <MenuItem
                         onClick={() => {

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -743,8 +743,20 @@ export interface QuestionsExportCodingQuestion {
   [key: string]: unknown;
 }
 
-/** Union type for quiz or coding question in export */
-export type QuestionsExportQuestion = QuestionsExportMCQQuestion | QuestionsExportCodingQuestion;
+/** Assessment export — subjective (free-text) question */
+export interface QuestionsExportSubjectiveQuestion {
+  id: number;
+  question_text: string;
+  evaluation_prompt: string;
+  max_marks: number;
+  question_type?: string;
+}
+
+/** Union type for quiz, coding, or subjective question in export */
+export type QuestionsExportQuestion =
+  | QuestionsExportMCQQuestion
+  | QuestionsExportCodingQuestion
+  | QuestionsExportSubjectiveQuestion;
 
 export function isCodingQuestion(q: QuestionsExportQuestion): q is QuestionsExportCodingQuestion {
   return "title" in q && typeof (q as QuestionsExportCodingQuestion).title === "string";
@@ -752,6 +764,18 @@ export function isCodingQuestion(q: QuestionsExportQuestion): q is QuestionsExpo
 
 export function isMCQQuestion(q: QuestionsExportQuestion): q is QuestionsExportMCQQuestion {
   return "question_text" in q && "option_a" in q;
+}
+
+export function isSubjectiveQuestion(
+  q: QuestionsExportQuestion,
+): q is QuestionsExportSubjectiveQuestion {
+  return (
+    "evaluation_prompt" in q &&
+    typeof (q as QuestionsExportSubjectiveQuestion).evaluation_prompt === "string" &&
+    "question_text" in q &&
+    typeof (q as QuestionsExportSubjectiveQuestion).question_text === "string" &&
+    !("title" in q)
+  );
 }
 
 export interface QuestionsExportSection {

--- a/lib/utils/assessment-questions-export-pdf.utils.ts
+++ b/lib/utils/assessment-questions-export-pdf.utils.ts
@@ -1,0 +1,775 @@
+import jsPDF from "jspdf";
+
+/** Plain rows built the same way as CSV export (values may include HTML strings). */
+export type AssessmentQuestionExportRow = Record<string, unknown>;
+
+export interface AssessmentQuestionsPdfMeta {
+  assessmentTitle: string;
+  baseSlug: string;
+}
+
+const INDIGO: [number, number, number] = [79, 70, 229];
+const INDIGO_DARK: [number, number, number] = [55, 48, 163];
+const TEAL: [number, number, number] = [13, 148, 136];
+const TEAL_DARK: [number, number, number] = [15, 118, 110];
+const VIOLET: [number, number, number] = [124, 58, 237];
+const VIOLET_DARK: [number, number, number] = [91, 33, 182];
+const LAVENDER_MIST: [number, number, number] = [237, 233, 254];
+const SLATE900: [number, number, number] = [15, 23, 42];
+const SLATE600: [number, number, number] = [71, 85, 105];
+const SLATE400: [number, number, number] = [148, 163, 184];
+const SLATE200: [number, number, number] = [226, 232, 240];
+const SLATE100: [number, number, number] = [241, 245, 249];
+const SLATE50: [number, number, number] = [248, 250, 252];
+const WHITE: [number, number, number] = [255, 255, 255];
+const VIOLET_MIST: [number, number, number] = [224, 231, 255];
+const EMERALD700: [number, number, number] = [4, 120, 87];
+const EMERALD50: [number, number, number] = [236, 253, 245];
+const MINT_STROKE: [number, number, number] = [167, 243, 208];
+
+/** Default line-height factor (leading) for body text — higher = airier PDF. */
+const LINE_HEIGHT_FACTOR = 1.48;
+/** Extra mm after each wrapped text line so paragraphs do not feel cramped. */
+const BETWEEN_WRAPPED_LINES_MM = 0.55;
+/** Space after a label block, option row, or similar section (mm). */
+const BLOCK_TAIL_MM = 3.6;
+const STEM_TAIL_MM = 3;
+
+function setFillRgb(pdf: InstanceType<typeof jsPDF>, [r, g, b]: [number, number, number]) {
+  pdf.setFillColor(r, g, b);
+}
+
+function setDrawRgb(pdf: InstanceType<typeof jsPDF>, [r, g, b]: [number, number, number]) {
+  pdf.setDrawColor(r, g, b);
+}
+
+function setTextRgb(pdf: InstanceType<typeof jsPDF>, [r, g, b]: [number, number, number]) {
+  pdf.setTextColor(r, g, b);
+}
+
+function cellStr(v: unknown): string {
+  if (v == null) return "";
+  return String(typeof v === "object" ? JSON.stringify(v) : v);
+}
+
+function htmlToPlainText(html: string): string {
+  if (!html || typeof html !== "string") return "";
+  let s = html;
+  s = s.replace(/<\/p>\s*<p>/gi, "\n");
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+  s = s.replace(/<sup>(\d+)<\/sup>/gi, "^$1");
+  s = s.replace(/<sub>(\d+)<\/sub>/gi, "_$1");
+  s = s.replace(/&le;/g, "≤").replace(/&ge;/g, "≥");
+  s = s.replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&").replace(/&nbsp;/g, " ");
+  s = s.replace(/<[^>]*>/g, " ");
+  s = s.replace(/[ \t]+/g, " ");
+  s = s.replace(/^\s+|\s+$/gm, "");
+  s = s.replace(/\n\s*\n/g, "\n").trim();
+  return s;
+}
+
+const PDF_UNICODE_SPACE_SEPARATORS =
+  /[\u00A0\u1680\u180E\u2000-\u200A\u202F\u205F\u3000]/g;
+const PDF_ZW_AND_FORMAT_MARKS =
+  /[\u00AD\u034F\u061C\u115F\u1160\u17B4\u17B5\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u2069\uFEFF]/g;
+const PDF_CONTROLS_EXCEPT_NEWLINE =
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g;
+
+function sanitizeForJsPdfText(s: string): string {
+  if (!s) return "";
+  let t = s
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/\u2028/g, "\n")
+    .replace(/\u2029/g, "\n\n");
+  t = t.replace(PDF_ZW_AND_FORMAT_MARKS, "");
+  t = t
+    .split("\n")
+    .map((line) =>
+      line
+        .replace(PDF_UNICODE_SPACE_SEPARATORS, " ")
+        .replace(PDF_CONTROLS_EXCEPT_NEWLINE, "")
+        .replace(/\t/g, " ")
+        .replace(/ +/g, " ")
+        .trim(),
+    )
+    .join("\n");
+  return t.replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function lineHeightMm(fontPt: number, factor = LINE_HEIGHT_FACTOR): number {
+  return ((fontPt * 25.4) / 72) * factor;
+}
+
+/** One baseline step for wrapped paragraphs (line height + small gap). */
+function wrappedLineStepMm(fontPt: number): number {
+  return lineHeightMm(fontPt) + BETWEEN_WRAPPED_LINES_MM;
+}
+
+function pdfSplit(pdf: InstanceType<typeof jsPDF>, text: string, maxW: number): string[] {
+  return pdf.splitTextToSize(text, maxW) as string[];
+}
+
+type PdfContext = {
+  pdf: InstanceType<typeof jsPDF>;
+  margin: number;
+  maxW: number;
+  pageW: number;
+  pageH: number;
+  y: number;
+  footerReserve: number;
+  continuationTitle: string;
+  accent: [number, number, number];
+};
+
+function drawContinuationHeader(ctx: PdfContext): void {
+  const { pdf, margin, pageW, maxW } = ctx;
+  const barH = 10;
+  setFillRgb(pdf, SLATE100);
+  pdf.rect(0, 0, pageW, margin + barH, "F");
+  setDrawRgb(pdf, SLATE200);
+  pdf.setLineWidth(0.25);
+  pdf.line(0, margin + barH, pageW, margin + barH);
+  setFillRgb(pdf, ctx.accent);
+  pdf.rect(0, 0, 2.2, margin + barH, "F");
+
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(8.5);
+  setTextRgb(pdf, SLATE600);
+  const lines = pdfSplit(pdf, ctx.continuationTitle, maxW - 5);
+  const lh = wrappedLineStepMm(8.5);
+  let yy = margin + 2;
+  for (const line of lines.slice(0, 2)) {
+    pdf.text(line, margin + 3.5, yy);
+    yy += lh;
+  }
+  ctx.y = margin + barH + 8;
+}
+
+function ensureSpace(ctx: PdfContext, needMm: number): void {
+  if (ctx.y + needMm > ctx.pageH - ctx.footerReserve) {
+    ctx.pdf.addPage();
+    drawContinuationHeader(ctx);
+  }
+}
+
+function writeLines(
+  ctx: PdfContext,
+  lines: string[],
+  x: number,
+  fontPt: number,
+  style: "normal" | "bold" | "italic",
+  textRgb: [number, number, number] = SLATE900,
+): void {
+  const step = wrappedLineStepMm(fontPt);
+  ctx.pdf.setFont("helvetica", style);
+  ctx.pdf.setFontSize(fontPt);
+  setTextRgb(ctx.pdf, textRgb);
+  for (const line of lines) {
+    ensureSpace(ctx, step);
+    ctx.pdf.text(line, x, ctx.y);
+    ctx.y += step;
+  }
+}
+
+function writeWrapped(
+  ctx: PdfContext,
+  text: string,
+  x: number,
+  fontPt: number,
+  style: "normal" | "bold" | "italic",
+  textRgb: [number, number, number] = SLATE900,
+  trailingGapMm = 1.2,
+): void {
+  const plain = sanitizeForJsPdfText(htmlToPlainText(text));
+  const body = plain.length ? plain : " ";
+  ctx.pdf.setFont("helvetica", style);
+  ctx.pdf.setFontSize(fontPt);
+  setTextRgb(ctx.pdf, textRgb);
+  const lines = pdfSplit(ctx.pdf, body, ctx.maxW);
+  writeLines(ctx, lines, x, fontPt, style, textRgb);
+  ctx.y += trailingGapMm;
+}
+
+function writeLabelBlock(ctx: PdfContext, label: string, value: string, valueFontPt = 9): void {
+  const indent = 3.5;
+  const innerW = ctx.maxW - indent;
+  const plain = sanitizeForJsPdfText(htmlToPlainText(value));
+  const body = plain.length ? plain : " ";
+
+  ctx.pdf.setFont("helvetica", "bold");
+  ctx.pdf.setFontSize(7);
+  const labelStep = wrappedLineStepMm(7);
+  ensureSpace(ctx, labelStep);
+  setTextRgb(ctx.pdf, SLATE400);
+  ctx.pdf.text(label.toUpperCase(), ctx.margin + indent, ctx.y);
+  ctx.y += labelStep * 1.05;
+
+  ctx.pdf.setFont("helvetica", "normal");
+  ctx.pdf.setFontSize(valueFontPt);
+  setTextRgb(ctx.pdf, SLATE900);
+  const lines = pdfSplit(ctx.pdf, body, innerW);
+  const step = wrappedLineStepMm(valueFontPt);
+  for (const line of lines) {
+    ensureSpace(ctx, step);
+    ctx.pdf.text(line, ctx.margin + indent, ctx.y);
+    ctx.y += step;
+  }
+  ctx.y += BLOCK_TAIL_MM;
+}
+
+function writeOptionRow(
+  ctx: PdfContext,
+  letter: string,
+  text: string,
+  accent: [number, number, number],
+): void {
+  const badgeR = 2.45;
+  const fontPt = 9;
+  const step = wrappedLineStepMm(fontPt);
+  const plain = sanitizeForJsPdfText(htmlToPlainText(text));
+  const lines = pdfSplit(ctx.pdf, plain.length ? plain : " ", ctx.maxW - 15);
+  ensureSpace(ctx, Math.max(8, lines.length * step + 4));
+
+  const cx = ctx.margin + 3.8 + badgeR;
+  const cy = ctx.y + badgeR * 0.55;
+  setFillRgb(ctx.pdf, accent);
+  ctx.pdf.circle(cx, cy, badgeR, "F");
+  ctx.pdf.setFont("helvetica", "bold");
+  ctx.pdf.setFontSize(7.2);
+  setTextRgb(ctx.pdf, WHITE);
+  const lw = ctx.pdf.getTextWidth(letter);
+  ctx.pdf.text(letter, cx - lw / 2, cy + 0.9);
+
+  ctx.pdf.setFont("helvetica", "normal");
+  ctx.pdf.setFontSize(fontPt);
+  setTextRgb(ctx.pdf, SLATE900);
+  let yy = ctx.y;
+  const textX = ctx.margin + 12;
+  for (const line of lines) {
+    ensureSpace(ctx, step);
+    ctx.pdf.text(line, textX, yy);
+    yy += step;
+  }
+  ctx.y = yy + 2.8;
+}
+
+function writeCorrectHighlight(ctx: PdfContext, correct: string): void {
+  const fontPt = 9.5;
+  const plain = sanitizeForJsPdfText(htmlToPlainText(correct));
+  const lines = pdfSplit(ctx.pdf, plain.length ? plain : "—", ctx.maxW - 10);
+  const answerStep = wrappedLineStepMm(fontPt);
+  const pad = 4.2;
+  const labelBand = 6.5;
+  const h = labelBand + lines.length * answerStep + pad * 2;
+  const w = ctx.maxW;
+  ensureSpace(ctx, h + 6);
+
+  const x0 = ctx.margin;
+  const y0 = ctx.y - 0.3;
+  setFillRgb(ctx.pdf, EMERALD50);
+  setDrawRgb(ctx.pdf, MINT_STROKE);
+  ctx.pdf.setLineWidth(0.28);
+  ctx.pdf.roundedRect(x0, y0, w, h, 1.6, 1.6, "FD");
+  setFillRgb(ctx.pdf, EMERALD700);
+  ctx.pdf.rect(x0, y0, 1.6, h, "F");
+
+  ctx.pdf.setFont("helvetica", "bold");
+  ctx.pdf.setFontSize(6.6);
+  setTextRgb(ctx.pdf, EMERALD700);
+  ctx.pdf.text("CORRECT ANSWER", x0 + 4.2, y0 + 4.2);
+
+  ctx.pdf.setFont("helvetica", "bold");
+  ctx.pdf.setFontSize(fontPt);
+  setTextRgb(ctx.pdf, SLATE900);
+  let yy = y0 + labelBand + pad;
+  const textX = x0 + 4.2;
+  for (const line of lines) {
+    ctx.pdf.text(line, textX, yy);
+    yy += answerStep;
+  }
+  ctx.y = y0 + h + 5;
+}
+
+/**
+ * Monospace block with background. Uses Courier for both measuring and drawing so
+ * splitTextToSize width matches rendered glyphs (Helvetica would underestimate width).
+ * Long rubrics are split across pages with a new bordered chunk per page.
+ */
+function writeMonoBlock(ctx: PdfContext, label: string, value: string): void {
+  const plain = sanitizeForJsPdfText(htmlToPlainText(value));
+  if (!plain.trim()) return;
+  const fontPt = 8;
+  const textInsetX = 4.5;
+  /** Text must stay inside roundedRect — keep inset symmetric vs ctx.maxW */
+  const innerW = Math.max(24, ctx.maxW - textInsetX * 2 - 1);
+  const step = wrappedLineStepMm(fontPt);
+  const padY = 4;
+
+  ctx.pdf.setFont("courier", "normal");
+  ctx.pdf.setFontSize(fontPt);
+  const lines = pdfSplit(ctx.pdf, plain, innerW) as string[];
+
+  let lineIdx = 0;
+  let firstChunk = true;
+  while (lineIdx < lines.length) {
+    const headerLabel = firstChunk ? label.toUpperCase() : `${label.toUpperCase()} (continued)`;
+    const headerH = firstChunk ? 7.5 : 6.2;
+    const topPad = firstChunk ? 5.2 : 4;
+
+    const bodyTop = ctx.y + headerH + topPad;
+    const maxY = ctx.pageH - ctx.footerReserve - padY;
+    const maxBodyLines = Math.max(1, Math.floor((maxY - bodyTop) / step));
+    const chunk = lines.slice(lineIdx, lineIdx + maxBodyLines);
+
+    if (chunk.length === 0) {
+      ctx.pdf.addPage();
+      drawContinuationHeader(ctx);
+      continue;
+    }
+
+    const bodyH = chunk.length * step + padY * 2;
+    const boxH = headerH + topPad + bodyH + 1.5;
+    ensureSpace(ctx, boxH + 3);
+
+    const x0 = ctx.margin;
+    const y0 = ctx.y;
+    setFillRgb(ctx.pdf, SLATE100);
+    setDrawRgb(ctx.pdf, SLATE200);
+    ctx.pdf.setLineWidth(0.25);
+    ctx.pdf.roundedRect(x0, y0, ctx.maxW, boxH, 1.4, 1.4, "FD");
+
+    ctx.pdf.setFont("helvetica", "bold");
+    ctx.pdf.setFontSize(7);
+    setTextRgb(ctx.pdf, SLATE400);
+    ctx.pdf.text(headerLabel, x0 + textInsetX, y0 + 4.2);
+
+    ctx.pdf.setFont("courier", "normal");
+    ctx.pdf.setFontSize(fontPt);
+    setTextRgb(ctx.pdf, SLATE900);
+    let yy = y0 + headerH + topPad;
+    const tx = x0 + textInsetX;
+    for (const line of chunk) {
+      ctx.pdf.text(line, tx, yy);
+      yy += step;
+    }
+
+    ctx.y = y0 + boxH + 3.5;
+    lineIdx += chunk.length;
+    firstChunk = false;
+  }
+}
+
+function drawCoverBand(
+  pdf: InstanceType<typeof jsPDF>,
+  pageW: number,
+  margin: number,
+  meta: AssessmentQuestionsPdfMeta,
+  kindTitle: string,
+  kindSubtitle: string,
+  accent: [number, number, number],
+  accentDark: [number, number, number],
+  questionCount: number,
+  kindTitleRgb: [number, number, number] = VIOLET_MIST,
+): number {
+  const coverH = 38;
+  setFillRgb(pdf, accentDark);
+  pdf.rect(0, 0, pageW, coverH * 0.42, "F");
+  setFillRgb(pdf, accent);
+  pdf.rect(0, coverH * 0.38, pageW, coverH * 0.62, "F");
+
+  const titleRaw =
+    meta.assessmentTitle.length > 80
+      ? `${meta.assessmentTitle.slice(0, 78)}…`
+      : meta.assessmentTitle;
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(17);
+  setTextRgb(pdf, WHITE);
+  const titleLines = pdfSplit(pdf, titleRaw, pageW - 2 * margin);
+  let ty = 12;
+  for (const tl of titleLines.slice(0, 2)) {
+    pdf.text(tl, margin, ty);
+    ty += 9;
+  }
+
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(10);
+  setTextRgb(pdf, kindTitleRgb);
+  pdf.text(kindTitle, margin, ty + 1.5);
+
+  pdf.setFont("helvetica", "normal");
+  pdf.setFontSize(8.3);
+  setTextRgb(pdf, [226, 232, 240]);
+  const metaLine = `${kindSubtitle}  ·  ${questionCount} item${questionCount !== 1 ? "s" : ""}  ·  ${new Date().toLocaleString()}`;
+  const metaLines = pdfSplit(pdf, metaLine, pageW - 2 * margin);
+  let my = ty + 7;
+  for (const ml of metaLines.slice(0, 2)) {
+    pdf.text(ml, margin, my);
+    my += 5;
+  }
+
+  pdf.setFontSize(7.5);
+  setTextRgb(pdf, [199, 210, 254]);
+  const slugLine = `Slug: ${meta.baseSlug}`;
+  pdf.text(slugLine.length > 90 ? `${slugLine.slice(0, 88)}…` : slugLine, margin, my + 1);
+
+  setDrawRgb(pdf, WHITE);
+  pdf.setLineWidth(0.2);
+  pdf.line(margin, coverH - 2.2, pageW - margin, coverH - 2.2);
+
+  return coverH + margin + 9;
+}
+
+function applyFootersToAllPages(
+  pdf: InstanceType<typeof jsPDF>,
+  margin: number,
+  pageW: number,
+  pageH: number,
+  slug: string,
+): void {
+  const n = pdf.getNumberOfPages();
+  for (let i = 1; i <= n; i++) {
+    pdf.setPage(i);
+    setDrawRgb(pdf, SLATE200);
+    pdf.setLineWidth(0.22);
+    pdf.line(margin, pageH - 10, pageW - margin, pageH - 10);
+    pdf.setFont("helvetica", "normal");
+    pdf.setFontSize(7);
+    setTextRgb(pdf, SLATE400);
+    const slugLine = slug.length > 62 ? `${slug.slice(0, 60)}…` : slug;
+    pdf.text(`AI-Linc · question export · ${slugLine}`, margin, pageH - 5.8);
+    pdf.text(`Page ${i} of ${n}`, pageW - margin, pageH - 5.8, { align: "right" });
+  }
+}
+
+function drawQuestionDivider(ctx: PdfContext): void {
+  ensureSpace(ctx, 10);
+  setDrawRgb(ctx.pdf, SLATE200);
+  ctx.pdf.setLineWidth(0.35);
+  ctx.pdf.line(ctx.margin, ctx.y, ctx.margin + ctx.maxW, ctx.y);
+  ctx.y += 9;
+}
+
+function drawQuestionHeaderBar(
+  ctx: PdfContext,
+  n: number,
+  id: string,
+  section: string,
+  order: string,
+): void {
+  const barH = 8.5;
+  ensureSpace(ctx, barH + 6);
+  const x0 = ctx.margin;
+  const y0 = ctx.y;
+  setFillRgb(ctx.pdf, SLATE50);
+  setDrawRgb(ctx.pdf, SLATE200);
+  ctx.pdf.setLineWidth(0.28);
+  ctx.pdf.roundedRect(x0, y0, ctx.maxW, barH, 1.3, 1.3, "FD");
+  setFillRgb(ctx.pdf, ctx.accent);
+  ctx.pdf.rect(x0, y0, 2, barH, "F");
+
+  ctx.pdf.setFont("helvetica", "bold");
+  ctx.pdf.setFontSize(9.2);
+  setTextRgb(ctx.pdf, SLATE900);
+  ctx.pdf.text(`Question ${n}`, x0 + 4.5, y0 + 5.6);
+  ctx.pdf.setFont("helvetica", "normal");
+  ctx.pdf.setFontSize(7.4);
+  setTextRgb(ctx.pdf, SLATE600);
+  const meta = `ID ${id}  ·  ${section}  ·  order ${order}`;
+  const metaShort = meta.length > 95 ? `${meta.slice(0, 93)}…` : meta;
+  ctx.pdf.text(metaShort, x0 + 34, y0 + 5.6);
+  ctx.y = y0 + barH + 7;
+}
+
+function drawCodingHeaderBar(
+  ctx: PdfContext,
+  n: number,
+  id: string,
+  section: string,
+  order: string,
+): void {
+  const barH = 8.5;
+  ensureSpace(ctx, barH + 6);
+  const x0 = ctx.margin;
+  const y0 = ctx.y;
+  setFillRgb(ctx.pdf, SLATE50);
+  setDrawRgb(ctx.pdf, SLATE200);
+  ctx.pdf.setLineWidth(0.28);
+  ctx.pdf.roundedRect(x0, y0, ctx.maxW, barH, 1.3, 1.3, "FD");
+  setFillRgb(ctx.pdf, ctx.accent);
+  ctx.pdf.rect(x0, y0, 2, barH, "F");
+
+  ctx.pdf.setFont("helvetica", "bold");
+  ctx.pdf.setFontSize(9.2);
+  setTextRgb(ctx.pdf, SLATE900);
+  ctx.pdf.text(`Problem ${n}`, x0 + 4.5, y0 + 5.6);
+  ctx.pdf.setFont("helvetica", "normal");
+  ctx.pdf.setFontSize(7.4);
+  setTextRgb(ctx.pdf, SLATE600);
+  const meta = `ID ${id}  ·  ${section}  ·  order ${order}`;
+  const metaShort = meta.length > 95 ? `${meta.slice(0, 93)}…` : meta;
+  ctx.pdf.text(metaShort, x0 + 36, y0 + 5.6);
+  ctx.y = y0 + barH + 7;
+}
+
+function drawSubjectiveHeaderBar(
+  ctx: PdfContext,
+  n: number,
+  id: string,
+  section: string,
+  order: string,
+): void {
+  const barH = 8.5;
+  ensureSpace(ctx, barH + 6);
+  const x0 = ctx.margin;
+  const y0 = ctx.y;
+  setFillRgb(ctx.pdf, SLATE50);
+  setDrawRgb(ctx.pdf, SLATE200);
+  ctx.pdf.setLineWidth(0.28);
+  ctx.pdf.roundedRect(x0, y0, ctx.maxW, barH, 1.3, 1.3, "FD");
+  setFillRgb(ctx.pdf, ctx.accent);
+  ctx.pdf.rect(x0, y0, 2, barH, "F");
+
+  ctx.pdf.setFont("helvetica", "bold");
+  ctx.pdf.setFontSize(9.2);
+  setTextRgb(ctx.pdf, SLATE900);
+  ctx.pdf.text(`Subjective ${n}`, x0 + 4.5, y0 + 5.6);
+  ctx.pdf.setFont("helvetica", "normal");
+  ctx.pdf.setFontSize(7.4);
+  setTextRgb(ctx.pdf, SLATE600);
+  const meta = `ID ${id}  ·  ${section}  ·  order ${order}`;
+  const metaShort = meta.length > 95 ? `${meta.slice(0, 93)}…` : meta;
+  ctx.pdf.text(metaShort, x0 + 40, y0 + 5.6);
+  ctx.y = y0 + barH + 7;
+}
+
+/** Build subjective questions PDF (one file). Caller should only call when `rows.length > 0`. */
+export function saveAssessmentSubjectiveQuestionsPdf(
+  meta: AssessmentQuestionsPdfMeta,
+  rows: AssessmentQuestionExportRow[],
+): void {
+  const pdf = new jsPDF({ orientation: "p", unit: "mm", format: "a4" });
+  const pageW = pdf.internal.pageSize.getWidth();
+  const pageH = pdf.internal.pageSize.getHeight();
+  const margin = 16;
+  const footerReserve = 12;
+  const maxW = pageW - 2 * margin;
+  const accent = VIOLET;
+  const continuationTitle = `Subjective bank (continued) — ${meta.assessmentTitle.length > 52 ? `${meta.assessmentTitle.slice(0, 50)}…` : meta.assessmentTitle}`;
+
+  const y0 = drawCoverBand(
+    pdf,
+    pageW,
+    margin,
+    meta,
+    "Subjective · question bank",
+    "Admin export (includes evaluation rubric)",
+    VIOLET,
+    VIOLET_DARK,
+    rows.length,
+    LAVENDER_MIST,
+  );
+
+  const ctx: PdfContext = {
+    pdf,
+    margin,
+    maxW,
+    pageW,
+    pageH,
+    y: y0,
+    footerReserve,
+    continuationTitle,
+    accent,
+  };
+
+  let n = 0;
+  for (const row of rows) {
+    n += 1;
+    drawSubjectiveHeaderBar(
+      ctx,
+      n,
+      cellStr(row.id),
+      cellStr(row.section_title),
+      cellStr(row.section_order),
+    );
+    writeLabelBlock(ctx, "Question", cellStr(row.question_text), 10);
+    writeMonoBlock(ctx, "Evaluation rubric (AI)", cellStr(row.evaluation_prompt));
+    writeLabelBlock(ctx, "Max marks", cellStr(row.max_marks));
+    if (cellStr(row.question_type)) {
+      writeLabelBlock(ctx, "Question type", cellStr(row.question_type));
+    }
+    drawQuestionDivider(ctx);
+  }
+
+  applyFootersToAllPages(pdf, margin, pageW, pageH, meta.baseSlug);
+  pdf.save(`assessment-${meta.baseSlug}-subjective-questions.pdf`);
+}
+
+/** Build MCQ questions PDF (one file). Caller should only call when `rows.length > 0`. */
+export function saveAssessmentMcqQuestionsPdf(
+  meta: AssessmentQuestionsPdfMeta,
+  rows: AssessmentQuestionExportRow[],
+): void {
+  const pdf = new jsPDF({ orientation: "p", unit: "mm", format: "a4" });
+  const pageW = pdf.internal.pageSize.getWidth();
+  const pageH = pdf.internal.pageSize.getHeight();
+  const margin = 16;
+  const footerReserve = 12;
+  const maxW = pageW - 2 * margin;
+  const accent = INDIGO;
+  const continuationTitle = `MCQ bank (continued) — ${meta.assessmentTitle.length > 52 ? `${meta.assessmentTitle.slice(0, 50)}…` : meta.assessmentTitle}`;
+
+  const y0 = drawCoverBand(
+    pdf,
+    pageW,
+    margin,
+    meta,
+    "Multiple choice · question bank",
+    "Admin export",
+    INDIGO,
+    INDIGO_DARK,
+    rows.length,
+    VIOLET_MIST,
+  );
+
+  const ctx: PdfContext = {
+    pdf,
+    margin,
+    maxW,
+    pageW,
+    pageH,
+    y: y0,
+    footerReserve,
+    continuationTitle,
+    accent,
+  };
+
+  let n = 0;
+  for (const row of rows) {
+    n += 1;
+    drawQuestionHeaderBar(
+      ctx,
+      n,
+      cellStr(row.id),
+      cellStr(row.section_title),
+      cellStr(row.section_order),
+    );
+    writeWrapped(ctx, cellStr(row.question_text), margin, 10.5, "bold", SLATE900, STEM_TAIL_MM);
+    writeOptionRow(ctx, "A", cellStr(row.option_a), INDIGO);
+    writeOptionRow(ctx, "B", cellStr(row.option_b), INDIGO);
+    writeOptionRow(ctx, "C", cellStr(row.option_c), INDIGO);
+    writeOptionRow(ctx, "D", cellStr(row.option_d), INDIGO);
+    writeCorrectHighlight(ctx, cellStr(row.correct_option));
+    if (cellStr(row.difficulty_level)) {
+      writeLabelBlock(ctx, "Difficulty", cellStr(row.difficulty_level));
+    }
+    if (cellStr(row.topic)) {
+      writeLabelBlock(ctx, "Topic", cellStr(row.topic));
+    }
+    if (cellStr(row.skills)) {
+      writeLabelBlock(ctx, "Skills", cellStr(row.skills));
+    }
+    if (cellStr(row.explanation)) {
+      writeLabelBlock(ctx, "Explanation", cellStr(row.explanation));
+    }
+    drawQuestionDivider(ctx);
+  }
+
+  applyFootersToAllPages(pdf, margin, pageW, pageH, meta.baseSlug);
+  pdf.save(`assessment-${meta.baseSlug}-mcq-questions.pdf`);
+}
+
+/** Build coding questions PDF (one file). Caller should only call when `rows.length > 0`. */
+export function saveAssessmentCodingQuestionsPdf(
+  meta: AssessmentQuestionsPdfMeta,
+  rows: AssessmentQuestionExportRow[],
+): void {
+  const pdf = new jsPDF({ orientation: "p", unit: "mm", format: "a4" });
+  const pageW = pdf.internal.pageSize.getWidth();
+  const pageH = pdf.internal.pageSize.getHeight();
+  const margin = 16;
+  const footerReserve = 12;
+  const maxW = pageW - 2 * margin;
+  const accent = TEAL;
+  const continuationTitle = `Coding bank (continued) — ${meta.assessmentTitle.length > 52 ? `${meta.assessmentTitle.slice(0, 50)}…` : meta.assessmentTitle}`;
+
+  const mintTitle: [number, number, number] = [204, 251, 241];
+  const y0 = drawCoverBand(
+    pdf,
+    pageW,
+    margin,
+    meta,
+    "Coding · question bank",
+    "Admin export",
+    TEAL,
+    TEAL_DARK,
+    rows.length,
+    mintTitle,
+  );
+
+  const ctx: PdfContext = {
+    pdf,
+    margin,
+    maxW,
+    pageW,
+    pageH,
+    y: y0,
+    footerReserve,
+    continuationTitle,
+    accent,
+  };
+
+  let n = 0;
+  for (const row of rows) {
+    n += 1;
+    drawCodingHeaderBar(
+      ctx,
+      n,
+      cellStr(row.id),
+      cellStr(row.section_title),
+      cellStr(row.section_order),
+    );
+    writeLabelBlock(ctx, "Title", cellStr(row.title), 10);
+    writeLabelBlock(ctx, "Problem statement", cellStr(row.problem_statement), 9.5);
+    writeLabelBlock(ctx, "Input format", cellStr(row.input_format));
+    writeLabelBlock(ctx, "Output format", cellStr(row.output_format));
+    writeMonoBlock(ctx, "Sample input", cellStr(row.sample_input));
+    writeMonoBlock(ctx, "Sample output", cellStr(row.sample_output));
+    writeLabelBlock(ctx, "Constraints", cellStr(row.constraints));
+    if (cellStr(row.difficulty_level)) {
+      writeLabelBlock(ctx, "Difficulty", cellStr(row.difficulty_level));
+    }
+    if (cellStr(row.tags)) {
+      writeLabelBlock(ctx, "Tags", cellStr(row.tags));
+    }
+    writeLabelBlock(ctx, "Time limit (sec)", cellStr(row.time_limit));
+    writeLabelBlock(ctx, "Memory limit (MB)", cellStr(row.memory_limit));
+    drawQuestionDivider(ctx);
+  }
+
+  applyFootersToAllPages(pdf, margin, pageW, pageH, meta.baseSlug);
+  pdf.save(`assessment-${meta.baseSlug}-coding-questions.pdf`);
+}
+
+/** Download MCQ, coding, and/or subjective PDFs (staggered saves), mirroring CSV export behavior. */
+export function saveAssessmentQuestionsPdfs(
+  meta: AssessmentQuestionsPdfMeta,
+  mcqFlat: AssessmentQuestionExportRow[],
+  codingFlat: AssessmentQuestionExportRow[],
+  subjectiveFlat: AssessmentQuestionExportRow[] = [],
+): { fileCount: number } {
+  const tasks: Array<() => void> = [];
+  if (mcqFlat.length > 0) {
+    tasks.push(() => saveAssessmentMcqQuestionsPdf(meta, mcqFlat));
+  }
+  if (codingFlat.length > 0) {
+    tasks.push(() => saveAssessmentCodingQuestionsPdf(meta, codingFlat));
+  }
+  if (subjectiveFlat.length > 0) {
+    tasks.push(() => saveAssessmentSubjectiveQuestionsPdf(meta, subjectiveFlat));
+  }
+  tasks.forEach((fn, i) => {
+    setTimeout(() => fn(), i * 140);
+  });
+  return { fileCount: tasks.length };
+}


### PR DESCRIPTION
- Add assessment-questions-export-pdf.utils (MCQ, coding, subjective) with styled PDFs
- Assessment list: CSV/PDF menu, subjective rows and third file; spacing/rubric fixes in PDF
- Assessment edit: subjective tab, downloads; subjective types and isSubjectiveQuestion guard
- Fix edit assessment save pass-band vs device validation block