### PR TITLE
feat(setup): tenant first-login setup wizard (8 steps)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,7 @@ import { I18nProvider } from "@/components/providers/I18nProvider";
 import { DirectionSync } from "@/components/providers/DirectionSync";
 import { TelemetryProvider } from "@/components/providers/TelemetryProvider";
 import { ProfileActivationBlocker } from "@/components/auth/ProfileActivationBlocker";
+import { TenantSetupBlocker } from "@/components/auth/TenantSetupBlocker";
 import { config } from "@/lib/config";
 
 /* ✅ Metadata (SEO) */
@@ -95,6 +96,7 @@ export default async function RootLayout({
                             <TelemetryProvider>
                               <ToastProvider>
                                 <ProfileActivationBlocker />
+                                <TenantSetupBlocker />
                                 {children}
                               </ToastProvider>
                             </TelemetryProvider>

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Cookies from "js-cookie";
+import { wizardService, type WizardState } from "@/lib/services/wizard.service";
+import { SetupWizard } from "@/components/setup/SetupWizard";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
+
+export default function SetupPage() {
+  const router = useRouter();
+  const { isAuthenticated, loading: isLoading } = useAuth();
+  const [state, setState] = useState<WizardState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!isAuthenticated) {
+      router.replace("/login?next=/setup");
+      return;
+    }
+    const role = Cookies.get("user_role") || "";
+    if (!isClientOrgAdminRole(role)) {
+      router.replace("/dashboard");
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const s = await wizardService.getState();
+        if (cancelled) return;
+        if (s.setup_completed) {
+          router.replace("/admin/dashboard");
+          return;
+        }
+        setState(s);
+      } catch (e: any) {
+        if (!cancelled) {
+          setError(
+            e?.response?.data?.detail ||
+              "Could not load the setup wizard."
+          );
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, isLoading, router]);
+
+  if (error) {
+    return (
+      <div className="grid min-h-screen place-items-center px-6">
+        <div className="max-w-md rounded-2xl border border-red-200 bg-red-50 p-6 text-center text-red-700">
+          <h2 className="text-lg font-semibold">Setup unavailable</h2>
+          <p className="mt-2 text-sm">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!state) {
+    return (
+      <div className="grid min-h-screen place-items-center">
+        <p className="font-mono text-xs uppercase tracking-widest text-gray-500">
+          Loading setup wizard…
+        </p>
+      </div>
+    );
+  }
+
+  return <SetupWizard initialState={state} />;
+}

--- a/components/auth/TenantSetupBlocker.tsx
+++ b/components/auth/TenantSetupBlocker.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import Cookies from "js-cookie";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
+
+/**
+ * Redirects tenant admins to `/setup` while their tenant hasn't completed the
+ * first-login setup wizard. Lets students and instructors through unchanged.
+ */
+export function TenantSetupBlocker() {
+  const { clientInfo, loading } = useClientInfo();
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (loading || !isAuthenticated || !clientInfo) return;
+    if (clientInfo.setup_completed !== false) return; // explicit false only
+    const role = Cookies.get("user_role") || "";
+    if (!isClientOrgAdminRole(role)) return;
+    if (pathname === "/setup" || pathname?.startsWith("/setup/")) return;
+    router.replace("/setup");
+  }, [clientInfo, loading, isAuthenticated, pathname, router]);
+
+  return null;
+}

--- a/components/setup/SetupWizard.tsx
+++ b/components/setup/SetupWizard.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { WizardLayout } from "./WizardLayout";
+import { WizardNav } from "./WizardNav";
+import { WelcomeStep } from "./steps/WelcomeStep";
+import { BrandStep } from "./steps/BrandStep";
+import { UrlStep } from "./steps/UrlStep";
+import { ThemeStep } from "./steps/ThemeStep";
+import { FeaturesStep } from "./steps/FeaturesStep";
+import { AdminCapsStep } from "./steps/AdminCapsStep";
+import { CourseLibraryStep } from "./steps/CourseLibraryStep";
+import { ReviewStep } from "./steps/ReviewStep";
+import { STEP_TITLES, TOTAL_WIZARD_STEPS, WizardData } from "@/lib/setup/wizardData";
+import { wizardService, WizardState } from "@/lib/services/wizard.service";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+
+const STEP_DESCRIPTIONS: string[] = [
+  "Let's make sure we have your basics right before we customise the platform.",
+  "Upload your logos and pick colours that match your brand. You'll see a live preview on the right.",
+  "Your LMS URL is permanent. Optionally connect a custom domain you already own.",
+  "Pick a starting template, default colour mode, and a welcome message for your learners.",
+  "Toggle the modules your learners and admins will see in the sidebar.",
+  "Decide what your tenant admins are allowed to do day-to-day.",
+  "Choose how your course library is seeded. You can always add more later.",
+  "Final check before going live.",
+];
+
+interface Props {
+  initialState: WizardState;
+}
+
+export function SetupWizard({ initialState }: Props) {
+  const router = useRouter();
+  const { refreshClientInfo } = useClientInfo();
+  const [state, setState] = useState<WizardState>(initialState);
+  const [data, setData] = useState<WizardData>(
+    (initialState.wizard_state as WizardData) || {}
+  );
+  const [step, setStep] = useState<number>(
+    Math.max(1, Math.min(initialState.setup_step || 1, TOTAL_WIZARD_STEPS))
+  );
+  const [saving, setSaving] = useState(false);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+
+  // Debounced autosave
+  const dirtyRef = useRef(false);
+  const saveTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const persist = async (override?: {
+    nextData?: WizardData;
+    nextStep?: number;
+  }) => {
+    const payload = {
+      wizard_state: override?.nextData ?? data,
+      setup_step: override?.nextStep ?? step,
+    };
+    setSaving(true);
+    try {
+      const updated = await wizardService.saveState(payload);
+      setState(updated);
+      dirtyRef.current = false;
+    } catch {
+      /* leave dirty for retry */
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Schedule debounced save when data changes
+  useEffect(() => {
+    if (!dirtyRef.current) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      void persist();
+    }, 800);
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  const updateData = (patch: Partial<WizardData>) => {
+    dirtyRef.current = true;
+    setData((prev) => ({ ...prev, ...patch }));
+  };
+
+  const goNext = async () => {
+    if (step < TOTAL_WIZARD_STEPS) {
+      const nextStep = step + 1;
+      setStep(nextStep);
+      await persist({ nextStep });
+      return;
+    }
+    // Final step → launch
+    await onLaunch();
+  };
+
+  const goBack = () => {
+    if (step > 1) {
+      const nextStep = step - 1;
+      setStep(nextStep);
+      void persist({ nextStep });
+    }
+  };
+
+  const jumpTo = (target: number) => {
+    if (target < 1 || target > TOTAL_WIZARD_STEPS) return;
+    setStep(target);
+    void persist({ nextStep: target });
+  };
+
+  const onLaunch = async () => {
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      await wizardService.launch(data);
+      await refreshClientInfo();
+      router.replace("/admin/dashboard");
+    } catch (err: any) {
+      setLaunchError(
+        err?.response?.data?.detail ||
+          err?.message ||
+          "We couldn't launch your LMS. Please try again."
+      );
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  const canGoNext = useMemo(() => {
+    switch (step) {
+      case 1:
+        return Boolean(
+          (data.welcome?.confirmed_org_name || state.organisation_name || "")
+            .trim().length >= 2
+        );
+      case 2:
+        // Require at least a primary colour or logo to move on
+        return Boolean(
+          data.brand?.primary_color || data.brand?.light_logo_url
+        );
+      case 5:
+        return (data.features?.selected_feature_ids?.length || 0) > 0;
+      case 7:
+        return Boolean(data.course_library?.choice);
+      default:
+        return true;
+    }
+  }, [step, data, state.organisation_name]);
+
+  return (
+    <WizardLayout
+      step={step}
+      title={STEP_TITLES[step - 1]}
+      description={STEP_DESCRIPTIONS[step - 1]}
+      saving={saving}
+    >
+      {step === 1 ? (
+        <WelcomeStep state={state} data={data} onChange={updateData} />
+      ) : null}
+      {step === 2 ? <BrandStep data={data} onChange={updateData} /> : null}
+      {step === 3 ? <UrlStep state={state} data={data} onChange={updateData} /> : null}
+      {step === 4 ? <ThemeStep data={data} onChange={updateData} /> : null}
+      {step === 5 ? <FeaturesStep data={data} onChange={updateData} /> : null}
+      {step === 6 ? <AdminCapsStep data={data} onChange={updateData} /> : null}
+      {step === 7 ? <CourseLibraryStep data={data} onChange={updateData} /> : null}
+      {step === 8 ? (
+        <ReviewStep state={state} data={data} onJumpToStep={jumpTo} />
+      ) : null}
+
+      {launchError ? (
+        <p className="mt-6 text-sm text-red-600">{launchError}</p>
+      ) : null}
+
+      <WizardNav
+        step={step}
+        canGoBack={step > 1 && !launching}
+        canGoNext={canGoNext}
+        onBack={goBack}
+        onNext={goNext}
+        nextLoading={launching}
+      />
+    </WizardLayout>
+  );
+}

--- a/components/setup/WizardLayout.tsx
+++ b/components/setup/WizardLayout.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { ReactNode } from "react";
+import { STEP_TITLES, TOTAL_WIZARD_STEPS } from "@/lib/setup/wizardData";
+
+interface WizardLayoutProps {
+  step: number; // 1..8
+  title: string;
+  description?: string;
+  children: ReactNode;
+  saving?: boolean;
+}
+
+export function WizardLayout({
+  step,
+  title,
+  description,
+  children,
+  saving,
+}: WizardLayoutProps) {
+  const progress = Math.round((step / TOTAL_WIZARD_STEPS) * 100);
+  return (
+    <div className="min-h-screen bg-[var(--bg-page,#f8fafc)] text-[var(--font-primary,#0f172a)]">
+      <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/80 backdrop-blur-md">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+              Setup wizard
+            </p>
+            <p className="text-sm text-gray-700">
+              Step {step} of {TOTAL_WIZARD_STEPS} ·{" "}
+              <span className="font-medium">{STEP_TITLES[step - 1]}</span>
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-gray-500">
+            {saving ? <span>Saving…</span> : <span>Autosaved</span>}
+            <span className="font-mono">{progress}%</span>
+          </div>
+        </div>
+        <div className="h-1 w-full bg-gray-100">
+          <div
+            className="h-full bg-gradient-to-r from-[var(--primary-500,#2356d6)] to-[var(--accent-blue,#00e0ff)] transition-all duration-500"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 py-12">
+        <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">
+          {title}
+        </h1>
+        {description ? (
+          <p className="mt-3 text-base leading-relaxed text-gray-600">
+            {description}
+          </p>
+        ) : null}
+        <div className="mt-10">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/components/setup/WizardNav.tsx
+++ b/components/setup/WizardNav.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { TOTAL_WIZARD_STEPS } from "@/lib/setup/wizardData";
+
+interface WizardNavProps {
+  step: number;
+  canGoBack?: boolean;
+  canGoNext?: boolean;
+  onBack: () => void;
+  onNext: () => void;
+  nextLabel?: string;
+  nextLoading?: boolean;
+}
+
+export function WizardNav({
+  step,
+  canGoBack = true,
+  canGoNext = true,
+  onBack,
+  onNext,
+  nextLabel,
+  nextLoading,
+}: WizardNavProps) {
+  const isFinal = step >= TOTAL_WIZARD_STEPS;
+  return (
+    <div className="mt-12 flex items-center justify-between border-t border-gray-200 pt-6">
+      <button
+        type="button"
+        onClick={onBack}
+        disabled={!canGoBack || step <= 1}
+        className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        ← Back
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={!canGoNext || nextLoading}
+        className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-[var(--primary-600,#1d4ed8)] to-[var(--accent-blue,#00e0ff)] px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {nextLoading ? (
+          <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-white border-r-transparent" />
+        ) : null}
+        {nextLabel || (isFinal ? "Launch My LMS" : "Continue")}
+        {!isFinal ? <span aria-hidden="true">→</span> : null}
+      </button>
+    </div>
+  );
+}

--- a/components/setup/steps/AdminCapsStep.tsx
+++ b/components/setup/steps/AdminCapsStep.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { WizardData } from "@/lib/setup/wizardData";
+
+interface Props {
+  data: WizardData;
+  onChange: (patch: Partial<WizardData>) => void;
+}
+
+const TOGGLES: {
+  key: keyof NonNullable<WizardData["admin_caps"]>;
+  label: string;
+  desc: string;
+}[] = [
+  {
+    key: "bulk_import",
+    label: "Bulk learner import",
+    desc: "Allow admins to upload CSV files to add learners in bulk.",
+  },
+  {
+    key: "ai_builder",
+    label: "AI course builder",
+    desc: "Generate course outlines and content with AI assistance.",
+  },
+  {
+    key: "sub_admin_creation",
+    label: "Sub-admins",
+    desc: "Let primary admins create additional sub-admin accounts.",
+  },
+  {
+    key: "api_access",
+    label: "API access",
+    desc: "Generate API keys for integrating with external systems.",
+  },
+];
+
+export function AdminCapsStep({ data, onChange }: Props) {
+  const caps = data.admin_caps || {};
+  const set = (patch: Partial<WizardData["admin_caps"]>) =>
+    onChange({ admin_caps: { ...caps, ...patch } });
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-gray-600">
+        Choose what your tenant administrators can do. Enable just what your
+        org needs — you can always change these later.
+      </p>
+
+      <div className="space-y-3">
+        {TOGGLES.map((t) => {
+          const on = Boolean(caps[t.key]);
+          return (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => set({ [t.key]: !on })}
+              className={`flex w-full items-start justify-between gap-4 rounded-xl border p-4 text-left transition ${
+                on
+                  ? "border-[var(--primary-500,#2356d6)] bg-[var(--primary-50,#eff6ff)]"
+                  : "border-gray-200 bg-white hover:border-gray-300"
+              }`}
+            >
+              <div className="flex-1">
+                <p className="text-sm font-semibold text-gray-900">{t.label}</p>
+                <p className="mt-0.5 text-xs text-gray-500">{t.desc}</p>
+              </div>
+              <div
+                className={`relative h-6 w-11 shrink-0 rounded-full transition ${
+                  on ? "bg-[var(--primary-500,#2356d6)]" : "bg-gray-200"
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-all ${
+                    on ? "left-5" : "left-0.5"
+                  }`}
+                />
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="rounded-xl border border-gray-200 bg-white p-4">
+        <p className="text-sm font-medium text-gray-700 mb-2">
+          Analytics depth
+        </p>
+        <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+          {(["basic", "advanced"] as const).map((d) => (
+            <button
+              key={d}
+              type="button"
+              onClick={() => set({ analytics_depth: d })}
+              className={`px-4 py-1.5 rounded-md text-sm font-medium transition ${
+                (caps.analytics_depth || "basic") === d
+                  ? "bg-white shadow-sm text-gray-900"
+                  : "text-gray-600"
+              }`}
+            >
+              {d === "basic" ? "Basic" : "Advanced"}
+            </button>
+          ))}
+        </div>
+        <p className="mt-2 text-xs text-gray-500">
+          Basic: progress, attempts, completion. Advanced adds funnels, cohort
+          comparisons, and time-on-task.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/setup/steps/BrandStep.tsx
+++ b/components/setup/steps/BrandStep.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState } from "react";
+import { WizardData } from "@/lib/setup/wizardData";
+import { wizardService } from "@/lib/services/wizard.service";
+
+interface Props {
+  data: WizardData;
+  onChange: (patch: Partial<WizardData>) => void;
+}
+
+async function upload(file: File, kind: string): Promise<string | null> {
+  try {
+    const r = await wizardService.uploadAsset(file, kind);
+    return r.url;
+  } catch {
+    return null;
+  }
+}
+
+function AssetField({
+  label,
+  hint,
+  kind,
+  value,
+  onUploaded,
+}: {
+  label: string;
+  hint?: string;
+  kind: string;
+  value?: string;
+  onUploaded: (url: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  return (
+    <div>
+      <p className="text-sm font-medium text-gray-700">{label}</p>
+      {hint ? <p className="text-xs text-gray-500">{hint}</p> : null}
+      <div className="mt-2 flex items-center gap-4">
+        <div className="grid h-16 w-16 place-items-center overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
+          {value ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={value}
+              alt={label}
+              className="h-full w-full object-contain"
+            />
+          ) : (
+            <span className="text-xs text-gray-400">—</span>
+          )}
+        </div>
+        <label className="cursor-pointer rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
+          {busy ? "Uploading…" : value ? "Replace" : "Upload"}
+          <input
+            type="file"
+            accept="image/*"
+            disabled={busy}
+            className="hidden"
+            onChange={async (e) => {
+              const f = e.target.files?.[0];
+              if (!f) return;
+              setBusy(true);
+              const url = await upload(f, kind);
+              setBusy(false);
+              if (url) onUploaded(url);
+              e.target.value = "";
+            }}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function ColorField({
+  label,
+  value,
+  onChange,
+  fallback,
+}: {
+  label: string;
+  value?: string;
+  onChange: (hex: string) => void;
+  fallback: string;
+}) {
+  const v = value || fallback;
+  return (
+    <label className="block">
+      <span className="text-sm font-medium text-gray-700">{label}</span>
+      <div className="mt-1.5 flex items-center gap-3">
+        <input
+          type="color"
+          value={v}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-10 w-12 cursor-pointer rounded-md border border-gray-300 bg-white"
+        />
+        <input
+          type="text"
+          value={v}
+          onChange={(e) => onChange(e.target.value)}
+          className="block w-32 rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm uppercase shadow-sm focus:border-[var(--primary-500,#2356d6)] focus:ring-1 focus:ring-[var(--primary-500,#2356d6)]"
+        />
+      </div>
+    </label>
+  );
+}
+
+export function BrandStep({ data, onChange }: Props) {
+  const brand = data.brand || {};
+  const set = (patch: Partial<WizardData["brand"]>) =>
+    onChange({ brand: { ...brand, ...patch } });
+
+  return (
+    <div className="grid gap-8 md:grid-cols-[1.1fr,1fr]">
+      <div className="space-y-6">
+        <AssetField
+          label="Light-mode logo"
+          hint="Used on the main app shell. PNG or SVG, transparent background works best."
+          kind="light_logo"
+          value={brand.light_logo_url}
+          onUploaded={(url) => set({ light_logo_url: url })}
+        />
+        <AssetField
+          label="Dark-mode logo"
+          hint="Optional. Same as above but tuned for dark backgrounds."
+          kind="dark_logo"
+          value={brand.dark_logo_url}
+          onUploaded={(url) => set({ dark_logo_url: url })}
+        />
+        <AssetField
+          label="Favicon"
+          hint="32×32 PNG or ICO. Shows in browser tabs."
+          kind="favicon"
+          value={brand.favicon_url}
+          onUploaded={(url) => set({ favicon_url: url })}
+        />
+        <div className="grid grid-cols-2 gap-4">
+          <ColorField
+            label="Primary"
+            value={brand.primary_color}
+            onChange={(v) => set({ primary_color: v })}
+            fallback="#2356d6"
+          />
+          <ColorField
+            label="Accent"
+            value={brand.accent_color}
+            onChange={(v) => set({ accent_color: v })}
+            fallback="#00e0ff"
+          />
+        </div>
+      </div>
+
+      <aside className="rounded-2xl border border-gray-200 bg-gray-50 p-6">
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+          Live preview
+        </p>
+        <div
+          className="mt-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
+          style={{
+            borderTopColor: brand.primary_color || "#2356d6",
+            borderTopWidth: 3,
+          }}
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+            <div className="flex items-center gap-2">
+              {brand.light_logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={brand.light_logo_url}
+                  alt=""
+                  className="h-6 w-auto"
+                />
+              ) : (
+                <span className="text-sm font-semibold text-gray-700">
+                  Logo
+                </span>
+              )}
+            </div>
+            <span
+              className="rounded-full px-3 py-1 text-xs font-medium text-white"
+              style={{ background: brand.primary_color || "#2356d6" }}
+            >
+              Get started
+            </span>
+          </div>
+          <div className="space-y-2 p-4">
+            <div className="h-2 w-3/4 rounded bg-gray-100" />
+            <div className="h-2 w-1/2 rounded bg-gray-100" />
+            <div
+              className="mt-3 inline-block rounded px-2 py-1 text-xs font-medium"
+              style={{
+                background: (brand.accent_color || "#00e0ff") + "20",
+                color: brand.accent_color || "#00e0ff",
+              }}
+            >
+              Accent badge
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/components/setup/steps/CourseLibraryStep.tsx
+++ b/components/setup/steps/CourseLibraryStep.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { WizardData } from "@/lib/setup/wizardData";
+
+interface Props {
+  data: WizardData;
+  onChange: (patch: Partial<WizardData>) => void;
+}
+
+const OPTIONS: {
+  value: NonNullable<WizardData["course_library"]>["choice"];
+  label: string;
+  desc: string;
+}[] = [
+  {
+    value: "import",
+    label: "Import from AI Linc catalogue",
+    desc: "Start with curated courses from 425+ titles. You can customise or remove them later.",
+  },
+  {
+    value: "build",
+    label: "Build with AI",
+    desc: "Use the embedded AI course builder to create courses from prompts and rubrics.",
+  },
+  {
+    value: "skip",
+    label: "Skip for now",
+    desc: "Launch with an empty library. Add courses anytime from the admin dashboard.",
+  },
+];
+
+export function CourseLibraryStep({ data, onChange }: Props) {
+  const lib = data.course_library || {};
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600">
+        Choose how to populate your course library. You can switch approaches
+        or mix and match anytime.
+      </p>
+
+      <div className="space-y-3">
+        {OPTIONS.map((opt) => {
+          const on = lib.choice === opt.value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() =>
+                onChange({
+                  course_library: { ...lib, choice: opt.value },
+                })
+              }
+              className={`flex w-full items-start gap-4 rounded-xl border p-4 text-left transition ${
+                on
+                  ? "border-[var(--primary-500,#2356d6)] bg-[var(--primary-50,#eff6ff)]"
+                  : "border-gray-200 bg-white hover:border-gray-300"
+              }`}
+            >
+              <div
+                className={`mt-1 grid h-5 w-5 place-items-center rounded-full border ${
+                  on
+                    ? "border-[var(--primary-500,#2356d6)] bg-[var(--primary-500,#2356d6)]"
+                    : "border-gray-300 bg-white"
+                }`}
+              >
+                {on ? (
+                  <span className="h-2 w-2 rounded-full bg-white" />
+                ) : null}
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-gray-900">
+                  {opt.label}
+                </p>
+                <p className="mt-0.5 text-xs text-gray-500">{opt.desc}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/setup/steps/FeaturesStep.tsx
+++ b/components/setup/steps/FeaturesStep.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import apiClient from "@/lib/services/api";
+import { WizardData } from "@/lib/setup/wizardData";
+
+interface Feature {
+  id: number;
+  name: string;
+}
+
+interface Props {
+  data: WizardData;
+  onChange: (patch: Partial<WizardData>) => void;
+}
+
+const FEATURE_DESCRIPTIONS: Record<string, string> = {
+  LMS: "Core learning management — courses, modules, lessons.",
+  Assessment: "Quizzes, tests, and assignments.",
+  "Live Class": "Real-time virtual classes with Zoom integration.",
+  "Community Forum": "Learner-to-learner discussion threads.",
+  "Mock Interview": "AI-driven mock interviews for prep.",
+  Proctoring: "Browser-based proctoring for high-stakes exams.",
+  "AI Tutor": "Per-lesson AI tutoring chat for learners.",
+};
+
+export function FeaturesStep({ data, onChange }: Props) {
+  const [features, setFeatures] = useState<Feature[]>([]);
+  const [loading, setLoading] = useState(true);
+  const selected = new Set<number>(
+    data.features?.selected_feature_ids || []
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiClient.get<Feature[] | { features: Feature[] }>(
+          "/accounts/features/"
+        );
+        const list = Array.isArray(res.data)
+          ? res.data
+          : res.data.features || [];
+        if (!cancelled) setFeatures(list);
+      } catch {
+        if (!cancelled) setFeatures([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggle = (id: number) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange({
+      features: {
+        ...(data.features || {}),
+        selected_feature_ids: Array.from(next),
+      },
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-gray-600">
+        Pick the modules your tenants will see in the sidebar. You can change
+        these anytime later in Settings.
+      </p>
+
+      {loading ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-500">
+          Loading available modules…
+        </div>
+      ) : features.length === 0 ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+          Couldn&apos;t load modules from the server. You can still launch and
+          enable modules later from Settings.
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {features.map((f) => {
+            const isOn = selected.has(f.id);
+            return (
+              <button
+                key={f.id}
+                type="button"
+                onClick={() => toggle(f.id)}
+                className={`flex items-start gap-3 rounded-xl border p-4 text-left transition ${
+                  isOn
+                    ? "border-[var(--primary-500,#2356d6)] bg-[var(--primary-50,#eff6ff)]"
+                    : "border-gray-200 bg-white hover:border-gray-300"
+                }`}
+              >
+                <div
+                  className={`mt-0.5 grid h-5 w-5 place-items-center rounded border transition ${
+                    isOn
+                      ? "border-[var(--primary-500,#2356d6)] bg-[var(--primary-500,#2356d6)]"
+                      : "border-gray-300 bg-white"
+                  }`}
+                >
+                  {isOn ? (
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="white"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <polyline points="20 6 9 17 4 12" />
+                    </svg>
+                  ) : null}
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900">
+                    {f.name}
+                  </p>
+                  {FEATURE_DESCRIPTIONS[f.name] ? (
+                    <p className="mt-0.5 text-xs text-gray-500">
+                      {FEATURE_DESCRIPTIONS[f.name]}
+                    </p>
+                  ) : null}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <p className="text-xs text-gray-500">
+        {selected.size} of {features.length} modules selected
+      </p>
+    </div>
+  );
+}

--- a/components/setup/steps/ReviewStep.tsx
+++ b/components/setup/steps/ReviewStep.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { WizardData, STEP_TITLES } from "@/lib/setup/wizardData";
+import { WizardState } from "@/lib/services/wizard.service";
+
+interface Props {
+  state: WizardState;
+  data: WizardData;
+  onJumpToStep: (step: number) => void;
+}
+
+function Row({
+  label,
+  value,
+  onEdit,
+}: {
+  label: string;
+  value: React.ReactNode;
+  onEdit?: () => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b border-gray-100 py-3 last:border-b-0">
+      <div className="flex-1">
+        <p className="text-xs font-medium uppercase tracking-widest text-gray-500">
+          {label}
+        </p>
+        <div className="mt-1 text-sm text-gray-900">{value || "—"}</div>
+      </div>
+      {onEdit ? (
+        <button
+          type="button"
+          onClick={onEdit}
+          className="text-xs font-semibold uppercase tracking-widest text-[var(--primary-600,#1d4ed8)] hover:text-[var(--primary-700,#1e3a8a)]"
+        >
+          Edit
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function ReviewStep({ state, data, onJumpToStep }: Props) {
+  const featureCount = data.features?.selected_feature_ids?.length || 0;
+  const capsOn = Object.entries(data.admin_caps || {})
+    .filter(([k, v]) => k !== "analytics_depth" && v)
+    .map(([k]) => k.replace(/_/g, " "));
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-gray-600">
+        Double-check everything below, then click <strong>Launch My LMS</strong>{" "}
+        to go live. You can change every choice from Settings afterwards.
+      </p>
+
+      <div className="rounded-2xl border border-gray-200 bg-white p-6">
+        <Row
+          label={STEP_TITLES[0]}
+          value={data.welcome?.confirmed_org_name || state.organisation_name}
+          onEdit={() => onJumpToStep(1)}
+        />
+        <Row
+          label={STEP_TITLES[1]}
+          value={
+            <div className="flex items-center gap-3">
+              {data.brand?.light_logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={data.brand.light_logo_url}
+                  alt=""
+                  className="h-6 w-auto"
+                />
+              ) : null}
+              <span className="font-mono text-xs">
+                {data.brand?.primary_color || "—"} ·{" "}
+                {data.brand?.accent_color || "—"}
+              </span>
+            </div>
+          }
+          onEdit={() => onJumpToStep(2)}
+        />
+        <Row
+          label={STEP_TITLES[2]}
+          value={
+            <span className="font-mono">
+              {state.subdomain}.ailinc.com
+              {data.url?.custom_domain
+                ? ` · ${data.url.custom_domain}`
+                : ""}
+            </span>
+          }
+          onEdit={() => onJumpToStep(3)}
+        />
+        <Row
+          label={STEP_TITLES[3]}
+          value={
+            <>
+              {data.theme?.template || "Default"} ·{" "}
+              {data.theme?.default_mode || "light"} mode
+              {data.theme?.welcome_message ? (
+                <p className="mt-1 text-xs text-gray-500">
+                  &ldquo;{data.theme.welcome_message}&rdquo;
+                </p>
+              ) : null}
+            </>
+          }
+          onEdit={() => onJumpToStep(4)}
+        />
+        <Row
+          label={STEP_TITLES[4]}
+          value={`${featureCount} module${featureCount === 1 ? "" : "s"} enabled`}
+          onEdit={() => onJumpToStep(5)}
+        />
+        <Row
+          label={STEP_TITLES[5]}
+          value={
+            <>
+              <span className="capitalize">
+                {data.admin_caps?.analytics_depth || "basic"} analytics
+              </span>
+              {capsOn.length ? (
+                <span className="text-gray-500"> · {capsOn.join(", ")}</span>
+              ) : null}
+            </>
+          }
+          onEdit={() => onJumpToStep(6)}
+        />
+        <Row
+          label={STEP_TITLES[6]}
+          value={
+            data.course_library?.choice === "import"
+              ? "Import from AI Linc catalogue"
+              : data.course_library?.choice === "build"
+                ? "Build with AI"
+                : data.course_library?.choice === "skip"
+                  ? "Skip for now"
+                  : "—"
+          }
+          onEdit={() => onJumpToStep(7)}
+        />
+      </div>
+
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+        Once launched, your tenant moves to <strong>live</strong> and learners
+        can sign in via <code className="rounded bg-amber-100 px-1">{state.subdomain}.ailinc.com</code>.
+        You can edit branding, modules, and team anytime from Settings.
+      </div>
+    </div>
+  );
+}

--- a/components/setup/steps/ThemeStep.tsx
+++ b/components/setup/steps/ThemeStep.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { WizardData } from "@/lib/setup/wizardData";
+import { wizardService } from "@/lib/services/wizard.service";
+
+interface Props {
+  data: WizardData;
+  onChange: (patch: Partial<WizardData>) => void;
+}
+
+const TEMPLATES: {
+  value: NonNullable<WizardData["theme"]>["template"];
+  label: string;
+  desc: string;
+}[] = [
+  { value: "minimal", label: "Minimal", desc: "Clean, content-first." },
+  { value: "academic", label: "Academic", desc: "Serif headlines, structured." },
+  { value: "vibrant", label: "Vibrant", desc: "Bold gradients, energy." },
+  { value: "corporate", label: "Corporate", desc: "Professional, restrained." },
+];
+
+export function ThemeStep({ data, onChange }: Props) {
+  const theme = data.theme || {};
+  const set = (patch: Partial<WizardData["theme"]>) =>
+    onChange({ theme: { ...theme, ...patch } });
+  const [uploading, setUploading] = useState(false);
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <p className="text-sm font-medium text-gray-700 mb-3">Template</p>
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {TEMPLATES.map((t) => (
+            <button
+              key={t.value}
+              type="button"
+              onClick={() => set({ template: t.value })}
+              className={`rounded-xl border p-4 text-left transition ${
+                theme.template === t.value
+                  ? "border-[var(--primary-500,#2356d6)] bg-[var(--primary-50,#eff6ff)]"
+                  : "border-gray-200 bg-white hover:border-gray-300"
+              }`}
+            >
+              <p className="text-sm font-semibold text-gray-900">{t.label}</p>
+              <p className="mt-1 text-xs text-gray-500">{t.desc}</p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-gray-700 mb-3">Default mode</p>
+        <div className="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+          {(["light", "dark"] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => set({ default_mode: mode })}
+              className={`px-4 py-1.5 rounded-md text-sm font-medium transition ${
+                (theme.default_mode || "light") === mode
+                  ? "bg-white shadow-sm text-gray-900"
+                  : "text-gray-600"
+              }`}
+            >
+              {mode === "light" ? "Light" : "Dark"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label className="block">
+          <span className="text-sm font-medium text-gray-700">
+            Welcome message
+          </span>
+          <p className="text-xs text-gray-500">
+            Shown on the login screen and learner dashboard.
+          </p>
+          <textarea
+            rows={3}
+            maxLength={200}
+            placeholder="Welcome to Acme Learning. Build real skills with AI tutors."
+            value={theme.welcome_message || ""}
+            onChange={(e) => set({ welcome_message: e.target.value })}
+            className="mt-1.5 block w-full resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[var(--primary-500,#2356d6)] focus:ring-1 focus:ring-[var(--primary-500,#2356d6)]"
+          />
+        </label>
+      </div>
+
+      <div>
+        <p className="text-sm font-medium text-gray-700">Hero image (optional)</p>
+        <div className="mt-2 flex items-center gap-4">
+          <div className="grid h-20 w-32 place-items-center overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
+            {theme.hero_image_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={theme.hero_image_url}
+                alt=""
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <span className="text-xs text-gray-400">No image</span>
+            )}
+          </div>
+          <label className="cursor-pointer rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
+            {uploading ? "Uploading…" : theme.hero_image_url ? "Replace" : "Upload"}
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              disabled={uploading}
+              onChange={async (e) => {
+                const f = e.target.files?.[0];
+                if (!f) return;
+                setUploading(true);
+                try {
+                  const r = await wizardService.uploadAsset(f, "hero");
+                  set({ hero_image_url: r.url });
+                } catch {
+                  /* ignore */
+                } finally {
+                  setUploading(false);
+                  e.target.value = "";
+                }
+              }}
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/setup/steps/UrlStep.tsx
+++ b/components/setup/steps/UrlStep.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { WizardData } from "@/lib/setup/wizardData";
+import { WizardState } from "@/lib/services/wizard.service";
+
+interface Props {
+  state: WizardState;
+  data: WizardData;
+  onChange: (patch: Partial<WizardData>) => void;
+}
+
+export function UrlStep({ state, data, onChange }: Props) {
+  const url = data.url || {};
+  return (
+    <div className="space-y-8">
+      <div className="rounded-xl border border-gray-200 bg-white p-6">
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+          Your AI Linc subdomain
+        </p>
+        <p className="mt-3 text-lg font-mono text-[var(--primary-700,#1e3a8a)]">
+          {state.subdomain}.ailinc.com
+        </p>
+        <p className="mt-2 text-sm text-gray-500">
+          Assigned by your AI Linc super-admin. This URL is permanent.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-6">
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+          Bring your own domain (optional)
+        </p>
+        <p className="mt-2 text-sm text-gray-600">
+          Point a domain you own at AI Linc. You can do this now or anytime
+          later from Settings → Domain.
+        </p>
+        <label className="mt-4 block">
+          <span className="text-sm font-medium text-gray-700">
+            Custom domain
+          </span>
+          <input
+            type="text"
+            placeholder="learn.your-org.com"
+            value={url.custom_domain || ""}
+            onChange={(e) =>
+              onChange({
+                url: { ...url, custom_domain: e.target.value.trim() },
+              })
+            }
+            className="mt-1.5 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[var(--primary-500,#2356d6)] focus:ring-1 focus:ring-[var(--primary-500,#2356d6)]"
+          />
+        </label>
+        {url.custom_domain ? (
+          <div className="mt-4 rounded-lg bg-white border border-gray-200 p-3 text-xs text-gray-600">
+            <p className="font-medium text-gray-800">DNS instructions</p>
+            <p className="mt-1">
+              Add a CNAME record pointing{" "}
+              <code className="rounded bg-gray-100 px-1">{url.custom_domain}</code>{" "}
+              → <code className="rounded bg-gray-100 px-1">tenants.ailinc.com</code>.
+              We&apos;ll auto-provision an SSL certificate once DNS resolves.
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/setup/steps/WelcomeStep.tsx
+++ b/components/setup/steps/WelcomeStep.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { WizardData } from "@/lib/setup/wizardData";
+import { WizardState } from "@/lib/services/wizard.service";
+
+interface Props {
+  state: WizardState;
+  data: WizardData;
+  onChange: (patch: Partial<WizardData>) => void;
+}
+
+export function WelcomeStep({ state, data, onChange }: Props) {
+  const welcome = data.welcome || {};
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-gray-200 bg-white p-6">
+        <p className="text-xs font-semibold uppercase tracking-widest text-gray-500">
+          From your intake form
+        </p>
+        <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-4 text-sm">
+          <div>
+            <dt className="text-gray-500">Organisation</dt>
+            <dd className="font-medium text-gray-900">
+              {state.organisation_name}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Your URL</dt>
+            <dd className="font-mono text-gray-900">
+              {state.subdomain}.ailinc.com
+            </dd>
+          </div>
+          {state.contact_email ? (
+            <div className="col-span-2">
+              <dt className="text-gray-500">Tenant admin</dt>
+              <dd className="text-gray-900">{state.contact_email}</dd>
+            </div>
+          ) : null}
+        </dl>
+      </div>
+
+      <div className="space-y-4">
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-700">
+            Confirm organisation name
+          </span>
+          <input
+            type="text"
+            value={welcome.confirmed_org_name ?? state.organisation_name}
+            onChange={(e) =>
+              onChange({
+                welcome: { ...welcome, confirmed_org_name: e.target.value },
+              })
+            }
+            className="mt-1.5 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[var(--primary-500,#2356d6)] focus:ring-1 focus:ring-[var(--primary-500,#2356d6)]"
+          />
+        </label>
+
+        <p className="text-sm text-gray-500">
+          You can edit branding, modules, and team in the next steps. None of
+          your choices are final until you launch.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/lib/services/client.service.ts
+++ b/lib/services/client.service.ts
@@ -111,6 +111,12 @@ export interface ClientInfo {
   certificate_signature_url?: string | null;
   certificate_signatory_name?: string | null;
   certificate_signatory_title?: string | null;
+  /** False for self-serve tenants that haven't finished the first-login setup wizard. */
+  setup_completed?: boolean;
+  /** Current wizard step (0-8). */
+  setup_step?: number;
+  /** Autosaved blob of in-progress wizard answers. */
+  wizard_state?: Record<string, any>;
   [key: string]: any; // Allow other properties from API
 }
 

--- a/lib/services/wizard.service.ts
+++ b/lib/services/wizard.service.ts
@@ -1,0 +1,59 @@
+import apiClient from "./api";
+
+export interface WizardState {
+  client_id: number;
+  organisation_name: string;
+  subdomain: string;
+  setup_completed: boolean;
+  setup_step: number;
+  total_steps: number;
+  wizard_state: Record<string, any>;
+  logo_url: string | null;
+  contact_email: string | null;
+}
+
+export interface UploadAssetResponse {
+  url: string;
+  kind: string;
+  filename: string;
+}
+
+export const wizardService = {
+  async getState(): Promise<WizardState> {
+    const res = await apiClient.get<WizardState>("/api/tenant/wizard/state/");
+    return res.data;
+  },
+
+  async saveState(payload: {
+    wizard_state?: Record<string, any>;
+    setup_step?: number;
+  }): Promise<WizardState> {
+    const res = await apiClient.patch<WizardState>(
+      "/api/tenant/wizard/state/",
+      payload
+    );
+    return res.data;
+  },
+
+  async uploadAsset(file: File, kind: string): Promise<UploadAssetResponse> {
+    const form = new FormData();
+    form.append("file", file);
+    form.append("kind", kind);
+    const res = await apiClient.post<UploadAssetResponse>(
+      "/api/tenant/wizard/upload-asset/",
+      form,
+      { headers: { "Content-Type": "multipart/form-data" } }
+    );
+    return res.data;
+  },
+
+  async launch(
+    finalState?: Record<string, any>
+  ): Promise<WizardState> {
+    const res = await apiClient.post<WizardState>(
+      "/api/tenant/wizard/launch/",
+      finalState ? { wizard_state: finalState } : {}
+    );
+    return res.data;
+  },
+};

--- a/lib/setup/wizardData.ts
+++ b/lib/setup/wizardData.ts
@@ -1,0 +1,56 @@
+export interface WizardData {
+  welcome?: {
+    confirmed_org_name?: string;
+    confirmed_contact_name?: string;
+  };
+  brand?: {
+    light_logo_url?: string;
+    dark_logo_url?: string;
+    favicon_url?: string;
+    primary_color?: string;
+    accent_color?: string;
+  };
+  url?: {
+    subdomain?: string;
+    custom_domain?: string;
+  };
+  theme?: {
+    template?: "minimal" | "academic" | "vibrant" | "corporate";
+    default_mode?: "dark" | "light";
+    hero_image_url?: string;
+    welcome_message?: string;
+  };
+  features?: {
+    selected_feature_ids?: number[];
+    ai_tutor?: boolean;
+    ai_grading?: boolean;
+    proctoring?: boolean;
+    blockchain_certificates?: boolean;
+    forums?: boolean;
+    live_classes?: boolean;
+  };
+  admin_caps?: {
+    bulk_import?: boolean;
+    ai_builder?: boolean;
+    analytics_depth?: "basic" | "advanced";
+    sub_admin_creation?: boolean;
+    api_access?: boolean;
+  };
+  course_library?: {
+    choice?: "import" | "build" | "skip";
+    import_count?: number;
+  };
+}
+
+export const TOTAL_WIZARD_STEPS = 8;
+
+export const STEP_TITLES = [
+  "Welcome",
+  "Brand identity",
+  "URL",
+  "Theme",
+  "Features",
+  "Admin capabilities",
+  "Course library",
+  "Review & launch",
+] as const;


### PR DESCRIPTION
## Summary
- Adds the 8-step first-login wizard that newly-approved tenants walk through on their LMS subdomain: Welcome → Brand identity → URL → Theme → Features → Admin capabilities → Course library → Review & launch.
- Wires a `/setup` route plus a `TenantSetupBlocker` mounted in the root layout that pushes any tenant admin with `setup_completed === false` into the wizard before they can use the rest of the app.
- Talks to the new tenant wizard endpoints in `ai-linc-backend` ([PR #194](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/194)): `GET/PATCH /api/tenant/wizard/state/`, `POST /api/tenant/wizard/upload-asset/`, `POST /api/tenant/wizard/launch/`.

## Commits
- `feat(setup): add 8-step tenant setup wizard UI` — `components/setup/*` (SetupWizard shell, layout, nav, eight step components) and `lib/setup/wizardData.ts`.
- `feat(setup): add wizard API service and ClientInfo wizard fields` — `lib/services/wizard.service.ts` plus the three new fields on `ClientInfo`.
- `feat(setup): wire wizard route and gate the app on incomplete setup` — `app/setup/page.tsx`, `components/auth/TenantSetupBlocker.tsx`, and the `<TenantSetupBlocker />` mount in `app/layout.tsx`.

## Test plan
- [ ] As an existing tenant (no `setup_completed` field, or `setup_completed === true`): app behaves exactly as before; no redirect to `/setup`, no visible change.
- [ ] As a newly-approved tenant admin (`setup_completed === false`): visiting any route redirects to `/setup`.
- [ ] Step 1 → 8 navigation works; back-button does not skip past unvisited steps.
- [ ] Brand identity uploads (light/dark logos, favicon) go through `POST /api/tenant/wizard/upload-asset/` and return URLs that render in the preview.
- [ ] Color pickers + welcome message + hero image persist on `PATCH /api/tenant/wizard/state/` (verify autosave).
- [ ] Refreshing mid-wizard restores progress from `setup_step` + `wizard_state`.
- [ ] Features step toggles `AppFeatures` and is reflected after launch.
- [ ] Review & launch sends `POST /api/tenant/wizard/launch/`, then `setup_completed` flips to `true`, `launched_at` is set, and the user is bounced to the LMS home (no longer blocked).
- [ ] After launch, `TenantSetupBlocker` no longer redirects.

## Depends on
- Backend PR: https://github.com/AI-Linc-LMS/ai-linc-backend/pull/194

🤖 Generated with [Claude Code](https://claude.com/claude-code)