### PR TITLE
add sample csv download for bulk enrollment

### DIFF
--- a/components/admin/manage-students/BulkEnrollmentDialog.tsx
+++ b/components/admin/manage-students/BulkEnrollmentDialog.tsx
@@ -285,6 +285,19 @@ export function BulkEnrollmentDialog({
     }
   };
 
+  const handleDownloadSampleCsv = () => {
+    const csvContent = "name,email\nJohn Doe,john.doe@example.com\nJane Smith,jane.smith@example.com\n";
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", "bulk_enrollment_sample.csv");
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
   const handleJobComplete = () => {
     setShowJobStatus(false);
     if (onSuccess) {
@@ -304,6 +317,16 @@ export function BulkEnrollmentDialog({
             <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
               {t("adminManageStudents.uploadStudentCsvDesc")}
             </Typography>
+            <Box sx={{ mb: 2 }}>
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleDownloadSampleCsv}
+                startIcon={<IconWrapper icon="mdi:download" size={18} />}
+              >
+                {t("adminManageStudents.downloadSampleCsv")}
+              </Button>
+            </Box>
 
             <Box
               sx={{

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -1361,6 +1361,7 @@
     "bulkStudentEnrollment": "التسجيل الجماعي للطلاب",
     "uploadStudentCsvTitle": "رفع ملف CSV للطلاب",
     "uploadStudentCsvDesc": "ارفع ملف CSV بالأعمدة: الاسم، البريد الإلكتروني، الهاتف (اختياري)",
+    "downloadSampleCsv": "تحميل نموذج CSV (الاسم، البريد الإلكتروني)",
     "clickToUpload": "انقر للرفع أو اسحب وأفلت",
     "csvFilesOnly": "ملفات CSV فقط (يدعم ملفات متعددة)",
     "uploadedFiles": "الملفات المرفوعة ({{count}}):",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1492,6 +1492,7 @@
     "bulkStudentEnrollment": "Bulk Student Enrollment",
     "uploadStudentCsvTitle": "Upload Student CSV File",
     "uploadStudentCsvDesc": "Upload a CSV file with columns: name, email, phone (optional)",
+    "downloadSampleCsv": "Download sample CSV (name, email)",
     "clickToUpload": "Click to upload or drag and drop",
     "csvFilesOnly": "CSV files only (multiple files supported)",
     "uploadedFiles": "Uploaded Files ({{count}}):",


### PR DESCRIPTION
Provide a downloadable name/email CSV template in the bulk enrollment dialog so admins can start from a valid format before uploading student files.