### PR TITLE
feat: Add re-attempt functionality for assessments

### DIFF
--- a/app/assessments/[slug]/device-check/page.tsx
+++ b/app/assessments/[slug]/device-check/page.tsx
@@ -99,6 +99,11 @@ export default function DeviceCheckPage({
     poorLightingThreshold: 0.4,
     minConfidenceForValidFace: 0.82, // Stricter on device check: reject hand covering face
     onViolation: (violation) => {
+      // Once the user has committed to starting the assessment, freeze
+      // validation state — stopping the detector for hand-off to the take
+      // page produces transient "no face / violation" events that would
+      // otherwise flash a misleading error during the countdown.
+      if (isNavigatingToAssessmentRef.current) return;
       setFaceValidationPassed(false);
       setFaceValidationMessage(violation.message);
     },
@@ -106,6 +111,7 @@ export default function DeviceCheckPage({
       // Status change will trigger useEffect below to update validation
     },
     onFaceCountChange: (count) => {
+      if (isNavigatingToAssessmentRef.current) return;
       if (count === 0) {
         setFaceValidationPassed(false);
         setFaceValidationMessage(t("assessments.deviceCheck.noFaceDetected"));
@@ -119,6 +125,7 @@ export default function DeviceCheckPage({
 
   // Update face validation status when faceCount or faceStatus changes
   useEffect(() => {
+    if (isNavigatingToAssessmentRef.current) return;
     if (faceCount === 1 && faceStatus === "NORMAL" && !latestViolation) {
       setFaceValidationPassed(true);
       setFaceValidationMessage("Face detected and positioned correctly");
@@ -419,7 +426,14 @@ export default function DeviceCheckPage({
         // Check if assessment is already submitted — block re-entry.
         // (`is_attempted` is true for in-progress too; only redirect when
         // actually submitted so resume-in-progress still works.)
-        if (data.status === "submitted" || data.status === "finalized") {
+        // EXCEPTION: if admin has granted an unconsumed retake, the
+        // start-assessment endpoint will consume it and create a fresh
+        // in-progress submission once the user reaches the take page, so we
+        // let the device-check flow proceed.
+        if (
+          (data.status === "submitted" || data.status === "finalized") &&
+          !data.can_reattempt
+        ) {
           showToast("This assessment has already been submitted", "warning");
           // replace, not push: don't leave device-check in history so
           // back-navigation can't return here.
@@ -759,7 +773,7 @@ export default function DeviceCheckPage({
               />
               
               {/* Face Detection Status Overlay */}
-              {deviceStatus.camera && (
+              {deviceStatus.camera && !isNavigatingToAssessment && (
                 <Box
                   sx={{
                     position: "absolute",
@@ -826,7 +840,7 @@ export default function DeviceCheckPage({
             </Box>
 
             {/* Face Validation Message */}
-            {deviceStatus.camera && !isFaceDetectionInitializing && (
+            {deviceStatus.camera && !isFaceDetectionInitializing && !isNavigatingToAssessment && (
               <Box sx={{ mt: 2 }}>
                 {faceValidationPassed ? (
                   <Alert severity="success" sx={{ mt: 1 }}>

--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -64,6 +64,27 @@ export default function AssessmentDetailPage({
   const isAlreadySubmitted =
     assessment?.status === "submitted" || assessment?.status === "finalized";
 
+  const assessmentEndAt = useMemo(
+    () => parseAssessmentStartTime(assessment?.end_time),
+    [assessment?.end_time],
+  );
+
+  // Expired = end_time is in the past AND the learner did not submit before
+  // it closed. A submitted-then-expired assessment is "submitted", not expired.
+  const isExpired = useMemo(() => {
+    if (!assessmentEndAt) return false;
+    if (isAlreadySubmitted) return false;
+    return Date.now() > assessmentEndAt.getTime();
+  }, [assessmentEndAt, isAlreadySubmitted]);
+
+  const expiredOnLabel = useMemo(() => {
+    if (!assessmentEndAt) return "";
+    return assessmentEndAt.toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  }, [assessmentEndAt]);
+
   useEffect(() => {
     if (!assessmentStartAt) return;
     if (Date.now() >= assessmentStartAt.getTime()) return;
@@ -108,13 +129,17 @@ export default function AssessmentDetailPage({
     }
   };
 
+  const canReattempt = assessment?.can_reattempt === true;
+
   const handleStart = () => {
     if (!assessment) return;
 
     // SECURITY: never re-enter the take flow if this assessment is already
-    // submitted/finalized. Route to the success page so the user can view
-    // their result (or just be informed) instead.
-    if (isAlreadySubmitted) {
+    // submitted/finalized — UNLESS an admin has granted this learner a
+    // retake (can_reattempt). In that case fall through; the backend
+    // start-assessment endpoint consumes the grant atomically when a new
+    // submission is created.
+    if (isAlreadySubmitted && !canReattempt) {
       showToast("This assessment has already been submitted", "warning");
       router.replace(`/assessments/${slug}/submission-success`);
       return;
@@ -623,18 +648,75 @@ export default function AssessmentDetailPage({
             </Paper>
           )}
 
+          {isExpired && (
+            <Alert
+              severity="error"
+              icon={<IconWrapper icon="mdi:clock-alert-outline" size={22} />}
+              sx={{ mb: 3, borderRadius: 2, fontWeight: 500 }}
+            >
+              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                {t("assessments.expiredHeading", {
+                  defaultValue: "This assessment has expired",
+                })}
+              </Typography>
+              <Typography variant="body2">
+                {expiredOnLabel
+                  ? t("assessments.expiredOn", {
+                      defaultValue: "The submission window closed on {{date}}.",
+                      date: expiredOnLabel,
+                    })
+                  : t("assessments.expiredGeneric", {
+                      defaultValue: "The submission window for this assessment has closed.",
+                    })}
+              </Typography>
+            </Alert>
+          )}
+
+          {canReattempt && isAlreadySubmitted && !isExpired && (
+            <Alert
+              severity="info"
+              icon={<IconWrapper icon="mdi:replay" size={22} />}
+              sx={{ mb: 3, borderRadius: 2 }}
+            >
+              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                {t("assessments.reattemptHeading", {
+                  defaultValue: "Re-attempt available",
+                })}
+              </Typography>
+              <Typography variant="body2">
+                {t("assessments.reattemptHelp", {
+                  defaultValue:
+                    "An admin has granted you a re-attempt for this assessment. Starting again will replace your previous score with the new attempt's score.",
+                })}
+              </Typography>
+            </Alert>
+          )}
+
           <Button
             variant="contained"
             size="large"
             fullWidth
             startIcon={
               <IconWrapper
-                icon={isAlreadySubmitted ? "mdi:check-circle-outline" : "mdi:play-circle-outline"}
+                icon={
+                  isExpired
+                    ? "mdi:clock-alert-outline"
+                    : canReattempt && isAlreadySubmitted
+                    ? "mdi:replay"
+                    : isAlreadySubmitted
+                    ? "mdi:check-circle-outline"
+                    : "mdi:play-circle-outline"
+                }
                 size={24}
               />
             }
             onClick={handleStart}
-            disabled={isAlreadySubmitted || !deviceAllowed || !canStartAssessment}
+            disabled={
+              isExpired ||
+              (isAlreadySubmitted && !canReattempt) ||
+              !deviceAllowed ||
+              !canStartAssessment
+            }
             sx={{
               backgroundColor: "var(--accent-indigo)",
               color: "var(--font-light)",
@@ -650,7 +732,11 @@ export default function AssessmentDetailPage({
               },
             }}
           >
-            {isAlreadySubmitted
+            {isExpired
+              ? t("assessments.expired")
+              : canReattempt && isAlreadySubmitted
+              ? t("assessments.reattempt", { defaultValue: "Re-attempt" })
+              : isAlreadySubmitted
               ? t("assessments.alreadySubmitted", { defaultValue: "Already submitted" })
               : t("assessments.startAssessment")}
           </Button>

--- a/app/assessments/[slug]/submission-success/page.tsx
+++ b/app/assessments/[slug]/submission-success/page.tsx
@@ -11,6 +11,7 @@ import {
   Paper,
   Alert,
   Divider,
+  CircularProgress,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
@@ -92,6 +93,16 @@ export default function SubmissionSuccessPage() {
     }
   }, [slug]);
 
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <Container sx={{ py: 8, display: "flex", justifyContent: "center" }}>
+          <CircularProgress />
+        </Container>
+      </MainLayout>
+    );
+  }
 
   if (!assessment) {
     return (

--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -36,7 +36,15 @@ import {
 
 const ITEMS_PER_PAGE = 12;
 
-type FilterType = "all" | "available" | "under_review" | "completed";
+type FilterType = "all" | "available" | "under_review" | "completed" | "expired";
+
+/** Assessment is past its end_time and the learner did not submit before it ended. */
+function isLearnerAssessmentExpired(a: Assessment): boolean {
+  if (!a.end_time) return false;
+  if (new Date(a.end_time).getTime() > Date.now()) return false;
+  // Don't surface submitted assessments under "expired" — they belong in completed/review.
+  return !isLearnerAssessmentSubmittedForCatalog(a);
+}
 type SortType = "recent" | "oldest" | "title";
 
 export default function AssessmentsPage() {
@@ -95,6 +103,8 @@ export default function AssessmentsPage() {
   const underReviewCount = assessments.filter((a) =>
     isLearnerAssessmentSubmittedUnderReview(a),
   ).length;
+
+  const expiredCount = assessments.filter((a) => isLearnerAssessmentExpired(a)).length;
   
   // Available: status is "not_started" or "in_progress"
   // If status is undefined/null, fallback to !is_attempted && !has_attempted for backward compatibility
@@ -127,6 +137,8 @@ export default function AssessmentsPage() {
       result = result.filter((a) => canViewLearnerAssessmentResults(a));
     } else if (filter === "under_review") {
       result = result.filter((a) => isLearnerAssessmentSubmittedUnderReview(a));
+    } else if (filter === "expired") {
+      result = result.filter((a) => isLearnerAssessmentExpired(a));
     } else if (filter === "available") {
       // Available: status is "not_started" or "in_progress"
       // Fallback to !is_attempted && !has_attempted for backward compatibility
@@ -527,6 +539,10 @@ export default function AssessmentsPage() {
             <Tab
               label={`${t("assessments.completed")} (${completedCount})`}
               value="completed"
+            />
+            <Tab
+              label={`${t("assessments.expired")} (${expiredCount})`}
+              value="expired"
             />
           </Tabs>
 

--- a/app/assessments/result/[slug]/page.tsx
+++ b/app/assessments/result/[slug]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { Box, Button, Paper,Alert, Typography } from "@mui/material";
+import { Box, Button, Paper,Alert, Typography, CircularProgress, Chip } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
   assessmentService,
@@ -42,6 +42,28 @@ import { CertificateLearnerToolbar } from "@/components/certificate/CertificateL
 import { DynamicCertificate } from "@/components/certificate/DynamicCertificate";
 import { getUploadedFiles } from "@/lib/services/file-upload.service";
 import { config } from "@/lib/config";
+
+async function getAssessmentResultWithRetry(
+  slug: string,
+  attemptId?: number | string,
+  retries = 3,
+  delayMs = 600,
+): Promise<AssessmentResult> {
+  let lastError: any;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await assessmentService.getAssessmentResult(slug, attemptId);
+    } catch (error: any) {
+      lastError = error;
+      const status = error?.response?.status;
+      // Retry only on 404 — covers the brief window after submit where the
+      // result row isn't queryable yet. Other errors (auth, server) fail fast.
+      if (status !== 404 || attempt === retries) throw error;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw lastError;
+}
 
 function sanitizeCertificateFileSegment(raw: string, fallback: string): string {
   const s = raw
@@ -321,7 +343,7 @@ export default function AssessmentResultPage() {
     return { assessment, learner };
   }, [assessmentResult, user, slug]);
 
-  const loadAssessmentResult = async () => {
+  const loadAssessmentResult = async (attemptId?: number | string) => {
     try {
       const slugLower = slug?.toLowerCase() || "";
 
@@ -338,7 +360,7 @@ export default function AssessmentResultPage() {
         return;
       }
 
-      const result = await assessmentService.getAssessmentResult(slug);
+      const result = await getAssessmentResultWithRetry(slug, attemptId);
       setAssessmentDetail(result?.assessment_details || null);
       if ((result as any).assessment_meta) {
         setPsychometricData(result);
@@ -351,6 +373,22 @@ export default function AssessmentResultPage() {
       setLoading(false);
     }
   };
+
+  const handleAttemptChange = async (attemptId: number) => {
+    if (attemptId === assessmentResult?.current_attempt_id) return;
+    setLoading(true);
+    await loadAssessmentResult(attemptId);
+  };
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <Box sx={{ py: 8, display: "flex", justifyContent: "center" }}>
+          <CircularProgress />
+        </Box>
+      </MainLayout>
+    );
+  }
 
   if (!assessmentResult && !psychometricData) return null;
 
@@ -514,6 +552,113 @@ export default function AssessmentResultPage() {
           assessmentTitle={assessmentResult?.assessment_name || ""}
           status={assessmentResult?.status || ""}
         />
+
+        {/* Multi-attempt selector. Renders only when this learner has more
+            than one submitted attempt — i.e. admin has granted at least one
+            retake that was consumed and finalized. Clicking an attempt
+            refetches the full result payload for that submission. */}
+        {assessmentResult?.attempts && assessmentResult.attempts.length > 1 && (
+          <Paper
+            elevation={0}
+            sx={{
+              mb: 3,
+              border: "1px solid var(--border-default)",
+              borderRadius: 2,
+              bgcolor: "var(--card-bg)",
+              overflow: "hidden",
+            }}
+          >
+            <Box
+              sx={{
+                px: 2,
+                py: 1.25,
+                borderBottom: "1px solid var(--border-default)",
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                bgcolor:
+                  "color-mix(in srgb, var(--accent-indigo) 5%, var(--card-bg))",
+              }}
+            >
+              <IconWrapper icon="mdi:history" size={18} color="var(--accent-indigo)" />
+              <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                Attempt history
+              </Typography>
+              <Chip
+                size="small"
+                label={`${assessmentResult.attempts.length} attempts`}
+                sx={{ ml: "auto", bgcolor: "var(--surface)", fontWeight: 600 }}
+              />
+            </Box>
+            <Box sx={{ p: 1, display: "flex", flexWrap: "wrap", gap: 1 }}>
+              {assessmentResult.attempts.map((att) => {
+                const isCurrent = att.id === assessmentResult.current_attempt_id;
+                const dateLabel = att.submitted_at
+                  ? new Date(att.submitted_at).toLocaleString(undefined, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    })
+                  : "—";
+                const scoreLabel = att.score != null ? `${att.score}` : "—";
+                return (
+                  <Button
+                    key={att.id}
+                    size="small"
+                    variant={isCurrent ? "contained" : "outlined"}
+                    onClick={() => handleAttemptChange(att.id)}
+                    disabled={loading}
+                    sx={{
+                      textTransform: "none",
+                      borderRadius: 1.5,
+                      fontWeight: 600,
+                      px: 1.5,
+                      ...(isCurrent
+                        ? {
+                            background:
+                              "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)",
+                            color: "var(--font-light)",
+                            "&:hover": {
+                              background:
+                                "linear-gradient(135deg, var(--accent-indigo-dark) 0%, var(--accent-indigo) 100%)",
+                            },
+                          }
+                        : {
+                            borderColor: "var(--border-default)",
+                            color: "var(--font-primary)",
+                          }),
+                    }}
+                  >
+                    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1.2 }}>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          fontSize: "0.7rem",
+                          fontWeight: 700,
+                          opacity: isCurrent ? 0.9 : 0.7,
+                        }}
+                      >
+                        Attempt {att.attempt_number}
+                        {isCurrent ? " · current" : ""}
+                      </Typography>
+                      <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                        Score: {scoreLabel}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          fontSize: "0.65rem",
+                          opacity: isCurrent ? 0.85 : 0.65,
+                        }}
+                      >
+                        {dateLabel}
+                      </Typography>
+                    </Box>
+                  </Button>
+                );
+              })}
+            </Box>
+          </Paper>
+        )}
 
         {resultHidden && (
           <Alert severity="info" sx={{ mb: 3 }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,8 @@
   --accent-teal: #319795;
   --accent-purple: #805ad5;
   --accent-pink: #d53f8c;
+  --accent-cyan: #06b6d4;
+  --accent-cyan-dark: #0891b2;
 
   /* Neutral Colors */
   --neutral-50: #f8f9fa;
@@ -175,6 +177,24 @@
   --assessment-catalog-psychometric-shadow-hover: 0 12px 32px color-mix(in srgb, var(--accent-purple) 28%, transparent);
   --assessment-catalog-psychometric-shadow-cta: 0 4px 14px color-mix(in srgb, var(--accent-purple) 42%, transparent);
   --assessment-catalog-psychometric-shadow-cta-hover: 0 6px 20px color-mix(in srgb, var(--accent-purple) 52%, transparent);
+
+  /* Re-attempt CTA (cyan): paired with the green "View Results" CTA on cards
+     where an admin has granted a learner one more attempt. Cyan vs green
+     differentiates the action (re-take vs view) while preserving paired-stack
+     proportions. Built from --accent-cyan / --accent-cyan-dark so it themes
+     consistently with the other catalog CTAs. */
+  --assessment-catalog-reattempt-cta-gradient: linear-gradient(
+    135deg,
+    var(--accent-cyan) 0%,
+    var(--accent-cyan-dark) 100%
+  );
+  --assessment-catalog-reattempt-cta-hover-gradient: linear-gradient(
+    135deg,
+    var(--accent-cyan-dark) 0%,
+    color-mix(in srgb, var(--accent-cyan-dark) 70%, var(--font-dark)) 100%
+  );
+  --assessment-catalog-reattempt-cta-shadow: 0 2px 6px color-mix(in srgb, var(--accent-cyan-dark) 28%, transparent);
+  --assessment-catalog-reattempt-cta-shadow-hover: 0 4px 10px color-mix(in srgb, var(--accent-cyan-dark) 40%, transparent);
 
   /* Manual-review cards: teal + pink (not indigo / orange / warning — reads as “instructor” vs auto) */
   --assessment-catalog-manual-stripe: var(--accent-teal);

--- a/components/admin/assessment/AssessmentTable.tsx
+++ b/components/admin/assessment/AssessmentTable.tsx
@@ -30,6 +30,8 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { Assessment } from "@/lib/services/admin/admin-assessment.service";
 import { isProctoredAssessmentInLiveWindow } from "@/lib/utils/assessment-live-window.utils";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import { useToast } from "@/components/common/Toast";
+import { RetakeGrantsDialog } from "./RetakeGrantsDialog";
 
 export interface AssessmentEmailJobInfo {
   task_id: string;
@@ -81,6 +83,11 @@ export function AssessmentTable({
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [anchorEl, setAnchorEl] = useState<{ [key: number]: HTMLElement | null }>({});
+  const [retakeDialog, setRetakeDialog] = useState<{
+    open: boolean;
+    assessmentId: number | null;
+    title: string;
+  }>({ open: false, assessmentId: null, title: "" });
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>, assessmentId: number) => {
     setAnchorEl({ ...anchorEl, [assessmentId]: event.currentTarget });
@@ -88,6 +95,35 @@ export function AssessmentTable({
 
   const handleMenuClose = (assessmentId: number) => {
     setAnchorEl({ ...anchorEl, [assessmentId]: null });
+  };
+
+  const { showToast } = useToast();
+
+  const handleCopyShareLink = async (assessment: Assessment) => {
+    if (!assessment.slug) {
+      showToast("This assessment has no share link yet.", "error");
+      return;
+    }
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    const url = `${origin}/assessments/${assessment.slug}`;
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        // Fallback for non-secure contexts (e.g. http://localhost over LAN)
+        const ta = document.createElement("textarea");
+        ta.value = url;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+      }
+      showToast("Assessment link copied to clipboard", "success");
+    } catch {
+      showToast("Could not copy link. Copy manually: " + url, "error");
+    }
   };
 
 
@@ -142,6 +178,7 @@ export function AssessmentTable({
   // Mobile Card View
   if (isMobile) {
     return (
+      <>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2, p: { xs: 1, sm: 0 } }}>
         {assessments.length === 0 ? (
           <Paper
@@ -436,7 +473,20 @@ export function AssessmentTable({
 
               {/* Actions */}
               <Divider sx={{ my: 1.5 }} />
-              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center" }}>
+              <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 0.5 }}>
+                <Tooltip title="Copy share link">
+                  <IconButton
+                    size="small"
+                    onClick={() => handleCopyShareLink(assessment)}
+                    sx={{
+                      color: "var(--font-secondary)",
+                      "&:hover": { bgcolor: "var(--surface)", color: "var(--accent-indigo)" },
+                    }}
+                    aria-label="Copy assessment share link"
+                  >
+                    <IconWrapper icon="mdi:link-variant" size={18} />
+                  </IconButton>
+                </Tooltip>
                 <IconButton
                   size="small"
                   onClick={(e) => handleMenuOpen(e, assessment.id)}
@@ -517,6 +567,23 @@ export function AssessmentTable({
                     </ListItemIcon>
                     <ListItemText>{t("certificatesUpload.menuCertificates")}</ListItemText>
                   </MenuItem>
+                  {!actionsReadOnly && (
+                    <MenuItem
+                      onClick={() => {
+                        handleMenuClose(assessment.id);
+                        setRetakeDialog({
+                          open: true,
+                          assessmentId: assessment.id,
+                          title: assessment.title,
+                        });
+                      }}
+                    >
+                      <ListItemIcon>
+                        <IconWrapper icon="mdi:replay" size={18} color="var(--accent-indigo)" />
+                      </ListItemIcon>
+                      <ListItemText>Manage re-attempts</ListItemText>
+                    </MenuItem>
+                  )}
                   {!actionsReadOnly && onTriggerEmailJob && (() => {
                     const job = assessmentEmailJobMap[assessment.id];
                     const isTriggering = triggeringEmailJobId === assessment.id;
@@ -660,6 +727,13 @@ export function AssessmentTable({
           ))
         )}
       </Box>
+      <RetakeGrantsDialog
+        open={retakeDialog.open}
+        onClose={() => setRetakeDialog({ open: false, assessmentId: null, title: "" })}
+        assessmentId={retakeDialog.assessmentId}
+        assessmentTitle={retakeDialog.title}
+      />
+      </>
     );
   }
 
@@ -1171,6 +1245,25 @@ export function AssessmentTable({
                       justifyContent: "center",
                     }}
                   >
+                    <Tooltip title="Copy share link">
+                      <IconButton
+                        size="small"
+                        onClick={() => handleCopyShareLink(assessment)}
+                        sx={{
+                          color: "var(--font-secondary)",
+                          "&:hover": {
+                            bgcolor:
+                              "color-mix(in srgb, var(--surface) 82%, var(--card-bg) 18%)",
+                            color: "var(--accent-indigo)",
+                          },
+                          transition: "all 0.2s ease",
+                          mr: 0.5,
+                        }}
+                        aria-label="Copy assessment share link"
+                      >
+                        <IconWrapper icon="mdi:link-variant" size={18} />
+                      </IconButton>
+                    </Tooltip>
                     <IconButton
                       size="small"
                       onClick={(e) => handleMenuOpen(e, assessment.id)}
@@ -1257,6 +1350,23 @@ export function AssessmentTable({
                         </ListItemIcon>
                         <ListItemText>{t("certificatesUpload.menuCertificates")}</ListItemText>
                       </MenuItem>
+                      {!actionsReadOnly && (
+                        <MenuItem
+                          onClick={() => {
+                            handleMenuClose(assessment.id);
+                            setRetakeDialog({
+                              open: true,
+                              assessmentId: assessment.id,
+                              title: assessment.title,
+                            });
+                          }}
+                        >
+                          <ListItemIcon>
+                            <IconWrapper icon="mdi:replay" size={18} color="var(--accent-indigo)" />
+                          </ListItemIcon>
+                          <ListItemText>Manage re-attempts</ListItemText>
+                        </MenuItem>
+                      )}
                       {!actionsReadOnly && onTriggerEmailJob && (() => {
                         const job = assessmentEmailJobMap[assessment.id];
                         const isTriggering = triggeringEmailJobId === assessment.id;
@@ -1403,6 +1513,12 @@ export function AssessmentTable({
         </TableBody>
       </Table>
     </TableContainer>
+    <RetakeGrantsDialog
+      open={retakeDialog.open}
+      onClose={() => setRetakeDialog({ open: false, assessmentId: null, title: "" })}
+      assessmentId={retakeDialog.assessmentId}
+      assessmentTitle={retakeDialog.title}
+    />
     </>
   );
 }

--- a/components/admin/assessment/RetakeGrantsDialog.tsx
+++ b/components/admin/assessment/RetakeGrantsDialog.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  IconButton,
+  Tooltip,
+  Divider,
+  Stack,
+  Chip,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import {
+  AssessmentRetakeGrant,
+  grantAssessmentRetake,
+  listAssessmentRetakeGrants,
+  revokeAssessmentRetake,
+} from "@/lib/services/admin/admin-assessment.service";
+import { config } from "@/lib/config";
+
+interface RetakeGrantsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  assessmentId: number | null;
+  assessmentTitle: string;
+}
+
+export function RetakeGrantsDialog({
+  open,
+  onClose,
+  assessmentId,
+  assessmentTitle,
+}: RetakeGrantsDialogProps) {
+  const { showToast } = useToast();
+  const [grants, setGrants] = useState<AssessmentRetakeGrant[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [granting, setGranting] = useState(false);
+  const [revokingId, setRevokingId] = useState<number | null>(null);
+  const [email, setEmail] = useState("");
+  const [note, setNote] = useState("");
+
+  useEffect(() => {
+    if (!open || !assessmentId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await listAssessmentRetakeGrants(config.clientId, assessmentId);
+        if (!cancelled) setGrants(data);
+      } catch (err: any) {
+        if (!cancelled) {
+          showToast(err?.message || "Failed to load re-attempt grants", "error");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, assessmentId, showToast]);
+
+  const handleGrant = async () => {
+    if (!assessmentId) return;
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed) {
+      showToast("Enter a learner email first.", "warning");
+      return;
+    }
+    try {
+      setGranting(true);
+      const created = await grantAssessmentRetake(config.clientId, assessmentId, {
+        user_email: trimmed,
+        note: note.trim() || undefined,
+      });
+      // Idempotent backend may return existing grant — dedupe by id.
+      setGrants((prev) => {
+        if (prev.some((g) => g.id === created.id)) return prev;
+        return [created, ...prev];
+      });
+      showToast(`Re-attempt granted to ${created.user_email}`, "success");
+      setEmail("");
+      setNote("");
+    } catch (err: any) {
+      showToast(err?.message || "Failed to grant re-attempt", "error");
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  const handleRevoke = async (grant: AssessmentRetakeGrant) => {
+    if (!assessmentId) return;
+    try {
+      setRevokingId(grant.id);
+      await revokeAssessmentRetake(config.clientId, assessmentId, grant.id);
+      setGrants((prev) => prev.filter((g) => g.id !== grant.id));
+      showToast(`Revoked re-attempt for ${grant.user_email}`, "success");
+    } catch (err: any) {
+      showToast(err?.message || "Failed to revoke re-attempt", "error");
+    } finally {
+      setRevokingId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ pr: 6 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <IconWrapper icon="mdi:replay" size={22} color="var(--accent-indigo)" />
+          <Typography component="span" sx={{ fontWeight: 700 }}>
+            Manage re-attempts
+          </Typography>
+        </Box>
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+          {assessmentTitle}
+        </Typography>
+        <IconButton
+          onClick={onClose}
+          sx={{ position: "absolute", right: 8, top: 8 }}
+          aria-label="Close"
+        >
+          <IconWrapper icon="mdi:close" size={20} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Each grant lets one learner re-attempt this assessment once. The grant
+          is consumed when they start their new attempt; their latest score will
+          replace the previous one on their result page.
+        </Alert>
+
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1 }}>
+          Grant a new re-attempt
+        </Typography>
+        <Stack spacing={1.5} sx={{ mb: 3 }}>
+          <TextField
+            label="Learner email"
+            placeholder="student@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            size="small"
+            fullWidth
+            disabled={granting}
+            type="email"
+          />
+          <TextField
+            label="Note (optional, internal)"
+            placeholder="e.g., approved after instructor review"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            size="small"
+            fullWidth
+            disabled={granting}
+            inputProps={{ maxLength: 255 }}
+          />
+          <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+            <Button
+              variant="contained"
+              startIcon={
+                granting ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : (
+                  <IconWrapper icon="mdi:plus" size={18} />
+                )
+              }
+              onClick={handleGrant}
+              disabled={granting || !email.trim()}
+            >
+              {granting ? "Granting..." : "Grant re-attempt"}
+            </Button>
+          </Box>
+        </Stack>
+
+        <Divider sx={{ mb: 2 }} />
+
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+            Active grants
+          </Typography>
+          <Chip
+            size="small"
+            label={`${grants.length} active`}
+            sx={{ bgcolor: "var(--surface)", fontWeight: 600 }}
+          />
+        </Box>
+
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+            <CircularProgress size={28} />
+          </Box>
+        ) : grants.length === 0 ? (
+          <Typography variant="body2" sx={{ color: "var(--font-tertiary)", py: 2 }}>
+            No active re-attempts. Grant one above to give a specific learner
+            another attempt.
+          </Typography>
+        ) : (
+          <Stack spacing={1} divider={<Divider flexItem />}>
+            {grants.map((g) => (
+              <Box
+                key={g.id}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1.5,
+                  py: 0.75,
+                }}
+              >
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: 600,
+                      color: "var(--font-primary)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {g.user_name || g.user_email}
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                    {g.user_email} · granted{" "}
+                    {new Date(g.granted_at).toLocaleString(undefined, {
+                      dateStyle: "medium",
+                      timeStyle: "short",
+                    })}
+                    {g.granted_by_email ? ` by ${g.granted_by_email}` : ""}
+                  </Typography>
+                  {g.note ? (
+                    <Typography
+                      variant="caption"
+                      sx={{ display: "block", color: "var(--font-secondary)", mt: 0.25 }}
+                    >
+                      Note: {g.note}
+                    </Typography>
+                  ) : null}
+                </Box>
+                <Tooltip title="Revoke">
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={() => handleRevoke(g)}
+                      disabled={revokingId === g.id}
+                      sx={{ color: "var(--error-500)" }}
+                      aria-label="Revoke re-attempt"
+                    >
+                      {revokingId === g.id ? (
+                        <CircularProgress size={16} color="inherit" />
+                      ) : (
+                        <IconWrapper icon="mdi:close-circle-outline" size={20} />
+                      )}
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              </Box>
+            ))}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -778,6 +778,58 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
           </Box>
         </Box>
 
+        {/* Re-attempt CTA (admin-granted, shown above primary CTA).
+            Styled to match the primary CTA's height/font/radius so the two
+            buttons read as a paired action stack; outlined variant
+            differentiates "secondary action" without breaking alignment. */}
+        {submissionComplete && assessment.can_reattempt && (
+          <Box sx={{ mt: 1 }}>
+            <Button
+              fullWidth
+              variant="outlined"
+              size="large"
+              disableRipple
+              onClick={(e) => {
+                e.stopPropagation();
+                router.push(`/assessments/${assessment.slug}`);
+              }}
+              endIcon={<IconWrapper icon="mdi:replay" size={18} color="currentColor" />}
+              sx={{
+                flexDirection: isRtl ? "row-reverse" : "row",
+                mb: 1,
+                py: 1,
+                borderRadius: 2,
+                fontWeight: 600,
+                fontSize: "0.875rem",
+                textTransform: "none",
+                // Cyan-filled, contained: matches View Results' solid look so
+                // the two CTAs read as a paired stack; cyan vs green
+                // differentiates the action (re-take vs view).
+                background: "var(--assessment-catalog-reattempt-cta-gradient)",
+                color: "var(--font-light)",
+                border: "none",
+                boxShadow: "var(--assessment-catalog-reattempt-cta-shadow)",
+                WebkitTapHighlightColor: "transparent",
+                transition: "box-shadow 0.22s ease, transform 0.2s ease, background 0.2s ease",
+                "& .MuiButton-endIcon": { color: "inherit" },
+                "&&:hover": {
+                  background: "var(--assessment-catalog-reattempt-cta-hover-gradient)",
+                  color: "var(--font-light)",
+                  boxShadow: "var(--assessment-catalog-reattempt-cta-shadow-hover)",
+                  transform: "translateY(-2px)",
+                  border: "none",
+                },
+                "&&:active": {
+                  transform: "translateY(0)",
+                  background: "var(--assessment-catalog-reattempt-cta-hover-gradient)",
+                },
+              }}
+            >
+              {t("assessments.reattempt", { defaultValue: "Re-attempt" })}
+            </Button>
+          </Box>
+        )}
+
         {/* CTA Button */}
         <Box sx={{ mt: "1" }}>
           {!isClickable && startDate && remainingTime && !showResults ? (

--- a/components/assessment/AssessmentTimerBar.tsx
+++ b/components/assessment/AssessmentTimerBar.tsx
@@ -116,8 +116,10 @@ export const AssessmentTimerBar = memo(function AssessmentTimerBar({
           </Typography>
         </Box>
 
-        {/* Hidden video element for proctoring only (no preview) */}
-        {proctoringVideoRef && (
+        {/* Hidden video element for proctoring only (no preview).
+            Suppressed during submission: the proctoring detector is torn down as part of
+            submit cleanup, which flips faceCount to 0 and would briefly flash "No Face". */}
+        {proctoringVideoRef && !submitting && (
           <Box
             sx={{
               display: "flex",

--- a/lib/hooks/useAssessmentTimer.ts
+++ b/lib/hooks/useAssessmentTimer.ts
@@ -15,34 +15,55 @@ export function useAssessmentTimer(options: UseAssessmentTimerOptions) {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const onTimeUpRef = useRef(onTimeUp);
   const remainingSecondsRef = useRef(initialTimeSeconds);
+  // Wallclock target — Date.now() ms when timer should hit zero.
+  // Set on (re)start, cleared on pause/reset. Drives all remaining-time math
+  // so background-throttled intervals and system sleep can't cause drift.
+  const deadlineMsRef = useRef<number | null>(null);
+  const timeUpFiredRef = useRef(false);
 
-  // Keep refs updated
   useEffect(() => {
     onTimeUpRef.current = onTimeUp;
   }, [onTimeUp]);
 
-  // Sync ref with state
   useEffect(() => {
     remainingSecondsRef.current = remainingSeconds;
   }, [remainingSeconds]);
 
-  // Track if timer has been initialized to prevent reset on initialTimeSeconds change
   const hasInitializedRef = useRef(false);
   const lastInitialTimeRef = useRef(initialTimeSeconds);
-  
-  // Update ref when initialTimeSeconds changes (for reset) - but only if not already initialized
-  // or if the value actually changed significantly
+
   useEffect(() => {
     const timeDiff = Math.abs(lastInitialTimeRef.current - initialTimeSeconds);
     if (!hasInitializedRef.current || timeDiff > 10) {
       hasInitializedRef.current = true;
       lastInitialTimeRef.current = initialTimeSeconds;
       remainingSecondsRef.current = initialTimeSeconds;
+      timeUpFiredRef.current = false;
       setRemainingSeconds(initialTimeSeconds);
+      if (isRunning) {
+        deadlineMsRef.current = Date.now() + initialTimeSeconds * 1000;
+      }
     }
-  }, [initialTimeSeconds]);
+  }, [initialTimeSeconds, isRunning]);
 
-  // Timer interval - only depends on isRunning to prevent resets
+  const computeRemaining = useCallback((): number => {
+    const deadline = deadlineMsRef.current;
+    if (deadline == null) return remainingSecondsRef.current;
+    return Math.max(0, Math.ceil((deadline - Date.now()) / 1000));
+  }, []);
+
+  const tick = useCallback(() => {
+    const next = computeRemaining();
+    remainingSecondsRef.current = next;
+    setRemainingSeconds(next);
+    if (next <= 0 && !timeUpFiredRef.current) {
+      timeUpFiredRef.current = true;
+      deadlineMsRef.current = null;
+      setIsRunning(false);
+      onTimeUpRef.current?.();
+    }
+  }, [computeRemaining]);
+
   useEffect(() => {
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
@@ -50,20 +71,11 @@ export function useAssessmentTimer(options: UseAssessmentTimerOptions) {
     }
 
     if (isRunning && remainingSecondsRef.current > 0) {
-      intervalRef.current = setInterval(() => {
-        setRemainingSeconds((prev) => {
-          const current = remainingSecondsRef.current;
-          if (current <= 1) {
-            setIsRunning(false);
-            onTimeUpRef.current?.();
-            remainingSecondsRef.current = 0;
-            return 0;
-          }
-          const newValue = current - 1;
-          remainingSecondsRef.current = newValue;
-          return newValue;
-        });
-      }, 1000);
+      if (deadlineMsRef.current == null) {
+        deadlineMsRef.current = Date.now() + remainingSecondsRef.current * 1000;
+      }
+      timeUpFiredRef.current = false;
+      intervalRef.current = setInterval(tick, 1000);
     }
 
     return () => {
@@ -72,18 +84,40 @@ export function useAssessmentTimer(options: UseAssessmentTimerOptions) {
         intervalRef.current = null;
       }
     };
-  }, [isRunning]); // Only depend on isRunning to prevent interval recreation
+  }, [isRunning, tick]);
+
+  // When the tab becomes visible after being hidden, browsers may have
+  // throttled the 1s interval. Recompute immediately from the wallclock
+  // deadline so the displayed time and any time-up callback are accurate.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onVisibility = () => {
+      if (document.visibilityState === "visible" && isRunning) {
+        tick();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [isRunning, tick]);
 
   const start = useCallback(() => {
     setIsRunning(true);
   }, []);
 
   const pause = useCallback(() => {
+    if (deadlineMsRef.current != null) {
+      const snapshot = Math.max(
+        0,
+        Math.ceil((deadlineMsRef.current - Date.now()) / 1000),
+      );
+      remainingSecondsRef.current = snapshot;
+      setRemainingSeconds(snapshot);
+    }
+    deadlineMsRef.current = null;
     setIsRunning(false);
   }, []);
 
   const reset = useCallback((newTimeSeconds: number) => {
-    // Clear any existing interval first
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
@@ -91,7 +125,9 @@ export function useAssessmentTimer(options: UseAssessmentTimerOptions) {
     remainingSecondsRef.current = newTimeSeconds;
     setRemainingSeconds(newTimeSeconds);
     setIsRunning(false);
-    hasInitializedRef.current = true; // Mark as initialized after manual reset
+    deadlineMsRef.current = null;
+    timeUpFiredRef.current = false;
+    hasInitializedRef.current = true;
   }, []);
 
   const formatTime = useCallback((seconds: number): string => {
@@ -122,4 +158,3 @@ export function useAssessmentTimer(options: UseAssessmentTimerOptions) {
     [remainingSeconds, formattedTime, isRunning, start, pause, reset]
   );
 }
-

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -1252,10 +1252,74 @@ export const getAssessmentAnalytics = async (
   }
 };
 
+export interface AssessmentRetakeGrant {
+  id: number;
+  user_id: number;
+  user_email: string;
+  user_name: string;
+  granted_at: string;
+  granted_by_email: string | null;
+  note: string;
+}
+
+export const listAssessmentRetakeGrants = async (
+  clientId: string | number,
+  assessmentId: number,
+): Promise<AssessmentRetakeGrant[]> => {
+  const res = await apiClient.get<AssessmentRetakeGrant[]>(
+    `/admin-dashboard/api/clients/${clientId}/assessments/${assessmentId}/retake-grants/`,
+  );
+  return res.data;
+};
+
+export const grantAssessmentRetake = async (
+  clientId: string | number,
+  assessmentId: number,
+  payload: { user_email?: string; user_id?: number; note?: string },
+): Promise<AssessmentRetakeGrant> => {
+  try {
+    const res = await apiClient.post<AssessmentRetakeGrant>(
+      `/admin-dashboard/api/clients/${clientId}/assessments/${assessmentId}/retake-grants/`,
+      payload,
+    );
+    return res.data;
+  } catch (err) {
+    const error = err as AxiosError<ApiErrorPayload>;
+    const message =
+      error.response?.data?.error ||
+      error.response?.data?.detail ||
+      error.response?.data?.message ||
+      "Failed to grant re-attempt";
+    throw new Error(message);
+  }
+};
+
+export const revokeAssessmentRetake = async (
+  clientId: string | number,
+  assessmentId: number,
+  grantId: number,
+): Promise<void> => {
+  try {
+    await apiClient.delete(
+      `/admin-dashboard/api/clients/${clientId}/assessments/${assessmentId}/retake-grants/${grantId}/`,
+    );
+  } catch (err) {
+    const error = err as AxiosError<ApiErrorPayload>;
+    const message =
+      error.response?.data?.error ||
+      error.response?.data?.detail ||
+      "Failed to revoke re-attempt";
+    throw new Error(message);
+  }
+};
+
 export const adminAssessmentService = {
   getAssessments,
   getAssessmentById,
   createAssessment,
+  listAssessmentRetakeGrants,
+  grantAssessmentRetake,
+  revokeAssessmentRetake,
   publishAssessment,
   updateAssessment,
   deleteAssessment,

--- a/lib/services/assessment.service.ts
+++ b/lib/services/assessment.service.ts
@@ -42,6 +42,8 @@ export interface Assessment {
   review_status?: "not_required" | "pending_evaluation" | "evaluated" | "published";
   tab_switch_limit_enabled?: boolean;
   tab_switch_limit_count?: number | null;
+  /** True when admin has granted this learner an unconsumed retake. Drives the "Re-attempt" CTA above View Result. */
+  can_reattempt?: boolean;
 }
 
 export interface AssessmentDetail extends Assessment {
@@ -214,6 +216,10 @@ export interface AssessmentResult {
   /** When false, show evaluation-in-progress message instead of full result */
   show_result?: boolean;
   review_status?: string;
+  /** All submitted/finalized attempts for this learner, oldest first. Drives the attempt selector when length > 1. */
+  attempts?: AssessmentAttemptSummary[];
+  /** id of the attempt this response is for. Matches AssessmentAttemptSummary.id from `attempts`. */
+  current_attempt_id?: number;
   auto_submitted_reason?: string | null;
   auto_submitted_meta?: Record<string, any>;
   auto_submit_message?: string;
@@ -255,6 +261,16 @@ export interface AssessmentResult {
     coding_problem_responses?: CodingProblemResponseItem[];
     subjective_responses?: SubjectiveResponseItem[];
   };
+}
+
+export interface AssessmentAttemptSummary {
+  id: number;
+  attempt_number: number;
+  started_at: string | null;
+  submitted_at: string | null;
+  score: number | null;
+  status: string;
+  review_status: string | null;
 }
 
 export interface QuizResponseItem {
@@ -510,9 +526,12 @@ export const assessmentService = {
 
   getAssessmentResult: async (
     assessmentIdOrSlug: number | string,
+    attemptId?: number | string,
   ): Promise<AssessmentResult> => {
+    const params = attemptId != null ? { attempt: attemptId } : undefined;
     const response = await apiClient.get<AssessmentResult>(
       `/assessment/api/client/${config.clientId}/assessment-result/${assessmentIdOrSlug}/`,
+      params ? { params } : undefined,
     );
     return response.data;
   },

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -634,6 +634,7 @@
     "durationMin": "د",
     "resume": "متابعة",
     "ended": "انتهى",
+    "expired": "منتهية",
     "availableNow": "متاح الآن",
     "starting": "جاري البدء...",
     "initializing": "جاري التهيئة...",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -633,6 +633,7 @@
     "durationMin": "min",
     "resume": "Resume",
     "ended": "Ended",
+    "expired": "Expired",
     "availableNow": "Available now",
     "availableFrom": "Available from {{date}}",
     "starting": "Starting...",


### PR DESCRIPTION
- Implemented a new dialog for managing re-attempt grants in the admin assessment table.
- Added logic to handle granting and revoking re-attempts for learners.
- Updated assessment service to include API calls for managing re-attempt grants.
- Enhanced assessment result page to support multiple attempts and loading states.
- Introduced a loading spinner for better user experience during data fetching.
- Added a new filter for expired assessments in the assessments page.
- Updated UI components to reflect changes in assessment states and actions.
- Localized new strings for expired assessments in English and Arabic.