### PR TITLE
add assessment tab-switch limit configuration and auto-submit UX

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -400,6 +400,8 @@ export default function AssessmentEditPage() {
   const [evaluationMode, setEvaluationMode] = useState<"auto" | "manual">("auto");
   const [allowMovementAcrossSections, setAllowMovementAcrossSections] =
     useState(true);
+  const [tabSwitchLimitEnabled, setTabSwitchLimitEnabled] = useState(false);
+  const [tabSwitchLimitCount, setTabSwitchLimitCount] = useState(2);
   const [certificateAvailable, setCertificateAvailable] = useState(false);
   const [passBandLowerPercent, setPassBandLowerPercent] = useState("");
   const [passBandUpperPercent, setPassBandUpperPercent] = useState("");
@@ -499,6 +501,12 @@ export default function AssessmentEditPage() {
       setShowResult((data as any).show_result ?? true);
       setEvaluationMode((data as any).evaluation_mode === "manual" ? "manual" : "auto");
       setAllowMovementAcrossSections(anyData.allow_movement !== false);
+      setTabSwitchLimitEnabled(Boolean(anyData.tab_switch_limit_enabled));
+      setTabSwitchLimitCount(
+        Number(anyData.tab_switch_limit_count) > 0
+          ? Number(anyData.tab_switch_limit_count)
+          : 2
+      );
       setCertificateAvailable(Boolean(anyData.certificate_available));
       setPassBandLowerPercent(
         anyData.pass_band_lower_min_percent != null &&
@@ -670,6 +678,10 @@ export default function AssessmentEditPage() {
       showToast(t("assessmentDevice.atLeastOne"), "error");
       return;
     }
+    if (tabSwitchLimitEnabled && tabSwitchLimitCount < 1) {
+      showToast("Allowed tab switches must be at least 1", "error");
+      return;
+    }
     try {
       setSaving(true);
       const payload: Partial<CreateAssessmentPayload> = {
@@ -690,6 +702,8 @@ export default function AssessmentEditPage() {
         evaluation_mode: evaluationMode,
         certificate_available: certificateAvailable,
         allow_movement: allowMovementAcrossSections,
+        tab_switch_limit_enabled: tabSwitchLimitEnabled,
+        tab_switch_limit_count: tabSwitchLimitEnabled ? tabSwitchLimitCount : null,
         allow_desktop: allowDesktop,
         allow_mobile: allowMobile,
         allow_tablet: allowTablet,
@@ -1302,6 +1316,8 @@ export default function AssessmentEditPage() {
                   showResult={showResult}
                   evaluationMode={evaluationMode}
                   allowMovementAcrossSections={allowMovementAcrossSections}
+                  tabSwitchLimitEnabled={tabSwitchLimitEnabled}
+                  tabSwitchLimitCount={tabSwitchLimitCount}
                   certificateAvailable={certificateAvailable}
                   passBandLowerPercent={passBandLowerPercent}
                   passBandUpperPercent={passBandUpperPercent}
@@ -1327,6 +1343,8 @@ export default function AssessmentEditPage() {
                   onAllowMovementAcrossSectionsChange={
                     setAllowMovementAcrossSections
                   }
+                  onTabSwitchLimitEnabledChange={setTabSwitchLimitEnabled}
+                  onTabSwitchLimitCountChange={setTabSwitchLimitCount}
                   onCertificateAvailableChange={setCertificateAvailable}
                   onPassBandLowerPercentChange={setPassBandLowerPercent}
                   onPassBandUpperPercentChange={setPassBandUpperPercent}

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -99,6 +99,8 @@ export default function CreateAssessmentPage() {
 
   const [allowMovementAcrossSections, setAllowMovementAcrossSections] =
     useState(true);
+  const [tabSwitchLimitEnabled, setTabSwitchLimitEnabled] = useState(false);
+  const [tabSwitchLimitCount, setTabSwitchLimitCount] = useState(2);
   const [certificateAvailable, setCertificateAvailable] = useState(false);
   const [passBandLowerPercent, setPassBandLowerPercent] = useState("");
   const [passBandUpperPercent, setPassBandUpperPercent] = useState("");
@@ -235,6 +237,10 @@ export default function CreateAssessmentPage() {
       if (passBandFieldErrors.lower || passBandFieldErrors.upper) {
         return;
       }
+      if (tabSwitchLimitEnabled && tabSwitchLimitCount < 1) {
+        showToast("Allowed tab switches must be at least 1", "error");
+        return;
+      }
     }
     if (activeStep === 1) {
       // Validate questions for each section
@@ -320,6 +326,9 @@ export default function CreateAssessmentPage() {
         return true;
       }
       if (passBandFieldErrors.lower || passBandFieldErrors.upper) {
+        return true;
+      }
+      if (tabSwitchLimitEnabled && tabSwitchLimitCount < 1) {
         return true;
       }
       return false;
@@ -742,6 +751,8 @@ export default function CreateAssessmentPage() {
         evaluation_mode: evaluationMode,
         certificate_available: certificateAvailable,
         allow_movement: allowMovementAcrossSections,
+        tab_switch_limit_enabled: tabSwitchLimitEnabled,
+        tab_switch_limit_count: tabSwitchLimitEnabled ? tabSwitchLimitCount : null,
         allow_desktop: allowDesktop,
         allow_mobile: allowMobile,
         allow_tablet: allowTablet,
@@ -933,6 +944,8 @@ export default function CreateAssessmentPage() {
               showResult={showResult}
               evaluationMode={evaluationMode}
               allowMovementAcrossSections={allowMovementAcrossSections}
+              tabSwitchLimitEnabled={tabSwitchLimitEnabled}
+              tabSwitchLimitCount={tabSwitchLimitCount}
               certificateAvailable={certificateAvailable}
               passBandLowerPercent={passBandLowerPercent}
               passBandUpperPercent={passBandUpperPercent}
@@ -956,6 +969,8 @@ export default function CreateAssessmentPage() {
               onShowResultChange={setShowResult}
               onEvaluationModeChange={setEvaluationMode}
               onAllowMovementAcrossSectionsChange={setAllowMovementAcrossSections}
+              onTabSwitchLimitEnabledChange={setTabSwitchLimitEnabled}
+              onTabSwitchLimitCountChange={setTabSwitchLimitCount}
               onCertificateAvailableChange={setCertificateAvailable}
               onPassBandLowerPercentChange={setPassBandLowerPercent}
               onPassBandUpperPercentChange={setPassBandUpperPercent}

--- a/app/assessments/[slug]/submission-success/page.tsx
+++ b/app/assessments/[slug]/submission-success/page.tsx
@@ -19,6 +19,7 @@ import { useStopCameraOnMount } from "@/lib/hooks/useStopCameraOnMount";
 import {
   assessmentService,
   AssessmentDetail,
+  AssessmentResult,
   ScholarshipStatus,
 } from "@/lib/services/assessment.service";
 
@@ -31,6 +32,7 @@ export default function SubmissionSuccessPage() {
   const [scholarshipStatus, setScholarshipStatus] =
     useState<ScholarshipStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const [autoSubmitMessage, setAutoSubmitMessage] = useState<string | null>(null);
   const { showToast } = useToast();
 
   // Stop any active camera and audio streams on this page
@@ -51,6 +53,20 @@ export default function SubmissionSuccessPage() {
           setScholarshipStatus(status);
         } catch (error) {
           // Scholarship status might not be available yet - silently fail
+        }
+        try {
+          const result = await assessmentService.getAssessmentResult(slug);
+          const reason = (result as AssessmentResult).auto_submitted_reason;
+          if (reason === "tab_switch_limit") {
+            setAutoSubmitMessage(
+              (result as AssessmentResult).auto_submit_message ||
+                "This assessment was auto-submitted because the tab-switch limit was reached."
+            );
+          } else {
+            setAutoSubmitMessage(null);
+          }
+        } catch {
+          setAutoSubmitMessage(null);
         }
       } catch (error: any) {
         showToast(t("assessments.failedToLoadDetails"), "error");
@@ -97,6 +113,12 @@ export default function SubmissionSuccessPage() {
           </Box>
 
           <Divider sx={{ my: 4 }} />
+
+          {autoSubmitMessage ? (
+            <Alert severity="warning" sx={{ mb: 3, textAlign: "left" }}>
+              <Typography variant="body2">{autoSubmitMessage}</Typography>
+            </Alert>
+          ) : null}
 
           {scholarshipStatus && scholarshipStatus.has_submitted && (
             <Box sx={{ mb: 4 }}>

--- a/app/assessments/[slug]/take/page.tsx
+++ b/app/assessments/[slug]/take/page.tsx
@@ -99,6 +99,7 @@ const MAX_VIOLATION_CAPTURE_RETRIES = 6;
 const MAX_SESSION_START_PROOF_ATTEMPTS = 6;
 
 const SECTION_COMPLETELY_ATTEMPTED_KEY = "section_completely_attempted";
+const AUTO_SUBMIT_REASON_TAB_SWITCH_LIMIT = "tab_switch_limit";
 
 /** First section index the learner may enter: skips timed sections already marked complete on the response sheet. */
 function firstTimedSectionEntryIndex(
@@ -247,6 +248,9 @@ export default function TakeAssessmentPage({
   const latestViolationTypeRef = useRef<string | null>(null);
   const lastTabSwitchCountAtScreenshotRef = useRef(-1);
   const handleFinalSubmitRef = useRef<() => void>(() => {});
+  const tabSwitchLimitAutoSubmitTriggeredRef = useRef(false);
+  const autoSubmitReasonRef = useRef<string | null>(null);
+  const autoSubmitMetaRef = useRef<Record<string, any> | null>(null);
   const mediaGraceUntilRef = useRef(0);
   const timedSectionsCompleteRef = useRef<Set<string>>(new Set());
   const prevSectionIndexMarkRef = useRef<number | null>(null);
@@ -722,6 +726,34 @@ export default function TakeAssessmentPage({
     );
   }, [tabSwitchCount, assessmentStarted, submitting, showToast]);
 
+  useEffect(() => {
+    if (!assessmentStarted || submitting) return;
+    if (!assessment?.tab_switch_limit_enabled) return;
+    const limit = Number(assessment?.tab_switch_limit_count || 0);
+    if (!Number.isFinite(limit) || limit <= 0) return;
+    if (tabSwitchCount < limit) return;
+    if (tabSwitchLimitAutoSubmitTriggeredRef.current) return;
+    tabSwitchLimitAutoSubmitTriggeredRef.current = true;
+    autoSubmitReasonRef.current = AUTO_SUBMIT_REASON_TAB_SWITCH_LIMIT;
+    autoSubmitMetaRef.current = {
+      limit,
+      current_count: tabSwitchCount,
+      triggered_at: new Date().toISOString(),
+    };
+    showToast(
+      "Tab-switch limit reached. Submitting your assessment automatically.",
+      "warning"
+    );
+    handleFinalSubmitRef.current();
+  }, [
+    assessmentStarted,
+    submitting,
+    assessment?.tab_switch_limit_enabled,
+    assessment?.tab_switch_limit_count,
+    tabSwitchCount,
+    showToast,
+  ]);
+
   // Show toast notifications for proctoring violations
   useEffect(() => {
     if (!assessmentStarted || submitting || !latestViolation) return;
@@ -1188,6 +1220,8 @@ export default function TakeAssessmentPage({
     setShowSubmitDialog,
     violationScreenshotSamplesRef: violationScreenshotEvidenceRef,
     timedSectionsCompleteRef,
+    autoSubmitReasonRef,
+    autoSubmitMetaRef,
   });
 
   useEffect(() => {

--- a/app/assessments/result/[slug]/page.tsx
+++ b/app/assessments/result/[slug]/page.tsx
@@ -93,6 +93,8 @@ export default function AssessmentResultPage() {
 
   const stats = assessmentResult?.stats || ({} as AssessmentResult["stats"]);
   const resultHidden = assessmentResult?.show_result === false;
+  const tabSwitchAutoSubmit =
+    assessmentResult?.auto_submitted_reason === "tab_switch_limit";
 
   const quizResponses = assessmentResult?.user_responses?.quiz_responses || [];
 
@@ -194,6 +196,15 @@ export default function AssessmentResultPage() {
               {assessmentResult?.review_status === "published"
                 ? "Result visibility is currently disabled."
                 : "Your assessment is under manual evaluation. Results will appear after publish."}
+            </Typography>
+          </Alert>
+        )}
+
+        {tabSwitchAutoSubmit && (
+          <Alert severity="warning" sx={{ mb: 3 }}>
+            <Typography variant="body2">
+              {assessmentResult?.auto_submit_message ||
+                "This assessment was auto-submitted because the tab-switch limit was reached."}
             </Typography>
           </Alert>
         )}

--- a/components/admin/assessment/AssessmentSettingsSection.tsx
+++ b/components/admin/assessment/AssessmentSettingsSection.tsx
@@ -37,6 +37,8 @@ interface AssessmentSettingsSectionProps {
 
   /** Assessment-wide: learners may move between section blocks (quiz, coding, etc.). */
   allowMovementAcrossSections: boolean;
+  tabSwitchLimitEnabled: boolean;
+  tabSwitchLimitCount: number;
   certificateAvailable: boolean;
   passBandLowerPercent: string;
   passBandUpperPercent: string;
@@ -65,6 +67,8 @@ interface AssessmentSettingsSectionProps {
   onShowResultChange: (value: boolean) => void;
   onEvaluationModeChange: (value: "auto" | "manual") => void;
   onAllowMovementAcrossSectionsChange: (value: boolean) => void;
+  onTabSwitchLimitEnabledChange: (value: boolean) => void;
+  onTabSwitchLimitCountChange: (value: number) => void;
   onCertificateAvailableChange: (value: boolean) => void;
   onPassBandLowerPercentChange: (value: string) => void;
   onPassBandUpperPercentChange: (value: string) => void;
@@ -243,6 +247,8 @@ export function AssessmentSettingsSection({
   liveStreaming = false,
   showLiveStreamingToggle = false,
   allowMovementAcrossSections,
+  tabSwitchLimitEnabled,
+  tabSwitchLimitCount,
   certificateAvailable,
   passBandLowerPercent,
   passBandUpperPercent,
@@ -271,6 +277,8 @@ export function AssessmentSettingsSection({
   onShowResultChange,
   onEvaluationModeChange,
   onAllowMovementAcrossSectionsChange,
+  onTabSwitchLimitEnabledChange,
+  onTabSwitchLimitCountChange,
   onCertificateAvailableChange,
   onPassBandLowerPercentChange,
   onPassBandUpperPercentChange,
@@ -753,6 +761,39 @@ export function AssessmentSettingsSection({
               onChange={onAllowMovementAcrossSectionsChange}
               disabled={readOnly}
             />
+            <PolicySwitchRow
+              icon="mdi:tab"
+              title="Auto-submit on tab switches"
+              subtitle="When enabled, attempt is auto-submitted once tab switch count reaches the configured limit."
+              checked={tabSwitchLimitEnabled}
+              onChange={onTabSwitchLimitEnabledChange}
+              disabled={readOnly}
+            />
+            <Collapse in={tabSwitchLimitEnabled} timeout="auto" unmountOnExit>
+              <ListItem
+                sx={{
+                  display: "block",
+                  px: 2,
+                  py: 2,
+                  bgcolor: "var(--surface)",
+                  borderBottom: "1px solid",
+                  borderColor: "var(--border-default)",
+                }}
+              >
+                <TextField
+                  label="Allowed tab switches"
+                  type="number"
+                  value={tabSwitchLimitCount > 0 ? tabSwitchLimitCount : ""}
+                  onChange={(e) => onTabSwitchLimitCountChange(Number(e.target.value || 0))}
+                  fullWidth
+                  required
+                  inputProps={{ min: 1 }}
+                  helperText="Attempt auto-submits immediately when this count is reached."
+                  FormHelperTextProps={helperFormProps}
+                  disabled={readOnly}
+                />
+              </ListItem>
+            </Collapse>
 
             <ListSubheader component="div" disableSticky sx={listSubheaderSx}>
               Certificates

--- a/lib/hooks/useAssessmentData.ts
+++ b/lib/hooks/useAssessmentData.ts
@@ -58,6 +58,8 @@ interface AssessmentResponse {
   proctoring_enabled?: boolean;
   /** When false, learners follow strict section order (no tab jumps, no Previous into prior sections). */
   allow_movement?: boolean;
+  tab_switch_limit_enabled?: boolean;
+  tab_switch_limit_count?: number | null;
 }
 
 export function useAssessmentData(slug: string) {

--- a/lib/hooks/useAssessmentSubmission.ts
+++ b/lib/hooks/useAssessmentSubmission.ts
@@ -40,6 +40,8 @@ interface UseAssessmentSubmissionOptions {
   violationScreenshotSamplesRef?: MutableRefObject<ViolationScreenshotSample[]>;
   /** Keys from `timedSectionCompletionKey` — merged into final payload. */
   timedSectionsCompleteRef?: MutableRefObject<Set<string>>;
+  autoSubmitReasonRef?: MutableRefObject<string | null>;
+  autoSubmitMetaRef?: MutableRefObject<Record<string, any> | null>;
 }
 
 export function useAssessmentSubmission({
@@ -55,6 +57,8 @@ export function useAssessmentSubmission({
   setShowSubmitDialog,
   violationScreenshotSamplesRef,
   timedSectionsCompleteRef,
+  autoSubmitReasonRef,
+  autoSubmitMetaRef,
 }: UseAssessmentSubmissionOptions) {
   const router = useRouter();
   const { showToast } = useToast();
@@ -276,6 +280,8 @@ export function useAssessmentSubmission({
         quizSectionId,
         codingProblemSectionId,
         subjectiveQuestionSectionId,
+        auto_submitted_reason: autoSubmitReasonRef?.current || undefined,
+        auto_submitted_meta: autoSubmitMetaRef?.current || undefined,
       };
 
       // Submit assessment - THIS IS THE CRITICAL STEP

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -172,6 +172,8 @@ export interface CreateAssessmentPayload {
    * move between section blocks (e.g. quiz ↔ coding). Do not send per-section.
    */
   allow_movement?: boolean;
+  tab_switch_limit_enabled?: boolean;
+  tab_switch_limit_count?: number | null;
   /** API: camelCase array of quiz sections */
   quizSection?: AssessmentQuizSectionWrite[];
   /** API: camelCase array of coding problem sections */
@@ -223,6 +225,8 @@ export interface Assessment {
   live_streaming?: boolean;
   /** Allow navigation across section blocks (assessment-wide). */
   allow_movement?: boolean;
+  tab_switch_limit_enabled?: boolean;
+  tab_switch_limit_count?: number | null;
   start_time?: string | null;
   end_time?: string | null;
   created_at: string;
@@ -252,6 +256,8 @@ export interface AssessmentDetail extends Assessment {
   certificate_available?: boolean;
   pass_band_lower_min_percent?: string;
   pass_band_upper_min_percent?: string;
+  tab_switch_limit_enabled?: boolean;
+  tab_switch_limit_count?: number | null;
   /** API: camelCase quiz sections (detail GET) */
   quizSection?: Array<{
     id: number;

--- a/lib/services/assessment.service.ts
+++ b/lib/services/assessment.service.ts
@@ -34,6 +34,8 @@ export interface Assessment {
   show_result?: boolean;
   evaluation_mode?: "auto" | "manual";
   review_status?: "not_required" | "pending_evaluation" | "evaluated" | "published";
+  tab_switch_limit_enabled?: boolean;
+  tab_switch_limit_count?: number | null;
 }
 
 export interface AssessmentDetail extends Assessment {
@@ -85,6 +87,9 @@ export interface FinalSubmissionResponse {
   review_status?: string;
   show_result?: boolean;
   message?: string;
+  auto_submitted_reason?: string | null;
+  auto_submitted_meta?: Record<string, any>;
+  auto_submit_message?: string;
 }
 
 export interface ScholarshipStatus {
@@ -151,6 +156,9 @@ export interface AssessmentResult {
   /** When false, show evaluation-in-progress message instead of full result */
   show_result?: boolean;
   review_status?: string;
+  auto_submitted_reason?: string | null;
+  auto_submitted_meta?: Record<string, any>;
+  auto_submit_message?: string;
   /** Optional server-provided feedback lines for the report */
   feedback_points?: string[];
   stats: {
@@ -386,12 +394,16 @@ export const assessmentService = {
       quizSectionId: Array<Record<string, any>>;
       codingProblemSectionId: Array<Record<string, any>>;
       subjectiveQuestionSectionId?: Array<Record<string, any>>;
+      auto_submitted_reason?: string;
+      auto_submitted_meta?: Record<string, any>;
     },
   ): Promise<FinalSubmissionResponse> => {
     const response = await apiClient.put<FinalSubmissionResponse>(
       `/assessment/api/client/${config.clientId}/assessment-submission/${assessmentId}/final/`,
       {
         response_sheet: payload,
+        auto_submitted_reason: payload.auto_submitted_reason,
+        auto_submitted_meta: payload.auto_submitted_meta,
       },
     );
     return response.data;


### PR DESCRIPTION
Wire tab-switch limit settings into admin create/edit flows, enforce threshold-triggered one-time auto-submit in take flow, and display explicit auto-submit reason in submission success and result pages.