### PR TITLE
Add community forum poll UI, markdown feed, threaded replies, and quick comment bar

### DIFF
--- a/app/community/[threadId]/page.tsx
+++ b/app/community/[threadId]/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import {
   Container,
   Box,
@@ -12,7 +14,6 @@ import {
   Avatar,
   Button,
   TextField,
-  IconButton,
   CircularProgress,
   Breadcrumbs,
   Link,
@@ -25,9 +26,38 @@ import {
   communityService,
   ThreadDetail,
   Comment as CommentType,
+  PostType,
+  POST_TYPE_CONFIG,
 } from "@/lib/services/community.service";
 import { useToast } from "@/components/common/Toast";
 import { formatDistanceToNow } from "@/lib/utils/date-utils";
+import { softBreakMarkdown } from "@/lib/utils/html-utils";
+import { config } from "@/lib/config";
+
+const THREAD_EXTRAS_KEY = `community_thread_extras_${config.clientId}`;
+
+interface ThreadExtras {
+  post_type?: PostType;
+  image_urls?: string[];
+  poll_options?: string[];
+  resource_url?: string;
+  tried_steps?: string;
+  humor_tone?: string;
+  punchline?: string;
+  stance?: string;
+  tldr?: string;
+}
+
+function loadThreadExtras(threadId: number): ThreadExtras {
+  try {
+    const raw = localStorage.getItem(THREAD_EXTRAS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      return (parsed[String(threadId)] as ThreadExtras) ?? {};
+    }
+  } catch {}
+  return {};
+}
 
 export default function ThreadDetailPage() {
   const params = useParams();
@@ -37,6 +67,7 @@ export default function ThreadDetailPage() {
   const threadId = Number(params.threadId);
 
   const [thread, setThread] = useState<ThreadDetail | null>(null);
+  const [extras, setExtras] = useState<ThreadExtras>({});
   const [loading, setLoading] = useState(true);
   const [commentBody, setCommentBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -124,6 +155,7 @@ export default function ThreadDetailPage() {
       optimisticCommentVotesRef.current = loadCommentVotesFromStorage();
       optimisticThreadVoteRef.current = loadThreadVoteFromStorage();
       optimisticThreadBookmarkRef.current = loadThreadBookmarkFromStorage();
+      setExtras(loadThreadExtras(threadId));
       loadThread();
     }
   }, [threadId]);
@@ -762,93 +794,173 @@ export default function ThreadDetailPage() {
 
             {/* Content */}
             <Box sx={{ flex: 1 }}>
+              {/* Post type badge */}
+              {(() => {
+                const pt = (thread.post_type || extras.post_type || "question") as PostType;
+                const cfg = POST_TYPE_CONFIG[pt];
+                return (
+                  <Box sx={{ mb: 1 }}>
+                    <Chip
+                      icon={<IconWrapper icon={cfg.icon} size={12} color={cfg.color} />}
+                      label={cfg.label}
+                      size="small"
+                      sx={{
+                        height: 22,
+                        fontSize: "0.7rem",
+                        fontWeight: 600,
+                        backgroundColor: `${cfg.color}12`,
+                        color: cfg.color,
+                        border: `1px solid ${cfg.color}28`,
+                        "& .MuiChip-icon": { ml: 0.5 },
+                      }}
+                    />
+                  </Box>
+                );
+              })()}
+
               {/* Title */}
               <Typography variant="h4" fontWeight={700} gutterBottom>
                 {thread.title}
               </Typography>
 
               {/* Tags */}
-              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mb: 2 }}>
-                {thread.tags.map((tag) => (
-                  <Chip
-                    key={tag.id}
-                    label={tag.name}
-                    size="small"
-                    sx={{
-                      backgroundColor: "#dbeafe",
-                      color: "var(--accent-indigo)",
-                      fontWeight: 500,
-                    }}
-                  />
-                ))}
-              </Box>
+              {thread.tags.length > 0 && (
+                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mb: 2 }}>
+                  {thread.tags.map((tag) => (
+                    <Chip
+                      key={tag.id}
+                      label={tag.name}
+                      size="small"
+                      sx={{
+                        backgroundColor:
+                          "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
+                        color: "var(--accent-indigo)",
+                        fontWeight: 500,
+                      }}
+                    />
+                  ))}
+                </Box>
+              )}
 
-              {/* Body */}
+              {/* Resource URL */}
+              {extras.resource_url && (
+                <Box
+                  sx={{
+                    mb: 2, p: 1.5, borderRadius: "8px",
+                    border: "1px solid #bfdbfe", backgroundColor: "#eff6ff",
+                    display: "flex", alignItems: "center", gap: 1,
+                  }}
+                >
+                  <IconWrapper icon="mdi:link-variant" size={16} color="#3b82f6" />
+                  <Link
+                    href={extras.resource_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={{ fontSize: "0.875rem", color: "#2563eb", wordBreak: "break-all" }}
+                  >
+                    {extras.resource_url}
+                  </Link>
+                </Box>
+              )}
+
+              {/* Tried steps (Question extra) */}
+              {extras.tried_steps && (
+                <Box sx={{ mb: 2.5, pl: 2, borderLeft: "3px solid #a5b4fc" }}>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 0.5 }}>
+                    <IconWrapper icon="mdi:wrench-clock-outline" size={13} color="#6366f1" />
+                    <Typography variant="caption" fontWeight={700} sx={{ color: "#6366f1", letterSpacing: "0.02em", textTransform: "uppercase", fontSize: "0.68rem" }}>
+                      What they already tried
+                    </Typography>
+                  </Box>
+                  <Typography variant="body2" sx={{ color: "var(--font-secondary)", lineHeight: 1.7, whiteSpace: "pre-wrap" }}>
+                    {extras.tried_steps}
+                  </Typography>
+                </Box>
+              )}
+
+              {/* Body — rendered as markdown */}
               <Box
-                dangerouslySetInnerHTML={{ __html: thread.body }}
                 sx={{
                   mb: 3,
-                  color: "var(--font-secondary)",
-                  lineHeight: 1.7,
-                  fontSize: "1rem",
-                  wordBreak: "break-word",
-                  overflowWrap: "break-word",
-                  overflow: "hidden",
-                  width: "100%",
-                  maxWidth: "100%",
-                  "& p": {
-                    margin: 0,
-                    marginBottom: "1rem",
-                    "&:last-child": {
-                      marginBottom: 0,
-                    },
-                  },
-                  "& b, & strong": {
-                    fontWeight: 600,
-                  },
-                  "& i, & em": {
-                    fontStyle: "italic",
-                  },
-                  "& img": {
-                    maxWidth: "100%",
-                    width: "100%",
-                    height: "auto",
-                    display: "block",
-                    margin: "1rem 0",
-                    borderRadius: "4px",
-                    objectFit: "contain",
-                  },
-                  "& a": {
-                    color: "var(--accent-indigo)",
-                    textDecoration: "none",
-                    wordBreak: "break-all",
-                    "&:hover": {
-                      textDecoration: "underline",
-                    },
-                  },
+                  "& p": { mb: 1, lineHeight: 1.8, color: "var(--font-primary)", fontSize: "0.95rem" },
+                  "& h1": { fontSize: "1.6rem", fontWeight: 700, mt: 2, mb: 1, color: "var(--font-primary)" },
+                  "& h2": { fontSize: "1.35rem", fontWeight: 700, mt: 2, mb: 1, color: "var(--font-primary)" },
+                  "& h3": { fontSize: "1.15rem", fontWeight: 600, mt: 1.5, mb: 0.75, color: "var(--font-primary)" },
+                  "& strong": { fontWeight: 700 },
+                  "& em": { fontStyle: "italic" },
                   "& code": {
-                    backgroundColor: "#f3f4f6",
-                    padding: "2px 6px",
-                    borderRadius: "4px",
-                    fontSize: "0.875em",
-                    fontFamily: "monospace",
-                    wordBreak: "break-word",
-                    overflowWrap: "break-word",
+                    fontFamily: "monospace", fontSize: "0.875em",
+                    backgroundColor: "rgba(0,0,0,0.06)", border: "1px solid rgba(0,0,0,0.1)",
+                    borderRadius: "4px", px: "5px", py: "1px",
                   },
                   "& pre": {
-                    backgroundColor: "#f3f4f6",
-                    padding: "0.75rem",
-                    borderRadius: "4px",
-                    overflow: "auto",
-                    margin: "1rem 0",
-                    maxWidth: "100%",
-                    "& code": {
-                      backgroundColor: "transparent",
-                      padding: 0,
-                    },
+                    backgroundColor: "#1a1b26", color: "#c0caf5",
+                    borderRadius: "10px", p: 2, overflowX: "auto",
+                    my: 1.5, fontSize: "0.875rem", lineHeight: 1.6,
+                    "& code": { backgroundColor: "transparent", border: "none", color: "inherit", p: 0 },
                   },
+                  "& blockquote": {
+                    borderLeft: "3px solid var(--accent-indigo)", pl: 2, ml: 0,
+                    color: "var(--font-secondary)", fontStyle: "italic", my: 1.5,
+                  },
+                  "& ul, & ol": { pl: 3, mb: 1 },
+                  "& li": { mb: 0.4, fontSize: "0.95rem", color: "var(--font-primary)" },
+                  "& a": { color: "var(--accent-indigo)", textDecoration: "underline", wordBreak: "break-all" },
+                  "& hr": { border: "none", borderTop: "1px solid var(--border-default)", my: 2 },
+                  "& table": { borderCollapse: "collapse", width: "100%", mb: 1.5 },
+                  "& th, & td": { border: "1px solid var(--border-default)", px: 1.5, py: 0.75, fontSize: "0.9rem" },
+                  "& th": { backgroundColor: "var(--surface)", fontWeight: 700 },
+                  "& img": { maxWidth: "100%", borderRadius: "8px", my: 1 },
                 }}
-              />
+              >
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {softBreakMarkdown(thread.body)}
+                </ReactMarkdown>
+              </Box>
+
+              {/* Attached images */}
+              {(() => {
+                const imageUrls = thread.image_urls?.length ? thread.image_urls : extras.image_urls;
+                return imageUrls && imageUrls.length > 0 ? (
+                  <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 2.5 }}>
+                    {imageUrls.map((url, i) => (
+                      <Box
+                        key={i}
+                        component="img"
+                        src={url}
+                        alt=""
+                        sx={{
+                          maxWidth: "100%",
+                          width: imageUrls.length === 1 ? "100%" : "calc(50% - 4px)",
+                          maxHeight: 360,
+                          objectFit: "cover",
+                          borderRadius: "10px",
+                          border: "1px solid var(--border-default)",
+                          cursor: "pointer",
+                        }}
+                        onClick={() => window.open(url, "_blank")}
+                      />
+                    ))}
+                  </Box>
+                ) : null;
+              })()}
+
+              {/* Humorous extras */}
+              {extras.punchline && (
+                <Box sx={{ mb: 2, p: 1.5, borderRadius: "8px", backgroundColor: "#fffbeb", border: "1px solid #fde68a" }}>
+                  <Typography variant="body2" fontWeight={700} sx={{ color: "#b45309" }}>
+                    ⚡ {extras.punchline}
+                  </Typography>
+                </Box>
+              )}
+
+              {/* Discussion TL;DR */}
+              {extras.tldr && (
+                <Box sx={{ mb: 2, p: 1.5, borderRadius: "8px", backgroundColor: "#f0fdf8", border: "1px solid #6ee7b7" }}>
+                  <Typography variant="caption" fontWeight={700} sx={{ color: "#065f46" }}>TL;DR</Typography>
+                  <Typography variant="body2" sx={{ color: "#065f46", mt: 0.25 }}>{extras.tldr}</Typography>
+                </Box>
+              )}
 
               {/* Author & Meta */}
               <Box
@@ -972,13 +1084,22 @@ export default function ThreadDetailPage() {
           {/* Comments List */}
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
             {thread.comments.map((comment) => (
-              <CommentItem
+              <Box
                 key={comment.id}
-                comment={comment}
-                threadId={threadId}
-                onVote={handleVoteComment}
-                onReply={handleReply}
-              />
+                sx={{
+                  p: 2,
+                  border: "1px solid var(--border-default)",
+                  borderRadius: 2,
+                  backgroundColor: "var(--card-bg)",
+                }}
+              >
+                <CommentItem
+                  comment={comment}
+                  threadId={threadId}
+                  onVote={handleVoteComment}
+                  onReply={handleReply}
+                />
+              </Box>
             ))}
 
             {thread.comments.length === 0 && (

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -18,6 +18,8 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Chip,
+  Divider,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { IconWrapper } from "@/components/common/IconWrapper";
@@ -26,24 +28,102 @@ import { CreateThreadDialog } from "@/components/community/CreateThreadDialog";
 import {
   communityService,
   Thread,
-  Tag,
+  PostType,
+  POST_TYPE_CONFIG,
 } from "@/lib/services/community.service";
 import { useToast } from "@/components/common/Toast";
+import { config } from "@/lib/config";
+
+type ActiveFilter = "all" | PostType | "my_posts";
+
+interface ThreadExtras {
+  post_type: PostType;
+  poll_options?: string[];
+  resource_url?: string;
+  tried_steps?: string;
+  humor_tone?: string;
+  punchline?: string;
+  stance?: string;
+  tldr?: string;
+  image_urls?: string[];
+}
+
+const POST_TYPES = Object.keys(POST_TYPE_CONFIG) as PostType[];
+const THREAD_EXTRAS_KEY = `community_thread_extras_${config.clientId}`;
+const PROFILE_LOCAL_KEY = `user_profile_extra_${config.clientId}`;
+
+function getCurrentUserAuthor() {
+  try {
+    const raw = localStorage.getItem(PROFILE_LOCAL_KEY);
+    if (raw) {
+      const p = JSON.parse(raw);
+      return {
+        id: p.id ?? 0,
+        user_name: p.user_name ?? "",
+        name: p.name ?? p.full_name ?? p.user_name ?? "You",
+        profile_pic_url: p.profile_pic_url ?? p.avatar ?? "",
+        role: p.role ?? "student",
+      };
+    }
+  } catch {}
+  return null;
+}
+
+function loadThreadExtras(): Map<number, ThreadExtras> {
+  try {
+    const stored = localStorage.getItem(THREAD_EXTRAS_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      return new Map(
+        Object.entries(parsed).map(([id, extras]) => [Number(id), extras as ThreadExtras])
+      );
+    }
+  } catch {}
+  return new Map();
+}
+
+function saveThreadExtras(extras: Map<number, ThreadExtras>): void {
+  try {
+    localStorage.setItem(THREAD_EXTRAS_KEY, JSON.stringify(Object.fromEntries(extras)));
+  } catch {}
+}
+
+function getCurrentUserName(): string | null {
+  try {
+    const raw = localStorage.getItem(PROFILE_LOCAL_KEY);
+    if (raw) {
+      const profile = JSON.parse(raw);
+      return profile.user_name || null;
+    }
+  } catch {}
+  return null;
+}
+
+const FILTER_CONFIG: { key: ActiveFilter; label: string; icon: string; color: string }[] = [
+  { key: "all", label: "All Posts", icon: "mdi:view-grid-outline", color: "#6b7280" },
+  ...POST_TYPES.map((t) => ({
+    key: t as ActiveFilter,
+    label: POST_TYPE_CONFIG[t].label,
+    icon: POST_TYPE_CONFIG[t].icon,
+    color: POST_TYPE_CONFIG[t].color,
+  })),
+  { key: "my_posts", label: "My Posts", icon: "mdi:account-outline", color: "#6b7280" },
+];
 
 export default function CommunityPage() {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [threads, setThreads] = useState<Thread[]>([]);
-  const [tags, setTags] = useState<Tag[]>([]);
   const [loading, setLoading] = useState(true);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [selectedPostType] = useState<PostType>("question");
   const [sortBy, setSortBy] = useState<"recent" | "popular">("recent");
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const optimisticVotesRef = useRef<Map<number, "upvote" | "downvote" | null>>(
-    new Map()
-  );
+  const threadExtrasRef = useRef<Map<number, ThreadExtras>>(new Map());
+  const optimisticVotesRef = useRef<Map<number, "upvote" | "downvote" | null>>(new Map());
   const optimisticBookmarksRef = useRef<Map<number, boolean>>(new Map());
 
   const VOTES_STORAGE_KEY = "community_thread_votes";
@@ -61,17 +141,14 @@ export default function CommunityPage() {
           ])
         );
       }
-    } catch (error) {
-    }
+    } catch {}
     return new Map();
   };
 
   const saveVotesToStorage = (votes: Map<number, "upvote" | "downvote" | null>) => {
     try {
-      const obj = Object.fromEntries(votes);
-      sessionStorage.setItem(VOTES_STORAGE_KEY, JSON.stringify(obj));
-    } catch (error) {
-    }
+      sessionStorage.setItem(VOTES_STORAGE_KEY, JSON.stringify(Object.fromEntries(votes)));
+    } catch {}
   };
 
   const loadBookmarksFromStorage = (): Map<number, boolean> => {
@@ -80,108 +157,89 @@ export default function CommunityPage() {
       if (stored) {
         const parsed = JSON.parse(stored);
         return new Map(
-          Object.entries(parsed).map(([id, bookmarked]) => [
-            Number(id),
-            bookmarked as boolean,
-          ])
+          Object.entries(parsed).map(([id, bookmarked]) => [Number(id), bookmarked as boolean])
         );
       }
-    } catch (error) {
-    }
+    } catch {}
     return new Map();
   };
 
   const saveBookmarksToStorage = (bookmarks: Map<number, boolean>) => {
     try {
-      const obj = Object.fromEntries(bookmarks);
-      sessionStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(obj));
-    } catch (error) {
-    }
+      sessionStorage.setItem(BOOKMARKS_STORAGE_KEY, JSON.stringify(Object.fromEntries(bookmarks)));
+    } catch {}
   };
 
   useEffect(() => {
-    // Load initial optimistic state from storage
     optimisticVotesRef.current = loadVotesFromStorage();
     optimisticBookmarksRef.current = loadBookmarksFromStorage();
+    threadExtrasRef.current = loadThreadExtras();
     loadData();
   }, []);
 
-  // Refresh data when page becomes visible again (user navigates back)
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        // Reload data to sync with backend when user returns to the page
-        loadData();
-      }
+      if (document.visibilityState === "visible") loadData();
     };
-
     document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
   }, []);
 
-  // Reset page when filters change
   useEffect(() => {
     setPage(1);
-  }, [searchQuery, sortBy]);
+  }, [searchQuery, sortBy, activeFilter]);
+
+  const mergeExtrasIntoThread = (thread: Thread): Thread => {
+    const extras = threadExtrasRef.current.get(thread.id);
+    // Backend now stores post_type/image_urls/poll_options; fall back to localStorage extras
+    // only when the backend value is absent/empty (e.g. threads created before the migration).
+    return {
+      ...thread,
+      post_type: thread.post_type || extras?.post_type,
+      poll_options: thread.poll_options?.length ? thread.poll_options : extras?.poll_options,
+      image_urls: thread.image_urls?.length ? thread.image_urls : extras?.image_urls,
+    };
+  };
 
   const loadData = async () => {
     try {
       setLoading(true);
-      const [threadsData, tagsData] = await Promise.all([
-        communityService.getThreads(),
-        communityService.getTags(),
-      ]);
+      const threadsData = await communityService.getThreads();
 
       const mergedThreads = threadsData.map((backendThread) => {
-        const optimisticVote = optimisticVotesRef.current.get(
-          backendThread.id
-        );
-        const optimisticBookmark = optimisticBookmarksRef.current.get(
-          backendThread.id
-        );
+        const optimisticVote = optimisticVotesRef.current.get(backendThread.id);
+        const optimisticBookmark = optimisticBookmarksRef.current.get(backendThread.id);
 
-        // Always trust backend data first - backend is the source of truth
-        // If backend provides user_vote (even if null), use it and clear optimistic state
-        // Only use optimistic state if backend doesn't provide the field at all (undefined)
         let userVote: "upvote" | "downvote" | null;
         if (backendThread.user_vote !== undefined) {
-          // Backend explicitly provided vote data (could be "upvote", "downvote", or null)
-          // This is the source of truth - use it and update optimistic state
           userVote = backendThread.user_vote;
           optimisticVotesRef.current.set(backendThread.id, backendThread.user_vote);
         } else {
-          // Backend didn't provide vote data - use optimistic state as fallback
           userVote = optimisticVote ?? null;
         }
 
         let userBookmarked: boolean;
         if (backendThread.user_bookmarked !== undefined) {
-          // Backend explicitly provided bookmark data - this is the source of truth
-          // Convert null to false for boolean type
           userBookmarked = backendThread.user_bookmarked ?? false;
           optimisticBookmarksRef.current.set(
             backendThread.id,
             backendThread.user_bookmarked ?? false
           );
         } else {
-          // Backend didn't provide bookmark data - use optimistic state as fallback
           userBookmarked = optimisticBookmark ?? false;
         }
 
-        return {
+        return mergeExtrasIntoThread({
           ...backendThread,
           user_vote: userVote,
           user_bookmarked: userBookmarked,
-        };
+        });
       });
 
       saveVotesToStorage(optimisticVotesRef.current);
       saveBookmarksToStorage(optimisticBookmarksRef.current);
       setThreads(mergedThreads);
-      setTags(tagsData);
-    } catch (error) {
+    } catch {
       showToast(t("community.failedToLoad"), "error");
     } finally {
       setLoading(false);
@@ -192,15 +250,85 @@ export default function CommunityPage() {
     title: string;
     body: string;
     tag_ids: number[];
+    post_type: PostType;
+    poll_options?: string[];
+    resource_url?: string;
+    tried_steps?: string;
+    humor_tone?: string;
+    punchline?: string;
+    stance?: string;
+    tldr?: string;
+    image_urls?: string[];
   }) => {
-    try {
-      const newThread = await communityService.createThread(data);
-      setThreads([newThread, ...threads]);
-      showToast(t("community.threadCreated"), "success");
-    } catch (error) {
-      showToast(t("community.failedToCreateThread"), "error");
-      throw error;
-    }
+    const tempId = -Date.now();
+    const author = getCurrentUserAuthor() ?? {
+      id: 0, user_name: "", name: "You", profile_pic_url: "", role: "student" as const,
+    };
+
+    const optimisticThread: Thread = {
+      id: tempId,
+      title: data.title,
+      body: data.body,
+      author,
+      tags: [],
+      upvotes: 0,
+      downvotes: 0,
+      user_vote: null,
+      bookmarks_count: 0,
+      user_bookmarked: false,
+      comments_count: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      post_type: data.post_type,
+      poll_options: data.poll_options,
+      image_urls: data.image_urls,
+    };
+
+    const extras: ThreadExtras = {
+      post_type: data.post_type,
+      poll_options: data.poll_options,
+      resource_url: data.resource_url,
+      tried_steps: data.tried_steps,
+      humor_tone: data.humor_tone,
+      punchline: data.punchline,
+      stance: data.stance,
+      tldr: data.tldr,
+      image_urls: data.image_urls,
+    };
+
+    threadExtrasRef.current.set(tempId, extras);
+
+    setThreads((prev) => [optimisticThread, ...prev]);
+
+    // Fire API in background — dialog closes immediately
+    communityService
+      .createThread({
+        title: data.title,
+        body: data.body,
+        tag_ids: data.tag_ids,
+        post_type: data.post_type,
+        poll_options: data.poll_options,
+        image_urls: data.image_urls,
+      })
+      .then((newThread) => {
+        threadExtrasRef.current.set(newThread.id, extras);
+        threadExtrasRef.current.delete(tempId);
+        saveThreadExtras(threadExtrasRef.current);
+
+        setThreads((prev) =>
+          prev.map((t) =>
+            t.id === tempId
+              ? { ...newThread, post_type: data.post_type, poll_options: data.poll_options, image_urls: data.image_urls }
+              : t
+          )
+        );
+        showToast(t("community.threadCreated"), "success");
+      })
+      .catch(() => {
+        setThreads((prev) => prev.filter((t) => t.id !== tempId));
+        threadExtrasRef.current.delete(tempId);
+        showToast(t("community.failedToCreateThread"), "error");
+      });
   };
 
   const handleVote = async (threadId: number, type: "upvote" | "downvote") => {
@@ -213,18 +341,12 @@ export default function CommunityPage() {
     let newUserVote: "upvote" | "downvote" | null = null;
 
     if (currentVote === type) {
-      if (type === "upvote") {
-        newUpvotes = Math.max(0, newUpvotes - 1);
-      } else {
-        newDownvotes = Math.max(0, newDownvotes - 1);
-      }
+      if (type === "upvote") newUpvotes = Math.max(0, newUpvotes - 1);
+      else newDownvotes = Math.max(0, newDownvotes - 1);
       newUserVote = null;
     } else if (currentVote === null) {
-      if (type === "upvote") {
-        newUpvotes += 1;
-      } else {
-        newDownvotes += 1;
-      }
+      if (type === "upvote") newUpvotes += 1;
+      else newDownvotes += 1;
       newUserVote = type;
     } else {
       if (type === "upvote") {
@@ -239,67 +361,100 @@ export default function CommunityPage() {
 
     optimisticVotesRef.current.set(threadId, newUserVote);
     saveVotesToStorage(optimisticVotesRef.current);
-
     setThreads((prev) =>
       prev.map((t) =>
         t.id === threadId
-          ? {
-              ...t,
-              upvotes: newUpvotes,
-              downvotes: newDownvotes,
-              user_vote: newUserVote,
-            }
+          ? { ...t, upvotes: newUpvotes, downvotes: newDownvotes, user_vote: newUserVote }
           : t
       )
     );
 
     try {
       await communityService.voteThread(threadId, type);
-      const [threadsData, tagsData] = await Promise.all([
-        communityService.getThreads(),
-        communityService.getTags(),
-      ]);
+      const threadsData = await communityService.getThreads();
 
       const mergedThreads = threadsData.map((backendThread) => {
-        const optimisticVote = optimisticVotesRef.current.get(
-          backendThread.id
-        );
-
-        // Always trust backend data first - if backend provides user_vote, use it
-        // Only use optimistic state as fallback if backend doesn't provide the data
+        const optimisticVote = optimisticVotesRef.current.get(backendThread.id);
         const finalUserVote =
-          backendThread.user_vote !== undefined
-            ? backendThread.user_vote
-            : optimisticVote ?? null;
-
-        // Update optimistic state to match backend if backend provided it
+          backendThread.user_vote !== undefined ? backendThread.user_vote : optimisticVote ?? null;
         if (backendThread.user_vote !== undefined) {
           optimisticVotesRef.current.set(backendThread.id, backendThread.user_vote);
         }
-
-        return {
-          ...backendThread,
-          upvotes: backendThread.upvotes,
-          downvotes: backendThread.downvotes,
-          user_vote: finalUserVote,
-        };
+        return mergeExtrasIntoThread({ ...backendThread, user_vote: finalUserVote });
       });
 
       saveVotesToStorage(optimisticVotesRef.current);
       setThreads(mergedThreads);
-      setTags(tagsData);
-    } catch (error) {
+    } catch {
       optimisticVotesRef.current.delete(threadId);
       saveVotesToStorage(optimisticVotesRef.current);
       setThreads((prev) =>
         prev.map((t) =>
           t.id === threadId
-            ? {
-                ...t,
-                upvotes: thread.upvotes,
-                downvotes: thread.downvotes,
-                user_vote: thread.user_vote ?? null,
-              }
+            ? { ...t, upvotes: thread.upvotes, downvotes: thread.downvotes, user_vote: thread.user_vote ?? null }
+            : t
+        )
+      );
+      showToast(t("community.failedToVote"), "error");
+    }
+  };
+
+  const handleQuickComment = async (threadId: number, body: string) => {
+    setThreads((prev) =>
+      prev.map((t) => t.id === threadId ? { ...t, comments_count: t.comments_count + 1 } : t)
+    );
+    try {
+      await communityService.createComment(threadId, { body });
+      showToast(t("community.commentAdded"), "success");
+    } catch {
+      setThreads((prev) =>
+        prev.map((t) => t.id === threadId ? { ...t, comments_count: Math.max(0, t.comments_count - 1) } : t)
+      );
+      showToast(t("community.failedToAddComment"), "error");
+    }
+  };
+
+  const handlePollVote = async (threadId: number, optionIndex: number) => {
+    const thread = threads.find((t) => t.id === threadId);
+    if (!thread || !thread.poll_options) return;
+
+    const currentVote = thread.user_poll_vote ?? null;
+    const pollResults = [...(thread.poll_results ?? thread.poll_options.map(() => 0))];
+    let newUserPollVote: number | null;
+
+    if (currentVote === optionIndex) {
+      pollResults[optionIndex] = Math.max(0, pollResults[optionIndex] - 1);
+      newUserPollVote = null;
+    } else {
+      if (currentVote !== null) {
+        pollResults[currentVote] = Math.max(0, pollResults[currentVote] - 1);
+      }
+      pollResults[optionIndex] = (pollResults[optionIndex] ?? 0) + 1;
+      newUserPollVote = optionIndex;
+    }
+
+    setThreads((prev) =>
+      prev.map((t) =>
+        t.id === threadId
+          ? { ...t, poll_results: pollResults, user_poll_vote: newUserPollVote }
+          : t
+      )
+    );
+
+    try {
+      const result = await communityService.votePoll(threadId, optionIndex);
+      setThreads((prev) =>
+        prev.map((t) =>
+          t.id === threadId
+            ? { ...t, poll_results: result.poll_results, user_poll_vote: result.user_poll_vote }
+            : t
+        )
+      );
+    } catch {
+      setThreads((prev) =>
+        prev.map((t) =>
+          t.id === threadId
+            ? { ...t, poll_results: thread.poll_results, user_poll_vote: thread.user_poll_vote ?? null }
             : t
         )
       );
@@ -312,104 +467,74 @@ export default function CommunityPage() {
     if (!thread) return;
 
     const isBookmarked = thread.user_bookmarked ?? false;
-    let newBookmarksCount = thread.bookmarks_count;
-    let newUserBookmarked = !isBookmarked;
-
-    if (isBookmarked) {
-      newBookmarksCount = Math.max(0, newBookmarksCount - 1);
-      newUserBookmarked = false;
-    } else {
-      newBookmarksCount += 1;
-      newUserBookmarked = true;
-    }
+    const newBookmarksCount = isBookmarked
+      ? Math.max(0, thread.bookmarks_count - 1)
+      : thread.bookmarks_count + 1;
+    const newUserBookmarked = !isBookmarked;
 
     optimisticBookmarksRef.current.set(threadId, newUserBookmarked);
     saveBookmarksToStorage(optimisticBookmarksRef.current);
-
     setThreads((prev) =>
       prev.map((t) =>
         t.id === threadId
-          ? {
-              ...t,
-              bookmarks_count: newBookmarksCount,
-              user_bookmarked: newUserBookmarked,
-            }
+          ? { ...t, bookmarks_count: newBookmarksCount, user_bookmarked: newUserBookmarked }
           : t
       )
     );
 
     try {
       await communityService.bookmarkThread(threadId);
-      const [threadsData, tagsData] = await Promise.all([
-        communityService.getThreads(),
-        communityService.getTags(),
-      ]);
+      const threadsData = await communityService.getThreads();
 
       const mergedThreads = threadsData.map((backendThread) => {
-        const optimisticBookmark = optimisticBookmarksRef.current.get(
-          backendThread.id
-        );
-
-        // Always trust backend data first - if backend provides user_bookmarked, use it
-        // Only use optimistic state as fallback if backend doesn't provide the data
+        const optimisticBookmark = optimisticBookmarksRef.current.get(backendThread.id);
         const finalUserBookmarked =
           backendThread.user_bookmarked !== undefined
             ? backendThread.user_bookmarked ?? false
             : optimisticBookmark ?? false;
-
-        // Update optimistic state to match backend if backend provided it
         if (backendThread.user_bookmarked !== undefined) {
           optimisticBookmarksRef.current.set(
             backendThread.id,
             backendThread.user_bookmarked ?? false
           );
         }
-
-        return {
-          ...backendThread,
-          bookmarks_count: backendThread.bookmarks_count,
-          user_bookmarked: finalUserBookmarked,
-        };
+        return mergeExtrasIntoThread({ ...backendThread, user_bookmarked: finalUserBookmarked });
       });
 
       setThreads(mergedThreads);
-      setTags(tagsData);
-
       showToast(
-        newUserBookmarked ? t("community.threadBookmarked") : t("community.bookmarkRemoved"),
+        newUserBookmarked
+          ? t("community.threadBookmarked")
+          : t("community.bookmarkRemoved"),
         "success"
       );
-    } catch (error) {
+    } catch {
       setThreads((prev) =>
         prev.map((t) =>
           t.id === threadId
-            ? {
-                ...t,
-                bookmarks_count: thread.bookmarks_count,
-                user_bookmarked: thread.user_bookmarked ?? false,
-              }
+            ? { ...t, bookmarks_count: thread.bookmarks_count, user_bookmarked: thread.user_bookmarked ?? false }
             : t
         )
       );
       optimisticBookmarksRef.current.delete(threadId);
-      setThreads((prev) =>
-        prev.map((t) =>
-          t.id === threadId
-            ? {
-                ...t,
-                bookmarks_count: thread.bookmarks_count,
-                user_bookmarked: thread.user_bookmarked ?? false,
-              }
-            : t
-        )
-      );
       showToast(t("community.failedToBookmark"), "error");
     }
   };
 
   const filteredThreads = useMemo(() => {
+    const currentUserName = getCurrentUserName();
     return threads
       .filter((thread) => {
+        // Post type / my posts filter
+        if (activeFilter !== "all") {
+          if (activeFilter === "my_posts") {
+            if (!currentUserName) return false;
+            return thread.author.user_name === currentUserName;
+          }
+          const threadType = thread.post_type ?? "question";
+          if (threadType !== activeFilter) return false;
+        }
+        // Search filter
         if (searchQuery) {
           const query = searchQuery.toLowerCase();
           return (
@@ -421,16 +546,11 @@ export default function CommunityPage() {
       })
       .sort((a, b) => {
         if (sortBy === "recent") {
-          return (
-            new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-          );
-        } else {
-          const scoreA = a.upvotes - a.downvotes;
-          const scoreB = b.upvotes - b.downvotes;
-          return scoreB - scoreA;
+          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
         }
+        return b.upvotes - b.downvotes - (a.upvotes - a.downvotes);
       });
-  }, [threads, searchQuery, sortBy]);
+  }, [threads, searchQuery, sortBy, activeFilter]);
 
   const paginatedThreads = useMemo(() => {
     const start = (page - 1) * pageSize;
@@ -474,67 +594,145 @@ export default function CommunityPage() {
                 {t("community.forumSubtitle")}
               </Typography>
             </Box>
+
+            {/* Create Post Button */}
             <Button
               variant="contained"
               size="large"
-              startIcon={<IconWrapper icon="mdi:plus" />}
+              startIcon={<IconWrapper icon="mdi:plus" size={18} />}
               onClick={() => setCreateDialogOpen(true)}
               sx={{
                 textTransform: "none",
+                fontWeight: 600,
+                borderRadius: "10px",
+                px: 2.5,
               }}
             >
-              {t("community.askQuestion")}
+              Create Post
             </Button>
           </Box>
 
-          {/* Search and Filters */}
+          {/* Search + Filters */}
           <Paper
             elevation={0}
             sx={{
               p: 2,
               border: "1px solid var(--border-default)",
               backgroundColor: "var(--card-bg)",
+              borderRadius: 2,
             }}
           >
+            {/* Row 1: Search */}
+            <TextField
+              placeholder={t("community.searchPlaceholder")}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              size="small"
+              fullWidth
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <IconWrapper icon="mdi:magnify" size={20} />
+                  </InputAdornment>
+                ),
+              }}
+            />
+
+            {/* Row 2: Filter pills + Sort */}
             <Box
               sx={{
                 display: "flex",
-                gap: 2,
-                flexWrap: "wrap",
                 alignItems: "center",
+                gap: 1,
+                mt: 1.75,
+                flexWrap: "wrap",
               }}
             >
-              {/* Search */}
-              <TextField
-                placeholder={t("community.searchPlaceholder")}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                size="small"
-                sx={{ flex: 1, minWidth: 250 }}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <IconWrapper icon="mdi:magnify" size={20} />
-                    </InputAdornment>
-                  ),
+              {/* Filter pills */}
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 0.75,
+                  flexWrap: "wrap",
+                  flex: 1,
+                  alignItems: "center",
                 }}
-              />
+              >
+                {FILTER_CONFIG.map((f) => {
+                  const active = activeFilter === f.key;
+                  return (
+                    <Chip
+                      key={f.key}
+                      icon={
+                        <IconWrapper
+                          icon={f.icon}
+                          size={13}
+                          color={active ? f.color : "var(--font-tertiary)"}
+                        />
+                      }
+                      label={f.label}
+                      onClick={() => setActiveFilter(f.key)}
+                      size="small"
+                      sx={{
+                        cursor: "pointer",
+                        height: 28,
+                        fontSize: "0.78rem",
+                        fontWeight: active ? 700 : 500,
+                        backgroundColor: active ? `${f.color}15` : "transparent",
+                        color: active ? f.color : "#111111",
+                        border: `1px solid ${active ? f.color : "#c0c0c0"}`,
+                        "& .MuiChip-icon": { ml: 0.75 },
+                        transition: "all 0.15s ease",
+                        "&:hover": {
+                          backgroundColor: `${f.color}10`,
+                          borderColor: f.color,
+                          color: f.color,
+                        },
+                      }}
+                    />
+                  );
+                })}
+              </Box>
+
+              {/* Divider */}
+              <Divider orientation="vertical" flexItem sx={{ mx: 0.5, my: 0.25 }} />
 
               {/* Sort Tabs */}
               <Tabs
                 value={sortBy}
                 onChange={(_, value) => setSortBy(value)}
-                sx={{ minHeight: 40 }}
+                sx={{
+                  minHeight: 32,
+                  "& .MuiTabs-indicator": { height: 2, borderRadius: 2 },
+                }}
               >
                 <Tab
-                  label={t("community.recent")}
+                  label="Recent"
                   value="recent"
-                  sx={{ minHeight: 40, textTransform: "none" }}
+                  icon={<IconWrapper icon="mdi:clock-outline" size={14} />}
+                  iconPosition="start"
+                  sx={{
+                    minHeight: 32,
+                    textTransform: "none",
+                    fontSize: "0.82rem",
+                    fontWeight: sortBy === "recent" ? 600 : 400,
+                    py: 0,
+                    gap: 0.5,
+                  }}
                 />
                 <Tab
-                  label={t("community.popular")}
+                  label="Popular"
                   value="popular"
-                  sx={{ minHeight: 40, textTransform: "none" }}
+                  icon={<IconWrapper icon="mdi:fire" size={14} />}
+                  iconPosition="start"
+                  sx={{
+                    minHeight: 32,
+                    textTransform: "none",
+                    fontSize: "0.82rem",
+                    fontWeight: sortBy === "popular" ? 600 : 400,
+                    py: 0,
+                    gap: 0.5,
+                  }}
                 />
               </Tabs>
             </Box>
@@ -568,6 +766,8 @@ export default function CommunityPage() {
             <Typography variant="body2" color="text.secondary">
               {searchQuery
                 ? t("community.tryDifferentSearch")
+                : activeFilter !== "all"
+                ? "No posts in this category yet."
                 : t("community.beFirstToStart")}
             </Typography>
           </Paper>
@@ -606,6 +806,8 @@ export default function CommunityPage() {
                   thread={thread}
                   onVote={handleVote}
                   onBookmark={handleBookmark}
+                  onPollVote={handlePollVote}
+                  onComment={handleQuickComment}
                 />
               ))}
             </Box>
@@ -632,7 +834,11 @@ export default function CommunityPage() {
                   showLastButton
                 />
                 <Typography variant="caption" color="text.secondary">
-                  {t("community.showingRange", { start: startItem, end: endItem, total: filteredThreads.length })}
+                  {t("community.showingRange", {
+                    start: startItem,
+                    end: endItem,
+                    total: filteredThreads.length,
+                  })}
                 </Typography>
               </Box>
             )}
@@ -644,7 +850,7 @@ export default function CommunityPage() {
           open={createDialogOpen}
           onClose={() => setCreateDialogOpen(false)}
           onSubmit={handleCreateThread}
-          availableTags={tags}
+          initialPostType={selectedPostType}
         />
       </Container>
     </MainLayout>

--- a/components/community/CommentItem.tsx
+++ b/components/community/CommentItem.tsx
@@ -1,23 +1,15 @@
 "use client";
 
 import { useState } from "react";
+
 import { useTranslation } from "react-i18next";
-import {
-  Box,
-  Paper,
-  Typography,
-  Avatar,
-  Chip,
-  Button,
-  TextField,
-  IconButton,
-  Collapse,
-} from "@mui/material";
+import { Box, Typography, Avatar, Chip, Button, TextField, IconButton, Collapse } from "@mui/material";
+
+import type { Comment } from "@/lib/services/community.service";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { Comment } from "@/lib/services/community.service";
 import { VoteButtons } from "./VoteButtons";
+
 import { formatDistanceToNow } from "@/lib/utils/date-utils";
-import { unescapeHtml } from "@/lib/utils/html-utils";
 
 interface CommentItemProps {
   comment: Comment;
@@ -25,6 +17,7 @@ interface CommentItemProps {
   onVote: (commentId: number, type: "upvote" | "downvote") => Promise<void>;
   onReply: (commentId: number, body: string) => Promise<void>;
   depth?: number;
+  parentAuthorName?: string;
 }
 
 export function CommentItem({
@@ -33,225 +26,197 @@ export function CommentItem({
   onVote,
   onReply,
   depth = 0,
+  parentAuthorName,
 }: CommentItemProps) {
   const { t } = useTranslation("common");
   const [showReplyForm, setShowReplyForm] = useState(false);
   const [replyBody, setReplyBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
+  const hasReplies = comment.replies && comment.replies.length > 0;
+  const maxDepth = 4;
+  const isMaxDepth = depth >= maxDepth;
+
   const handleSubmitReply = async () => {
     if (!replyBody.trim()) return;
-
     setSubmitting(true);
     try {
       await onReply(comment.id, replyBody.trim());
       setReplyBody("");
       setShowReplyForm(false);
-    } catch (error) {
-      // Silently handle reply error
+    } catch {
+      // silently handled
     } finally {
       setSubmitting(false);
     }
   };
 
-  const maxDepth = 3;
-  const isMaxDepth = depth >= maxDepth;
+  const avatarSize = depth === 0 ? 34 : 28;
 
   return (
-    <Box
-      sx={{
-        paddingInlineStart: depth > 0 ? 32 : 0,
-        borderInlineStart: depth > 0 ? "2px solid #e5e7eb" : "none",
-      }}
-    >
-      <Paper
-        elevation={0}
-        sx={{
-          p: 2,
-          border: "1px solid #e5e7eb",
-          borderRadius: 2,
-          backgroundColor: depth % 2 === 0 ? "#ffffff" : "#fafafa",
-          width: "100%",
-          maxWidth: "100%",
-          overflow: "hidden",
-        }}
-      >
-        {/* Comment Header */}
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            gap: 1,
-            mb: 1.5,
-          }}
-        >
+    <Box>
+      {/* Comment row: avatar column + content column */}
+      <Box sx={{ display: "flex", gap: 1.5, alignItems: "flex-start" }}>
+        {/* Left column: avatar + thread line */}
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0, width: avatarSize }}>
           <Avatar
             src={comment.author.profile_pic_url}
-            sx={{ width: 32, height: 32 }}
+            sx={{ width: avatarSize, height: avatarSize, fontSize: depth === 0 ? "0.9rem" : "0.75rem" }}
           >
             {comment.author.name.charAt(0)}
           </Avatar>
-          <Box sx={{ flex: 1 }}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <Typography variant="body2" fontWeight={600}>
-                {comment.author.name}
-              </Typography>
-              <Chip
-                label={comment.author.role}
-                size="small"
-                sx={{
-                  height: 18,
-                  fontSize: "0.65rem",
-                  backgroundColor: "var(--surface)",
-                  border: "1px solid var(--border-default)",
-                  color: "var(--font-secondary)",
-                }}
-              />
-              <Typography variant="caption" color="text.secondary">
-                {formatDistanceToNow(comment.created_at)}
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-
-        {/* Comment Body */}
-        <Box
-          dangerouslySetInnerHTML={{
-            __html: (() => {
-              // Check if HTML is escaped and unescape it before rendering
-              let body = comment.body || "";
-              if (body && (body.includes("&lt;") || body.includes("&gt;"))) {
-                body = unescapeHtml(body);
-              }
-              return body;
-            })(),
-          }}
-          sx={{
-            mb: 1.5,
-            color: "var(--font-secondary)",
-            fontSize: "0.875rem",
-            lineHeight: 1.6,
-            wordBreak: "break-word",
-            overflowWrap: "break-word",
-            overflow: "hidden",
-            width: "100%",
-            maxWidth: "100%",
-            "& p": {
-              margin: 0,
-              marginBottom: "0.5rem",
-              "&:last-child": {
-                marginBottom: 0,
-              },
-            },
-            "& b, & strong": {
-              fontWeight: 600,
-            },
-            "& i, & em": {
-              fontStyle: "italic",
-            },
-            "& img": {
-              maxWidth: "100%",
-              width: "100%",
-              height: "auto",
-              display: "block",
-              margin: "0.5rem 0",
-              borderRadius: "4px",
-              objectFit: "contain",
-            },
-            "& a": {
-              color: "var(--accent-indigo)",
-              textDecoration: "none",
-              wordBreak: "break-all",
-              "&:hover": {
-                textDecoration: "underline",
-              },
-            },
-            "& code": {
-              backgroundColor: "#f3f4f6",
-              padding: "2px 6px",
-              borderRadius: "4px",
-              fontSize: "0.875em",
-              fontFamily: "monospace",
-              wordBreak: "break-word",
-              overflowWrap: "break-word",
-            },
-            "& pre": {
-              backgroundColor: "#f3f4f6",
-              padding: "0.75rem",
-              borderRadius: "4px",
-              overflow: "auto",
-              margin: "0.5rem 0",
-              maxWidth: "100%",
-              "& code": {
-                backgroundColor: "transparent",
-                padding: 0,
-              },
-            },
-          }}
-        />
-
-        {/* Actions */}
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <VoteButtons
-            upvotes={comment.upvotes}
-            downvotes={comment.downvotes}
-            userVote={comment.user_vote}
-            onVote={(type) => onVote(comment.id, type)}
-            size="small"
-            orientation="horizontal"
-          />
-
-          {!isMaxDepth && (
-            <Button
-              size="small"
-              startIcon={<IconWrapper icon="mdi:reply" size={16} />}
-              onClick={() => setShowReplyForm(!showReplyForm)}
-              sx={{ textTransform: "none", minWidth: "auto" }}
-            >
-              {t("community.reply")}
-            </Button>
+          {/* Thread line going down to replies */}
+          {hasReplies && (
+            <Box
+              sx={{
+                width: 2,
+                flex: 1,
+                minHeight: 20,
+                mt: 0.5,
+                backgroundColor: "color-mix(in srgb, var(--accent-indigo) 25%, var(--border-default) 75%)",
+                borderRadius: 1,
+              }}
+            />
           )}
         </Box>
 
-        {/* Reply Form */}
-        <Collapse in={showReplyForm}>
-          <Box sx={{ mt: 2 }}>
-            <TextField
-              placeholder={t("community.writeReplyPlaceholder")}
-              value={replyBody}
-              onChange={(e) => setReplyBody(e.target.value)}
-              fullWidth
-              multiline
-              rows={3}
+        {/* Right column: header + body + actions */}
+        <Box sx={{ flex: 1, minWidth: 0, pb: hasReplies ? 1.5 : 0 }}>
+          {/* Header */}
+          <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 0.75, mb: 0.4 }}>
+            <Typography variant={depth === 0 ? "body2" : "caption"} fontWeight={700} sx={{ color: "var(--font-primary)" }}>
+              {comment.author.name}
+            </Typography>
+            <Chip
+              label={comment.author.role}
               size="small"
+              sx={{
+                height: 16, fontSize: "0.62rem",
+                backgroundColor: "var(--surface)", border: "1px solid var(--border-default)",
+                color: "var(--font-secondary)",
+              }}
             />
-            <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
+            <Typography variant="caption" color="var(--font-secondary)" sx={{ fontSize: "0.72rem" }}>
+              {formatDistanceToNow(comment.created_at)}
+            </Typography>
+          </Box>
+
+          {/* Reply-to indicator */}
+          {depth > 0 && parentAuthorName && (
+            <Typography
+              variant="caption"
+              sx={{ color: "var(--accent-indigo)", display: "block", mb: 0.4, fontSize: "0.72rem" }}
+            >
+              ↩ replying to @{parentAuthorName}
+            </Typography>
+          )}
+
+          {/* Body */}
+          <Typography
+            variant="body2"
+            sx={{
+              color: "var(--font-secondary)",
+              lineHeight: 1.65,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              fontSize: depth === 0 ? "0.875rem" : "0.85rem",
+              mb: 0.75,
+            }}
+          >
+            {comment.body}
+          </Typography>
+
+          {/* Actions */}
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+            <VoteButtons
+              upvotes={comment.upvotes}
+              downvotes={comment.downvotes}
+              userVote={comment.user_vote}
+              onVote={(type) => onVote(comment.id, type)}
+              size="small"
+              orientation="horizontal"
+            />
+
+            {!isMaxDepth && (
               <Button
                 size="small"
-                variant="contained"
-                onClick={handleSubmitReply}
-                disabled={!replyBody.trim() || submitting}
-              >
-                {submitting ? t("community.posting") : t("community.postReply")}
-              </Button>
-              <Button
-                size="small"
-                onClick={() => {
-                  setShowReplyForm(false);
-                  setReplyBody("");
+                startIcon={<IconWrapper icon="mdi:reply" size={14} />}
+                onClick={() => setShowReplyForm(!showReplyForm)}
+                sx={{
+                  textTransform: "none",
+                  fontSize: "0.78rem",
+                  minWidth: "auto",
+                  px: 1,
+                  py: 0.25,
+                  color: showReplyForm ? "var(--accent-indigo)" : "var(--font-secondary)",
+                  "&:hover": { color: "var(--accent-indigo)", backgroundColor: "color-mix(in srgb, var(--accent-indigo) 8%, transparent)" },
                 }}
               >
-                {t("common.cancel")}
+                {t("community.reply")}
               </Button>
-            </Box>
+            )}
           </Box>
-        </Collapse>
-      </Paper>
 
-      {/* Nested Replies */}
-      {comment.replies && comment.replies.length > 0 && (
-        <Box sx={{ mt: 2, display: "flex", flexDirection: "column", gap: 2 }}>
-          {comment.replies.map((reply) => (
+          {/* Reply form */}
+          <Collapse in={showReplyForm}>
+            <Box sx={{ mt: 1.25 }}>
+              <TextField
+                placeholder={`Reply to ${comment.author.name}…`}
+                value={replyBody}
+                onChange={(e) => setReplyBody(e.target.value)}
+                fullWidth
+                multiline
+                rows={2}
+                size="small"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey && replyBody.trim()) {
+                    e.preventDefault();
+                    handleSubmitReply();
+                  }
+                }}
+                sx={{ "& .MuiOutlinedInput-root": { borderRadius: "8px", fontSize: "0.875rem" } }}
+              />
+              <Box sx={{ display: "flex", gap: 1, mt: 0.75 }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={handleSubmitReply}
+                  disabled={!replyBody.trim() || submitting}
+                  sx={{
+                    textTransform: "none", fontSize: "0.78rem", borderRadius: "7px",
+                    backgroundColor: "var(--accent-indigo)", boxShadow: "none",
+                    "&:hover": { backgroundColor: "var(--accent-indigo)", filter: "brightness(0.9)", boxShadow: "none" },
+                  }}
+                >
+                  {submitting ? t("community.posting") : t("community.postReply")}
+                </Button>
+                <Button
+                  size="small"
+                  onClick={() => { setShowReplyForm(false); setReplyBody(""); }}
+                  sx={{ textTransform: "none", fontSize: "0.78rem", color: "var(--font-secondary)" }}
+                >
+                  {t("common.cancel")}
+                </Button>
+              </Box>
+            </Box>
+          </Collapse>
+        </Box>
+      </Box>
+
+      {/* Nested replies — connected via thread line from parent avatar */}
+      {hasReplies && (
+        <Box
+          sx={{
+            ml: `${avatarSize / 2 + 12}px`,
+            mt: 0,
+            pl: 2,
+            borderLeft: "2px solid color-mix(in srgb, var(--accent-indigo) 25%, var(--border-default) 75%)",
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+          }}
+        >
+          {comment.replies!.map((reply) => (
             <CommentItem
               key={reply.id}
               comment={reply}
@@ -259,6 +224,7 @@ export function CommentItem({
               onVote={onVote}
               onReply={onReply}
               depth={depth + 1}
+              parentAuthorName={comment.author.name}
             />
           ))}
         </Box>
@@ -266,4 +232,3 @@ export function CommentItem({
     </Box>
   );
 }
-

--- a/components/community/CreateThreadDialog.tsx
+++ b/components/community/CreateThreadDialog.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useTranslation } from "react-i18next";
+import { useState, useEffect, useRef } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import {
   Dialog,
-  DialogTitle,
   DialogContent,
   DialogActions,
   TextField,
@@ -12,145 +12,871 @@ import {
   Box,
   Chip,
   Typography,
-  Autocomplete,
+  IconButton,
+  Tooltip,
+  Divider,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { Tag } from "@/lib/services/community.service";
+import { PostType, POST_TYPE_CONFIG, communityService } from "@/lib/services/community.service";
+import { softBreakMarkdown } from "@/lib/utils/html-utils";
 
 interface CreateThreadDialogProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (data: { title: string; body: string; tag_ids: number[] }) => Promise<void>;
-  availableTags: Tag[];
+  onSubmit: (data: {
+    title: string;
+    body: string;
+    tag_ids: number[];
+    post_type: PostType;
+    poll_options?: string[];
+    resource_url?: string;
+    tried_steps?: string;
+    humor_tone?: string;
+    punchline?: string;
+    stance?: string;
+    tldr?: string;
+    image_urls?: string[];
+  }) => Promise<void>;
+  initialPostType?: PostType;
 }
+
+interface AttachedFile {
+  fileId: string;
+  name: string;
+  type: string;
+  size: number;
+  previewUrl?: string; // blob URL for immediate local preview
+  s3Url?: string;      // permanent S3 URL after upload
+  uploading: boolean;
+  uploadFailed: boolean;
+}
+
+const POST_TYPES = Object.keys(POST_TYPE_CONFIG) as PostType[];
+
+const TITLE_PLACEHOLDERS: Record<PostType, string> = {
+  question: "e.g. How do I handle JWT refresh tokens in Django?",
+  poll: "e.g. Which state management library do you prefer?",
+  resource: "e.g. Best guide for learning React hooks (2024)",
+  humorous: "e.g. When you forget a semicolon at 2 AM...",
+  discussion: "e.g. Is TypeScript worth it for solo projects?",
+};
+
+const BODY_PLACEHOLDERS: Record<PostType, string> = {
+  question:
+    "**Problem:**\nDescribe what you're seeing...\n\n**What I expected:**\n\n**Actual result:**\n\n```\n// Paste relevant code here\n```",
+  poll: "Provide context for the poll — why are you asking the community?",
+  resource: "Describe what this resource covers and *why it's valuable*...",
+  humorous: "Set the scene... the more detail the funnier it gets 😄",
+  discussion:
+    "Share your perspective. Be specific and invite pushback — good discussions have two sides...",
+};
+
+const BODY_LABEL: Record<PostType, string> = {
+  question: "Problem description",
+  poll: "Context",
+  resource: "About this resource",
+  humorous: "The story",
+  discussion: "Your take",
+};
+
+const EDITOR_BG: Record<PostType, string> = {
+  question: "#f7f8ff",
+  poll: "#faf8ff",
+  resource: "#f0f9ff",
+  humorous: "#fffcf0",
+  discussion: "#f0fdf8",
+};
+
+const HUMOR_TONES = [
+  { key: "relatable", emoji: "😅", label: "Relatable", color: "#f59e0b" },
+  { key: "hot_take", emoji: "🌶️", label: "Hot Take", color: "#ef4444" },
+  { key: "meme", emoji: "🤣", label: "Pure Meme", color: "#8b5cf6" },
+  { key: "vibes", emoji: "✨", label: "Just Vibes", color: "#ec4899" },
+] as const;
+
+type HumorTone = (typeof HUMOR_TONES)[number]["key"] | "";
+
+const STANCES = [
+  { key: "for", emoji: "👍", label: "I'm For It", color: "#10b981" },
+  { key: "against", emoji: "👎", label: "I'm Against", color: "#ef4444" },
+  { key: "neutral", emoji: "🤔", label: "Neutral / Curious", color: "#f59e0b" },
+] as const;
+
+type Stance = (typeof STANCES)[number]["key"] | "";
+
+// ── HTML → Markdown converter for paste handling ─────────────────────────────
+
+function convertHtmlToMarkdown(html: string): string {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+
+  function walk(node: Node): string {
+    if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+    if (node.nodeType !== Node.ELEMENT_NODE) return "";
+    const el = node as HTMLElement;
+    const tag = el.tagName.toLowerCase();
+    const children = Array.from(el.childNodes).map(walk).join("");
+
+    switch (tag) {
+      case "strong": case "b": return `**${children.trim()}**`;
+      case "em": case "i": return `*${children.trim()}*`;
+      case "h1": return `# ${children.trim()}\n\n`;
+      case "h2": return `## ${children.trim()}\n\n`;
+      case "h3": return `### ${children.trim()}\n\n`;
+      case "h4": case "h5": case "h6": return `#### ${children.trim()}\n\n`;
+      case "p": return `${children.trim()}\n\n`;
+      case "br": return "\n";
+      case "a": return `[${children}](${el.getAttribute("href") ?? ""})`;
+      case "code": return el.closest("pre") ? children : `\`${children}\``;
+      case "pre": return `\`\`\`\n${el.textContent ?? ""}\n\`\`\`\n\n`;
+      case "ul": return `${children}\n`;
+      case "ol": return `${children}\n`;
+      case "li": return `- ${children.trim()}\n`;
+      case "blockquote": return `> ${children.trim()}\n\n`;
+      case "img": return `![${el.getAttribute("alt") ?? ""}](${el.getAttribute("src") ?? ""})\n`;
+      case "hr": return `---\n\n`;
+      case "table": return `${children}\n`;
+      case "thead": case "tbody": case "tr": return children;
+      case "th": return ` ${children.trim()} |`;
+      case "td": return ` ${children.trim()} |`;
+      default: return children;
+    }
+  }
+
+  return walk(div).replace(/\n{3,}/g, "\n\n").trim();
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
 
 export function CreateThreadDialog({
   open,
   onClose,
   onSubmit,
-  availableTags,
+  initialPostType = "question",
 }: CreateThreadDialogProps) {
-  const { t } = useTranslation("common");
+  const [postType, setPostType] = useState<PostType>(initialPostType);
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
-  const [selectedTags, setSelectedTags] = useState<Tag[]>([]);
+  const [isPreview, setIsPreview] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+
+  const [pollOptions, setPollOptions] = useState<string[]>(["", ""]);
+  const [resourceUrl, setResourceUrl] = useState("");
+  const [triedSteps, setTriedSteps] = useState("");
+  const [humorTone, setHumorTone] = useState<HumorTone>("");
+  const [punchline, setPunchline] = useState("");
+  const [stance, setStance] = useState<Stance>("");
+  const [tldr, setTldr] = useState("");
+  const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
+
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) {
       setTitle("");
       setBody("");
-      setSelectedTags([]);
+      setIsPreview(false);
+      setPollOptions(["", ""]);
+      setResourceUrl("");
+      setTriedSteps("");
+      setHumorTone("");
+      setPunchline("");
+      setStance("");
+      setTldr("");
+      attachedFiles.forEach((f) => f.previewUrl && URL.revokeObjectURL(f.previewUrl));
+      setAttachedFiles([]);
+    } else {
+      setPostType(initialPostType);
     }
-  }, [open]);
+  }, [open, initialPostType]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Markdown toolbar ──────────────────────────────────────────────────────
+
+  const insertAtCursor = (before: string, after = "", defaultText = "text") => {
+    const el = bodyRef.current;
+    if (!el) { setBody((p) => p + before + defaultText + after); return; }
+    const s = el.selectionStart ?? 0;
+    const e = el.selectionEnd ?? 0;
+    const sel = body.slice(s, e) || defaultText;
+    const newBody = body.slice(0, s) + before + sel + after + body.slice(e);
+    setBody(newBody);
+    setTimeout(() => {
+      el.focus();
+      el.setSelectionRange(s + before.length, s + before.length + sel.length);
+    }, 0);
+  };
+
+  const insertHeading = () => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const s = el.selectionStart ?? 0;
+    const ls = body.lastIndexOf("\n", s - 1) + 1;
+    const already = body.slice(ls).startsWith("## ");
+    const nb = already ? body.slice(0, ls) + body.slice(ls + 3) : body.slice(0, ls) + "## " + body.slice(ls);
+    setBody(nb);
+    setTimeout(() => { el.focus(); el.setSelectionRange(s + (already ? -3 : 3), s + (already ? -3 : 3)); }, 0);
+  };
+
+  const insertLink = () => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const sel = body.slice(el.selectionStart ?? 0, el.selectionEnd ?? 0);
+    sel ? insertAtCursor("[", "](https://)", sel) : insertAtCursor("[link text](", ")", "https://");
+  };
+
+  // ── Paste handler — converts rich HTML to markdown ────────────────────────
+
+  const handleBodyPaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const html = e.clipboardData.getData("text/html");
+    if (!html) return;
+    e.preventDefault();
+    const markdown = convertHtmlToMarkdown(html);
+    const el = bodyRef.current;
+    const s = el?.selectionStart ?? body.length;
+    const end = el?.selectionEnd ?? body.length;
+    const newBody = body.slice(0, s) + markdown + body.slice(end);
+    setBody(newBody);
+    const pos = s + markdown.length;
+    setTimeout(() => { el?.focus(); el?.setSelectionRange(pos, pos); }, 0);
+  };
+
+  // ── Poll helpers ──────────────────────────────────────────────────────────
+
+  const updatePollOption = (i: number, v: string) =>
+    setPollOptions((p) => p.map((o, idx) => (idx === i ? v : o)));
+  const addPollOption = () => { if (pollOptions.length < 6) setPollOptions((p) => [...p, ""]); };
+  const removePollOption = (i: number) => {
+    if (pollOptions.length > 2) setPollOptions((p) => p.filter((_, idx) => idx !== i));
+  };
+
+  // ── File attachment ───────────────────────────────────────────────────────
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+
+    files.forEach((file) => {
+      const fileId = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const newFile: AttachedFile = {
+        fileId,
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        previewUrl: file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined,
+        uploading: true,
+        uploadFailed: false,
+      };
+      setAttachedFiles((prev) => [...prev, newFile]);
+
+      communityService
+        .uploadFile(file)
+        .then((result) => {
+          setAttachedFiles((prev) =>
+            prev.map((f) =>
+              f.fileId === fileId ? { ...f, s3Url: result.url, uploading: false } : f
+            )
+          );
+        })
+        .catch(() => {
+          setAttachedFiles((prev) =>
+            prev.map((f) =>
+              f.fileId === fileId ? { ...f, uploading: false, uploadFailed: true } : f
+            )
+          );
+        });
+    });
+  };
+
+  const removeFile = (fileId: string) => {
+    setAttachedFiles((prev) => {
+      const file = prev.find((f) => f.fileId === fileId);
+      if (file?.previewUrl) URL.revokeObjectURL(file.previewUrl);
+      return prev.filter((f) => f.fileId !== fileId);
+    });
+  };
+
+  const fileSizeLabel = (b: number) =>
+    b < 1024 ? `${b}B` : b < 1048576 ? `${(b / 1024).toFixed(0)}KB` : `${(b / 1048576).toFixed(1)}MB`;
+
+  const fileIcon = (t: string) =>
+    t.startsWith("image/") ? "mdi:image-outline" : t.startsWith("video/") ? "mdi:video-outline" : "mdi:file-outline";
+
+  // ── Submit ────────────────────────────────────────────────────────────────
+
+  const bodyRequired = postType !== "poll" && postType !== "resource";
 
   const handleSubmit = async () => {
-    if (!title.trim() || !body.trim()) return;
-
+    if (!title.trim()) return;
+    if (bodyRequired && !body.trim()) return;
+    if (postType === "poll" && pollOptions.filter((o) => o.trim()).length < 2) return;
     setSubmitting(true);
     try {
       await onSubmit({
         title: title.trim(),
         body: body.trim(),
-        tag_ids: selectedTags.map((tag) => tag.id),
+        tag_ids: [],
+        post_type: postType,
+        poll_options: postType === "poll" ? pollOptions.filter((o) => o.trim()) : undefined,
+        resource_url: postType === "resource" && resourceUrl.trim() ? resourceUrl.trim() : undefined,
+        tried_steps: postType === "question" && triedSteps.trim() ? triedSteps.trim() : undefined,
+        humor_tone: postType === "humorous" && humorTone ? humorTone : undefined,
+        punchline: postType === "humorous" && punchline.trim() ? punchline.trim() : undefined,
+        stance: postType === "discussion" && stance ? stance : undefined,
+        tldr: postType === "discussion" && tldr.trim() ? tldr.trim() : undefined,
+        image_urls: attachedFiles
+          .filter((f) => f.s3Url)
+          .map((f) => f.s3Url!),
       });
       onClose();
-    } catch (error) {
-      // Silently handle thread creation error
+    } catch {
+      // handled by parent
     } finally {
       setSubmitting(false);
     }
   };
 
-  return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <IconWrapper
-            icon="mdi:forum"
-            size={24}
-            color="var(--accent-indigo)"
-          />
-          <Typography variant="h6" fontWeight={600}>
-            {t("community.createNewThread")}
-          </Typography>
-        </Box>
-      </DialogTitle>
+  const typeConfig = POST_TYPE_CONFIG[postType];
+  const anyUploading = attachedFiles.some((f) => f.uploading);
+  const isSubmitDisabled =
+    !title.trim() ||
+    (bodyRequired && !body.trim()) ||
+    submitting ||
+    anyUploading ||
+    (postType === "poll" && pollOptions.filter((o) => o.trim()).length < 2);
 
-      <DialogContent>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
-          {/* Title */}
+  const editorBg = EDITOR_BG[postType];
+
+  const mdPreviewSx = {
+    minHeight: postType === "poll" ? 100 : 200,
+    maxHeight: 380,
+    overflowY: "auto" as const,
+    px: 2.5,
+    py: 1.75,
+    backgroundColor: editorBg,
+    "& h1,& h2,& h3": { fontWeight: 700, mt: 0, mb: 0.75 },
+    "& h1": { fontSize: "1.4rem" },
+    "& h2": { fontSize: "1.2rem" },
+    "& h3": { fontSize: "1.05rem" },
+    "& p": { mb: 0.75, lineHeight: 1.7, color: "var(--font-primary)", fontSize: "0.9rem" },
+    "& code": { fontFamily: "monospace", fontSize: "0.84rem", backgroundColor: "rgba(0,0,0,0.05)", border: "1px solid rgba(0,0,0,0.08)", borderRadius: "4px", px: "4px", py: "1px" },
+    "& pre": { backgroundColor: "#1a1b26", color: "#c0caf5", borderRadius: "8px", p: 1.5, overflowX: "auto", "& code": { backgroundColor: "transparent", border: "none", color: "inherit", p: 0 } },
+    "& blockquote": { borderLeft: `3px solid ${typeConfig.color}`, pl: 2, ml: 0, color: "var(--font-secondary)", fontStyle: "italic" },
+    "& ul,& ol": { pl: 2.5, mb: 0.75 },
+    "& li": { mb: 0.2, fontSize: "0.9rem" },
+    "& a": { color: typeConfig.color, textDecoration: "underline" },
+    "& strong": { fontWeight: 700 },
+    "& table": { borderCollapse: "collapse", width: "100%", mb: 1 },
+    "& th,& td": { border: "1px solid var(--border-default)", px: 1.5, py: 0.75, fontSize: "0.875rem" },
+    "& th": { backgroundColor: "var(--surface)", fontWeight: 700 },
+    "& img": { maxWidth: "100%", borderRadius: "8px", mt: 1 },
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "16px",
+          border: "1px solid var(--border-default)",
+          boxShadow: "0 24px 64px rgba(0,0,0,0.13)",
+          overflow: "hidden",
+        },
+      }}
+    >
+      {/* ── Type Selector Header ──────────────────────────────────────────── */}
+      <Box
+        sx={{
+          px: 3,
+          pt: 2.5,
+          pb: 2,
+          borderBottom: "1px solid var(--border-default)",
+          backgroundColor: "var(--surface)",
+        }}
+      >
+        <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap" }}>
+          {POST_TYPES.map((type) => {
+            const cfg = POST_TYPE_CONFIG[type];
+            const active = postType === type;
+            return (
+              <Chip
+                key={type}
+                icon={<IconWrapper icon={cfg.icon} size={13} color={active ? "#fff" : cfg.color} />}
+                label={cfg.label}
+                onClick={() => setPostType(type)}
+                size="small"
+                sx={{
+                  cursor: "pointer",
+                  height: 30,
+                  fontSize: "0.8rem",
+                  fontWeight: 600,
+                  backgroundColor: active ? cfg.color : `${cfg.color}12`,
+                  color: active ? "#fff" : cfg.color,
+                  border: `1.5px solid ${active ? cfg.color : `${cfg.color}40`}`,
+                  "& .MuiChip-icon": { ml: 0.75 },
+                  transition: "all 0.18s ease",
+                  "&:hover": { backgroundColor: active ? cfg.color : `${cfg.color}22`, filter: active ? "brightness(1.05)" : "none" },
+                }}
+              />
+            );
+          })}
+        </Box>
+      </Box>
+
+      <DialogContent sx={{ p: 0 }}>
+        <Box sx={{ px: 3, pt: 2.5, pb: 1 }}>
+
+          {/* ── Title ──────────────────────────────────────────────────── */}
           <TextField
-            label={t("community.titleLabel")}
-            placeholder={t("community.titlePlaceholder")}
+            placeholder={TITLE_PLACEHOLDERS[postType]}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             fullWidth
-            required
             autoFocus
+            variant="standard"
+            inputProps={{ maxLength: 200 }}
+            InputProps={{
+              disableUnderline: false,
+              sx: {
+                fontSize: "1.15rem",
+                fontWeight: 700,
+                color: "var(--font-primary)",
+                "&:before": { borderColor: "var(--border-default)" },
+                "&:after": { borderColor: typeConfig.color },
+              },
+            }}
+            sx={{ mb: 2.5 }}
           />
 
-          {/* Body */}
-          <TextField
-            label={t("community.descriptionLabel")}
-            placeholder={t("community.descriptionPlaceholder")}
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            fullWidth
-            multiline
-            rows={8}
-            required
-          />
+          {/* ════ TYPE-SPECIFIC EXTRAS ════ */}
 
-          {/* Tags */}
-          <Autocomplete
-            multiple
-            options={availableTags}
-            getOptionLabel={(option) => option.name}
-            value={selectedTags}
-            onChange={(_, newValue) => setSelectedTags(newValue)}
-            renderInput={(params) => (
+          {/* Question */}
+          {postType === "question" && (
+            <Box sx={{ mb: 2, borderRadius: "10px", border: "1px solid #c7d2fe", overflow: "hidden", backgroundColor: "#f5f7ff" }}>
+              <Box sx={{ px: 2, py: 1.25, display: "flex", alignItems: "center", gap: 1, borderBottom: "1px solid #c7d2fe", backgroundColor: "#eef2ff" }}>
+                <IconWrapper icon="mdi:wrench-clock-outline" size={15} color="#6366f1" />
+                <Typography variant="body2" fontWeight={700} sx={{ color: "#6366f1" }}>
+                  What have you already tried?
+                </Typography>
+                <Chip label="optional" size="small" sx={{ ml: "auto", height: 18, fontSize: "0.65rem", backgroundColor: "#c7d2fe", color: "#4338ca" }} />
+              </Box>
               <TextField
-                {...params}
-                label={t("community.tagsLabel")}
-                placeholder={t("community.tagsPlaceholder")}
+                placeholder="e.g. I tried X but got error Y. Also checked the docs for Z — didn't help because..."
+                value={triedSteps}
+                onChange={(e) => setTriedSteps(e.target.value)}
+                fullWidth multiline minRows={2} maxRows={4} variant="outlined"
+                InputProps={{
+                  sx: {
+                    borderRadius: 0, border: "none", "& fieldset": { border: "none" },
+                    fontSize: "0.875rem", lineHeight: 1.6, backgroundColor: "#f5f7ff",
+                    fontFamily: "inherit", "& textarea": { px: 2, py: 1.25 },
+                  },
+                }}
+              />
+            </Box>
+          )}
+
+          {/* Humorous */}
+          {postType === "humorous" && (
+            <Box sx={{ mb: 2, display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <Box sx={{ p: 2, borderRadius: "10px", border: "1px solid #fde68a", backgroundColor: "#fffbeb" }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1.25 }}>
+                  <Typography variant="body2" fontWeight={700} sx={{ color: "#b45309" }}>
+                    What&apos;s the vibe?
+                  </Typography>
+                  <Chip label="optional" size="small" sx={{ height: 18, fontSize: "0.65rem", backgroundColor: "#fde68a", color: "#92400e" }} />
+                </Box>
+                <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap" }}>
+                  {HUMOR_TONES.map((tone) => {
+                    const active = humorTone === tone.key;
+                    return (
+                      <Box
+                        key={tone.key}
+                        onClick={() => setHumorTone(active ? "" : tone.key)}
+                        sx={{
+                          display: "flex", alignItems: "center", gap: 0.75, px: 1.5, py: 0.75,
+                          borderRadius: "8px", border: `1.5px solid ${active ? tone.color : "#e5e7eb"}`,
+                          backgroundColor: active ? `${tone.color}15` : "#fff",
+                          cursor: "pointer", transition: "all 0.15s",
+                          "&:hover": { borderColor: tone.color, backgroundColor: `${tone.color}0e` },
+                        }}
+                      >
+                        <Typography sx={{ fontSize: "1rem", lineHeight: 1 }}>{tone.emoji}</Typography>
+                        <Typography variant="caption" fontWeight={active ? 700 : 500} sx={{ color: active ? tone.color : "#374151" }}>
+                          {tone.label}
+                        </Typography>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              </Box>
+              <TextField
+                label="⚡ The Kicker (optional)"
+                placeholder="One-liner punchline... e.g. Turns out it was a missing comma"
+                value={punchline}
+                onChange={(e) => setPunchline(e.target.value.slice(0, 120))}
+                size="small" fullWidth inputProps={{ maxLength: 120 }}
+                helperText={punchline.length > 80 ? `${punchline.length}/120` : undefined}
+                sx={{ "& .MuiOutlinedInput-root": { borderRadius: "8px" }, "& label": { fontWeight: 600 } }}
+              />
+            </Box>
+          )}
+
+          {/* Discussion */}
+          {postType === "discussion" && (
+            <Box sx={{ mb: 2, display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <Box>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+                  <Typography variant="body2" fontWeight={700} sx={{ color: "#0f766e" }}>Your Stance</Typography>
+                  <Chip label="optional" size="small" sx={{ height: 18, fontSize: "0.65rem", backgroundColor: "#ccfbf1", color: "#0f766e" }} />
+                </Box>
+                <Box sx={{ display: "flex", gap: 1 }}>
+                  {STANCES.map((s) => {
+                    const active = stance === s.key;
+                    return (
+                      <Box
+                        key={s.key}
+                        onClick={() => setStance(active ? "" : s.key)}
+                        sx={{
+                          flex: 1, py: 1.5, px: 1.25, borderRadius: "12px",
+                          border: `2px solid ${active ? s.color : "#e5e7eb"}`,
+                          backgroundColor: active ? `${s.color}10` : "#fff",
+                          cursor: "pointer", textAlign: "center", transition: "all 0.18s",
+                          "&:hover": { borderColor: s.color, backgroundColor: `${s.color}08` },
+                        }}
+                      >
+                        <Typography sx={{ fontSize: "1.4rem", lineHeight: 1, mb: 0.5 }}>{s.emoji}</Typography>
+                        <Typography variant="caption" fontWeight={active ? 700 : 500} sx={{ color: active ? s.color : "#374151", display: "block", lineHeight: 1.3 }}>
+                          {s.label}
+                        </Typography>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              </Box>
+              <TextField
+                label="TL;DR (optional one-liner)"
+                placeholder="e.g. TypeScript adds safety but slows you down in the short term"
+                value={tldr}
+                onChange={(e) => setTldr(e.target.value.slice(0, 140))}
+                size="small" fullWidth inputProps={{ maxLength: 140 }}
+                helperText={tldr.length > 100 ? `${tldr.length}/140` : undefined}
+                sx={{ "& .MuiOutlinedInput-root": { borderRadius: "8px" }, "& label": { fontWeight: 600 } }}
+              />
+            </Box>
+          )}
+
+          {/* Resource URL */}
+          {postType === "resource" && (
+            <TextField
+              label="Resource URL (optional)"
+              placeholder="https://..."
+              value={resourceUrl}
+              onChange={(e) => setResourceUrl(e.target.value)}
+              fullWidth size="small" type="url"
+              InputProps={{
+                startAdornment: (
+                  <Box sx={{ mr: 1, display: "flex" }}>
+                    <IconWrapper icon="mdi:link-variant" size={18} color="#3b82f6" />
+                  </Box>
+                ),
+              }}
+              sx={{ mb: 2, "& .MuiOutlinedInput-root": { borderRadius: "8px" } }}
+            />
+          )}
+
+          {/* Poll Options */}
+          {postType === "poll" && (
+            <Box sx={{ mb: 2, p: 2, border: "1px solid var(--border-default)", borderRadius: "10px", backgroundColor: `${POST_TYPE_CONFIG.poll.color}06` }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+                <IconWrapper icon="mdi:chart-bar" size={16} color={POST_TYPE_CONFIG.poll.color} />
+                <Typography variant="body2" fontWeight={700} color={POST_TYPE_CONFIG.poll.color}>Poll Options</Typography>
+                <Typography variant="caption" color="var(--font-tertiary)" sx={{ ml: "auto" }}>
+                  {pollOptions.filter((o) => o.trim()).length}/{pollOptions.length} filled
+                </Typography>
+              </Box>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+                {pollOptions.map((option, i) => (
+                  <Box key={i} sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+                    <Box sx={{
+                      width: 22, height: 22, borderRadius: "50%",
+                      background: option.trim() ? `${POST_TYPE_CONFIG.poll.color}20` : "var(--surface)",
+                      border: `1.5px solid ${option.trim() ? POST_TYPE_CONFIG.poll.color : "var(--border-light)"}`,
+                      display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0, transition: "all 0.15s",
+                    }}>
+                      <Typography variant="caption" sx={{ fontSize: "0.62rem", fontWeight: 700, color: POST_TYPE_CONFIG.poll.color }}>{i + 1}</Typography>
+                    </Box>
+                    <TextField
+                      placeholder={`Option ${i + 1}`}
+                      value={option}
+                      onChange={(e) => updatePollOption(i, e.target.value)}
+                      size="small" fullWidth inputProps={{ maxLength: 120 }}
+                      sx={{ "& .MuiOutlinedInput-root": { borderRadius: "8px" } }}
+                    />
+                    <IconButton
+                      size="small"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => removePollOption(i)}
+                      disabled={pollOptions.length <= 2}
+                      sx={{ color: "var(--font-tertiary)", opacity: pollOptions.length <= 2 ? 0.25 : 0.7, "&:hover": { color: "var(--accent-red)", opacity: 1 } }}
+                    >
+                      <IconWrapper icon="mdi:close" size={15} />
+                    </IconButton>
+                  </Box>
+                ))}
+              </Box>
+              {pollOptions.length < 6 && (
+                <Button
+                  size="small"
+                  startIcon={<IconWrapper icon="mdi:plus" size={14} />}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={addPollOption}
+                  sx={{ mt: 1, textTransform: "none", color: POST_TYPE_CONFIG.poll.color, fontSize: "0.78rem", px: 1, "&:hover": { backgroundColor: `${POST_TYPE_CONFIG.poll.color}10` } }}
+                >
+                  Add option
+                </Button>
+              )}
+            </Box>
+          )}
+
+          {/* ── Markdown Editor ──────────────────────────────────────────── */}
+          <Box sx={{ border: "1px solid var(--border-default)", borderRadius: "10px", overflow: "hidden" }}>
+            {/* Toolbar */}
+            <Box sx={{
+              display: "flex", alignItems: "center", px: 1.5, py: 0.75, gap: 0.25,
+              backgroundColor: "var(--surface)", borderBottom: "1px solid var(--border-default)",
+            }}>
+              {/* Write / Preview toggle */}
+              <Box sx={{ display: "flex", border: "1px solid var(--border-default)", borderRadius: "7px", overflow: "hidden", mr: 1.5 }}>
+                {[{ label: "Write", active: !isPreview }, { label: "Preview", active: isPreview }].map(({ label, active }) => (
+                  <Box
+                    key={label}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => setIsPreview(label === "Preview")}
+                    sx={{
+                      px: 1.5, py: 0.4, fontSize: "0.76rem", fontWeight: active ? 600 : 400,
+                      cursor: "pointer", backgroundColor: active ? "#fff" : "transparent",
+                      color: active ? "var(--font-primary)" : "var(--font-secondary)",
+                      transition: "all 0.15s", userSelect: "none",
+                      "&:hover": { color: "var(--font-primary)" },
+                    }}
+                  >
+                    {label}
+                  </Box>
+                ))}
+              </Box>
+
+              {!isPreview && (
+                <>
+                  <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+                  {[
+                    { title: "Bold", icon: "mdi:format-bold", action: () => insertAtCursor("**", "**", "bold") },
+                    { title: "Italic", icon: "mdi:format-italic", action: () => insertAtCursor("*", "*", "italic") },
+                    { title: "Heading", icon: "mdi:format-header-2", action: insertHeading },
+                    { title: "Code block", icon: "mdi:code-braces", action: () => insertAtCursor("```\n", "\n```", "code here") },
+                    { title: "Link", icon: "mdi:link-variant", action: insertLink },
+                    { title: "Bullet list", icon: "mdi:format-list-bulleted", action: () => insertAtCursor("- ", "", "item") },
+                  ].map(({ title, icon, action }) => (
+                    <Tooltip key={title} title={title} placement="top">
+                      <IconButton
+                        size="small"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={action}
+                        sx={{ width: 28, height: 28, borderRadius: "6px", color: "var(--font-secondary)", "&:hover": { backgroundColor: "var(--border-default)", color: "var(--font-primary)" } }}
+                      >
+                        <IconWrapper icon={icon} size={16} />
+                      </IconButton>
+                    </Tooltip>
+                  ))}
+                  <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
+                  <Tooltip title="Attach image or video">
+                    <IconButton
+                      size="small"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => fileInputRef.current?.click()}
+                      sx={{ width: 28, height: 28, borderRadius: "6px", color: "var(--font-secondary)", "&:hover": { backgroundColor: "var(--border-default)", color: "var(--font-primary)" } }}
+                    >
+                      <IconWrapper icon="mdi:paperclip" size={16} />
+                    </IconButton>
+                  </Tooltip>
+                  <input type="file" ref={fileInputRef} accept="image/*,video/*" multiple style={{ display: "none" }} onChange={handleFileSelect} />
+                </>
+              )}
+
+              <Box sx={{ ml: "auto", display: "flex", alignItems: "center", gap: 0.75 }}>
+                {!bodyRequired && (
+                  <Chip label="optional" size="small" sx={{ height: 18, fontSize: "0.65rem", backgroundColor: "var(--surface)", border: "1px solid var(--border-default)", color: "var(--font-secondary)" }} />
+                )}
+                <IconWrapper icon="mdi:language-markdown-outline" size={14} color="var(--font-tertiary)" />
+                <Typography variant="caption" color="var(--font-tertiary)" sx={{ fontSize: "0.68rem" }}>Markdown</Typography>
+              </Box>
+            </Box>
+
+            {/* Editor / Preview */}
+            {isPreview ? (
+              <Box sx={mdPreviewSx}>
+                {body.trim() ? (
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{softBreakMarkdown(body)}</ReactMarkdown>
+                ) : (
+                  <Typography variant="body2" color="var(--font-tertiary)" sx={{ fontStyle: "italic" }}>
+                    Nothing to preview yet — start writing in the editor.
+                  </Typography>
+                )}
+              </Box>
+            ) : (
+              <TextField
+                placeholder={BODY_PLACEHOLDERS[postType]}
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                fullWidth multiline
+                minRows={postType === "poll" ? 3 : postType === "question" ? 6 : 7}
+                maxRows={14}
+                inputRef={bodyRef}
+                variant="outlined"
+                inputProps={{ onPaste: handleBodyPaste }}
+                InputProps={{
+                  sx: {
+                    borderRadius: 0, border: "none", "& fieldset": { border: "none" },
+                    fontSize: "0.9rem", lineHeight: 1.7,
+                    fontFamily: postType === "question" ? "monospace" : "inherit",
+                    backgroundColor: editorBg,
+                    alignItems: "flex-start", p: 0,
+                    "& textarea": { px: 2, py: 1.75 },
+                  },
+                }}
               />
             )}
-            renderTags={(value, getTagProps) =>
-              value.map((option, index) => (
-                <Chip
-                  label={option.name}
-                  {...getTagProps({ index })}
-                  size="small"
-                  sx={{
-                    backgroundColor: "#dbeafe",
-                    color: "var(--accent-indigo)",
-                  }}
-                />
-              ))
-            }
-          />
+          </Box>
 
-          <Typography variant="caption" color="text.secondary">
-            {t("community.tagsTip")}
-          </Typography>
+          {/* ── Attached files / images ──────────────────────────────────── */}
+          {attachedFiles.length > 0 && (
+            <Box sx={{ mt: 1.5 }}>
+              {/* Image previews */}
+              {attachedFiles.some((f) => f.previewUrl) && (
+                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 1 }}>
+                  {attachedFiles
+                    .filter((f) => f.previewUrl)
+                    .map((file) => (
+                      <Box key={file.fileId} sx={{ position: "relative" }}>
+                        <Box
+                          component="img"
+                          src={file.previewUrl}
+                          alt={file.name}
+                          sx={{
+                            width: 80, height: 80, objectFit: "cover",
+                            borderRadius: "8px",
+                            border: `1px solid ${file.uploadFailed ? "#ef4444" : "var(--border-default)"}`,
+                            display: "block",
+                            opacity: file.uploading ? 0.5 : 1,
+                            transition: "opacity 0.2s",
+                          }}
+                        />
+                        {/* Upload status overlay */}
+                        {file.uploading && (
+                          <Box sx={{
+                            position: "absolute", inset: 0, display: "flex",
+                            alignItems: "center", justifyContent: "center",
+                            borderRadius: "8px", backgroundColor: "rgba(0,0,0,0.25)",
+                          }}>
+                            <Box sx={{
+                              width: 18, height: 18, border: "2px solid #fff",
+                              borderTopColor: "transparent", borderRadius: "50%",
+                              animation: "spin 0.7s linear infinite",
+                              "@keyframes spin": { to: { transform: "rotate(360deg)" } },
+                            }} />
+                          </Box>
+                        )}
+                        {file.uploadFailed && (
+                          <Box sx={{
+                            position: "absolute", inset: 0, display: "flex",
+                            alignItems: "center", justifyContent: "center",
+                            borderRadius: "8px", backgroundColor: "rgba(239,68,68,0.18)",
+                          }}>
+                            <IconWrapper icon="mdi:alert-circle-outline" size={22} color="#ef4444" />
+                          </Box>
+                        )}
+                        {!file.uploading && !file.uploadFailed && file.s3Url && (
+                          <Box sx={{
+                            position: "absolute", bottom: 4, right: 4,
+                            backgroundColor: "#10b981", borderRadius: "50%",
+                            width: 14, height: 14, display: "flex",
+                            alignItems: "center", justifyContent: "center",
+                          }}>
+                            <IconWrapper icon="mdi:check" size={10} color="#fff" />
+                          </Box>
+                        )}
+                        <IconButton
+                          size="small"
+                          onClick={() => removeFile(file.fileId)}
+                          sx={{
+                            position: "absolute", top: -6, right: -6, width: 18, height: 18,
+                            backgroundColor: "#111", color: "#fff", padding: 0,
+                            "&:hover": { backgroundColor: "#333" },
+                          }}
+                        >
+                          <IconWrapper icon="mdi:close" size={11} />
+                        </IconButton>
+                      </Box>
+                    ))}
+                </Box>
+              )}
+              {/* Non-image file chips */}
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
+                {attachedFiles
+                  .filter((f) => !f.previewUrl)
+                  .map((file, i) => (
+                    <Chip
+                      key={i}
+                      icon={<IconWrapper icon={fileIcon(file.type)} size={14} color="var(--font-secondary)" />}
+                      label={
+                        <Box sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
+                          <Typography variant="caption" noWrap sx={{ maxWidth: 110 }}>{file.name}</Typography>
+                          <Typography variant="caption" color="var(--font-tertiary)">{fileSizeLabel(file.size)}</Typography>
+                        </Box>
+                      }
+                      onDelete={() => removeFile(file.fileId)}
+                      size="small"
+                      sx={{ height: 26, backgroundColor: "var(--surface)", border: "1px solid var(--border-default)", "& .MuiChip-icon": { ml: 0.5 } }}
+                    />
+                  ))}
+              </Box>
+            </Box>
+          )}
         </Box>
       </DialogContent>
 
-      <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={onClose} disabled={submitting}>
-          {t("common.cancel")}
+      {/* ── Footer ─────────────────────────────────────────────────────────── */}
+      <DialogActions sx={{ px: 3, py: 2, borderTop: "1px solid var(--border-default)", backgroundColor: "var(--surface)", gap: 1 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="caption" color="var(--font-tertiary)">
+            {BODY_LABEL[postType]} · {body.length} chars
+            {postType === "poll" && ` · ${pollOptions.filter((o) => o.trim()).length} options`}
+            {postType === "humorous" && humorTone && ` · ${HUMOR_TONES.find((t) => t.key === humorTone)?.label}`}
+            {postType === "discussion" && stance && ` · ${STANCES.find((s) => s.key === stance)?.label}`}
+            {attachedFiles.length > 0 && ` · ${attachedFiles.length} file${attachedFiles.length > 1 ? "s" : ""}`}
+          </Typography>
+        </Box>
+        <Button onClick={onClose} disabled={submitting} sx={{ textTransform: "none", color: "var(--font-secondary)" }}>
+          Cancel
         </Button>
         <Button
           variant="contained"
           onClick={handleSubmit}
-          disabled={!title.trim() || !body.trim() || submitting}
-          startIcon={<IconWrapper icon="mdi:send" />}
+          disabled={isSubmitDisabled}
+          startIcon={submitting ? undefined : <IconWrapper icon="mdi:send" size={15} />}
+          sx={{
+            textTransform: "none", fontWeight: 600, borderRadius: "8px", px: 2.5,
+            backgroundColor: typeConfig.color, boxShadow: "none",
+            "&:hover": { backgroundColor: typeConfig.color, filter: "brightness(0.9)", boxShadow: "none" },
+            "&.Mui-disabled": { backgroundColor: "var(--border-default)", color: "var(--font-tertiary)" },
+          }}
         >
-          {submitting ? t("community.creating") : t("community.createThread")}
+          {submitting ? "Posting..." : anyUploading ? "Uploading images..." : `Post ${typeConfig.label}`}
         </Button>
       </DialogActions>
     </Dialog>
   );
 }
-

--- a/components/community/PollWidget.tsx
+++ b/components/community/PollWidget.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import type { Thread } from "@/lib/services/community.service";
+
+const POLL_COLOR = "#8b5cf6";
+
+interface PollWidgetProps {
+  thread: Thread;
+  onPollVote?: (threadId: number, optionIndex: number) => Promise<void>;
+  isSaving?: boolean;
+}
+
+export function PollWidget({ thread, onPollVote, isSaving = false }: PollWidgetProps) {
+  if (!thread.poll_options || thread.poll_options.length === 0) return null;
+
+  const pollResults = thread.poll_results ?? thread.poll_options.map(() => 0);
+  const totalVotes = pollResults.reduce((a, b) => a + b, 0);
+  const hasVoted = thread.user_poll_vote !== null && thread.user_poll_vote !== undefined;
+
+  return (
+    <Box sx={{ mb: 1.5 }}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+        {thread.poll_options.map((option, i) => {
+          const votes = pollResults[i] ?? 0;
+          const pct = totalVotes > 0 ? Math.round((votes / totalVotes) * 100) : 0;
+          const isVoted = thread.user_poll_vote === i;
+
+          return (
+            <Box
+              key={i}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!isSaving && onPollVote) onPollVote(thread.id, i);
+              }}
+              sx={{
+                position: "relative",
+                border: `1.5px solid ${isVoted ? POLL_COLOR : "var(--border-default)"}`,
+                borderRadius: "8px",
+                overflow: "hidden",
+                cursor: isSaving || !onPollVote ? "default" : "pointer",
+                transition: "border-color 0.15s",
+                ...(!isSaving && onPollVote ? { "&:hover": { borderColor: POLL_COLOR } } : {}),
+              }}
+            >
+              {hasVoted && pct > 0 && (
+                <Box
+                  sx={{
+                    position: "absolute",
+                    left: 0, top: 0, bottom: 0,
+                    width: `${pct}%`,
+                    backgroundColor: isVoted ? `${POLL_COLOR}1a` : "var(--surface)",
+                    transition: "width 0.4s ease",
+                  }}
+                />
+              )}
+              <Box sx={{ position: "relative", px: 1.5, py: 0.875, display: "flex", alignItems: "center", gap: 1 }}>
+                {isVoted && <IconWrapper icon="mdi:check-circle" size={14} color={POLL_COLOR} />}
+                <Typography variant="body2" sx={{ flex: 1, fontWeight: isVoted ? 600 : 400, fontSize: "0.875rem" }}>
+                  {option}
+                </Typography>
+                {hasVoted && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: isVoted ? POLL_COLOR : "var(--font-secondary)",
+                      fontWeight: isVoted ? 700 : 500,
+                      minWidth: "3ch",
+                      textAlign: "right",
+                    }}
+                  >
+                    {pct}%
+                  </Typography>
+                )}
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+      <Typography variant="caption" color="var(--font-secondary)" sx={{ mt: 0.75, display: "block" }}>
+        {totalVotes} {totalVotes === 1 ? "vote" : "votes"}
+        {!hasVoted && totalVotes === 0 && " · Be the first to vote!"}
+      </Typography>
+    </Box>
+  );
+}

--- a/components/community/QuickCommentBar.tsx
+++ b/components/community/QuickCommentBar.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+
+import { Box, IconButton, InputBase } from "@mui/material";
+
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+interface QuickCommentBarProps {
+  threadId: number;
+  onComment: (threadId: number, body: string) => Promise<void>;
+}
+
+export function QuickCommentBar({ threadId, onComment }: QuickCommentBarProps) {
+  const [commentBar, setCommentBar] = useState({
+    input: "",
+    isFocused: false,
+    isSubmitting: false,
+  });
+
+  const handleSubmit = async () => {
+    if (!commentBar.input.trim()) return;
+    setCommentBar((prev) => ({ ...prev, isSubmitting: true }));
+    try {
+      await onComment(threadId, commentBar.input.trim());
+      setCommentBar({ input: "", isFocused: false, isSubmitting: false });
+    } catch {
+      // handled by parent
+      setCommentBar((prev) => ({ ...prev, isSubmitting: false }));
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        px: 3,
+        py: 1,
+        borderTop: "1px solid var(--border-default)",
+        backgroundColor: commentBar.isFocused
+          ? "color-mix(in srgb, var(--accent-indigo) 4%, var(--card-bg))"
+          : "transparent",
+        transition: "background-color 0.15s",
+        display: "flex",
+        alignItems: "center",
+        gap: 1.25,
+      }}
+    >
+      <IconWrapper icon="mdi:comment-outline" size={15} color="var(--font-tertiary)" />
+      <InputBase
+        placeholder="Write a comment…"
+        value={commentBar.input}
+        onChange={(e) => setCommentBar((prev) => ({ ...prev, input: e.target.value }))}
+        onFocus={() => setCommentBar((prev) => ({ ...prev, isFocused: true }))}
+        onBlur={() => {
+          if (!commentBar.input) setCommentBar((prev) => ({ ...prev, isFocused: false }));
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey && commentBar.input.trim()) {
+            e.preventDefault();
+            handleSubmit();
+          }
+        }}
+        sx={{
+          flex: 1,
+          fontSize: "0.84rem",
+          color: "var(--font-primary)",
+          "& input": {
+            py: 0.375,
+            "&::placeholder": { color: "var(--font-tertiary)", opacity: 1, fontSize: "0.84rem" },
+          },
+        }}
+      />
+      {(commentBar.input.trim() || commentBar.isSubmitting) && (
+        <IconButton
+          size="small"
+          onClick={handleSubmit}
+          disabled={commentBar.isSubmitting || !commentBar.input.trim()}
+          sx={{
+            color: "var(--accent-indigo)",
+            p: 0.5,
+            "&:hover": { backgroundColor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)" },
+          }}
+        >
+          <IconWrapper icon={commentBar.isSubmitting ? "mdi:loading" : "mdi:send"} size={15} />
+        </IconButton>
+      )}
+    </Box>
+  );
+}

--- a/components/community/ThreadCard.tsx
+++ b/components/community/ThreadCard.tsx
@@ -1,236 +1,281 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+
 import { useTranslation } from "react-i18next";
-import {
-  Box,
-  Paper,
-  Typography,
-  Chip,
-  Avatar,
-  IconButton,
-  Tooltip,
-} from "@mui/material";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { Box, Paper, Typography, Chip, Avatar, IconButton, Tooltip } from "@mui/material";
+
+import { POST_TYPE_CONFIG, type Thread } from "@/lib/services/community.service";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { Thread } from "@/lib/services/community.service";
 import { VoteButtons } from "./VoteButtons";
+import { PollWidget } from "./PollWidget";
+import { QuickCommentBar } from "./QuickCommentBar";
+
 import { formatDistanceToNow } from "@/lib/utils/date-utils";
-import { getHtmlPreview } from "@/lib/utils/html-utils";
+
+const CARD_MD_SX = {
+  "& p": { mb: 0.35, mt: 0, lineHeight: 1.65, color: "var(--font-secondary)", fontSize: "0.875rem" },
+  "& h1, & h2, & h3, & h4": {
+    fontSize: "0.92rem", fontWeight: 700, mb: 0.25, mt: 0.25,
+    color: "var(--font-primary)", lineHeight: 1.4,
+  },
+  "& strong": { fontWeight: 700 },
+  "& em": { fontStyle: "italic" },
+  "& code": {
+    fontFamily: "monospace", fontSize: "0.8em",
+    backgroundColor: "rgba(0,0,0,0.06)", borderRadius: "3px", px: "3px", py: "1px",
+  },
+  "& pre": {
+    backgroundColor: "#1a1b26", color: "#c0caf5", borderRadius: "6px",
+    p: 0.75, my: 0.5, overflowX: "auto", fontSize: "0.78rem",
+    "& code": { backgroundColor: "transparent", px: 0 },
+  },
+  "& ul, & ol": { pl: 2, mb: 0.35, mt: 0 },
+  "& li": { mb: 0.1, fontSize: "0.875rem", color: "var(--font-secondary)" },
+  "& blockquote": {
+    borderLeft: "2px solid var(--border-default)", pl: 1, ml: 0,
+    color: "var(--font-secondary)", my: 0.4,
+  },
+  "& a": { color: "var(--accent-indigo)", textDecoration: "underline" },
+  "& hr": { border: "none", borderTop: "1px solid var(--border-default)", my: 0.75 },
+  "& img": { maxWidth: "100%", borderRadius: "6px", my: 0.5 },
+  "& table": { borderCollapse: "collapse", width: "100%", mb: 0.75 },
+  "& th, & td": { border: "1px solid var(--border-default)", px: 1, py: 0.4, fontSize: "0.8rem" },
+};
 
 interface ThreadCardProps {
   thread: Thread;
   onVote: (threadId: number, type: "upvote" | "downvote") => Promise<void>;
   onBookmark?: (threadId: number) => Promise<void>;
+  onPollVote?: (threadId: number, optionIndex: number) => Promise<void>;
+  onComment?: (threadId: number, body: string) => Promise<void>;
 }
 
-export function ThreadCard({ thread, onVote, onBookmark }: ThreadCardProps) {
+export function ThreadCard({ thread, onVote, onBookmark, onPollVote, onComment }: ThreadCardProps) {
   const router = useRouter();
   const { t } = useTranslation("common");
 
+  const isSaving = thread.id < 0;
+  const isPoll = thread.post_type === "poll" && !!thread.poll_options?.length;
+  const isBodyLong = (thread.body?.length ?? 0) > 400;
+
   const handleThreadClick = () => {
+    if (isSaving) return;
     router.push(`/community/${thread.id}`);
   };
+
+  const pt = (thread.post_type || "question") as keyof typeof POST_TYPE_CONFIG;
+  const postTypeCfg = POST_TYPE_CONFIG[pt];
 
   return (
     <Paper
       elevation={0}
       sx={{
-        p: 3,
         border: "1px solid var(--border-default)",
         borderRadius: 2,
         background: "var(--card-bg)",
         transition: "all 0.2s",
-        "&:hover": {
-          borderColor:
-            "color-mix(in srgb, var(--border-default) 70%, var(--font-secondary) 30%)",
-          boxShadow:
-            "0 2px 8px color-mix(in srgb, var(--font-primary) 18%, transparent)",
-        },
+        opacity: isSaving ? 0.72 : 1,
+        overflow: "hidden",
+        ...(isSaving ? {} : {
+          "&:hover": {
+            borderColor: "color-mix(in srgb, var(--border-default) 70%, var(--font-secondary) 30%)",
+            boxShadow: "0 2px 8px color-mix(in srgb, var(--font-primary) 18%, transparent)",
+          },
+        }),
       }}
     >
-      <Box sx={{ display: "flex", gap: 3 }}>
-        {/* Vote Buttons */}
-        <Box
-          sx={{
-            minWidth: 56,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-          }}
-        >
-          <VoteButtons
-            upvotes={thread.upvotes}
-            downvotes={thread.downvotes}
-            userVote={thread.user_vote}
-            onVote={(type) => onVote(thread.id, type)}
-            size="small"
-            orientation="vertical"
-          />
-        </Box>
-
-        {/* Thread Content */}
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          {/* Title */}
-          <Typography
-            variant="h6"
-            fontWeight={600}
-            sx={{
-              mb: 1,
-              cursor: "pointer",
-              color: "var(--font-primary)",
-              "&:hover": {
-                color: "var(--accent-indigo)",
-              },
-            }}
-            onClick={handleThreadClick}
-          >
-            {thread.title}
-          </Typography>
-
-          {/* Body Preview */}
-          <Typography
-            variant="body2"
-            color="var(--font-secondary)"
-            sx={{
-              mb: 1.5,
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-            }}
-          >
-            {thread.body ? getHtmlPreview(thread.body, 150) : ""}
-          </Typography>
-
-          {/* Tags */}
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 2 }}>
-            {thread.tags.map((tag) => (
-              <Chip
-                key={tag.id}
-                label={tag.name}
-                size="small"
-                sx={{
-                  backgroundColor:
-                    "color-mix(in srgb, var(--accent-indigo) 18%, var(--surface) 82%)",
-                  color: "var(--accent-indigo)",
-                  fontWeight: 600,
-                  fontSize: "0.75rem",
-                  height: 26,
-                  borderRadius: "6px",
-                  "&:hover": {
-                    backgroundColor:
-                      "color-mix(in srgb, var(--accent-indigo) 26%, var(--surface) 74%)",
-                  },
-                }}
-              />
-            ))}
+      <Box sx={{ p: 3 }}>
+        <Box sx={{ display: "flex", gap: 3, alignItems: "flex-start" }}>
+          {/* Vote Buttons */}
+          <Box sx={{ minWidth: 56, display: "flex", flexDirection: "column", alignItems: "center", pt: 0.25 }}>
+            <VoteButtons
+              upvotes={thread.upvotes}
+              downvotes={thread.downvotes}
+              userVote={thread.user_vote}
+              onVote={(type) => onVote(thread.id, type)}
+              size="small"
+              orientation="vertical"
+              disabled={isSaving}
+            />
           </Box>
 
-          {/* Meta Info */}
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 3,
-              flexWrap: "wrap",
-            }}
-          >
-            {/* Author */}
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <Avatar
-                src={thread.author.profile_pic_url}
-                sx={{ width: 20, height: 20 }}
-              >
-                {thread.author.name.charAt(0)}
-              </Avatar>
-              <Typography variant="caption" color="var(--font-secondary)">
-                {thread.author.name}
-              </Typography>
+          {/* Thread Content */}
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {/* Top row: post-type badge + timestamp */}
+            <Box sx={{ display: "flex", alignItems: "center", mb: 0.75 }}>
               <Chip
-                label={thread.author.role}
+                icon={<IconWrapper icon={postTypeCfg.icon} size={12} color={postTypeCfg.color} />}
+                label={postTypeCfg.label}
                 size="small"
                 sx={{
-                  height: 18,
-                  fontSize: "0.65rem",
-                  backgroundColor: "var(--surface)",
-                  border: "1px solid var(--border-default)",
-                  color: "var(--font-secondary)",
+                  height: 20, fontSize: "0.67rem", fontWeight: 600, letterSpacing: "0.02em",
+                  backgroundColor: `${postTypeCfg.color}12`, color: postTypeCfg.color,
+                  border: `1px solid ${postTypeCfg.color}28`,
+                  "& .MuiChip-icon": { ml: 0.5 },
                 }}
               />
-            </Box>
-
-            {/* Stats */}
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 2,
-                ml: "auto",
-              }}
-            >
-              <Tooltip title={t("community.comments")}>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                  <IconWrapper
-                    icon="mdi:comment-outline"
-                    size={16}
-                    color="var(--font-secondary)"
-                  />
-                  <Typography variant="caption" color="var(--font-secondary)">
-                    {thread.comments_count}
-                  </Typography>
-                </Box>
-              </Tooltip>
-
-              <Tooltip title={t("community.bookmarks")}>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                  <IconWrapper
-                    icon="mdi:bookmark-outline"
-                    size={16}
-                    color="var(--font-secondary)"
-                  />
-                  <Typography variant="caption" color="var(--font-secondary)">
-                    {thread.bookmarks_count}
-                  </Typography>
-                </Box>
-              </Tooltip>
-
-              <Typography variant="caption" color="var(--font-secondary)">
+              <Typography variant="caption" sx={{ ml: "auto", color: "var(--font-secondary)", whiteSpace: "nowrap", fontSize: "0.75rem" }}>
                 {formatDistanceToNow(thread.created_at)}
               </Typography>
             </Box>
 
-            {/* Bookmark Button */}
-            {onBookmark && (
-              <Box sx={{ marginInlineStart: "auto" }}>
-                <Tooltip title={thread.user_bookmarked ? t("community.removeBookmark") : t("community.bookmark")}>
-                  <IconButton
-                    size="small"
-                    onClick={() => onBookmark(thread.id)}
-                    sx={{
-                      color: "var(--font-secondary)",
-                      backgroundColor: "transparent",
-                      "&:hover": {
-                        backgroundColor:
-                          "color-mix(in srgb, var(--font-primary) 8%, transparent)",
-                      },
-                    }}
-                  >
-                    <IconWrapper
-                      icon={
-                        thread.user_bookmarked
-                          ? "mdi:bookmark"
-                          : "mdi:bookmark-outline"
-                      }
-                      size={20}
-                    />
-                  </IconButton>
-                </Tooltip>
+            {/* Title */}
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.75 }}>
+              <Typography
+                variant="h6"
+                fontWeight={600}
+                onClick={handleThreadClick}
+                sx={{
+                  cursor: isSaving ? "default" : "pointer",
+                  color: "var(--font-primary)",
+                  ...(!isSaving && { "&:hover": { color: "var(--accent-indigo)" } }),
+                }}
+              >
+                {thread.title}
+              </Typography>
+              {isSaving && (
+                <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontStyle: "italic", whiteSpace: "nowrap", flexShrink: 0 }}>
+                  Saving…
+                </Typography>
+              )}
+            </Box>
+
+            {/* Body — rendered as markdown, gradient fade for long posts */}
+            {thread.body && (
+              <Box
+                sx={{
+                  position: "relative",
+                  mb: isPoll ? 1 : 1.5,
+                  ...(isBodyLong ? {
+                    maxHeight: 96,
+                    overflow: "hidden",
+                    "&::after": {
+                      content: '""',
+                      position: "absolute",
+                      bottom: 0, left: 0, right: 0,
+                      height: 48,
+                      background: "linear-gradient(to bottom, transparent, var(--card-bg))",
+                      pointerEvents: "none",
+                    },
+                  } : {}),
+                  ...CARD_MD_SX,
+                }}
+              >
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{thread.body}</ReactMarkdown>
               </Box>
             )}
+
+            {/* Attached images */}
+            {thread.image_urls && thread.image_urls.length > 0 && (
+              <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap", mb: isPoll ? 1 : 1.5 }}>
+                {thread.image_urls.slice(0, 4).map((url, i) => (
+                  <Box
+                    key={i}
+                    component="img"
+                    src={url}
+                    alt=""
+                    sx={{ width: 72, height: 72, objectFit: "cover", borderRadius: "8px", border: "1px solid var(--border-default)", cursor: "pointer" }}
+                    onClick={handleThreadClick}
+                  />
+                ))}
+                {thread.image_urls.length > 4 && (
+                  <Box
+                    onClick={handleThreadClick}
+                    sx={{
+                      width: 72, height: 72, borderRadius: "8px",
+                      border: "1px solid var(--border-default)", backgroundColor: "var(--surface)",
+                      display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer",
+                    }}
+                  >
+                    <Typography variant="caption" fontWeight={600} color="var(--font-secondary)">
+                      +{thread.image_urls.length - 4}
+                    </Typography>
+                  </Box>
+                )}
+              </Box>
+            )}
+
+            {/* Inline Poll */}
+            {isPoll && (
+              <PollWidget thread={thread} onPollVote={onPollVote} isSaving={isSaving} />
+            )}
+
+            {/* Tags */}
+            {thread.tags.length > 0 && (
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 2 }}>
+                {thread.tags.map((tag) => (
+                  <Chip
+                    key={tag.id}
+                    label={tag.name}
+                    size="small"
+                    sx={{
+                      backgroundColor: "color-mix(in srgb, var(--accent-indigo) 18%, var(--surface) 82%)",
+                      color: "var(--accent-indigo)", fontWeight: 600, fontSize: "0.75rem",
+                      height: 26, borderRadius: "6px",
+                      "&:hover": { backgroundColor: "color-mix(in srgb, var(--accent-indigo) 26%, var(--surface) 74%)" },
+                    }}
+                  />
+                ))}
+              </Box>
+            )}
+
+            {/* Meta row: author + stats */}
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Avatar src={thread.author.profile_pic_url} sx={{ width: 20, height: 20 }}>
+                  {thread.author.name.charAt(0)}
+                </Avatar>
+                <Typography variant="caption" color="var(--font-secondary)">{thread.author.name}</Typography>
+                <Chip
+                  label={thread.author.role}
+                  size="small"
+                  sx={{ height: 18, fontSize: "0.65rem", backgroundColor: "var(--surface)", border: "1px solid var(--border-default)", color: "var(--font-secondary)" }}
+                />
+              </Box>
+
+              <Box sx={{ ml: "auto", display: "flex", alignItems: "center", gap: 0.5 }}>
+                <Tooltip title={t("community.comments")}>
+                  <Box
+                    onClick={handleThreadClick}
+                    sx={{ display: "flex", alignItems: "center", gap: 0.5, px: 1, cursor: "pointer", borderRadius: "6px", "&:hover": { backgroundColor: "color-mix(in srgb, var(--font-primary) 6%, transparent)" } }}
+                  >
+                    <IconWrapper icon="mdi:comment-outline" size={16} color="var(--font-secondary)" />
+                    <Typography variant="caption" color="var(--font-secondary)">{thread.comments_count}</Typography>
+                  </Box>
+                </Tooltip>
+
+                {onBookmark && !isSaving && (
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                    <Tooltip title={thread.user_bookmarked ? t("community.removeBookmark") : t("community.bookmark")}>
+                      <IconButton
+                        size="small"
+                        onClick={() => onBookmark(thread.id)}
+                        sx={{ color: "var(--font-secondary)", "&:hover": { backgroundColor: "color-mix(in srgb, var(--font-primary) 8%, transparent)" } }}
+                      >
+                        <IconWrapper icon={thread.user_bookmarked ? "mdi:bookmark" : "mdi:bookmark-outline"} size={20} />
+                      </IconButton>
+                    </Tooltip>
+                    <Typography
+                      variant="caption"
+                      sx={{ color: "var(--font-secondary)", fontSize: "0.75rem", minWidth: "1ch", visibility: thread.bookmarks_count > 0 ? "visible" : "hidden" }}
+                    >
+                      {thread.bookmarks_count}
+                    </Typography>
+                  </Box>
+                )}
+              </Box>
+            </Box>
           </Box>
         </Box>
       </Box>
+
+      {/* Quick comment bar */}
+      {onComment && !isSaving && (
+        <QuickCommentBar threadId={thread.id} onComment={onComment} />
+      )}
     </Paper>
   );
 }

--- a/components/community/VoteButtons.tsx
+++ b/components/community/VoteButtons.tsx
@@ -11,6 +11,7 @@ interface VoteButtonsProps {
   onVote: (type: "upvote" | "downvote") => Promise<void>;
   size?: "small" | "medium";
   orientation?: "vertical" | "horizontal";
+  disabled?: boolean;
 }
 
 export function VoteButtons({
@@ -20,6 +21,7 @@ export function VoteButtons({
   onVote,
   size = "medium",
   orientation = "vertical",
+  disabled = false,
 }: VoteButtonsProps) {
   const [voting, setVoting] = useState(false);
 
@@ -58,7 +60,7 @@ export function VoteButtons({
         <IconButton
           size={size}
           onClick={() => handleVote("upvote")}
-          disabled={voting}
+          disabled={voting || disabled}
           sx={{
             color: "var(--font-secondary)",
             backgroundColor: "transparent",

--- a/lib/services/community.service.ts
+++ b/lib/services/community.service.ts
@@ -1,6 +1,48 @@
 import apiClient from "./api";
 import { config } from "../config";
 
+export type PostType = "question" | "poll" | "resource" | "humorous" | "discussion";
+
+export interface PostTypeConfig {
+  label: string;
+  icon: string;
+  color: string;
+  description: string;
+}
+
+export const POST_TYPE_CONFIG: Record<PostType, PostTypeConfig> = {
+  question: {
+    label: "Question",
+    icon: "mdi:help-circle-outline",
+    color: "#6366f1",
+    description: "Ask the community",
+  },
+  poll: {
+    label: "Poll",
+    icon: "mdi:chart-bar",
+    color: "#8b5cf6",
+    description: "Get community opinion",
+  },
+  resource: {
+    label: "Resource",
+    icon: "mdi:book-open-outline",
+    color: "#0ea5e9",
+    description: "Share a useful resource",
+  },
+  humorous: {
+    label: "Humorous",
+    icon: "mdi:emoticon-happy-outline",
+    color: "#f59e0b",
+    description: "Share something fun",
+  },
+  discussion: {
+    label: "Discussion",
+    icon: "mdi:forum-outline",
+    color: "#10b981",
+    description: "Start a conversation",
+  },
+};
+
 export interface Author {
   id: number;
   user_name: string;
@@ -28,6 +70,11 @@ export interface Thread {
   comments_count: number;
   created_at: string;
   updated_at: string;
+  post_type?: PostType;
+  poll_options?: string[];
+  poll_results?: number[];
+  user_poll_vote?: number | null;
+  image_urls?: string[];
 }
 
 export interface Comment {
@@ -51,6 +98,9 @@ export interface CreateThreadRequest {
   title: string;
   body: string;
   tag_ids: number[];
+  post_type?: PostType;
+  poll_options?: string[];
+  image_urls?: string[];
 }
 
 export interface CreateCommentRequest {
@@ -170,12 +220,36 @@ export const communityService = {
     return response.data;
   },
 
+  // Poll voting
+  votePoll: async (
+    threadId: number,
+    optionIndex: number
+  ): Promise<{ user_poll_vote: number | null; poll_results: number[] }> => {
+    const response = await apiClient.post(
+      `/community-forum/api/clients/${config.clientId}/threads/${threadId}/poll-vote/`,
+      { option_index: optionIndex }
+    );
+    return response.data;
+  },
+
   // Bookmarks
   bookmarkThread: async (
     threadId: number
   ): Promise<{ id: number; message: string }> => {
     const response = await apiClient.post<{ id: number; message: string }>(
       `/community-forum/api/clients/${config.clientId}/threads/${threadId}/bookmark/`
+    );
+    return response.data;
+  },
+
+  // File uploads
+  uploadFile: async (file: File): Promise<{ id: number; url: string; storage_path: string }> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("module", "community_forum");
+    const response = await apiClient.post(
+      `/api/clients/${config.clientId}/upload/`,
+      formData
     );
     return response.data;
   },

--- a/lib/utils/html-utils.ts
+++ b/lib/utils/html-utils.ts
@@ -36,6 +36,45 @@ export const getHtmlPreview = (html: string, maxLength: number = 150): string =>
 };
 
 /**
+ * Treat single newlines as paragraph breaks so user-entered Enter
+ * renders as visible line separation in ReactMarkdown output.
+ * Code fences are left untouched.
+ */
+export const softBreakMarkdown = (md: string): string => {
+  if (!md) return md;
+  const parts = md.split(/(```[\s\S]*?```)/g);
+  return parts
+    .map((chunk, i) =>
+      i % 2 === 1
+        ? chunk
+        : chunk.replace(/(?<!\n)\n(?!\n)/g, "\n\n")
+    )
+    .join("");
+};
+
+/**
+ * Strip markdown syntax for clean plain-text preview in feed cards.
+ */
+export const stripMarkdownForPreview = (md: string, maxLength = 160): string => {
+  if (!md) return "";
+  const text = md
+    .replace(/```[\s\S]*?```/g, "[code]")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*\*([^*]+)\*\*\*/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/#{1,6}\s+(.+)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/^\s*\d+\.\s+/gm, "")
+    .replace(/^\s*>\s+/gm, "")
+    .replace(/!\[([^\]]*)\]\([^\)]+\)/g, "$1")
+    .replace(/\n+/g, " ")
+    .trim();
+  return text.length > maxLength ? text.slice(0, maxLength).trimEnd() + "…" : text;
+};
+
+/**
  * Check if HTML is escaped (contains &lt; or &gt;)
  */
 export const isHtmlEscaped = (text: string): boolean => {


### PR DESCRIPTION


- Poll options render inline in thread feed with live vote percentages
- ReactMarkdown with gradient fade for long post bodies in feed
- Instagram-style threaded replies with avatar column and connecting lines
- QuickCommentBar on each thread card for commenting without opening thread
- PollWidget and QuickCommentBar extracted as standalone components
- votePoll service method; optimistic updates for poll votes and quick comments
- Post body optional for poll and resource post types in CreateThreadDialog