### PR TITLE
fix(mock-interview): fix interviewer voice and remove skip speech test button

### DIFF
--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -4,20 +4,7 @@ import { createHash } from "crypto";
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_TTS_URL = "https://api.openai.com/v1/audio/speech";
 const OPENAI_TTS_MODEL = process.env.OPENAI_TTS_MODEL || "tts-1";
-const OPENAI_TTS_VOICE = process.env.OPENAI_TTS_VOICE || "alloy";
-const ALLOWED_VOICES = new Set([
-  "alloy",
-  "ash",
-  "ballad",
-  "coral",
-  "echo",
-  "fable",
-  "onyx",
-  "nova",
-  "sage",
-  "shimmer",
-  "verse",
-]);
+const INTERVIEWER_VOICE = "onyx";
 const MAX_TEXT_LENGTH = 4000;
 const CACHE_MAX_ENTRIES = 200;
 const UPSTREAM_TIMEOUT_MS = 12000;
@@ -123,10 +110,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const requestedVoice = typeof payload.voice === "string" ? payload.voice : "";
-  const voice = ALLOWED_VOICES.has(requestedVoice) ? requestedVoice : OPENAI_TTS_VOICE;
-
-  const cacheKey = makeCacheKey(OPENAI_TTS_MODEL, voice, text);
+  const cacheKey = makeCacheKey(OPENAI_TTS_MODEL, INTERVIEWER_VOICE, text);
   const cached = cacheGet(cacheKey);
   if (cached) {
     return new NextResponse(new Uint8Array(cached), {
@@ -141,7 +125,7 @@ export async function POST(request: NextRequest) {
 
   let upstream: Response;
   try {
-    upstream = await fetchOpenAiTts(OPENAI_TTS_MODEL, voice, text);
+    upstream = await fetchOpenAiTts(OPENAI_TTS_MODEL, INTERVIEWER_VOICE, text);
   } catch (err) {
     return NextResponse.json(
       { error: "tts-upstream-failed", detail: (err as Error).message },

--- a/app/mock-interview/[id]/device-check/page.tsx
+++ b/app/mock-interview/[id]/device-check/page.tsx
@@ -58,7 +58,7 @@ export default function MockInterviewDeviceCheckPage() {
   const [isListening, setIsListening] = useState(false);
   const [recognizedText, setRecognizedText] = useState<string>("");
   const [ttsMatch, setTtsMatch] = useState<boolean>(false);
-  const [speechSkipped, setSpeechSkipped] = useState<boolean>(false);
+
   const [speechTip, setSpeechTip] = useState<string | null>(null);
   const [browserName, setBrowserName] = useState<BrowserName>("other");
   const [platformName, setPlatformName] = useState<PlatformName>("other");
@@ -341,7 +341,7 @@ export default function MockInterviewDeviceCheckPage() {
           attempt >= SPEECH_TIP_RETRY_THRESHOLD
         ) {
           setSpeechTip(
-            "Speech recognition can fail in Edge if Online Speech Recognition is off. Open Windows Settings → Privacy & Security → Speech and turn it on, then reload. You can also click 'Skip speech test' below if your microphone is detected."
+            "Speech recognition can fail in Edge if Online Speech Recognition is off. Open Windows Settings → Privacy & Security → Speech and turn it on, then reload."
           );
         } else if (
           browser === "edge" &&
@@ -349,7 +349,7 @@ export default function MockInterviewDeviceCheckPage() {
           attempt >= SPEECH_TIP_RETRY_THRESHOLD
         ) {
           setSpeechTip(
-            "On Edge for macOS, allow microphone access in System Settings → Privacy & Security → Microphone, then reload. If speech still doesn&apos;t match, click 'Skip speech test' and continue."
+            "On Edge for macOS, allow microphone access in System Settings → Privacy & Security → Microphone, then reload."
           );
         } else if (
           platform === "mac" &&
@@ -357,7 +357,7 @@ export default function MockInterviewDeviceCheckPage() {
           attempt >= SPEECH_TIP_RETRY_THRESHOLD
         ) {
           setSpeechTip(
-            "On macOS, allow microphone access for your browser in System Settings → Privacy & Security → Microphone, then reload. If speech still doesn't match, click 'Skip speech test' and continue."
+            "On macOS, allow microphone access for your browser in System Settings → Privacy & Security → Microphone, then reload."
           );
         }
         if (attempt <= SPEECH_RETRY_DELAYS_MS.length) {
@@ -382,7 +382,7 @@ export default function MockInterviewDeviceCheckPage() {
       showToast(t("mockInterview.deviceCheck.speechNotSupported"), "warning");
       // No browser STT at all — make sure user can still proceed via skip.
       setSpeechTip(
-        "Speech recognition isn't available in this browser. Once your microphone is detected, you can click 'Skip speech test' to continue and type your answers during the interview."
+        "Speech recognition isn't available in this browser. Please try Chrome or Edge to complete the speech test."
       );
     }
   }, [showToast, t]);
@@ -439,33 +439,14 @@ export default function MockInterviewDeviceCheckPage() {
     setIsListening(true);
     setRecognizedText("");
     setTtsMatch(false);
-    setSpeechSkipped(false);
     recognition.start();
-  };
-
-  const handleSkipSpeechTest = () => {
-    if (speechRetryTimeoutRef.current) {
-      clearTimeout(speechRetryTimeoutRef.current);
-      speechRetryTimeoutRef.current = null;
-    }
-    if (recognition) {
-      try {
-        recognition.stop();
-      } catch {}
-    }
-    setIsListening(false);
-    setSpeechSkipped(true);
-    showToast(
-      "Speech test skipped. You can type your answers during the interview.",
-      "info"
-    );
   };
 
   const handleProceed = async () => {
     if (
       !deviceStatus.camera ||
       !deviceStatus.microphone ||
-      (!ttsMatch && !speechSkipped) ||
+      !ttsMatch ||
       !faceValidationPassed
     ) {
       showToast(t("mockInterview.deviceCheck.completeAllChecks"), "error");
@@ -499,19 +480,11 @@ export default function MockInterviewDeviceCheckPage() {
     }
   };
 
-  const canSkipSpeech =
-    deviceStatus.microphone &&
-    !ttsMatch &&
-    !speechSkipped &&
-    (audioLevelObservedRef.current ||
-      speechRetryCountRef.current >= SPEECH_TIP_RETRY_THRESHOLD ||
-      !recognition);
-
   const canProceed =
     deviceStatus.camera &&
     deviceStatus.microphone &&
     deviceStatus.browserSupported &&
-    (ttsMatch || speechSkipped) &&
+    ttsMatch &&
     faceValidationPassed;
 
   return (
@@ -768,11 +741,11 @@ export default function MockInterviewDeviceCheckPage() {
               p: 3,
               borderRadius: 3,
               border: "1px solid var(--border-default)",
-              backgroundColor: ttsMatch || speechSkipped ? "var(--success-50)" : "var(--error-100)",
+              backgroundColor: ttsMatch ? "var(--success-50)" : "var(--error-100)",
             }}
           >
             <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2 }}>
-              {ttsMatch || speechSkipped ? (
+              {ttsMatch ? (
                 <CheckCircle size={32} color="var(--ats-success)" />
               ) : (
                 <XCircle size={32} color="var(--ats-error)" />
@@ -784,9 +757,7 @@ export default function MockInterviewDeviceCheckPage() {
                 <Typography variant="body2" sx={{ color: "#6b7280" }}>
                   {ttsMatch
                     ? t("mockInterview.deviceCheck.textMatches")
-                    : speechSkipped
-                      ? "Speech test skipped — you can type answers during the interview."
-                      : t("mockInterview.deviceCheck.readToVerify")}
+                    : t("mockInterview.deviceCheck.readToVerify")}
                 </Typography>
                 {micError && (
                   <Alert severity="error" sx={{ mt: 2 }}>
@@ -907,34 +878,34 @@ export default function MockInterviewDeviceCheckPage() {
                 )}
               </Box>
             )}
-            {browserName === "edge" && platformName === "windows" && !ttsMatch && !speechSkipped && (
+            {browserName === "edge" && platformName === "windows" && !ttsMatch && (
               <Alert severity="info" icon={<AlertCircle size={20} />} sx={{ mb: 2 }}>
                 <Typography variant="body2" fontWeight={600} gutterBottom>
                   Using Microsoft Edge?
                 </Typography>
                 <Typography variant="body2">
                   If speech isn&apos;t recognized, open <b>Windows Settings → Privacy &amp; Security → Speech</b> and turn on{" "}
-                  <b>Online speech recognition</b>, then reload this page. You can also click <b>Skip speech test</b> below to continue and type your answers during the interview.
+                  <b>Online speech recognition</b>, then reload this page.
                 </Typography>
               </Alert>
             )}
-            {browserName === "edge" && platformName === "mac" && !ttsMatch && !speechSkipped && (
+            {browserName === "edge" && platformName === "mac" && !ttsMatch && (
               <Alert severity="info" icon={<AlertCircle size={20} />} sx={{ mb: 2 }}>
                 <Typography variant="body2" fontWeight={600} gutterBottom>
                   Using Microsoft Edge on macOS?
                 </Typography>
                 <Typography variant="body2">
-                  If speech isn&apos;t recognized, open <b>System Settings → Privacy &amp; Security → Microphone</b> and allow access for Edge, then reload this page. You can also click <b>Skip speech test</b> to continue and type answers during the interview.
+                  If speech isn&apos;t recognized, open <b>System Settings → Privacy &amp; Security → Microphone</b> and allow access for Edge, then reload this page.
                 </Typography>
               </Alert>
             )}
-            {platformName === "mac" && (browserName === "chrome" || browserName === "safari" || browserName === "other") && !ttsMatch && !speechSkipped && (
+            {platformName === "mac" && (browserName === "chrome" || browserName === "safari" || browserName === "other") && !ttsMatch && (
               <Alert severity="info" icon={<AlertCircle size={20} />} sx={{ mb: 2 }}>
                 <Typography variant="body2" fontWeight={600} gutterBottom>
                   Using macOS?
                 </Typography>
                 <Typography variant="body2">
-                  If speech isn&apos;t recognized, open <b>System Settings → Privacy &amp; Security → Microphone</b> and allow access for your browser, then reload this page. You can also click <b>Skip speech test</b> to continue and type answers during the interview.
+                  If speech isn&apos;t recognized, open <b>System Settings → Privacy &amp; Security → Microphone</b> and allow access for your browser, then reload this page.
                 </Typography>
               </Alert>
             )}
@@ -943,18 +914,11 @@ export default function MockInterviewDeviceCheckPage() {
                 <Typography variant="body2">{speechTip}</Typography>
               </Alert>
             )}
-            {speechSkipped && (
-              <Alert severity="success" sx={{ mb: 2 }}>
-                <Typography variant="body2">
-                  Speech test skipped. Your microphone is detected — you can type answers during the interview.
-                </Typography>
-              </Alert>
-            )}
             <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
               <Button
                 variant="outlined"
                 onClick={handleStartTTS}
-                disabled={isListening || !deviceStatus.microphone || speechSkipped}
+                disabled={isListening || !deviceStatus.microphone}
                 startIcon={
                   isListening ? (
                     <CircularProgress size={18} />
@@ -983,20 +947,6 @@ export default function MockInterviewDeviceCheckPage() {
                   ? t("mockInterview.deviceCheck.listening").split("...")[0]
                   : t("mockInterview.deviceCheck.startSpeechTest")}
               </Button>
-              {canSkipSpeech && (
-                <Button
-                  variant="text"
-                  onClick={handleSkipSpeechTest}
-                  sx={{
-                    textTransform: "none",
-                    fontWeight: 500,
-                    color: "#6b7280",
-                    "&:hover": { color: "#374151", backgroundColor: "#f3f4f6" },
-                  }}
-                >
-                  Skip speech test
-                </Button>
-              )}
             </Box>
           </Paper>
         </Box>

--- a/app/mock-interview/voice-sample/page.tsx
+++ b/app/mock-interview/voice-sample/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const SAMPLE_TEXT =
+  "Welcome to your mock interview. I'll be your interviewer today. Please take a moment to settle in, and we'll begin when you're ready. Tell me a bit about yourself and your background.";
+
+export default function VoiceSamplePage() {
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [playing, setPlaying] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = () => {
+      const all = window.speechSynthesis.getVoices();
+      setVoices(all.filter((v) => v.lang.startsWith("en")));
+    };
+    load();
+    window.speechSynthesis.onvoiceschanged = load;
+    return () => { window.speechSynthesis.onvoiceschanged = null; };
+  }, []);
+
+  const play = (voice: SpeechSynthesisVoice) => {
+    window.speechSynthesis.cancel();
+    const utt = new SpeechSynthesisUtterance(SAMPLE_TEXT);
+    utt.voice = voice;
+    utt.rate = 0.95;
+    utt.volume = 1.0;
+    utt.onstart = () => setPlaying(voice.voiceURI);
+    utt.onend = () => setPlaying(null);
+    utt.onerror = () => setPlaying(null);
+    window.speechSynthesis.resume();
+    window.speechSynthesis.speak(utt);
+  };
+
+  return (
+    <div style={{ maxWidth: 680, margin: "48px auto", padding: "0 24px", fontFamily: "system-ui, sans-serif" }}>
+      <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 6 }}>Voice Sampler</h1>
+      <p style={{ color: "#6b7280", fontSize: 14, marginBottom: 24 }}>
+        All English voices on this device. Click Play to hear the interview opener.
+      </p>
+
+      {voices.length === 0 && <p style={{ color: "#9ca3af" }}>Loading voices...</p>}
+
+      {voices.map((v) => (
+        <div key={v.voiceURI} style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "11px 16px", borderRadius: 8, marginBottom: 8,
+          border: "1px solid #e5e7eb",
+          background: playing === v.voiceURI ? "#eff6ff" : "#fff",
+        }}>
+          <div>
+            <span style={{ fontWeight: 600, fontSize: 14 }}>{v.name}</span>
+            <span style={{ marginLeft: 8, fontSize: 12, color: "#9ca3af" }}>{v.lang}</span>
+          </div>
+          <button
+            onClick={() => playing === v.voiceURI ? (window.speechSynthesis.cancel(), setPlaying(null)) : play(v)}
+            style={{
+              padding: "6px 14px", borderRadius: 6, border: "none",
+              background: playing === v.voiceURI ? "#dc2626" : "#2563eb",
+              color: "#fff", fontWeight: 600, cursor: "pointer", fontSize: 13,
+            }}
+          >
+            {playing === v.voiceURI ? "Stop" : "Play"}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/hooks/useInterviewerVoice.ts
+++ b/lib/hooks/useInterviewerVoice.ts
@@ -172,7 +172,7 @@ export function useInterviewerVoice(
           const res = await fetch(TTS_API, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ text: question, voice: "alloy" }),
+            body: JSON.stringify({ text: question }),
             signal: controller.signal,
           });
 
@@ -216,6 +216,11 @@ export function useInterviewerVoice(
         window.speechSynthesis.cancel();
       } catch {}
 
+      // Chrome on Mac silences audio when speak() is called immediately after cancel().
+      // A short delay lets the audio pipeline reset.
+      await wait(60);
+      if (isStale()) return;
+
       await voicesReady();
       if (isStale()) return;
 
@@ -236,6 +241,17 @@ export function useInterviewerVoice(
 
       let firedComplete = false;
 
+      // Chrome on Mac pauses speechSynthesis silently after ~15s of speech.
+      // Periodic resume() keeps it alive for longer answers.
+      let keepAliveInterval: ReturnType<typeof setInterval> | null = null;
+
+      const clearKeepAlive = () => {
+        if (keepAliveInterval) {
+          clearInterval(keepAliveInterval);
+          keepAliveInterval = null;
+        }
+      };
+
       utterance.onstart = () => {
         if (isStale()) return;
         if (!didStart) {
@@ -243,21 +259,37 @@ export function useInterviewerVoice(
           onSpeakStartRef.current?.();
         }
         setAudioActive(true);
+        keepAliveInterval = setInterval(() => {
+          try {
+            if (window.speechSynthesis.speaking) {
+              window.speechSynthesis.pause();
+              window.speechSynthesis.resume();
+            } else {
+              clearKeepAlive();
+            }
+          } catch {}
+        }, 10000);
       };
       utterance.onend = () => {
         if (firedComplete) return;
         firedComplete = true;
+        clearKeepAlive();
         finish();
       };
       utterance.onerror = () => {
         if (firedComplete) return;
         firedComplete = true;
+        clearKeepAlive();
         finish();
       };
 
       try {
+        // resume() ensures synthesis isn't in a suspended/paused state before speaking.
+        // This is the primary fix for inaudible audio on macOS Chrome/Safari.
+        window.speechSynthesis.resume();
         window.speechSynthesis.speak(utterance);
       } catch {
+        clearKeepAlive();
         finish();
       }
     };

--- a/lib/utils/tts-voice-picker.ts
+++ b/lib/utils/tts-voice-picker.ts
@@ -1,30 +1,22 @@
 "use client";
 
-const QUALITY_PATTERNS: RegExp[] = [
-  // Microsoft Online Natural voices (highest quality) - male
+// Ordered list of preferred interviewer voices.
+// William is the AI avatar's designated voice; the rest are device-specific fallbacks.
+const PREFERRED_VOICE_PATTERNS: RegExp[] = [
+  /Microsoft William Multilingual Online \(Natural\)/i,
+  /Microsoft William/i,
   /Microsoft Guy Online \(Natural\)/i,
   /Microsoft Davis Online \(Natural\)/i,
   /Microsoft Tony Online \(Natural\)/i,
   /Microsoft Daniel Online \(Natural\)/i,
   /Microsoft Alex Online \(Natural\)/i,
-  // Microsoft Online Standard voices - male
-  /Microsoft (Guy|Davis|Tony|Daniel|Alex)/i,
-  // Google voices - male
-  /Google US English/i,
-  /Google UK English/i,
-  // Chrome built-in male voices
-  /\bGoogle UK English Male\b/i,
-  /\bGoogle US English Male\b/i,
-  /\bGoogle Mandarin Chinese\b/i,
-  /\bChrome\b.*\b(Male|David|John|Mark|Peter|Sam|William)\b/i,
-  // Generic male name patterns (cross-browser)
-  /\b(Daniel|David|John|Mark|Peter|Sam|William|Robert|James|Michael|Joseph|Thomas|Charles|Christopher|Richard|Matthew|Anthony|Mark|Donald|Andrew|Joshua|Kenneth|George|Edward|Brian|Ronald|Kevin|Jason|Mathew|Gary|Nicholas|Eric|Jonathan|Stephen|Larry|Justin|Scott|Brandon|Benjamin|Samuel|Patrick|Alexander|Raymond|Jack|Dennis|Jerry|Tyler|Aaron|Jose|Adam|Henry|Douglas|Peter|Zachary|Kyle|Walter|Harold|Keith|Christian|Roger|Noah|Gerald|Carl|Arthur|Ryan|Roger|Juan|Elijah|Wayne|Billy|Vincent|Ralph|Roy|Russell|Louis|Philip|Johnny|Ernest|Martin|Randall|Vincent|Ralph|Eugene|Claude|Edwin|Bernie|Ellis|Marvin|Olin|Leigh)\b/i,
-  // Female voices (lower priority - should be last)
-  /Microsoft Aria Online \(Natural\)/i,
-  /Microsoft Jenny Online \(Natural\)/i,
-  /Microsoft (Aria|Jenny|Sara|Emma)/i,
-  /Samantha/i,
-  /Karen/i,
+  /Microsoft (Guy|Davis|Tony|Daniel|Alex)\b/i,
+  /Microsoft (David|Mark) Desktop/i,
+  /\bAlex\b/i,
+  /\bTom\b/i,
+  /\bFred\b/i,
+  /Google UK English Male/i,
+  /Google US English Male/i,
 ];
 
 const PREFERRED_VOICE_STORAGE_KEY = "mockInterview.preferredInterviewerVoice";
@@ -52,28 +44,18 @@ function clearStoredVoiceName(): void {
   } catch {}
 }
 
-/** Clean up and validate stored voice preferences on app init */
+function isPreferredVoice(name: string): boolean {
+  return PREFERRED_VOICE_PATTERNS.some((p) => p.test(name));
+}
+
 export function initializeVoicePreferences(): void {
   if (typeof window === "undefined") return;
   try {
     const stored = window.localStorage.getItem(PREFERRED_VOICE_STORAGE_KEY);
-    // If stored voice is feminine or suspicious, clear it
-    if (stored && !/\b(Guy|Davis|Tony|Daniel|Alex|David|John|Mark|Peter|Sam|William|Google US|Google UK|Male)\b/i.test(stored)) {
+    if (stored && !isPreferredVoice(stored)) {
       window.localStorage.removeItem(PREFERRED_VOICE_STORAGE_KEY);
     }
   } catch {}
-}
-
-function isManlyVoiceName(name: string): boolean {
-  // Microsoft male voices
-  if (/Microsoft (Guy|Davis|Tony|Daniel|Alex)/i.test(name)) return true;
-  // Generic male names
-  if (/\b(Daniel|David|John|Mark|Peter|Sam|William|Robert|James|Michael|Joseph|Thomas|Charles|Christopher|Richard|Matthew|Anthony|Mark|Donald|Andrew|Joshua|Kenneth|George|Edward|Brian|Ronald|Kevin|Jason|Mathew|Gary|Nicholas|Eric|Jonathan|Stephen|Larry|Justin|Scott|Brandon|Benjamin|Samuel|Patrick|Alexander|Raymond|Jack|Dennis|Jerry|Tyler|Aaron|Jose|Adam|Henry|Douglas|Peter|Zachary|Kyle|Walter|Harold|Keith|Christian|Roger|Noah|Gerald|Carl|Arthur|Ryan|Roger|Juan|Elijah|Wayne|Billy|Vincent|Ralph|Roy|Russell|Louis|Philip|Johnny|Ernest|Martin|Randall|Vincent|Ralph|Eugene|Claude|Edwin|Bernie|Ellis|Marvin|Olin|Leigh)\b/i.test(name)) return true;
-  // Google male voices
-  if (/Google (US|UK) English/i.test(name)) return true;
-  // Chrome built-in
-  if (/Chrome.*Male/i.test(name)) return true;
-  return false;
 }
 
 let cachedReady: Promise<void> | null = null;
@@ -98,7 +80,7 @@ export function voicesReady(): Promise<void> {
       resolve();
     };
     synth.addEventListener("voiceschanged", handler);
-    // Some browsers (Safari) never fire voiceschanged but populate later.
+    // Safari may never fire voiceschanged but populates voices later.
     setTimeout(() => {
       if (resolved) return;
       resolved = true;
@@ -112,88 +94,54 @@ export function voicesReady(): Promise<void> {
 
 export interface PickedVoice {
   voice: SpeechSynthesisVoice;
-  /** Lower = better. 0 = top quality match, larger = fallback. */
   rank: number;
-  /** True if voice is network-backed (typically higher quality than local). */
   network: boolean;
 }
 
-export function pickBestVoice(
-  preferredLang = "en-US"
-): PickedVoice | null {
+export function pickBestVoice(preferredLang = "en-US"): PickedVoice | null {
   if (typeof window === "undefined" || !("speechSynthesis" in window)) return null;
   const voices = window.speechSynthesis.getVoices();
   if (!voices.length) return null;
 
-  const englishVoices = voices.filter((v) => /^en[-_]/i.test(v.lang) || v.lang === "en");
-  if (!englishVoices.length) return null;
+  const english = voices.filter((v) => /^en[-_]/i.test(v.lang) || v.lang === "en");
+  if (!english.length) return null;
 
-  // Check stored voice: validate it exists AND is male
-  const storedName = getStoredVoiceName();
-  if (storedName) {
-    const storedVoice = englishVoices.find((voice) => voice.name === storedName);
-    
-    // If stored voice no longer exists or is feminine, clear it
-    if (!storedVoice) {
-      clearStoredVoiceName();
-    } else if (isManlyVoiceName(storedVoice.name)) {
-      // Stored voice is valid and male - use it
-      return { voice: storedVoice, rank: -1, network: !storedVoice.localService };
-    } else {
-      // Stored voice exists but is feminine - clear it
-      clearStoredVoiceName();
+  // William is the designated voice — always pick it first if available,
+  // bypassing any cached preference so devices that have it always use it.
+  const william = english.find((v) => /Microsoft William/i.test(v.name));
+  if (william) {
+    storeVoiceName(william.name);
+    return { voice: william, rank: 0, network: !william.localService };
+  }
+
+  // Use cached preference if it's still on this device and still preferred.
+  const stored = getStoredVoiceName();
+  if (stored) {
+    const match = english.find((v) => v.name === stored);
+    if (match && isPreferredVoice(match.name)) {
+      return { voice: match, rank: -1, network: !match.localService };
+    }
+    clearStoredVoiceName();
+  }
+
+  // Walk the priority list — prefer exact lang match, fall back to any English.
+  for (let i = 0; i < PREFERRED_VOICE_PATTERNS.length; i++) {
+    const pattern = PREFERRED_VOICE_PATTERNS[i];
+    const exact = english.find((v) => pattern.test(v.name) && v.lang.toLowerCase() === preferredLang.toLowerCase());
+    if (exact) {
+      storeVoiceName(exact.name);
+      return { voice: exact, rank: i, network: !exact.localService };
+    }
+    const any = english.find((v) => pattern.test(v.name));
+    if (any) {
+      storeVoiceName(any.name);
+      return { voice: any, rank: i, network: !any.localService };
     }
   }
 
-  // Find best matching male voice from QUALITY_PATTERNS
-  for (let i = 0; i < QUALITY_PATTERNS.length; i++) {
-    const pattern = QUALITY_PATTERNS[i];
-    
-    // Prioritize exact language match
-    const exactLang = englishVoices.find(
-      (v) => pattern.test(v.name) && v.lang.toLowerCase() === preferredLang.toLowerCase()
-    );
-    if (exactLang && isManlyVoiceName(exactLang.name)) {
-      storeVoiceName(exactLang.name);
-      return { voice: exactLang, rank: i, network: !exactLang.localService };
-    }
-    
-    // Fallback to any English voice matching pattern
-    const anyLang = englishVoices.find((v) => pattern.test(v.name) && isManlyVoiceName(v.name));
-    if (anyLang) {
-      storeVoiceName(anyLang.name);
-      return { voice: anyLang, rank: i, network: !anyLang.localService };
-    }
-  }
-
-  // Fallback: any network-backed English voice (usually higher quality)
-  const networkVoice = englishVoices.find(
-    (v) => v.localService === false && v.lang.toLowerCase() === preferredLang.toLowerCase()
-  );
-  if (networkVoice && isManlyVoiceName(networkVoice.name)) {
-    storeVoiceName(networkVoice.name);
-    return { voice: networkVoice, rank: QUALITY_PATTERNS.length, network: true };
-  }
-
-  // Last resort: pick any English voice that's male
-  const maleVoice = englishVoices.find((v) => isManlyVoiceName(v.name));
-  if (maleVoice) {
-    storeVoiceName(maleVoice.name);
-    return { voice: maleVoice, rank: QUALITY_PATTERNS.length + 1, network: !maleVoice.localService };
-  }
-
-  // If no male voice found, use first available English voice
-  const firstVoice = englishVoices.find((voice) => voice.lang.toLowerCase() === preferredLang.toLowerCase()) || englishVoices[0];
-  if (firstVoice) {
-    storeVoiceName(firstVoice.name);
-    return { voice: firstVoice, rank: QUALITY_PATTERNS.length + 2, network: !firstVoice.localService };
-  }
-
-  // Nothing available — signal caller to use cloud fallback.
   return null;
 }
 
-/** Force-load the voices list. Some browsers populate lazily. */
 export function warmVoices(): void {
   if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
   try {


### PR DESCRIPTION

- Lock TTS API to onyx voice (OpenAI); remove multi-voice allowlist
- Rewrite tts-voice-picker with explicit preferred voice list (William on Edge/Windows, Alex/Tom/Fred on Mac) — no gender heuristics
- Always prefer William over cached localStorage preference so Edge users with stale stored voice still get William when available
- Fix Mac/Chrome crushed audio: 60ms delay after cancel(), resume() before speak(), 10s keep-alive interval for long utterances
- Remove "Skip speech test" button and all related state/handlers from device-check page; users must now pass the speech test
- Add voice-sample test page at /mock-interview/voice-sample