### PR TITLE
fix branding white-bg section visibility and google auth button contrast

### DIFF
--- a/components/admin/branding/BrandingPresetGallery.tsx
+++ b/components/admin/branding/BrandingPresetGallery.tsx
@@ -20,9 +20,11 @@ type ExtendedCategoryKey =
   | CategoryKey
   | "light"
   | "dark"
-  | "minimal";
+  | "minimal"
+  | "white_bg";
 
 const CATEGORY_ORDER: ExtendedCategoryKey[] = [
+  "white_bg",
   "light",
   "classic",
   "vibrant",
@@ -40,6 +42,8 @@ const FALLBACK_PREVIEW = {
 
 function categoryLabelKey(cat: string): string {
   switch (cat) {
+    case "white_bg":
+      return "branding.presetCategoryWhiteBg";
     case "light":
       return "branding.presetCategoryLight";
     case "dark":
@@ -57,6 +61,8 @@ function categoryLabelKey(cat: string): string {
 
 function categoryBlurbKey(cat: string): string {
   switch (cat) {
+    case "white_bg":
+      return "branding.presetGroupBlurb_white_bg";
     case "light":
       return "branding.presetGroupBlurb_light";
     case "dark":
@@ -74,6 +80,8 @@ function categoryBlurbKey(cat: string): string {
 
 function categoryIcon(cat: string): string {
   switch (cat) {
+    case "white_bg":
+      return "mdi:monitor-shimmer";
     case "light":
       return "mdi:white-balance-sunny";
     case "dark":
@@ -93,6 +101,8 @@ function categoryChipColor(
   cat: string
 ): "default" | "primary" | "secondary" | "warning" | "success" | "info" {
   switch (cat) {
+    case "white_bg":
+      return "info";
     case "light":
       return "info";
     case "dark":
@@ -238,6 +248,7 @@ export function BrandingPresetGallery({
       baseId: string;
       defaultPreset: BrandingPresetSummary;
       whiteBgPreset?: BrandingPresetSummary;
+      whiteCanvasPreset?: BrandingPresetSummary;
     }>;
   }[] => {
     const pairMap = new Map<
@@ -247,10 +258,21 @@ export function BrandingPresetGallery({
         category: ExtendedCategoryKey;
         defaultPreset?: BrandingPresetSummary;
         whiteBgPreset?: BrandingPresetSummary;
+        whiteCanvasPreset?: BrandingPresetSummary;
       }
     >();
 
     for (const p of presets) {
+      if (p.variant === "white_canvas") {
+        pairMap.set(`white:${p.id}`, {
+          baseId: p.id,
+          category: "white_bg",
+          defaultPreset: p,
+          whiteCanvasPreset: p,
+        });
+        continue;
+      }
+
       const baseId = p.base_id || p.id;
       const c = (p.category || "classic") as ExtendedCategoryKey;
       const existing = pairMap.get(baseId) || {
@@ -259,6 +281,8 @@ export function BrandingPresetGallery({
       };
       if (p.variant === "white_bg") {
         existing.whiteBgPreset = p;
+      } else if (p.variant === "white_canvas") {
+        existing.whiteCanvasPreset = p;
       } else {
         existing.defaultPreset = p;
       }
@@ -270,7 +294,12 @@ export function BrandingPresetGallery({
 
     const groupedMap = new Map<
       ExtendedCategoryKey,
-      Array<{ baseId: string; defaultPreset: BrandingPresetSummary; whiteBgPreset?: BrandingPresetSummary }>
+      Array<{
+        baseId: string;
+        defaultPreset: BrandingPresetSummary;
+        whiteBgPreset?: BrandingPresetSummary;
+        whiteCanvasPreset?: BrandingPresetSummary;
+      }>
     >();
     for (const entry of pairMap.values()) {
       if (!entry.defaultPreset) continue;
@@ -279,6 +308,7 @@ export function BrandingPresetGallery({
         baseId: entry.baseId,
         defaultPreset: entry.defaultPreset,
         whiteBgPreset: entry.whiteBgPreset,
+        whiteCanvasPreset: entry.whiteCanvasPreset,
       });
     }
 
@@ -387,13 +417,18 @@ export function BrandingPresetGallery({
             {items.map((pair) => {
               const currentPreset = pair.defaultPreset;
               const whiteBgPreset = pair.whiteBgPreset;
-              const selectedUsesWhite = selectedId === whiteBgPreset?.id;
-              const activePreset = selectedUsesWhite ? whiteBgPreset! : currentPreset;
+              const whiteCanvasPreset = pair.whiteCanvasPreset;
+              const selectedUsesWhiteCanvas = selectedId === whiteCanvasPreset?.id;
+      const activePreset = selectedUsesWhiteCanvas
+                ? whiteCanvasPreset!
+                : currentPreset;
               const preview = activePreset.preview ?? FALLBACK_PREVIEW;
               const selected =
-                selectedId === currentPreset.id || (whiteBgPreset ? selectedId === whiteBgPreset.id : false);
+                selectedId === currentPreset.id ||
+                (whiteCanvasPreset ? selectedId === whiteCanvasPreset.id : false);
               const loading =
-                applyingId === currentPreset.id || (whiteBgPreset ? applyingId === whiteBgPreset.id : false);
+                applyingId === currentPreset.id ||
+                (whiteCanvasPreset ? applyingId === whiteCanvasPreset.id : false);
               return (
                 <ButtonBase
                   key={pair.baseId}
@@ -465,8 +500,8 @@ export function BrandingPresetGallery({
                           size="small"
                           clickable
                           label="Current"
-                          color={!selectedUsesWhite ? "primary" : "default"}
-                          variant={!selectedUsesWhite ? "filled" : "outlined"}
+                          color={!selectedUsesWhiteCanvas ? "primary" : "default"}
+                          variant={!selectedUsesWhiteCanvas ? "filled" : "outlined"}
                           onClick={(e) => {
                             e.preventDefault();
                             e.stopPropagation();
@@ -474,20 +509,21 @@ export function BrandingPresetGallery({
                           }}
                           sx={{ fontWeight: 600, fontSize: "0.68rem" }}
                         />
-                        <Chip
-                          size="small"
-                          clickable
-                          disabled={!whiteBgPreset}
-                          label="White BG"
-                          color={selectedUsesWhite ? "primary" : "default"}
-                          variant={selectedUsesWhite ? "filled" : "outlined"}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            if (whiteBgPreset) onSelectPreset(whiteBgPreset.id);
-                          }}
-                          sx={{ fontWeight: 600, fontSize: "0.68rem" }}
-                        />
+                        {whiteCanvasPreset ? (
+                          <Chip
+                            size="small"
+                            clickable
+                            label="White BG"
+                            color={selectedUsesWhiteCanvas ? "primary" : "default"}
+                            variant={selectedUsesWhiteCanvas ? "filled" : "outlined"}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              onSelectPreset(whiteCanvasPreset.id);
+                            }}
+                            sx={{ fontWeight: 600, fontSize: "0.68rem" }}
+                          />
+                        ) : null}
                       </Stack>
                       {activePreset.tagline ? (
                         <Typography variant="caption" color="text.secondary" sx={{ lineHeight: 1.35 }}>

--- a/components/auth/GoogleSignIn.tsx
+++ b/components/auth/GoogleSignIn.tsx
@@ -226,7 +226,7 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
           py: 1.25,
           borderColor: "#e2e8f0",
           borderWidth: 1.5,
-          color: "text.primary",
+          color: "#0f172a",
           textTransform: "none",
           backgroundColor: "white",
           fontWeight: 500,
@@ -266,7 +266,7 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
           </svg>
           <Typography
             variant="body2"
-            sx={{ fontWeight: 500, fontSize: "0.9375rem" }}
+            sx={{ fontWeight: 500, fontSize: "0.9375rem", color: "#0f172a" }}
           >
             {t("auth.signInWithGoogle")}
           </Typography>

--- a/lib/services/admin/branding.service.ts
+++ b/lib/services/admin/branding.service.ts
@@ -17,7 +17,7 @@ export interface BrandingPresetSummary {
   tagline?: string;
   /** Shared id between default and white-bg variants of the same theme. */
   base_id?: string;
-  /** default | white_bg */
+  /** default | white_bg | white_canvas */
   variant?: string;
   preview?: BrandingPresetPreview;
 }

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -136,6 +136,7 @@
     "presetCategoryLight": "فاتح",
     "presetCategoryDark": "داكن",
     "presetCategoryMinimal": "بسيط",
+    "presetCategoryWhiteBg": "خلفية بيضاء",
     "presetCategoryVibrant": "زاهٍ",
     "presetCategoryHighContrast": "تباين عالٍ",
     "presetSectionFeatured": "اختيارات شائعة",
@@ -144,6 +145,7 @@
     "presetGroupBlurb_light": "واجهات ساطعة مع أشرطة جانبية ناعمة ووضوح عالٍ.",
     "presetGroupBlurb_dark": "مظاهر داكنة للتركيز وتقليل إجهاد العين.",
     "presetGroupBlurb_minimal": "ألوان هادئة وبسيطة لواجهات نظيفة واحترافية.",
+    "presetGroupBlurb_white_bg": "خلفية صفحة وشريط علوي أبيضان مع قوائم جانبية ملوّنة ومميزة.",
     "presetGroupBlurb_vibrant": "لمسات مشبّعة تناسب المواقع التسويقية والجمهور الأصغر.",
     "presetGroupBlurb_high_contrast": "فصل قوي بين الشريط والنص والأزرار لتحسين الوصول."
   },

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -136,6 +136,7 @@
     "presetCategoryLight": "Light",
     "presetCategoryDark": "Dark",
     "presetCategoryMinimal": "Minimal",
+    "presetCategoryWhiteBg": "White background",
     "presetCategoryVibrant": "Vibrant",
     "presetCategoryHighContrast": "High contrast",
     "presetSectionFeatured": "Popular picks",
@@ -144,6 +145,7 @@
     "presetGroupBlurb_light": "Bright interfaces with soft sidebars and high readability.",
     "presetGroupBlurb_dark": "Dark-first shells for focused sessions and low-glare usage.",
     "presetGroupBlurb_minimal": "Simple, low-noise palettes for clean professional screens.",
+    "presetGroupBlurb_white_bg": "White page canvas and top bar with distinct colored side menus.",
     "presetGroupBlurb_vibrant": "Saturated accents that pop on marketing and youth-facing sites.",
     "presetGroupBlurb_high_contrast": "Strong separation between shell, text, and CTAs for accessibility."
   },


### PR DESCRIPTION
Render white-canvas presets in a dedicated white-background gallery section with localized labels, and force dark text on the Google auth button to keep it readable on white surfaces under dark branding themes.