### PR TITLE
feat: add MCQQuestionModal component for multiple choice questions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -308,6 +308,16 @@
   --interview-badge-speaking-bg: rgba(99, 102, 241, 0.9);
   --interview-overlay-bg: rgba(248, 250, 252, 0.85);
   --interview-spinner-border: #e2e8f0;
+
+  /* AI Linc brand gradient — matches the gradient stops in the dark-mode mark SVG
+     at /public/logos/ai-linc-mark-darkmode.svg. Used by the AiLincLoader (and any
+     future brand-mark renderers) so the brand identity is centralized here and the
+     loader doesn't carry inline hex literals. */
+  --ailinc-brand-gradient-start: #5b86ff;
+  --ailinc-brand-gradient-end: #00e0ff;
+  /* White shimmer that travels along the mark while the loader is alive. Kept as a
+     token (rather than a literal #FFFFFF) so any future contrast tweak is one edit. */
+  --ailinc-brand-highlight: #ffffff;
 }
 
 @theme inline {

--- a/app/mock-interview/[id]/device-check/page.tsx
+++ b/app/mock-interview/[id]/device-check/page.tsx
@@ -817,7 +817,15 @@ export default function MockInterviewDeviceCheckPage() {
                   }
                 }}
               />
-              {deviceStatus.camera && (
+              {/* Face-detection chip stack. Hidden once the candidate has clicked
+                  "Start Interview" — at that point the "Starting interview…" overlay
+                  covers the camera feed, so the model momentarily sees a black frame and
+                  starts reporting `faceCount === 0`. Showing a "No face" chip + warning
+                  in that exact window made the candidate think they were being told to
+                  fix something even though the camera pre-flight had already passed and
+                  the interview was already kicking off. We freeze the post-Start state
+                  to whatever the validation showed at the moment of click. */}
+              {deviceStatus.camera && !isNavigatingToInterview && (
                 <Box
                   sx={{
                     position: "absolute",
@@ -882,7 +890,7 @@ export default function MockInterviewDeviceCheckPage() {
                 </Box>
               )}
             </Box>
-            {deviceStatus.camera && !isFaceDetectionInitializing && (
+            {deviceStatus.camera && !isFaceDetectionInitializing && !isNavigatingToInterview && (
               <Box sx={{ mt: 2 }}>
                 {faceValidationPassed ? (
                   <Alert severity="success" sx={{ mt: 1 }}>

--- a/app/mock-interview/[id]/result/page.tsx
+++ b/app/mock-interview/[id]/result/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Box, Container, CircularProgress } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
+import { AiLincLoader } from "@/components/common/AiLincLoader";
 import mockInterviewService from "@/lib/services/mock-interview.service";
 import { useToast } from "@/components/common/Toast";
 import { useStopCameraOnMount } from "@/lib/hooks/useStopCameraOnMount";
@@ -32,6 +33,21 @@ interface InterviewResult {
     type: string;
     question_text: string;
     expected_key_points: string[];
+    // Structured-question payloads — present only on the turns where the AI inserted a
+    // coding problem or an MCQ during the live interview. The QuestionPerformance row
+    // surfaces a "View problem" / "View MCQ" button that re-renders these via
+    // StructuredQuestionViewModal so the candidate / reviewer can revisit the exact
+    // problem statement, sample I/O, options, etc.
+    coding_problem?: {
+      statement: string;
+      starter_code: string;
+      language: string;
+      sample_input?: string;
+      sample_output?: string;
+    };
+    mcq_options?: { id: string; text: string }[];
+    mcq_multi_select?: boolean;
+    mcq_correct_option_ids?: string[];
   }>;
   grading_scheme: Record<
     string,
@@ -102,29 +118,85 @@ export default function InterviewResultPage() {
   const [loading, setLoading] = useState(true);
   const [result, setResult] = useState<InterviewResult | null>(null);
   const [expandedQuestion, setExpandedQuestion] = useState<number | false>(1);
+  // True while we're polling for the LLM evaluation to finish. The submit endpoint now
+  // returns 202 immediately and runs evaluation in a background thread on the server —
+  // the result page polls /detail/ until `evaluation_score.overall_percentage` shows up.
+  const [evaluationPending, setEvaluationPending] = useState(false);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Stop any active camera streams on this page
   useStopCameraOnMount();
 
   useEffect(() => {
-    const loadResult = async () => {
+    const interviewId = Number(params.id);
+    if (!interviewId) return;
+
+    let cancelled = false;
+
+    const isEvaluationReady = (data: { evaluation_score?: { overall_percentage?: number } } | null) => {
+      return (
+        !!data &&
+        !!data.evaluation_score &&
+        typeof data.evaluation_score.overall_percentage === "number"
+      );
+    };
+
+    const fetchOnce = async () => {
       try {
-        setLoading(true);
-        const data = await mockInterviewService.getInterviewDetail(
-          Number(params.id)
-        );
-        setResult(data as any);
+        const data = await mockInterviewService.getInterviewDetail(interviewId);
+        if (cancelled) return;
+        setResult(data as InterviewResult);
+        if (isEvaluationReady(data as { evaluation_score?: { overall_percentage?: number } })) {
+          setEvaluationPending(false);
+          setLoading(false);
+          if (pollIntervalRef.current) {
+            clearInterval(pollIntervalRef.current);
+            pollIntervalRef.current = null;
+          }
+        } else {
+          // Server has the row but the background evaluation worker hasn't finished
+          // writing the score yet. Stay in pending mode and let the interval re-poll.
+          setEvaluationPending(true);
+          setLoading(false);
+        }
       } catch (error) {
+        if (cancelled) return;
         showToast("Failed to load interview result", "error");
         router.push("/mock-interview");
-      } finally {
-        setLoading(false);
       }
     };
 
-    if (params.id) {
-      loadResult();
-    }
+    // First load — always blocks the page with the loader until we know whether the
+    // evaluation is ready or pending.
+    void fetchOnce();
+
+    // Polling — fires every 1s while we're still waiting on the evaluation worker. The
+    // background worker typically finishes in 5-12s with the slimmed eval prompt, so a 1s
+    // poll catches it within a second of completion instead of up to 2s of staring at the
+    // loader. We give up after ~90s; at that point the worker probably crashed or the LLM
+    // is permanently failing, and the page renders whatever's there.
+    const maxAttempts = 90;
+    let attempt = 0;
+    pollIntervalRef.current = setInterval(() => {
+      attempt += 1;
+      if (attempt > maxAttempts) {
+        if (pollIntervalRef.current) {
+          clearInterval(pollIntervalRef.current);
+          pollIntervalRef.current = null;
+        }
+        setEvaluationPending(false);
+        return;
+      }
+      void fetchOnce();
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+    };
   }, [params.id, router, showToast]);
 
   const getScoreColor = useCallback((percentage: number) => {
@@ -182,7 +254,11 @@ export default function InterviewResultPage() {
             py: 8,
           }}
         >
-          <CircularProgress size={40} sx={{ color: "#6366f1" }} />
+          <AiLincLoader
+            variant="inline"
+            label="AI LINC · LOADING"
+            subMessage="Loading your interview result…"
+          />
         </Box>
       </MainLayout>
     );
@@ -190,6 +266,53 @@ export default function InterviewResultPage() {
 
   if (!result) {
     return null;
+  }
+
+  // Evaluation is still being computed by the backend worker — render a loading screen
+  // with friendly copy. The poller (set up in the effect above) will keep checking and
+  // flip evaluationPending → false once the score is written.
+  if (evaluationPending) {
+    return (
+      <MainLayout>
+        <Container maxWidth="md" sx={{ py: 8, textAlign: "center" }}>
+          <AiLincLoader
+            variant="inline"
+            label="EVALUATING YOUR INTERVIEW"
+            subMessage="Our AI is reviewing your answers and preparing detailed feedback. This usually takes 5–15 seconds."
+            size={260}
+          />
+          <Typography
+            variant="caption"
+            sx={{
+              display: "block",
+              mt: 3,
+              color: "var(--font-tertiary)",
+              fontStyle: "italic",
+            }}
+          >
+            You can safely keep this page open — your result will appear here as soon as it's ready.
+          </Typography>
+        </Container>
+      </MainLayout>
+    );
+  }
+
+  // Defensive: if the poller timed out without an evaluation, the backend evaluator
+  // probably crashed for this interview. Show a friendly recovery screen instead of
+  // crashing on `result.evaluation_score.overall_percentage`.
+  if (!result.evaluation_score || typeof result.evaluation_score.overall_percentage !== "number") {
+    return (
+      <MainLayout>
+        <Container maxWidth="md" sx={{ py: 8, textAlign: "center" }}>
+          <Typography variant="h6" sx={{ fontWeight: 700, mb: 1 }}>
+            Evaluation taking longer than usual
+          </Typography>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 3 }}>
+            Our scoring service is busy. Your transcript is saved — please check back in a minute.
+          </Typography>
+        </Container>
+      </MainLayout>
+    );
   }
 
   const scoreColors = getScoreColor(result.evaluation_score.overall_percentage);

--- a/app/mock-interview/[id]/take/page.tsx
+++ b/app/mock-interview/[id]/take/page.tsx
@@ -15,6 +15,7 @@ import { useFullscreenMonitor } from "@/lib/hooks/useFullscreenMonitor";
 import { useSpeechToText } from "@/lib/hooks/useSpeechToText";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { stopAllMediaTracks, registerMediaStream } from "@/lib/utils/cameraUtils";
+import { cleanInterviewTitle } from "@/lib/utils/mock-interview-title";
 import {
   InterviewHeader,
   VideoPreviewArea,
@@ -23,6 +24,8 @@ import {
   FullscreenWarningDialog,
   EndInterviewDialog,
 } from "@/components/mock-interview";
+import { CodingQuestionModal } from "@/components/mock-interview/CodingQuestionModal";
+import { MCQQuestionModal } from "@/components/mock-interview/MCQQuestionModal";
 
 const INTERVIEW_AVATAR_SRC = "/videos/Interview.mp4";
 
@@ -63,6 +66,20 @@ export default function TakeMockInterviewPage() {
   const [isClosingRemark, setIsClosingRemark] = useState<boolean>(false);
   const [isFetchingNext, setIsFetchingNext] = useState(false);
 
+  const [isCodingModalOpen, setIsCodingModalOpen] = useState<boolean>(false);
+  const [isMCQModalOpen, setIsMCQModalOpen] = useState<boolean>(false);
+  const lastStructuredQuestionIdRef = useRef<number | null>(null);
+
+  const [closingRemarkIdleStartedAt, setClosingRemarkIdleStartedAt] = useState<
+    number | null
+  >(null);
+  const [autoSubmitSecondsLeft, setAutoSubmitSecondsLeft] = useState<number | null>(
+    null,
+  );
+
+  const [codingTimeBudgetSeconds, setCodingTimeBudgetSeconds] = useState<number>(0);
+  const [interviewBonusSeconds, setInterviewBonusSeconds] = useState<number>(0);
+
   const isInitializingRef = useRef(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
@@ -72,6 +89,17 @@ export default function TakeMockInterviewPage() {
   const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const eyeMovementCountRef = useRef(0);
   const lastEyeMovementWarningRef = useRef(0);
+  // Timestamp recorded when proctoring starts. Used to silently drop NO_FACE /
+  // POOR_LIGHTING violation toasts during the first PROCTORING_WARMUP_MS while the
+  // camera stream is still attaching + the face-detection model is warming up. The
+  // shared ProctoringService also has its own warmup (5.5s) but that only activates
+  // after videoElement.readyState >= 2 — on the take page the video is sometimes still
+  // at readyState 1 when proctoring kicks off, so the service-level warmup never
+  // arms and the first detection tick fires a "no face" toast at the candidate. This
+  // consumer-level grace period mirrors what the assessment proctoring stack does
+  // implicitly and fixes the reported "click Proceed → no face detected toast" bug.
+  const proctoringStartedAtRef = useRef<number | null>(null);
+  const PROCTORING_WARMUP_MS = 6000;
 
   // Proctoring hooks with enhanced configuration
   const {
@@ -92,6 +120,19 @@ export default function TakeMockInterviewPage() {
     detectionInterval: 250, // Check every 500ms for faster updates
     violationCooldown: 1000, // 1 second cooldown between same violation
     onViolation: (violation) => {
+      // Suppress face-detection violations during the startup warmup so a slow camera
+      // attach doesn't toast the candidate "no face detected!" the moment they click
+      // Proceed. The ProctoringService has its own internal grace period but it only
+      // arms after videoElement.readyState >= 2; this consumer-level filter is a
+      // belt-and-suspenders catch for the readyState-1-at-startup case.
+      const isStartupNoiseViolation =
+        violation.type === "NO_FACE" || violation.type === "POOR_LIGHTING";
+      const startedAt = proctoringStartedAtRef.current;
+      const inWarmup =
+        startedAt !== null && Date.now() - startedAt < PROCTORING_WARMUP_MS;
+      if (isStartupNoiseViolation && inWarmup) {
+        return;
+      }
       // Show toast for high severity violations
       if (violation.severity === "high") {
         showToast(violation.message, "error");
@@ -218,6 +259,7 @@ export default function TakeMockInterviewPage() {
 
         // Video element is ready, start proctoring immediately
         // Proctoring service will reuse existing stream if available
+        proctoringStartedAtRef.current = Date.now();
         startProctoring().catch((error) => {
           // Silently fail - will retry or user will see error when starting interview
         });
@@ -273,6 +315,17 @@ export default function TakeMockInterviewPage() {
     return cleaned;
   }, []);
 
+  // EVALUATION TRANSCRIPT NOTE:
+  // `useSpeechToText` is configured with `preferWhisper: true` below — that means
+  // browser STT drives transcripts whenever it's working (free, fast, accurate enough
+  // for most Chrome users), and Whisper takes over as a fallback when browser STT
+  // fails (Edge `network` errors, Safari/Firefox without native STT, etc.). Whichever
+  // engine is active for a given utterance pipes its `final` chunk through `onFinal`
+  // here → `setCurrentAnswer` → ultimately the `transcript.responses[].answer` field
+  // the backend evaluator reads. So the evaluation transcript IS Whisper-quality
+  // whenever browser STT is unreliable. To upgrade ALL evaluations to Whisper-quality
+  // (at the cost of additional OpenAI spend or a separate audio-upload pipeline), see
+  // the "Whisper-on-recorded-audio" architectural note in the project README.
   const speechToText = useSpeechToText({
     onFinal: (text) => {
       const cleaned = sanitizeSttFragment(text || "");
@@ -302,9 +355,11 @@ export default function TakeMockInterviewPage() {
     needsTypingFallback,
   } = speechToText;
 
-  // Disable ESC and right-click
+  const isAdminClipboardWindow =
+    isCodingModalOpen && interview?.duration_minutes === 2;
   useKeyboardShortcuts({
     enabled: interviewStarted,
+    suspend: isAdminClipboardWindow,
     onEscape: () => {
       showToast("ESC key is disabled during the interview", "warning");
     },
@@ -339,6 +394,12 @@ export default function TakeMockInterviewPage() {
       }
       if (typeof started.max_turns === "number") {
         setDynamicMaxTurns(started.max_turns);
+      }
+      // Seed the visible timer's bonus accumulator from the backend so a mid-interview
+      // reload preserves the correct effective budget. /start/ surfaces it as
+      // `bonus_seconds` on the MockInterview row.
+      if (typeof started.bonus_seconds === "number") {
+        setInterviewBonusSeconds(started.bonus_seconds);
       }
       // On a fresh dynamic interview, /start/ only returns the OPENING question. The opening
       // is final only if max_turns is 1 (degenerate case).
@@ -512,7 +573,9 @@ export default function TakeMockInterviewPage() {
         showToast("Failed to enter fullscreen mode", "warning");
       });
 
-      // Start proctoring immediately
+      // Start proctoring immediately. Reset the warmup window so the camera
+      // re-attach doesn't surface a stale "no face" toast (see onViolation suppression).
+      proctoringStartedAtRef.current = Date.now();
       await startProctoring().catch((error) => {
         showToast(
           "Camera initialization failed. Please ensure camera permissions are granted.",
@@ -575,6 +638,50 @@ export default function TakeMockInterviewPage() {
     return question.question_text || question.question || "";
   }, []);
 
+  useEffect(() => {
+    if (!currentQuestion) return;
+    if (lastStructuredQuestionIdRef.current === currentQuestion.id) return;
+    const qtype = (currentQuestion.type || "").toLowerCase();
+    if (qtype === "coding" && currentQuestion.coding_problem) {
+      setIsCodingModalOpen(true);
+      setIsMCQModalOpen(false);
+      lastStructuredQuestionIdRef.current = currentQuestion.id;
+    } else if (qtype === "mcq" && (currentQuestion.mcq_options?.length ?? 0) >= 2) {
+      setIsMCQModalOpen(true);
+      setIsCodingModalOpen(false);
+      lastStructuredQuestionIdRef.current = currentQuestion.id;
+    } else {
+      setIsCodingModalOpen(false);
+      setIsMCQModalOpen(false);
+    }
+  }, [currentQuestion]);
+
+
+  // Build the "conversation so far" list shown in place of the live transcript textarea.
+  // Pulls from the candidate's already-answered turns (each `responses` entry has the
+  // question_text we stamped on it) and appends the current question if it hasn't been
+  // recorded yet. Closing-remark turns are excluded — those aren't questions, they're the
+  // interviewer's wrap-up speech.
+  const questionHistory = useMemo(() => {
+    const seen = new Set<number>();
+    const out: Array<{ id: number; question_text: string }> = [];
+    for (const r of responses) {
+      if (typeof r.question_id !== "number" || seen.has(r.question_id)) continue;
+      seen.add(r.question_id);
+      out.push({
+        id: r.question_id,
+        question_text: r.question_text || "",
+      });
+    }
+    if (currentQuestion && !seen.has(currentQuestion.id) && !isClosingRemark) {
+      out.push({
+        id: currentQuestion.id,
+        question_text: getQuestionText(currentQuestion),
+      });
+    }
+    return out;
+  }, [responses, currentQuestion, isClosingRemark, getQuestionText]);
+
   // Handle question read complete
   const handleSpeakComplete = useCallback(() => {
     setIsSpeaking(false);
@@ -598,6 +705,10 @@ export default function TakeMockInterviewPage() {
       const newResponse: InterviewResponse = {
         question_id: currentQuestion.id,
         answer: currentAnswer,
+        // Stamp the question text so the question-history panel can render the full
+        // conversation without a separate id→text lookup.
+        question_text:
+          currentQuestion.question_text || currentQuestion.question || "",
       };
 
       if (existingIndex >= 0) {
@@ -614,7 +725,13 @@ export default function TakeMockInterviewPage() {
   // want the JSX to re-render on every audio tick.
   const silenceAdvanceTimerRef = useRef<number | null>(null);
   const lastTranscriptChangeAtRef = useRef<number>(0);
-  const handleNextQuestionRef = useRef<(() => Promise<void>) | null>(null);
+  const handleNextQuestionRef = useRef<
+    | ((
+        overrideAnswerText?: unknown,
+        options?: { forceClose?: boolean },
+      ) => Promise<void>)
+    | null
+  >(null);
   // Live mic energy mirrored into a ref so the silence interval can read it without making
   // the page re-render. We bump lastTranscriptChangeAtRef whenever audio crosses a "user is
   // speaking" threshold — that way, an "umm" or a half-second of resumed speech (which won't
@@ -626,6 +743,12 @@ export default function TakeMockInterviewPage() {
   const answerAtAdvanceRef = useRef<string>("");
   const previousQuestionIdAtAdvanceRef = useRef<number | null>(null);
   const [conversationStatus, setConversationStatus] = useState<string>("");
+  // 0-1 value the answer-input area renders as the "Interviewer is waiting" bar.
+  // Updated by the silence detector on every poll — climbs from 0 → 1 over the
+  // SILENCE_THRESHOLD_MS window of quiet, drops back to 0 when the candidate speaks
+  // again. Gives the candidate a visible thinking budget instead of an invisible
+  // countdown.
+  const [pauseProgress, setPauseProgress] = useState<number>(0);
 
   useEffect(() => {
     audioLevelRef.current = audioLevel;
@@ -667,12 +790,13 @@ export default function TakeMockInterviewPage() {
     };
   }, [currentAnswer, currentQuestion, handleSaveAnswer]);
 
-  // Handle submit interview
+  const submitInFlightRef = useRef(false);
   const handleSubmitInterview = useCallback(async () => {
     if (!interview || !startTime) return;
+    if (submitInFlightRef.current) return;
+    submitInFlightRef.current = true;
 
     try {
-      // Get latest responses (including any unsaved answer)
       let finalResponses = [...responses];
       if (currentAnswer && currentQuestion) {
         const existingIndex = finalResponses.findIndex(
@@ -681,6 +805,8 @@ export default function TakeMockInterviewPage() {
         const newResponse: InterviewResponse = {
           question_id: currentQuestion.id,
           answer: currentAnswer,
+          question_text:
+            currentQuestion.question_text || currentQuestion.question || "",
         };
         if (existingIndex >= 0) {
           finalResponses[existingIndex] = newResponse;
@@ -779,14 +905,24 @@ export default function TakeMockInterviewPage() {
       await new Promise((resolve) => setTimeout(resolve, 50));
       stopAllMediaTracks();
 
-      // Navigate to success page
-      showToast("Interview submitted successfully!", "success");
+      // Backend now returns 202 immediately and runs LLM evaluation in a background
+      // thread, so this navigation is instant. The submission-success page shows a quick
+      // confirmation, then the candidate clicks through to /result/ which polls for the
+      // evaluation to finish (typically 5–15s).
+      showToast(
+        "Interview submitted. Your evaluation is being prepared.",
+        "success"
+      );
       router.push(`/mock-interview/${interviewId}/submission-success`);
     } catch (error) {
+      const statusCode =
+        (error as { response?: { status?: number } })?.response?.status;
+      if (statusCode === 400) {
+        router.push(`/mock-interview/${interviewId}/submission-success`);
+        return;
+      }
       showToast("Failed to submit interview", "error");
-      // Reset the "ending" lock so End Interview stays clickable. Without this, a failed
-      // submit (e.g., a transient 500 from the eval LLM call) would trap the candidate with
-      // a permanently disabled End button.
+      submitInFlightRef.current = false;
       setIsEndingInterview(false);
     }
   }, [
@@ -804,22 +940,58 @@ export default function TakeMockInterviewPage() {
     showToast,
   ]);
 
-  // Handle next question
-  const handleNextQuestion = useCallback(async () => {
-    // Clear auto-save timer; we want to record the answer for THIS question right now.
+  useEffect(() => {
+    if (!isClosingRemark) return;
+    if (isSpeaking) return;
+    if (closingRemarkIdleStartedAt !== null) return;
+    setClosingRemarkIdleStartedAt(Date.now());
+  }, [isClosingRemark, isSpeaking, closingRemarkIdleStartedAt]);
+
+  useEffect(() => {
+    if (closingRemarkIdleStartedAt === null) return;
+    const IDLE_GRACE_SECONDS = 30;
+    const COUNTDOWN_SECONDS = 10;
+    const intervalId = window.setInterval(() => {
+      const elapsedSeconds = (Date.now() - closingRemarkIdleStartedAt) / 1000;
+      if (elapsedSeconds >= IDLE_GRACE_SECONDS + COUNTDOWN_SECONDS) {
+        window.clearInterval(intervalId);
+        setAutoSubmitSecondsLeft(0);
+        handleSubmitInterview();
+        return;
+      }
+      if (elapsedSeconds >= IDLE_GRACE_SECONDS) {
+        const remaining = Math.max(
+          0,
+          Math.ceil(IDLE_GRACE_SECONDS + COUNTDOWN_SECONDS - elapsedSeconds),
+        );
+        setAutoSubmitSecondsLeft(remaining);
+      }
+    }, 250);
+    return () => window.clearInterval(intervalId);
+  }, [closingRemarkIdleStartedAt, handleSubmitInterview]);
+
+  const handleNextQuestion = useCallback(async (
+    overrideAnswerText?: unknown,
+    options?: { forceClose?: boolean },
+  ) => {
+    const overrideString =
+      typeof overrideAnswerText === "string" ? overrideAnswerText : undefined;
+    const forceClose = !!options?.forceClose;
+
     if (autoSaveTimerRef.current) {
       clearTimeout(autoSaveTimerRef.current);
       autoSaveTimerRef.current = null;
     }
 
-    // ===== Dynamic (turn-based) flow =====
     if (isDynamicInterview) {
       if (!currentQuestion) return;
       if (isFetchingNext) return; // guard against double-tap
 
       // Capture the answer text for this turn and record it locally so the transcript stays
-      // in sync with what the backend will receive at submit time.
-      const answerForThisTurn = currentAnswer.trim();
+      // in sync with what the backend will receive at submit time. Structured-question
+      // modals pass their formatted text via `overrideString` so we don't rely on the
+      // stale `currentAnswer` state.
+      const answerForThisTurn = (overrideString ?? currentAnswer).trim();
       const questionTextForThisTurn =
         currentQuestion.question_text || currentQuestion.question || "";
 
@@ -830,6 +1002,7 @@ export default function TakeMockInterviewPage() {
         const entry: InterviewResponse = {
           question_id: currentQuestion.id,
           answer: answerForThisTurn,
+          question_text: questionTextForThisTurn,
         };
         if (existingIndex >= 0) {
           const copy = [...prev];
@@ -868,9 +1041,13 @@ export default function TakeMockInterviewPage() {
         return;
       }
 
-      // If the question we just answered was the FINAL question of the interview, we don't
-      // ask for another follow-up — we submit.
-      if (dynamicIsFinalQuestion) {
+      // If we already finished the closing remark and the candidate is hitting Submit, do
+      // exactly that. Note we DON'T short-circuit on `dynamicIsFinalQuestion` — even when
+      // the LLM marked its last question as final, we still want to call /next-question/
+      // so the backend can hand back the closing remark (thank-you + light feedback +
+      // "you can submit when you're ready"). The candidate would otherwise lose the
+      // wrap-up speech entirely.
+      if (isClosingRemark) {
         handleSubmitInterview();
         return;
       }
@@ -897,15 +1074,17 @@ export default function TakeMockInterviewPage() {
           await mockInterviewService.getNextQuestion(interviewId, {
             previous_question_id: currentQuestion.id,
             candidate_answer: answerForThisTurn,
+            force_close: forceClose,
           });
 
-        // Closing-remark path: backend says we're in the final minute, hands us a natural
-        // verbal wrap-up text instead of another question. We surface it to the candidate
-        // by treating it as a "question" the avatar speaks, but mark dynamicIsFinalQuestion
-        // and a separate isClosingRemark flag so:
+        // Closing-remark path: backend says we're at the wrap-up, hands us a natural
+        // verbal close instead of another question. We surface it to the candidate by
+        // treating it as a "question" the avatar speaks, but mark a separate
+        // `isClosingRemark` flag (which is what now drives the "Submit Interview" button
+        // label via `isLastQuestion`) so:
         //   - silence-detection auto-advance is suppressed (no answer expected)
-        //   - the action button reads "Submit Interview" (already gated on
-        //     dynamicIsFinalQuestion via isLastQuestion)
+        //   - the action button reads "Submit Interview"
+        //   - the closing-remark grace timer starts once the avatar finishes speaking
         //   - the candidate hears the close, then taps Submit when ready
         if (next.is_closing_remark && next.closing_remark) {
           const closingTurn: InterviewQuestion = {
@@ -968,11 +1147,21 @@ export default function TakeMockInterviewPage() {
         setDynamicTurnNumber(next.turn_number);
         setDynamicMaxTurns(next.max_turns);
         setDynamicIsFinalQuestion(!!next.is_final_question);
+        // Capture per-coding-turn budget (5/7/10 min based on interview difficulty). The
+        // backend always sends 0 for non-coding turns, so this resets cleanly when the
+        // candidate finishes a coding modal and the AI moves on. The CodingQuestionModal
+        // reads this via its `budgetSeconds` prop to render its own countdown.
+        setCodingTimeBudgetSeconds(
+          typeof next.coding_time_budget_seconds === "number"
+            ? next.coding_time_budget_seconds
+            : 0,
+        );
+        if (typeof next.bonus_seconds === "number") {
+          setInterviewBonusSeconds(next.bonus_seconds);
+        }
         setCurrentAnswer("");
         setInterimTranscript("");
-        setIsSpeaking(true); // Avatar narrates the new question (drives facial movement).
-        // Reset the snapshot so a future advance doesn't accidentally treat stale state as
-        // "continuation."
+        setIsSpeaking(true);
         answerAtAdvanceRef.current = "";
         previousQuestionIdAtAdvanceRef.current = null;
         void questionTextForThisTurn;
@@ -1030,6 +1219,30 @@ export default function TakeMockInterviewPage() {
     handleNextQuestionRef.current = handleNextQuestion;
   }, [handleNextQuestion]);
 
+  const handleCodingModalSubmit = useCallback(
+    (payload: { code: string; language: string }) => {
+      const formatted = `[Coding answer · ${payload.language}]\n${payload.code}`;
+      setIsCodingModalOpen(false);
+      setCurrentAnswer(formatted);
+      void handleNextQuestion(formatted);
+    },
+    [handleNextQuestion],
+  );
+
+  const handleMCQModalSubmit = useCallback(
+    (payload: { ids: string[]; labels: string[] }) => {
+      const selectionText = payload.labels.length
+        ? payload.labels.join(", ")
+        : "(no option selected)";
+      const idsText = payload.ids.length ? payload.ids.join(", ") : "—";
+      const formatted = `[MCQ answer] Selected: ${selectionText} (ids: ${idsText})`;
+      setIsMCQModalOpen(false);
+      setCurrentAnswer(formatted);
+      void handleNextQuestion(formatted);
+    },
+    [handleNextQuestion],
+  );
+
   // Bump the "last transcript change" timestamp whenever the candidate types or speaks.
   useEffect(() => {
     if (!isDynamicInterview) return;
@@ -1053,17 +1266,20 @@ export default function TakeMockInterviewPage() {
     // delivering a wrap-up. We're not waiting for another answer, so auto-advance is moot —
     // the candidate just hits Submit when ready.
     if (isClosingRemark) return;
+    // Structured-question mode (coding / mcq popup is open). The answer comes from the
+    // modal's Submit button, not from STT — so silence here is meaningless and we mustn't
+    // auto-advance with an empty STT buffer.
+    if (isCodingModalOpen || isMCQModalOpen) return;
 
     // Silence threshold tuning:
-    // - 500ms feels snappy — matches the cadence of a real interviewer who jumps in the
-    //   instant they hear the candidate finish a thought. Risk of cutting off a thinking
-    //   pause is mitigated by (a) the audio-level gate below — if the candidate is still
-    //   making sound (mid-word, breathing), we don't count that as silence; and (b) the
-    //   noise-floor calibration from device-check, so background hum doesn't fool it.
-    // - CONFIRM_PAUSE_MS (150) flips the status hint to "Wrapping up…" at ~350ms elapsed,
-    //   giving the candidate a brief visual cue before the advance fires.
-    const SILENCE_THRESHOLD_MS = 500;
-    const CONFIRM_PAUSE_MS = 150;
+    // - 3000ms (3 seconds) is intentionally generous so the candidate has a VISIBLE
+    //   thinking budget. A quick 500ms detector ate thinking pauses with no warning,
+    //   which is what the user reported as "if I think for 4-5 seconds it jumps". Now
+    //   the progress bar gives them 3s of visible "Interviewer is waiting" before the
+    //   advance fires — and any speech resets the bar to 0 instantly.
+    // - The bar's `pauseProgress` (0..1) is computed every tick from
+    //   sinceLastChange / SILENCE_THRESHOLD_MS so the candidate sees the wait elapsing.
+    const SILENCE_THRESHOLD_MS = 3000;
     const POLL_INTERVAL_MS = 100;
 
     // Audio activity gate: anything below this level is treated as silence. By default we
@@ -1093,32 +1309,44 @@ export default function TakeMockInterviewPage() {
       // very moment the avatar finishes speaking we'd auto-advance with an empty answer.
       if (!text) {
         setConversationStatus("Listening — speak when you're ready.");
+        setPauseProgress(0);
         return;
       }
       // STT might still have an interim chunk in flight; don't advance until it settles.
       if (interimTranscript) {
         setConversationStatus("Listening…");
+        setPauseProgress(0);
         return;
       }
       // Live audio: if the candidate is currently making noise above the calibrated
       // threshold, they're probably still talking — STT just hasn't chunked the words yet.
       if (audioLevelRef.current > audioGateThreshold) {
         setConversationStatus("Listening…");
+        setPauseProgress(0);
         return;
       }
       const sinceLastChange = Date.now() - lastTranscriptChangeAtRef.current;
-      const remaining = SILENCE_THRESHOLD_MS - sinceLastChange;
-      if (remaining <= 0) {
-        // Fire once, then let the next render's guard (isFetchingNext) suppress re-entry.
+      // 0..1 progress into the silence window — drives the visible "Interviewer is
+      // waiting" bar in AnswerInputArea. The candidate can interrupt by speaking again,
+      // which resets the bar above.
+      const progress = Math.min(1, sinceLastChange / SILENCE_THRESHOLD_MS);
+      setPauseProgress(progress);
+      if (sinceLastChange >= SILENCE_THRESHOLD_MS) {
+        // Bar filled — auto-advance. Fire once and stop the interval; the next
+        // handleNextQuestion call (via the ref) will set isFetchingNext which prevents
+        // re-entry until the new question is mounted.
         window.clearInterval(intervalId);
         silenceAdvanceTimerRef.current = null;
         setConversationStatus("Got it — following up.");
+        setPauseProgress(0);
         const fn = handleNextQuestionRef.current;
         if (fn) {
           void fn();
         }
-      } else if (remaining <= CONFIRM_PAUSE_MS) {
-        setConversationStatus("Wrapping up — speak now if you want to add more.");
+      } else if (progress >= 0.55) {
+        // Halfway through the wait — switch the status text to "Interviewer is waiting"
+        // so the candidate knows the bar's about to fill.
+        setConversationStatus("Interviewer is waiting…");
       } else {
         setConversationStatus("Listening…");
       }
@@ -1137,6 +1365,8 @@ export default function TakeMockInterviewPage() {
     isFetchingNext,
     isEndingInterview,
     isClosingRemark,
+    isCodingModalOpen,
+    isMCQModalOpen,
     // Re-bind when these change so the threshold check sees fresh values without depending
     // on a stale closure.
     currentAnswer,
@@ -1313,16 +1543,38 @@ export default function TakeMockInterviewPage() {
     isDynamicRef.current = !!interview?.is_dynamic;
   }, [interview?.is_dynamic]);
 
+  const [needsTimerWrapUp, setNeedsTimerWrapUp] = useState(false);
+  const isClosingRemarkRef = useRef(isClosingRemark);
+  useEffect(() => {
+    isClosingRemarkRef.current = isClosingRemark;
+  }, [isClosingRemark]);
+
   const handleTimeUp = useCallback(() => {
-    if (isDynamicRef.current) {
-      showToastRef.current(
-        "You're past the suggested time — wrap up your current answer.",
-        "info"
-      );
+    if (!isDynamicRef.current) {
+      submitInterviewRef.current();
       return;
     }
-    submitInterviewRef.current();
+    if (isClosingRemarkRef.current) return;
+    showToastRef.current(
+      "Time's up — wrapping up the interview now.",
+      "info"
+    );
+    setNeedsTimerWrapUp(true);
   }, []);
+
+  useEffect(() => {
+    if (!needsTimerWrapUp) return;
+    if (isClosingRemark) {
+      setNeedsTimerWrapUp(false);
+      return;
+    }
+    if (isFetchingNext) {
+      return;
+    }
+    setNeedsTimerWrapUp(false);
+    const fn = handleNextQuestionRef.current;
+    if (fn) void fn(undefined, { forceClose: true });
+  }, [needsTimerWrapUp, isFetchingNext, isClosingRemark]);
 
   if (!interview) {
     return null;
@@ -1357,11 +1609,6 @@ export default function TakeMockInterviewPage() {
           startTime ||
           (interview.started_at ? new Date(interview.started_at) : null)
         }
-        // For dynamic interviews the timer is advisory — we just nudge the candidate to wrap
-        // up instead of auto-submitting. CRITICAL: this must reference a stable callback. The
-        // page re-renders ~60×/sec (audio level updates) and InterviewTimer keys its
-        // setInterval on the onTimeUp ref — a new arrow each render would clear+recreate the
-        // interval before its 1-second tick fires, freezing the timer. See handleTimeUp below.
         onTimeUp={handleTimeUp}
         onEndInterview={handleEndInterview}
         endInterviewDisabled={showEndInterviewDialog || isEndingInterview}
@@ -1369,7 +1616,48 @@ export default function TakeMockInterviewPage() {
         proctoringStatus={proctoringStatus}
         faceCount={faceCount}
         latestViolation={latestViolationProp}
+        timerPaused={isCodingModalOpen}
+        bonusSeconds={interviewBonusSeconds}
       />
+
+      {autoSubmitSecondsLeft !== null && autoSubmitSecondsLeft > 0 && (
+        <Box
+          sx={{
+            position: "sticky",
+            top: 0,
+            zIndex: 1100,
+            px: 3,
+            py: 1.25,
+            backgroundColor: "var(--accent-indigo)",
+            color: "var(--font-light)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.5,
+            fontWeight: 600,
+            fontSize: "0.95rem",
+            letterSpacing: "0.02em",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.18)",
+          }}
+        >
+          <Box
+            component="span"
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              minWidth: 32,
+              height: 32,
+              borderRadius: "50%",
+              backgroundColor: "rgba(255,255,255,0.2)",
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {autoSubmitSecondsLeft}
+          </Box>
+          <span>Auto-submitting in {autoSubmitSecondsLeft}s — click Submit Interview to send now.</span>
+        </Box>
+      )}
 
       {/* Main Content */}
       <Box sx={{ flex: 1, display: "flex", overflow: "hidden" }}>
@@ -1399,7 +1687,7 @@ export default function TakeMockInterviewPage() {
             onSpeakComplete={handleSpeakComplete}
             isUserSpeaking={isListening}
             interviewVideoSrc={INTERVIEW_AVATAR_SRC}
-            interviewTitle={interview?.title}
+            interviewTitle={cleanInterviewTitle(interview?.title)}
             questionsCount={questions?.length}
             durationMinutes={interview.duration_minutes}
           />
@@ -1417,8 +1705,14 @@ export default function TakeMockInterviewPage() {
               // answer doesn't match how a real interview works, so Previous is disabled.
               canGoPrevious={!isDynamicInterview && currentQuestionIndex > 0}
               isLastQuestion={
+                // The "Submit Interview" button label is reserved for the closing-remark
+                // phase only — every QUESTION (even the LLM's final synthesizing one) keeps
+                // the "Follow up" affordance so the candidate's last answer routes through
+                // /next-question/, which then returns the closing remark for the avatar to
+                // speak. Without this guard the AI's last question would submit immediately
+                // without the wrap-up speech the user asked for.
                 isDynamicInterview
-                  ? dynamicIsFinalQuestion
+                  ? isClosingRemark
                   : currentQuestionIndex >= totalQuestions - 1
               }
               isListening={isListening}
@@ -1430,6 +1724,15 @@ export default function TakeMockInterviewPage() {
               conversationStatus={
                 isDynamicInterview ? conversationStatus : undefined
               }
+              pauseProgress={
+                isDynamicInterview && !isClosingRemark ? pauseProgress : 0
+              }
+              // Dynamic interviews hide the live transcript on screen and show the
+              // running question history instead. Legacy interviews keep the textarea
+              // since they still rely on the candidate seeing/editing their answer text.
+              showAnswerTextarea={!isDynamicInterview}
+              questionHistory={isDynamicInterview ? questionHistory : []}
+              submitDisabled={isClosingRemark && isSpeaking}
             />
           )}
         </Box>
@@ -1462,6 +1765,22 @@ export default function TakeMockInterviewPage() {
         open={showEndInterviewDialog}
         onConfirm={handleConfirmEndInterview}
         onCancel={handleCancelEndInterview}
+      />
+
+      <CodingQuestionModal
+        open={isCodingModalOpen}
+        problem={currentQuestion?.coding_problem ?? null}
+        spokenIntro={getQuestionText(currentQuestion)}
+        budgetSeconds={codingTimeBudgetSeconds}
+        allowClipboard={interview?.duration_minutes === 2}
+        onSubmit={handleCodingModalSubmit}
+      />
+      <MCQQuestionModal
+        open={isMCQModalOpen}
+        options={currentQuestion?.mcq_options ?? []}
+        multiSelect={!!currentQuestion?.mcq_multi_select}
+        spokenIntro={getQuestionText(currentQuestion)}
+        onSubmit={handleMCQModalSubmit}
       />
     </Box>
   );

--- a/app/mock-interview/courses/page.tsx
+++ b/app/mock-interview/courses/page.tsx
@@ -7,6 +7,7 @@ import { MainLayout } from "@/components/layout/MainLayout";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { useStopCameraOnMount } from "@/lib/hooks/useStopCameraOnMount";
+import { cleanInterviewTitle } from "@/lib/utils/mock-interview-title";
 import mockInterviewService, {
   type PendingCourseInterview,
 } from "@/lib/services/mock-interview.service";
@@ -201,7 +202,7 @@ export default function MockInterviewCoursesPage() {
                     variant="subtitle1"
                     sx={{ fontWeight: 700, flex: 1 }}
                   >
-                    {tmpl.title}
+                    {cleanInterviewTitle(tmpl.title)}
                   </Typography>
                   <Chip
                     label={tmpl.difficulty}

--- a/app/mock-interview/quick-start/page.tsx
+++ b/app/mock-interview/quick-start/page.tsx
@@ -8,6 +8,7 @@ import {
   QuickStartFormData,
 } from "@/components/mock-interview/QuickStartForm";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { AiLincLoader } from "@/components/common/AiLincLoader";
 import mockInterviewService from "@/lib/services/mock-interview.service";
 import { useToast } from "@/components/common/Toast";
 import { useRouter } from "next/navigation";
@@ -37,6 +38,35 @@ export default function QuickStartPage() {
     },
     [showToast, router]
   );
+
+  // While the create call is in flight, REPLACE the entire page with a clean loader
+  // screen — no form behind it, no header, no breadcrumb. The previous inline overlay
+  // looked busy because the loader's caption visibly overlapped form text underneath
+  // (translucent backdrop didn't fully mask the dense form content). This separated
+  // "creating" view gives the loader its own canvas and reads as a quiet transition
+  // beat between picking preferences and landing on the device-check page.
+  if (loading) {
+    return (
+      <MainLayout>
+        <Box
+          sx={{
+            minHeight: "calc(100vh - 96px)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            px: 2,
+          }}
+        >
+          <AiLincLoader
+            variant="inline"
+            label="AI LINC · CREATING YOUR INTERVIEW"
+            subMessage="Setting things up — this usually takes a few seconds…"
+            size={260}
+          />
+        </Box>
+      </MainLayout>
+    );
+  }
 
   return (
     <MainLayout>

--- a/components/common/AiLincLoader.tsx
+++ b/components/common/AiLincLoader.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+
+export interface AiLincLoaderProps {
+  variant?: "fullscreen" | "inline";
+  label?: string;
+  subMessage?: string;
+  size?: number;
+  hidePercent?: boolean;
+}
+
+export function AiLincLoader({
+  variant = "fullscreen",
+  label = "AI LINC · LOADING",
+  subMessage,
+  size,
+  hidePercent = false,
+}: AiLincLoaderProps) {
+  const [pct, setPct] = useState(0);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    let p = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const tick = () => {
+      if (!mountedRef.current) return;
+      p += Math.random() * 11 + 4;
+      if (p >= 99) {
+        setPct(99);
+        return;
+      }
+      setPct(Math.floor(p));
+      timer = setTimeout(tick, 80 + Math.random() * 110);
+    };
+    const startTimer = setTimeout(tick, 120);
+    return () => {
+      mountedRef.current = false;
+      clearTimeout(startTimer);
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  const markSize = size ?? (variant === "fullscreen" ? 320 : 180);
+
+  const markPath =
+    "M 200 120 C 150 48.5, 105 48.5, 100 120 C 95 191.5, 150 191.5, 200 120 C 282.5 9.999999999999986, 356.75 9.999999999999986, 365 120 C 373.25 230, 282.5 230, 200 120 Z M 200 120 C 164 69, 129.6 69, 126 120 C 122.4 171, 164 171, 200 120 C 268.5 34, 332.15 34, 339 120 C 345.85 206, 268.5 206, 200 120 Z";
+
+  const content = (
+    <Box
+      sx={{
+        width: markSize,
+        height: Math.round(markSize * 0.6),
+        mx: "auto",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Box
+        sx={{
+          width: "100%",
+          height: "100%",
+          animation:
+            "ailinc-mark-fadein 0.6s ease-out both, ailinc-mark-breathe 3.4s ease-in-out 0.6s infinite",
+        }}
+      >
+        <Box
+          component="svg"
+          viewBox="0 0 400 240"
+          sx={{
+            width: "100%",
+            height: "100%",
+            display: "block",
+          }}
+          aria-hidden
+        >
+          <defs>
+            <linearGradient
+              id="ailinc-loader-grad"
+              x1="40"
+              y1="120"
+              x2="380"
+              y2="120"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop
+                offset="0"
+                style={{ stopColor: "var(--ailinc-brand-gradient-start)" }}
+              />
+              <stop
+                offset="1"
+                style={{ stopColor: "var(--ailinc-brand-gradient-end)" }}
+              />
+            </linearGradient>
+            <linearGradient
+              id="ailinc-loader-trace"
+              x1="40"
+              y1="120"
+              x2="380"
+              y2="120"
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop
+                offset="0"
+                style={{
+                  stopColor: "var(--ailinc-brand-highlight)",
+                  stopOpacity: 0,
+                }}
+              />
+              <stop
+                offset="0.5"
+                style={{
+                  stopColor: "var(--ailinc-brand-highlight)",
+                  stopOpacity: 0.9,
+                }}
+              />
+              <stop
+                offset="1"
+                style={{
+                  stopColor: "var(--ailinc-brand-highlight)",
+                  stopOpacity: 0,
+                }}
+              />
+            </linearGradient>
+          </defs>
+          <g transform="rotate(-7 200 120)">
+            <path
+              d={markPath}
+              fill="url(#ailinc-loader-grad)"
+              fillRule="evenodd"
+            />
+            <path
+              d={markPath}
+              fill="none"
+              stroke="url(#ailinc-loader-trace)"
+              strokeWidth={4}
+              strokeLinecap="round"
+              fillRule="evenodd"
+              style={{
+                strokeDasharray: 1600,
+                strokeDashoffset: 1600,
+                mixBlendMode: "screen",
+                animation:
+                  "ailinc-mark-trace 2.6s cubic-bezier(.22,1,.36,1) infinite",
+              }}
+            />
+          </g>
+        </Box>
+      </Box>
+
+      <Box
+        component="style"
+        dangerouslySetInnerHTML={{
+          __html: `
+            @keyframes ailinc-mark-fadein {
+              from { opacity: 0; transform: scale(0.92); }
+              to   { opacity: 1; transform: scale(1); }
+            }
+            @keyframes ailinc-mark-breathe {
+              0%, 100% { transform: scale(1); }
+              50%      { transform: scale(1.035); }
+            }
+            @keyframes ailinc-mark-trace {
+              0%   { stroke-dashoffset: 1600; }
+              60%  { stroke-dashoffset: 0; }
+              100% { stroke-dashoffset: -1600; }
+            }
+          `,
+        }}
+      />
+    </Box>
+  );
+
+  const captionBlock = (
+    <Box sx={{ textAlign: "center", mt: 3 }}>
+      {!hidePercent && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.5,
+            fontFamily:
+              "ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', 'Liberation Mono', monospace",
+            fontSize: 11,
+            letterSpacing: "0.2em",
+            color: "var(--font-secondary)",
+          }}
+        >
+          <Box component="span" sx={{ fontWeight: 500 }}>
+            {label}
+          </Box>
+          <Box
+            component="span"
+            sx={{
+              display: "inline-block",
+              minWidth: 24,
+              color: "var(--ailinc-brand-gradient-end)",
+              fontVariantNumeric: "tabular-nums",
+              fontWeight: 600,
+              textAlign: "right",
+            }}
+          >
+            {String(pct).padStart(2, "0")}
+          </Box>
+        </Box>
+      )}
+      {subMessage && (
+        <Typography
+          variant="body2"
+          sx={{
+            mt: 1.5,
+            color: "var(--font-secondary)",
+            fontSize: "0.875rem",
+            fontWeight: 500,
+          }}
+        >
+          {subMessage}
+        </Typography>
+      )}
+    </Box>
+  );
+
+  if (variant === "inline") {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          py: 4,
+          backgroundColor: "transparent",
+        }}
+        role="status"
+        aria-label={label}
+      >
+        {content}
+        {captionBlock}
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      role="status"
+      aria-label={label}
+      sx={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1400,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "transparent",
+      }}
+    >
+      {content}
+      {captionBlock}
+    </Box>
+  );
+}

--- a/components/editor/MonacoEditor.tsx
+++ b/components/editor/MonacoEditor.tsx
@@ -35,6 +35,14 @@ interface MonacoEditorProps {
   height?: string;
   readOnly?: boolean;
   theme?: "vs-dark" | "light";
+  /**
+   * When true, the editor's Ctrl/Cmd + X/C/V shortcuts and the right-click context menu
+   * are NOT intercepted — the candidate can paste code in. Off by default everywhere so
+   * we keep the standard "no copy-paste" interview hardening; the mock-interview flow
+   * flips this on ONLY for the admin-only 2-min test interview so the testing flow
+   * (paste a known-good answer, hit submit) is quick. See CodingQuestionModal.
+   */
+  allowClipboard?: boolean;
 }
 
 export function CodeEditor({
@@ -44,6 +52,7 @@ export function CodeEditor({
   height = "500px",
   readOnly = false,
   theme = "vs-dark",
+  allowClipboard = false,
 }: MonacoEditorProps) {
   const [mounted, setMounted] = useState(false);
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
@@ -87,16 +96,21 @@ export function CodeEditor({
   const handleEditorMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
 
-    // Disable cut, copy, paste keyboard shortcuts
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX, () => {
-      return null;
-    });
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyC, () => {
-      return null;
-    });
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
-      return null;
-    });
+    // Default: disable cut, copy, paste keyboard shortcuts so candidates can't paste a
+    // pre-written solution. When `allowClipboard` is true (admin-only 2-min test
+    // interview path), we leave the shortcuts alone so the tester can paste known-good
+    // code and exercise the rest of the flow quickly.
+    if (!allowClipboard) {
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyX, () => {
+        return null;
+      });
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyC, () => {
+        return null;
+      });
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV, () => {
+        return null;
+      });
+    }
   };
 
   if (!mounted) {
@@ -151,7 +165,10 @@ export function CodeEditor({
           wordWrap: "on",
           formatOnPaste: true,
           formatOnType: true,
-          contextmenu: false,
+          // Right-click context menu (which includes Copy/Cut/Paste entries) is normally
+          // disabled to harden the interview against pasted solutions. Enabled only in
+          // admin-only test mode.
+          contextmenu: allowClipboard,
           fixedOverflowWidgets: true,
         }}
         onMount={handleEditorMount}

--- a/components/mock-interview/AIAvatar.tsx
+++ b/components/mock-interview/AIAvatar.tsx
@@ -6,8 +6,16 @@ import { useInterviewerVoice } from "@/lib/hooks/useInterviewerVoice";
 
 const SPEAKING_LOOP_END = 2.2;
 const POST_QUESTION_START = 2.6;
-const POST_QUESTION_END = 6;
-const WAITING_LAST_FRAME = 5.8;
+// Idle-loop range (in seconds) — the segment of the clip that shows the interviewer
+// making small natural movements (head tilts, blinks, slight body shift) without lip
+// motion. Looped continuously while the avatar is "waiting" (candidate is speaking or
+// the interviewer is between questions), so the avatar feels alive instead of frozen.
+// The window is intentionally pushed past POST_QUESTION_START — the first ~0.5s after
+// the avatar finishes speaking still contains residual mouth motion + camera-shift
+// that looked jarring when looped, so we start the idle slice at 3.1 and trim the
+// tail to 5.5 to keep just the calm "listening" beats.
+const IDLE_LOOP_START = 3.1;
+const IDLE_LOOP_END = 5.5;
 
 type VideoPhase = "speaking" | "post-question" | "waiting";
 
@@ -35,35 +43,52 @@ export const AIAvatar = memo(function AIAvatar({
     const video = interviewVideoRef.current;
     if (!interviewVideoSrc || !video) return;
 
-    const seekToLastFrame = () => {
+    // Drop into the idle-loop segment of the clip and keep playing — gives the avatar
+    // subtle, continuous movement (head, eyes, breath) instead of a frozen still frame
+    // while the candidate is speaking. This is the "Avatar stands still like a photo"
+    // fix.
+    const enterIdleLoop = () => {
       const v = interviewVideoRef.current;
       if (!v || videoPhaseRef.current !== "waiting") return;
-      const end = Number.isFinite(v.duration) ? Math.min(WAITING_LAST_FRAME, v.duration) : WAITING_LAST_FRAME;
-      v.currentTime = end;
-      v.pause();
+      const duration = Number.isFinite(v.duration) ? v.duration : IDLE_LOOP_END;
+      const start = Math.min(IDLE_LOOP_START, duration);
+      // Only seek if we're not already inside the idle range — avoids resetting the
+      // playhead mid-loop on every tick.
+      if (v.currentTime < start || v.currentTime > Math.min(IDLE_LOOP_END, duration)) {
+        v.currentTime = start;
+      }
+      // Continue playing the idle segment; the timeupdate handler below loops it.
+      v.play().catch((e: unknown) => {
+        if ((e as { name?: string })?.name === "AbortError") return;
+      });
     };
 
     const onTimeUpdate = () => {
       const phase = videoPhaseRef.current;
       const t = video.currentTime;
       const duration = video.duration;
-      const end = Number.isFinite(duration) ? Math.min(POST_QUESTION_END, duration) : POST_QUESTION_END;
+      const loopEnd = Number.isFinite(duration)
+        ? Math.min(IDLE_LOOP_END, duration)
+        : IDLE_LOOP_END;
 
       if (phase === "speaking" && t >= SPEAKING_LOOP_END) {
+        // Loop the speaking lip-sync segment until handleSpeakComplete flips us out.
         video.currentTime = 0;
-      } else if (phase === "post-question" && t >= end) {
+      } else if (phase === "post-question" && t >= loopEnd) {
+        // Post-question idle finished — drop straight into the continuous waiting loop.
         videoPhaseRef.current = "waiting";
-        seekToLastFrame();
+        enterIdleLoop();
+      } else if (phase === "waiting" && t >= loopEnd) {
+        // Loop the idle segment continuously so the avatar never freezes.
+        video.currentTime = IDLE_LOOP_START;
       }
     };
 
     const onEnded = () => {
       const phase = videoPhaseRef.current;
-      if (phase === "post-question") {
+      if (phase === "post-question" || phase === "waiting") {
         videoPhaseRef.current = "waiting";
-        seekToLastFrame();
-      } else if (phase === "waiting") {
-        seekToLastFrame();
+        enterIdleLoop();
       }
     };
 
@@ -135,7 +160,11 @@ export const AIAvatar = memo(function AIAvatar({
         alignItems: "center",
         justifyContent: "center",
         backgroundColor: "var(--interview-surface)",
-        borderRadius: 3,
+        // No inner borderRadius — the parent tile in VideoPreviewArea already clips with
+        // `borderRadius: 2 + overflow: hidden`, exactly the way the user-video tile does.
+        // Setting a higher radius here was leaving the video visibly rounded on the AI
+        // side while the user side stayed square — see the parent wrapper for the actual
+        // tile shape.
         overflow: "hidden",
         "@keyframes listenDot": {
           "0%, 100%": { transform: "scale(0.9)", opacity: 0.9 },
@@ -190,10 +219,15 @@ export const AIAvatar = memo(function AIAvatar({
                 onLoadedMetadata={(e) => {
                   const v = e.currentTarget;
                   if (!isAnimating) {
+                    // Initial state — start the idle loop instead of freezing on the
+                    // last frame, so the avatar feels alive before any question fires.
                     videoPhaseRef.current = "waiting";
-                    const end = Number.isFinite(v.duration) ? Math.min(WAITING_LAST_FRAME, v.duration) : WAITING_LAST_FRAME;
-                    v.currentTime = end;
-                    v.pause();
+                    const duration = Number.isFinite(v.duration) ? v.duration : IDLE_LOOP_END;
+                    v.currentTime = Math.min(IDLE_LOOP_START, duration);
+                    v.play().catch((err: unknown) => {
+                      if ((err as { name?: string })?.name === "AbortError") return;
+                      if ((err as { name?: string })?.name === "NotAllowedError") return;
+                    });
                   }
                 }}
               />
@@ -303,6 +337,49 @@ export const AIAvatar = memo(function AIAvatar({
         )}
       </Box>
 
+      {/* Interviewer caption — what the avatar is saying, rendered as subtitle text
+          at the bottom of the tile while the speaking animation is active. Always
+          visible during speech (not gated on accessibility setting) since the user
+          explicitly asked for captions to be shown by default. The text fades in/out
+          via opacity so the transition feels natural. */}
+      {isAnimating && question && (
+        <Box
+          sx={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 5,
+            px: 2.5,
+            py: 1.5,
+            background:
+              "linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.55) 35%, rgba(0,0,0,0.78) 100%)",
+            pointerEvents: "none",
+          }}
+        >
+          <Box
+            component="p"
+            sx={{
+              margin: 0,
+              color: "var(--font-light)",
+              fontSize: { xs: "0.85rem", sm: "0.95rem" },
+              lineHeight: 1.45,
+              fontWeight: 500,
+              textShadow: "0 1px 4px rgba(0,0,0,0.6)",
+              // Limit to ~2 visual lines so long openings don't blanket the whole tile.
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+            aria-live="polite"
+          >
+            {question}
+          </Box>
+        </Box>
+      )}
+
       {isSpeaking && !isAnimating && (
         <Box
           sx={{
@@ -312,7 +389,7 @@ export const AIAvatar = memo(function AIAvatar({
             alignItems: "center",
             justifyContent: "center",
             backgroundColor: "var(--interview-overlay-bg)",
-            borderRadius: 3,
+            // No inner radius — the parent tile already clips with overflow: hidden.
           }}
         >
           <Box

--- a/components/mock-interview/AnswerInputArea.tsx
+++ b/components/mock-interview/AnswerInputArea.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Paper, Typography, TextField, Button, Chip } from "@mui/material";
+import { Box, Paper, Typography, TextField, Button, Chip, Tooltip } from "@mui/material";
 import { CheckCircle } from "lucide-react";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
@@ -31,6 +31,28 @@ export interface AnswerInputAreaProps {
    * is true (e.g., "Listening…", "Moving on…").
    */
   conversationStatus?: string;
+  /**
+   * Pause-detection progress in the range [0, 1]. Drives the visible "Interviewer is
+   * waiting" bar that fills while the candidate is silent. 0 = candidate is currently
+   * speaking (or no silence yet), 1 = fully expired (about to advance). The parent
+   * computes this from elapsed-silence vs the wait threshold.
+   */
+  pauseProgress?: number;
+  /**
+   * When false, hide the live-transcript textarea and the "Your Answer" header. The
+   * candidate's STT stream still runs in the background (for the final evaluation
+   * transcript) but isn't echoed back on screen — matches the "show questions, not the
+   * raw user transcript" UX. Falls back to showing the textarea when `typingFallback`
+   * is true, since typing is the only path when STT is dead.
+   */
+  showAnswerTextarea?: boolean;
+  /**
+   * Numbered list of questions the interviewer has asked so far. Rendered in place of
+   * the textarea when `showAnswerTextarea` is false. Each item is one question; the
+   * most recent appears at the bottom.
+   */
+  questionHistory?: Array<{ id: number; question_text: string }>;
+  submitDisabled?: boolean;
 }
 
 export const AnswerInputArea = memo(function AnswerInputArea({
@@ -47,6 +69,10 @@ export const AnswerInputArea = memo(function AnswerInputArea({
   typingFallback = false,
   hideNavigationButtons = false,
   conversationStatus,
+  pauseProgress = 0,
+  showAnswerTextarea = true,
+  questionHistory = [],
+  submitDisabled = false,
 }: AnswerInputAreaProps) {
   const { t } = useTranslation("common");
   const displayValue =
@@ -55,7 +81,7 @@ export const AnswerInputArea = memo(function AnswerInputArea({
     <Paper
       elevation={0}
       sx={{
-        p: 3,
+        p: 2,
         backgroundColor: "var(--card-bg)",
         borderRadius: 3,
         border: "1px solid var(--border-default)",
@@ -67,9 +93,9 @@ export const AnswerInputArea = memo(function AnswerInputArea({
       {/* Clear listening state so user always knows */}
       <Box
         sx={{
-          mb: 2,
-          py: 1.5,
-          px: 2,
+          mb: 1.25,
+          py: 1,
+          px: 1.5,
           borderRadius: 2,
           display: "flex",
           alignItems: "center",
@@ -107,7 +133,9 @@ export const AnswerInputArea = memo(function AnswerInputArea({
                 Microphone on — listening
               </Typography>
               <Typography variant="caption" sx={{ color: "var(--accent-indigo)" }}>
-                Speak your answer; your words will appear in the box below. You can also type if you prefer.
+                {showAnswerTextarea
+                  ? "Speak your answer; your words will appear in the box below. You can also type if you prefer."
+                  : "Speak naturally. Your answer is being recorded for evaluation."}
               </Typography>
             </Box>
             <Box
@@ -134,121 +162,324 @@ export const AnswerInputArea = memo(function AnswerInputArea({
         )}
       </Box>
 
-      <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2, flexWrap: "wrap" }}>
-        <Typography
-          variant="h6"
-          sx={{ fontWeight: 600, flex: 1, color: "var(--font-primary-dark)" }}
-        >
-          Your Answer
-        </Typography>
-        {isQuestionAnswered && (
-          <Chip
-            icon={<CheckCircle size={16} />}
-            label="Answered"
-            size="small"
+      {/* Two render modes for the answer region:
+          - Legacy / typing-fallback: show "Your Answer" header + multiline textarea
+            so the candidate can see and edit what STT is producing (or type it themselves
+            when STT is broken).
+          - Hidden-answer mode (the new dynamic-interview default): replace both with a
+            minimal numbered list of interviewer questions, like a real interview's
+            "conversation so far" view. The candidate's transcript still streams in the
+            background to the evaluator — it's just not echoed on screen. */}
+      {showAnswerTextarea || typingFallback ? (
+        <>
+          <Box
+            sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2, flexWrap: "wrap" }}
+          >
+            <Typography
+              variant="h6"
+              sx={{ fontWeight: 600, flex: 1, color: "var(--font-primary-dark)" }}
+            >
+              Your Answer
+            </Typography>
+            {isQuestionAnswered && (
+              <Chip
+                icon={<CheckCircle size={16} />}
+                label="Answered"
+                size="small"
+                sx={{
+                  backgroundColor: "var(--ats-success)",
+                  color: "var(--font-light)",
+                }}
+              />
+            )}
+          </Box>
+          <TextField
+            fullWidth
+            multiline
+            rows={6}
+            value={displayValue}
+            onChange={(e) => onAnswerChange(e.target.value)}
+            placeholder="Type your answer here or speak naturally — your speech will appear here as you talk."
             sx={{
-              backgroundColor: "var(--ats-success)",
-              color: "var(--font-light)",
+              "& .MuiOutlinedInput-root": {
+                backgroundColor: "var(--card-bg)",
+                color: "var(--font-primary-dark)",
+                "& fieldset": {
+                  borderColor: isListening
+                    ? "var(--primary-200)"
+                    : "var(--border-light)",
+                },
+                "&:hover fieldset": {
+                  borderColor: isListening
+                    ? "var(--accent-indigo)"
+                    : "var(--font-tertiary)",
+                },
+                "&.Mui-focused fieldset": {
+                  borderColor: "var(--accent-indigo)",
+                },
+              },
+              "& .MuiInputBase-input": {
+                color: "var(--font-primary-dark)",
+              },
             }}
           />
-        )}
-      </Box>
-      <TextField
-        fullWidth
-        multiline
-        rows={6}
-        value={displayValue}
-        onChange={(e) => onAnswerChange(e.target.value)}
-        placeholder="Type your answer here or speak naturally — your speech will appear here as you talk."
-        sx={{
-          "& .MuiOutlinedInput-root": {
-            backgroundColor: "var(--card-bg)",
-            color: "var(--font-primary-dark)",
-            "& fieldset": {
-              borderColor: isListening ? "var(--primary-200)" : "var(--border-light)",
-            },
-            "&:hover fieldset": {
-              borderColor: isListening ? "var(--accent-indigo)" : "var(--font-tertiary)",
-            },
-            "&.Mui-focused fieldset": {
-              borderColor: "var(--accent-indigo)",
-            },
-          },
-          "& .MuiInputBase-input": {
-            color: "var(--font-primary-dark)",
-          },
-        }}
-      />
-      {hideNavigationButtons ? (
-        // Silence-driven mode is the PRIMARY way to advance, but speech recognition isn't
-        // perfect — sometimes the candidate finishes and the silence threshold doesn't fire
-        // (e.g., audio level still bouncing from background noise). We keep a single
-        // explicit button as a manual fallback so the candidate can always advance even when
-        // auto-detect misses.
-        <Box
-          sx={{
-            mt: 2,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 2,
-            minHeight: 36,
-          }}
-        >
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flex: 1 }}>
-            <Box
-              sx={{
-                width: 8,
-                height: 8,
-                borderRadius: "50%",
-                backgroundColor: isListening
-                  ? "var(--ats-success)"
-                  : "var(--font-tertiary)",
-                animation: isListening
-                  ? "convStatusPulse 1.2s ease-in-out infinite"
-                  : undefined,
-                "@keyframes convStatusPulse": {
-                  "0%, 100%": { opacity: 1, transform: "scale(1)" },
-                  "50%": { opacity: 0.5, transform: "scale(1.3)" },
-                },
-              }}
-            />
-            <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-              {conversationStatus ||
-                "Speak naturally — pause when you're done and the interviewer will follow up."}
-            </Typography>
-          </Box>
-          <Button
-            variant="contained"
-            onClick={onNextQuestion}
-            // For mid-interview "Follow up" turns we require some answer text before
-            // letting the candidate skip. For the FINAL action ("Submit Interview" — fired
-            // either after the last question OR after the closing remark) we always allow
-            // the click: the candidate may have nothing to say to a thank-you, and we
-            // don't want to trap them in a disabled-button limbo.
-            disabled={!isLastQuestion && !currentAnswer.trim()}
+        </>
+      ) : (
+        <Box>
+          <Box
             sx={{
-              backgroundColor: isLastQuestion
-                ? "var(--ats-success)"
-                : "var(--accent-indigo)",
-              color: "var(--font-light)",
-              textTransform: "none",
-              fontWeight: 600,
-              px: 2.5,
-              py: 0.75,
-              "&:hover": {
-                backgroundColor: isLastQuestion
-                  ? "var(--ats-success-muted)"
-                  : "var(--accent-indigo-dark)",
-              },
-              "&.Mui-disabled": {
-                backgroundColor: "var(--surface)",
-                color: "var(--font-tertiary)",
-              },
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              mb: 1,
             }}
           >
-            {isLastQuestion ? "Submit Interview" : "Follow up"}
-          </Button>
+            <IconWrapper
+              icon="mdi:comment-question-outline"
+              size={20}
+              color="var(--font-tertiary)"
+            />
+            <Typography
+              variant="subtitle2"
+              sx={{
+                fontWeight: 700,
+                color: "var(--font-primary-dark)",
+                letterSpacing: "0.02em",
+                textTransform: "uppercase",
+                fontSize: "0.75rem",
+              }}
+            >
+              Conversation so far
+            </Typography>
+            <Chip
+              label={questionHistory.length}
+              size="small"
+              sx={{
+                height: 18,
+                fontSize: "0.7rem",
+                fontWeight: 700,
+                backgroundColor: "var(--surface)",
+                color: "var(--font-secondary)",
+              }}
+            />
+          </Box>
+          {questionHistory.length === 0 ? (
+            <Box
+              sx={{
+                py: 3,
+                textAlign: "center",
+                color: "var(--font-tertiary)",
+                fontStyle: "italic",
+              }}
+            >
+              <Typography variant="body2">
+                The interview hasn&apos;t started yet — the first question will appear here.
+              </Typography>
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 1.5,
+                maxHeight: 200,
+                overflowY: "auto",
+                pr: 1,
+                // Subtle styling for the scroll thumb so the panel reads as scrollable.
+                "&::-webkit-scrollbar": { width: 6 },
+                "&::-webkit-scrollbar-thumb": {
+                  backgroundColor: "var(--border-light)",
+                  borderRadius: 3,
+                },
+              }}
+            >
+              {questionHistory.map((q, idx) => {
+                const isCurrent = idx === questionHistory.length - 1;
+                return (
+                  <Box
+                    key={q.id}
+                    sx={{
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: 1.5,
+                      p: 1.5,
+                      borderRadius: 2,
+                      backgroundColor: isCurrent
+                        ? "var(--surface-indigo-light)"
+                        : "var(--surface)",
+                      border: "1px solid",
+                      borderColor: isCurrent
+                        ? "var(--accent-indigo)"
+                        : "var(--border-default)",
+                      transition: "all 0.2s ease",
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        flexShrink: 0,
+                        width: 24,
+                        height: 24,
+                        borderRadius: "50%",
+                        backgroundColor: isCurrent
+                          ? "var(--accent-indigo)"
+                          : "var(--border-default)",
+                        color: isCurrent
+                          ? "var(--font-light)"
+                          : "var(--font-secondary)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontSize: "0.7rem",
+                        fontWeight: 700,
+                        fontVariantNumeric: "tabular-nums",
+                      }}
+                    >
+                      {idx + 1}
+                    </Box>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        flex: 1,
+                        color: isCurrent
+                          ? "var(--font-primary-dark)"
+                          : "var(--font-secondary)",
+                        fontWeight: isCurrent ? 500 : 400,
+                        lineHeight: 1.55,
+                      }}
+                    >
+                      {q.question_text}
+                    </Typography>
+                  </Box>
+                );
+              })}
+            </Box>
+          )}
+        </Box>
+      )}
+      {hideNavigationButtons ? (
+        // Dynamic interview mode. Two stacked rows:
+        //   1. Live status pill ("Listening…" while speaking, "Interviewer is waiting"
+        //      while paused), plus the explicit fallback button (Follow up / Submit).
+        //   2. Visible progress bar that fills during silence so the candidate SEES
+        //      the wait elapsing and can interrupt by speaking again (which resets it).
+        // The progress bar replaces the old invisible silence detector — candidates
+        // were thinking and getting auto-advanced with no warning. Now the pause is
+        // a deliberate, visible state.
+        <Box sx={{ mt: 2, display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 2,
+              minHeight: 36,
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flex: 1 }}>
+              <Box
+                sx={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  backgroundColor: isListening
+                    ? "var(--ats-success)"
+                    : "var(--accent-indigo)",
+                  animation: isListening
+                    ? "convStatusPulse 1.2s ease-in-out infinite"
+                    : pauseProgress > 0
+                      ? "convStatusPulse 1.2s ease-in-out infinite"
+                      : undefined,
+                  "@keyframes convStatusPulse": {
+                    "0%, 100%": { opacity: 1, transform: "scale(1)" },
+                    "50%": { opacity: 0.5, transform: "scale(1.3)" },
+                  },
+                }}
+              />
+              <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                {conversationStatus ||
+                  (isListening
+                    ? "Listening…"
+                    : "Speak naturally — pause when you're done and the interviewer will follow up.")}
+              </Typography>
+            </Box>
+            <Tooltip
+              title={
+                isLastQuestion
+                  ? submitDisabled
+                    ? "Available once the interviewer finishes their closing feedback."
+                    : "Finish the interview and view your evaluation."
+                  : "Tap if the interviewer doesn't pick up that you've finished. Asks them to move on to the next question right away."
+              }
+              arrow
+              placement="top"
+            >
+              <span>
+                <Button
+                  variant="contained"
+                  onClick={onNextQuestion}
+                  disabled={
+                    (isLastQuestion && submitDisabled) ||
+                    (!isLastQuestion && !currentAnswer.trim())
+                  }
+                  sx={{
+                    backgroundColor: isLastQuestion
+                      ? "var(--ats-success)"
+                      : "var(--accent-indigo)",
+                    color: "var(--font-light)",
+                    textTransform: "none",
+                    fontWeight: 600,
+                    px: 2.5,
+                    py: 0.75,
+                    "&:hover": {
+                      backgroundColor: isLastQuestion
+                        ? "var(--ats-success-muted)"
+                        : "var(--accent-indigo-dark)",
+                    },
+                    "&.Mui-disabled": {
+                      backgroundColor: "var(--surface)",
+                      color: "var(--font-tertiary)",
+                    },
+                  }}
+                >
+                  {isLastQuestion ? "Submit Interview" : "Follow up"}
+                </Button>
+              </span>
+            </Tooltip>
+          </Box>
+          {/* Pause progress bar. Width animates from 0% → 100% based on the parent's
+              pauseProgress prop. When the candidate resumes speaking, the parent sets
+              pauseProgress back to 0 — the bar visibly collapses, signalling "you have
+              the floor again". When it reaches 100% the parent auto-advances. */}
+          <Box
+            sx={{
+              position: "relative",
+              height: 6,
+              borderRadius: 999,
+              backgroundColor: "var(--surface)",
+              overflow: "hidden",
+              border: "1px solid var(--border-default)",
+            }}
+          >
+            <Box
+              sx={{
+                position: "absolute",
+                inset: 0,
+                width: `${Math.min(100, Math.max(0, pauseProgress * 100))}%`,
+                background:
+                  pauseProgress > 0
+                    ? "linear-gradient(90deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)"
+                    : "var(--ats-success)",
+                opacity: pauseProgress > 0 || isListening ? 1 : 0.25,
+                // Smooth growth during silence; instant collapse when the candidate
+                // resumes speaking (transition off when pauseProgress drops to 0 so the
+                // reset isn't laggy).
+                transition:
+                  pauseProgress > 0
+                    ? "width 150ms linear"
+                    : "width 0ms linear, opacity 200ms ease",
+              }}
+            />
+          </Box>
         </Box>
       ) : (
       <Box
@@ -296,6 +527,7 @@ export const AnswerInputArea = memo(function AnswerInputArea({
         <Button
           variant="contained"
           onClick={onNextQuestion}
+          disabled={isLastQuestion && submitDisabled}
           sx={{
             backgroundColor: isLastQuestion ? "var(--ats-success)" : "var(--accent-indigo)",
             color: "var(--font-light)",

--- a/components/mock-interview/CodingQuestionModal.tsx
+++ b/components/mock-interview/CodingQuestionModal.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import { memo, useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  IconButton,
+  MenuItem,
+  Paper,
+  Select,
+  Typography,
+} from "@mui/material";
+import { CodeEditor } from "@/components/editor/MonacoEditor";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export interface CodingProblemPayload {
+  statement: string;
+  starter_code: string;
+  language: string;
+  sample_input?: string;
+  sample_output?: string;
+}
+
+interface CodingQuestionModalProps {
+  open: boolean;
+  problem: CodingProblemPayload | null;
+  spokenIntro?: string;
+  budgetSeconds?: number;
+  allowClipboard?: boolean;
+  onSubmit: (payload: { code: string; language: string }) => void;
+}
+
+const LANGUAGE_OPTIONS = [
+  { value: "python", label: "Python" },
+  { value: "javascript", label: "JavaScript" },
+  { value: "java", label: "Java" },
+  { value: "cpp", label: "C++" },
+  { value: "sql", label: "SQL" },
+];
+
+function CodingQuestionModalComponent({
+  open,
+  problem,
+  spokenIntro,
+  budgetSeconds = 0,
+  allowClipboard = false,
+  onSubmit,
+}: CodingQuestionModalProps) {
+  const initialLang = useMemo(
+    () => (problem?.language || "python").toLowerCase(),
+    [problem?.language],
+  );
+  const [language, setLanguage] = useState<string>(initialLang);
+  const [code, setCode] = useState<string>(problem?.starter_code || "");
+
+  useEffect(() => {
+    setLanguage(initialLang);
+    setCode(problem?.starter_code || "");
+  }, [problem?.starter_code, initialLang]);
+
+  const [secondsLeft, setSecondsLeft] = useState<number>(budgetSeconds);
+  useEffect(() => {
+    if (!open) return;
+    setSecondsLeft(budgetSeconds);
+  }, [open, budgetSeconds]);
+  useEffect(() => {
+    if (!open) return;
+    if (budgetSeconds <= 0) return;
+    const id = window.setInterval(() => {
+      setSecondsLeft((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [open, budgetSeconds]);
+
+  const formatMmSs = (totalSec: number) => {
+    const safe = Math.max(0, totalSec);
+    const m = Math.floor(safe / 60);
+    const s = safe % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  const timerColor = (() => {
+    if (budgetSeconds <= 0) return "var(--font-secondary)";
+    const remainingFrac = secondsLeft / budgetSeconds;
+    if (remainingFrac < 0.15) return "var(--ats-error)";
+    if (remainingFrac < 0.35) return "var(--warning-500)";
+    return "var(--accent-indigo)";
+  })();
+
+  const handleSubmit = () => {
+    onSubmit({ code: code.trim() || "// (no code submitted)", language });
+  };
+
+  if (!problem) return null;
+
+  return (
+    <Dialog
+      open={open}
+      maxWidth="lg"
+      fullWidth
+      disableEscapeKeyDown
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          backgroundColor: "var(--card-bg)",
+          color: "var(--font-primary-dark)",
+          maxHeight: "92vh",
+        },
+      }}
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", height: "92vh" }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            px: 3,
+            py: 2,
+            borderBottom: "1px solid var(--border-default)",
+            backgroundColor: "var(--surface)",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+            <IconWrapper icon="mdi:code-braces" size={22} color="var(--accent-indigo)" />
+            <Typography
+              variant="subtitle1"
+              sx={{ fontWeight: 700, color: "var(--font-primary-dark)" }}
+            >
+              Coding Question
+            </Typography>
+            <Box
+              component="span"
+              sx={{
+                ml: 1,
+                px: 1,
+                py: 0.25,
+                borderRadius: 1,
+                backgroundColor: "var(--surface-indigo-light)",
+                color: "var(--accent-indigo)",
+                fontSize: "0.7rem",
+                fontWeight: 600,
+                letterSpacing: "0.04em",
+              }}
+            >
+              MAIN TIMER PAUSED
+            </Box>
+          </Box>
+          {budgetSeconds > 0 && (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.75,
+                px: 1.25,
+                py: 0.5,
+                borderRadius: 1.5,
+                backgroundColor: "var(--card-bg)",
+                border: "1px solid",
+                borderColor: timerColor,
+                color: timerColor,
+                fontVariantNumeric: "tabular-nums",
+                transition: "border-color 0.3s ease, color 0.3s ease",
+              }}
+            >
+              <IconWrapper
+                icon="mdi:timer-outline"
+                size={16}
+                color={timerColor}
+              />
+              <Typography
+                variant="body2"
+                sx={{
+                  fontWeight: 700,
+                  letterSpacing: "0.04em",
+                  fontFamily:
+                    "ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', monospace",
+                  fontSize: "0.85rem",
+                  color: timerColor,
+                }}
+              >
+                {formatMmSs(secondsLeft)}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 600,
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                  fontSize: "0.65rem",
+                  color: timerColor,
+                  opacity: 0.85,
+                }}
+              >
+                left
+              </Typography>
+            </Box>
+          )}
+        </Box>
+
+        <Box sx={{ display: "flex", flex: 1, minHeight: 0 }}>
+          <Box
+            sx={{
+              width: 380,
+              flexShrink: 0,
+              borderRight: "1px solid var(--border-default)",
+              overflowY: "auto",
+              px: 3,
+              py: 2.5,
+              backgroundColor: "var(--card-bg)",
+            }}
+          >
+            {spokenIntro && (
+              <Paper
+                elevation={0}
+                sx={{
+                  p: 1.5,
+                  mb: 2,
+                  backgroundColor: "var(--surface-indigo-light)",
+                  border: "1px solid var(--accent-indigo)",
+                  borderRadius: 2,
+                }}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{
+                    display: "block",
+                    textTransform: "uppercase",
+                    fontWeight: 700,
+                    letterSpacing: "0.05em",
+                    color: "var(--accent-indigo)",
+                    mb: 0.5,
+                  }}
+                >
+                  Interviewer
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ color: "var(--font-primary-dark)", lineHeight: 1.55 }}
+                >
+                  {spokenIntro}
+                </Typography>
+              </Paper>
+            )}
+            <Typography
+              variant="subtitle2"
+              sx={{
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                color: "var(--font-secondary)",
+                mb: 1,
+              }}
+            >
+              Problem
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                whiteSpace: "pre-wrap",
+                lineHeight: 1.6,
+                color: "var(--font-primary-dark)",
+                mb: 2.5,
+              }}
+            >
+              {problem.statement}
+            </Typography>
+
+            {problem.sample_input && (
+              <>
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    fontWeight: 700,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                    color: "var(--font-secondary)",
+                    mt: 1,
+                    mb: 0.5,
+                  }}
+                >
+                  Sample Input
+                </Typography>
+                <Paper
+                  elevation={0}
+                  sx={{
+                    p: 1.25,
+                    fontFamily: "ui-monospace, Menlo, monospace",
+                    fontSize: "0.8rem",
+                    backgroundColor: "var(--surface)",
+                    border: "1px solid var(--border-default)",
+                    borderRadius: 1.5,
+                    whiteSpace: "pre-wrap",
+                    color: "var(--font-primary-dark)",
+                  }}
+                >
+                  {problem.sample_input}
+                </Paper>
+              </>
+            )}
+            {problem.sample_output && (
+              <>
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    fontWeight: 700,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                    color: "var(--font-secondary)",
+                    mt: 1.5,
+                    mb: 0.5,
+                  }}
+                >
+                  Sample Output
+                </Typography>
+                <Paper
+                  elevation={0}
+                  sx={{
+                    p: 1.25,
+                    fontFamily: "ui-monospace, Menlo, monospace",
+                    fontSize: "0.8rem",
+                    backgroundColor: "var(--surface)",
+                    border: "1px solid var(--border-default)",
+                    borderRadius: 1.5,
+                    whiteSpace: "pre-wrap",
+                    color: "var(--font-primary-dark)",
+                  }}
+                >
+                  {problem.sample_output}
+                </Paper>
+              </>
+            )}
+          </Box>
+
+          <Box sx={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                px: 2,
+                py: 1,
+                borderBottom: "1px solid var(--border-default)",
+                backgroundColor: "var(--surface)",
+              }}
+            >
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 700,
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                  color: "var(--font-secondary)",
+                }}
+              >
+                Editor
+              </Typography>
+              <Select
+                size="small"
+                value={language}
+                onChange={(e) => setLanguage(String(e.target.value))}
+                sx={{ minWidth: 130, fontSize: "0.85rem" }}
+              >
+                {LANGUAGE_OPTIONS.map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value} sx={{ fontSize: "0.85rem" }}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </Box>
+            <Box sx={{ flex: 1, minHeight: 0, p: 1.5 }}>
+              <CodeEditor
+                value={code}
+                onChange={(v) => setCode(v ?? "")}
+                language={language}
+                height="100%"
+                theme="vs-dark"
+                allowClipboard={allowClipboard}
+              />
+            </Box>
+          </Box>
+        </Box>
+
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            px: 3,
+            py: 2,
+            borderTop: "1px solid var(--border-default)",
+            backgroundColor: "var(--surface)",
+          }}
+        >
+          <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+            Your code is auto-scored when the interview is submitted. There's no run button —
+            focus on getting the logic right.
+          </Typography>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={!code.trim()}
+            sx={{
+              textTransform: "none",
+              fontWeight: 600,
+              backgroundColor: "var(--accent-indigo)",
+              "&:hover": { backgroundColor: "var(--accent-indigo-dark)" },
+            }}
+          >
+            Submit Code &amp; Continue
+          </Button>
+        </Box>
+      </Box>
+    </Dialog>
+  );
+}
+
+export const CodingQuestionModal = memo(CodingQuestionModalComponent);
+CodingQuestionModal.displayName = "CodingQuestionModal";

--- a/components/mock-interview/InterviewHeader.tsx
+++ b/components/mock-interview/InterviewHeader.tsx
@@ -4,6 +4,7 @@ import { Box, Typography, Button, IconButton } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { InterviewTimer } from "./InterviewTimer";
 import { memo } from "react";
+import { cleanInterviewTitle } from "@/lib/utils/mock-interview-title";
 
 interface InterviewHeaderProps {
   title: string;
@@ -24,6 +25,17 @@ interface InterviewHeaderProps {
     type: string;
     message: string;
   } | null;
+  /**
+   * When true, the embedded `InterviewTimer` is visually paused (no tick, "PAUSED" badge).
+   * Set by the take page while a coding-question modal is open.
+   */
+  timerPaused?: boolean;
+  /**
+   * Extra seconds added to the timer's effective budget (e.g. +5/+7/+10 min credited when
+   * a coding question fires). Forwarded into `InterviewTimer.bonusSeconds` so the visible
+   * countdown stays in lock-step with the backend's effective budget.
+   */
+  bonusSeconds?: number;
 }
 
 export const InterviewHeader = memo(function InterviewHeader({
@@ -41,6 +53,8 @@ export const InterviewHeader = memo(function InterviewHeader({
   proctoringStatus,
   faceCount,
   latestViolation,
+  timerPaused = false,
+  bonusSeconds = 0,
 }: InterviewHeaderProps) {
   return (
     <Box
@@ -66,7 +80,7 @@ export const InterviewHeader = memo(function InterviewHeader({
             variant="h6"
             sx={{ fontWeight: 700, fontSize: "1.25rem", color: "#111827" }}
           >
-            {title}
+            {cleanInterviewTitle(title)}
           </Typography>
           <Typography
             variant="caption"
@@ -140,6 +154,8 @@ export const InterviewHeader = memo(function InterviewHeader({
             durationMinutes={durationMinutes}
             startedAt={startedAt || new Date()}
             onTimeUp={onTimeUp}
+            paused={timerPaused}
+            bonusSeconds={bonusSeconds}
           />
         )}
 

--- a/components/mock-interview/InterviewModeSelector.tsx
+++ b/components/mock-interview/InterviewModeSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Paper, Typography, Button, Tooltip, IconButton, Chip } from "@mui/material";
+import { Box, Paper, Typography, Button, Tooltip, IconButton, Chip, CircularProgress } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useRouter } from "next/navigation";
 import { memo, useState } from "react";
@@ -11,12 +11,22 @@ const InterviewModeSelectorComponent = () => {
   const router = useRouter();
   const [quickStartHover, setQuickStartHover] = useState(false);
   const [scheduleHover, setScheduleHover] = useState(false);
+  // "Which card is the user navigating away from?" — set the instant they click so the UI
+  // gives them feedback before Next.js finishes loading the destination chunk. Addresses
+  // the "slight delay on first click of mode selection cards" complaint: previously the
+  // button looked frozen until the route changed; now it visibly switches to a loading
+  // state on the same paint as the click.
+  const [navigatingTo, setNavigatingTo] = useState<"quick-start" | "schedule" | null>(null);
 
   const handleQuickStart = () => {
+    if (navigatingTo) return;
+    setNavigatingTo("quick-start");
     router.push("/mock-interview/quick-start");
   };
 
   const handleSchedule = () => {
+    if (navigatingTo) return;
+    setNavigatingTo("schedule");
     router.push("/mock-interview/schedule");
   };
 
@@ -208,7 +218,14 @@ const InterviewModeSelectorComponent = () => {
             fullWidth
             variant="contained"
             onClick={handleQuickStart}
-            endIcon={<IconWrapper icon="mdi:arrow-right" size={22} />}
+            disabled={navigatingTo !== null}
+            endIcon={
+              navigatingTo === "quick-start" ? (
+                <CircularProgress size={18} sx={{ color: "var(--font-light)" }} />
+              ) : (
+                <IconWrapper icon="mdi:arrow-right" size={22} />
+              )
+            }
             sx={{
               backgroundColor: "var(--success-500)",
               color: "var(--font-light)",
@@ -225,9 +242,16 @@ const InterviewModeSelectorComponent = () => {
                 boxShadow: "0 6px 20px color-mix(in srgb, var(--success-500) 50%, transparent)",
                 transform: "scale(1.02)",
               },
+              "&.Mui-disabled": {
+                backgroundColor: "var(--success-500)",
+                color: "var(--font-light)",
+                opacity: 0.8,
+              },
             }}
           >
-            {t("mockInterview.modeSelector.goQuick")}
+            {navigatingTo === "quick-start"
+              ? "Loading…"
+              : t("mockInterview.modeSelector.goQuick")}
           </Button>
         </Paper>
 
@@ -362,7 +386,14 @@ const InterviewModeSelectorComponent = () => {
             fullWidth
             variant="outlined"
             onClick={handleSchedule}
-            endIcon={<IconWrapper icon="mdi:arrow-right" size={22} />}
+            disabled={navigatingTo !== null}
+            endIcon={
+              navigatingTo === "schedule" ? (
+                <CircularProgress size={18} sx={{ color: "var(--accent-indigo)" }} />
+              ) : (
+                <IconWrapper icon="mdi:arrow-right" size={22} />
+              )
+            }
             sx={{
               borderColor: "var(--accent-indigo)",
               color: "var(--accent-indigo)",
@@ -384,9 +415,16 @@ const InterviewModeSelectorComponent = () => {
                   "0 6px 20px color-mix(in srgb, var(--accent-indigo) 40%, transparent)",
                 transform: "scale(1.02)",
               },
+              "&.Mui-disabled": {
+                borderColor: "var(--accent-indigo)",
+                color: "var(--accent-indigo)",
+                opacity: 0.8,
+              },
             }}
           >
-            {t("mockInterview.modeSelector.scheduleNow")}
+            {navigatingTo === "schedule"
+              ? "Loading…"
+              : t("mockInterview.modeSelector.scheduleNow")}
           </Button>
         </Paper>
       </Box>

--- a/components/mock-interview/InterviewTimer.tsx
+++ b/components/mock-interview/InterviewTimer.tsx
@@ -8,44 +8,45 @@ interface InterviewTimerProps {
   durationMinutes: number;
   onTimeUp?: () => void;
   startedAt?: Date;
+  paused?: boolean;
+  bonusSeconds?: number;
 }
 
 export function InterviewTimer({
   durationMinutes,
   onTimeUp,
   startedAt,
+  paused = false,
+  bonusSeconds = 0,
 }: InterviewTimerProps) {
   const [timeRemaining, setTimeRemaining] = useState(durationMinutes * 60);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const startTimeRef = useRef<Date>(startedAt || new Date());
+  const initialBonusRef = useRef(bonusSeconds);
 
   useEffect(() => {
     if (startedAt) {
       startTimeRef.current = startedAt;
-      // Calculate elapsed time
-      const elapsed = Math.floor(
+      const wallElapsed = Math.floor(
         (new Date().getTime() - startedAt.getTime()) / 1000
       );
-      setTimeRemaining(Math.max(0, durationMinutes * 60 - elapsed));
+      const adjustedElapsed = Math.max(
+        0,
+        wallElapsed - initialBonusRef.current,
+      );
+      setTimeRemaining(Math.max(0, durationMinutes * 60 - adjustedElapsed));
     } else {
       setTimeRemaining(durationMinutes * 60);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [durationMinutes, startedAt]);
 
   useEffect(() => {
-    if (timeRemaining <= 0) {
-      onTimeUp?.();
-      return;
-    }
+    if (paused) return;
+    if (timeRemaining <= 0) return;
 
     intervalRef.current = setInterval(() => {
-      setTimeRemaining((prev) => {
-        if (prev <= 1) {
-          onTimeUp?.();
-          return 0;
-        }
-        return prev - 1;
-      });
+      setTimeRemaining((prev) => (prev > 0 ? prev - 1 : 0));
     }, 1000);
 
     return () => {
@@ -53,6 +54,17 @@ export function InterviewTimer({
         clearInterval(intervalRef.current);
       }
     };
+  }, [timeRemaining, paused]);
+
+  const onTimeUpFiredRef = useRef(false);
+  useEffect(() => {
+    if (timeRemaining > 0) {
+      onTimeUpFiredRef.current = false;
+      return;
+    }
+    if (onTimeUpFiredRef.current) return;
+    onTimeUpFiredRef.current = true;
+    onTimeUp?.();
   }, [timeRemaining, onTimeUp]);
 
   const formatTime = (seconds: number): string => {
@@ -88,7 +100,11 @@ export function InterviewTimer({
         border: `1px solid ${getTimeColor()}40`,
       }}
     >
-      <IconWrapper icon="mdi:timer-outline" size={20} color={getTimeColor()} />
+      <IconWrapper
+        icon={paused ? "mdi:timer-pause-outline" : "mdi:timer-outline"}
+        size={20}
+        color={getTimeColor()}
+      />
       <Typography
         variant="body1"
         sx={{
@@ -97,10 +113,24 @@ export function InterviewTimer({
           color: getTimeColor(),
           fontFamily: "monospace",
           letterSpacing: "0.05em",
+          opacity: paused ? 0.6 : 1,
         }}
       >
         {formatTime(timeRemaining)}
       </Typography>
+      {paused && (
+        <Typography
+          variant="caption"
+          sx={{
+            color: getTimeColor(),
+            fontWeight: 600,
+            letterSpacing: "0.06em",
+            fontSize: "0.65rem",
+          }}
+        >
+          PAUSED
+        </Typography>
+      )}
     </Box>
   );
 }

--- a/components/mock-interview/MCQQuestionModal.tsx
+++ b/components/mock-interview/MCQQuestionModal.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { memo, useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Typography,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export interface MCQOption {
+  id: string;
+  text: string;
+}
+
+interface MCQQuestionModalProps {
+  open: boolean;
+  options: MCQOption[];
+  multiSelect: boolean;
+  spokenIntro?: string;
+  onSubmit: (selected: { ids: string[]; labels: string[] }) => void;
+}
+
+function MCQQuestionModalComponent({
+  open,
+  options,
+  multiSelect,
+  spokenIntro,
+  onSubmit,
+}: MCQQuestionModalProps) {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (open) setSelectedIds([]);
+  }, [open, options]);
+
+  const toggleId = (id: string) => {
+    if (multiSelect) {
+      setSelectedIds((prev) =>
+        prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+      );
+    } else {
+      setSelectedIds([id]);
+    }
+  };
+
+  const handleSubmit = () => {
+    const labels = options
+      .filter((o) => selectedIds.includes(o.id))
+      .map((o) => o.text);
+    onSubmit({ ids: selectedIds, labels });
+  };
+
+  if (!options || options.length === 0) return null;
+
+  return (
+    <Dialog
+      open={open}
+      maxWidth="sm"
+      fullWidth
+      disableEscapeKeyDown
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          backgroundColor: "var(--card-bg)",
+          color: "var(--font-primary-dark)",
+        },
+      }}
+    >
+      <Box sx={{ p: 3, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <IconWrapper icon="mdi:format-list-checks" size={22} color="var(--accent-indigo)" />
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            Quick Multiple Choice
+          </Typography>
+          {multiSelect && (
+            <Box
+              component="span"
+              sx={{
+                ml: 1,
+                px: 1,
+                py: 0.25,
+                borderRadius: 1,
+                backgroundColor: "var(--surface-indigo-light)",
+                color: "var(--accent-indigo)",
+                fontSize: "0.7rem",
+                fontWeight: 600,
+              }}
+            >
+              SELECT ALL THAT APPLY
+            </Box>
+          )}
+        </Box>
+
+        {spokenIntro && (
+          <Typography
+            variant="body2"
+            sx={{
+              color: "var(--font-primary-dark)",
+              lineHeight: 1.55,
+              backgroundColor: "var(--surface)",
+              p: 1.5,
+              borderRadius: 2,
+              border: "1px solid var(--border-default)",
+            }}
+          >
+            {spokenIntro}
+          </Typography>
+        )}
+
+        {multiSelect ? (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+            {options.map((opt) => (
+              <FormControlLabel
+                key={opt.id}
+                control={
+                  <Checkbox
+                    checked={selectedIds.includes(opt.id)}
+                    onChange={() => toggleId(opt.id)}
+                  />
+                }
+                label={opt.text}
+                sx={{
+                  m: 0,
+                  p: 1,
+                  borderRadius: 2,
+                  border: "1px solid",
+                  borderColor: selectedIds.includes(opt.id)
+                    ? "var(--accent-indigo)"
+                    : "var(--border-default)",
+                  backgroundColor: selectedIds.includes(opt.id)
+                    ? "var(--surface-indigo-light)"
+                    : "transparent",
+                  transition: "all 0.15s ease",
+                }}
+              />
+            ))}
+          </Box>
+        ) : (
+          <RadioGroup
+            value={selectedIds[0] || ""}
+            onChange={(_, v) => toggleId(v)}
+            sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}
+          >
+            {options.map((opt) => (
+              <FormControlLabel
+                key={opt.id}
+                value={opt.id}
+                control={<Radio />}
+                label={opt.text}
+                sx={{
+                  m: 0,
+                  p: 1,
+                  borderRadius: 2,
+                  border: "1px solid",
+                  borderColor: selectedIds.includes(opt.id)
+                    ? "var(--accent-indigo)"
+                    : "var(--border-default)",
+                  backgroundColor: selectedIds.includes(opt.id)
+                    ? "var(--surface-indigo-light)"
+                    : "transparent",
+                  transition: "all 0.15s ease",
+                }}
+              />
+            ))}
+          </RadioGroup>
+        )}
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1.5, pt: 1 }}>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            disabled={selectedIds.length === 0}
+            sx={{
+              textTransform: "none",
+              fontWeight: 600,
+              backgroundColor: "var(--accent-indigo)",
+              "&:hover": { backgroundColor: "var(--accent-indigo-dark)" },
+            }}
+          >
+            Submit Answer
+          </Button>
+        </Box>
+      </Box>
+    </Dialog>
+  );
+}
+
+export const MCQQuestionModal = memo(MCQQuestionModalComponent);
+MCQQuestionModal.displayName = "MCQQuestionModal";

--- a/components/mock-interview/PreviousInterviewsTable.tsx
+++ b/components/mock-interview/PreviousInterviewsTable.tsx
@@ -13,6 +13,7 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { MockInterview } from "@/lib/services/mock-interview.service";
 import { memo, useCallback, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { cleanInterviewTitle } from "@/lib/utils/mock-interview-title";
 
 interface PreviousInterviewsTableProps {
   interviews: MockInterview[];
@@ -179,7 +180,7 @@ const PreviousInterviewsTableComponent = ({
                       variant="h6"
                       sx={{ fontWeight: 700, fontSize: "1.1rem", mb: 0.5 }}
                     >
-                      {interview.title}
+                      {cleanInterviewTitle(interview.title)}
                     </Typography>
                     <Box
                       sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 1 }}

--- a/components/mock-interview/QuickStartForm.tsx
+++ b/components/mock-interview/QuickStartForm.tsx
@@ -10,10 +10,11 @@ import {
   FormControl,
   InputLabel,
   Select,
-  CircularProgress,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { useState, useCallback, memo } from "react";
+import { useState, useCallback, memo, useMemo } from "react";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
 
 interface QuickStartFormProps {
   onSubmit: (data: QuickStartFormData) => void;
@@ -26,7 +27,8 @@ export interface QuickStartFormData {
   scheduled_date_time: string;
   subtopic: string;
   // Candidate-chosen interview length in minutes. The backend scales the number of AI turns
-  // so the conversation wraps naturally within this window. Valid range 5..20.
+  // so the conversation wraps naturally within this window. Valid range 5..20 for normal
+  // users; admins can additionally pick 2 from the form for testing (see `useAdminDurations`).
   duration_minutes: number;
 }
 
@@ -36,6 +38,7 @@ const interviewTopics = [
   "TypeScript",
   "Node.js",
   "Python",
+  "SQL",
   "System Design",
   "Data Structures & Algorithms",
   "Algorithms",
@@ -49,19 +52,23 @@ const CUSTOM_TOPIC_VALUE = "__CUSTOM__";
 
 const difficultyLevels = ["Easy", "Medium", "Hard"];
 
-// Duration options shown to the candidate. The backend accepts any integer 5..20; this list
-// is just the preset choices we expose in the UI. Default is 7 to match the natural
-// 5-7-minute "real interview" feel from earlier product feedback.
-const durationOptions = [5, 7, 10, 15, 20];
+const DURATION_OPTIONS_REGULAR = [5, 7, 10, 15, 20];
+const DURATION_OPTIONS_ADMIN = [2, ...DURATION_OPTIONS_REGULAR];
 const DEFAULT_DURATION_MINUTES = 7;
 
 const QuickStartFormComponent = ({
   onSubmit,
   loading,
 }: QuickStartFormProps) => {
-  // Set default date to today
   const defaultDate = new Date();
-  defaultDate.setHours(9, 0, 0, 0); // Set to 9 AM today
+  defaultDate.setHours(9, 0, 0, 0);
+
+  const { user } = useAuth();
+  const isAdmin = isClientOrgAdminRole(user?.role);
+  const durationOptions = useMemo(
+    () => (isAdmin ? DURATION_OPTIONS_ADMIN : DURATION_OPTIONS_REGULAR),
+    [isAdmin],
+  );
 
   const [formData, setFormData] = useState<QuickStartFormData>({
     topic: "",
@@ -133,33 +140,6 @@ const QuickStartFormComponent = ({
 
   return (
     <Box sx={{ position: "relative" }}>
-      {loading && (
-        <Box
-          sx={{
-            position: "absolute",
-            top: 0,
-            insetInlineStart: 0,
-            insetInlineEnd: 0,
-            bottom: 0,
-            backgroundColor: "rgba(255, 255, 255, 0.9)",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 2,
-            zIndex: 1000,
-            borderRadius: 3,
-          }}
-        >
-          <CircularProgress size={48} sx={{ color: "#10b981" }} />
-          <Typography variant="h6" sx={{ fontWeight: 600, color: "#1f2937" }}>
-            Creating Interview...
-          </Typography>
-          <Typography variant="body2" sx={{ color: "#6b7280" }}>
-            Please wait while we set up your interview
-          </Typography>
-        </Box>
-      )}
       <Paper
         elevation={0}
         sx={{
@@ -305,6 +285,7 @@ const QuickStartFormComponent = ({
             >
               {durationOptions.map((mins) => {
                 const selected = formData.duration_minutes === mins;
+                const isAdminOnlyOption = mins < 5;
                 return (
                   <Box
                     key={mins}
@@ -322,6 +303,7 @@ const QuickStartFormComponent = ({
                       cursor: "pointer",
                       textAlign: "center",
                       transition: "all 0.2s ease",
+                      position: "relative",
                       "&:hover": {
                         borderColor: "var(--course-cta)",
                         backgroundColor:
@@ -338,6 +320,27 @@ const QuickStartFormComponent = ({
                     >
                       {mins} min
                     </Typography>
+                    {isAdminOnlyOption && (
+                      <Box
+                        sx={{
+                          position: "absolute",
+                          top: -8,
+                          right: -8,
+                          px: 0.75,
+                          py: 0.1,
+                          borderRadius: 999,
+                          fontSize: "0.6rem",
+                          fontWeight: 700,
+                          letterSpacing: "0.06em",
+                          textTransform: "uppercase",
+                          backgroundColor: "var(--accent-indigo)",
+                          color: "var(--font-light)",
+                          lineHeight: 1.4,
+                        }}
+                      >
+                        Admin · Test
+                      </Box>
+                    )}
                   </Box>
                 );
               })}

--- a/components/mock-interview/ScheduledInterviewsTable.tsx
+++ b/components/mock-interview/ScheduledInterviewsTable.tsx
@@ -14,6 +14,7 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { MockInterview } from "@/lib/services/mock-interview.service";
 import { memo, useCallback, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { cleanInterviewTitle } from "@/lib/utils/mock-interview-title";
 
 interface ScheduledInterviewsTableProps {
   interviews: MockInterview[];
@@ -224,7 +225,7 @@ const ScheduledInterviewsTableComponent = ({
                           color: "var(--font-primary)",
                         }}
                       >
-                        {interview.title}
+                        {cleanInterviewTitle(interview.title)}
                       </Typography>
                       <Box
                         sx={{

--- a/components/mock-interview/VideoPreviewArea.tsx
+++ b/components/mock-interview/VideoPreviewArea.tsx
@@ -93,15 +93,37 @@ export const VideoPreviewArea = memo(function VideoPreviewArea({
             p: 2,
           }}
         >
-          {/* User Video Preview */}
+          {/* User Video Preview. The border becomes a Google-Meet-style speaking ring
+              (animated outer glow + bright border) when the user is speaking. Subtle when
+              idle so the layout doesn't shift. */}
           <Box
             sx={{
               flex: 1,
               borderRadius: 2,
               overflow: "hidden",
               backgroundColor: "var(--interview-user-video-bg)",
-              border: "2px solid var(--border-default)",
+              border: "2px solid",
+              borderColor: isUserSpeaking
+                ? "var(--ats-success)"
+                : "var(--border-default)",
+              boxShadow: isUserSpeaking
+                ? "0 0 0 4px color-mix(in srgb, var(--ats-success) 32%, transparent), 0 0 24px color-mix(in srgb, var(--ats-success) 28%, transparent)"
+                : "none",
+              transition: "border-color 0.2s ease, box-shadow 0.2s ease",
               position: "relative",
+              animation: isUserSpeaking
+                ? "meet-speaking-pulse 1.6s ease-in-out infinite"
+                : "none",
+              "@keyframes meet-speaking-pulse": {
+                "0%, 100%": {
+                  boxShadow:
+                    "0 0 0 4px color-mix(in srgb, var(--ats-success) 32%, transparent), 0 0 24px color-mix(in srgb, var(--ats-success) 28%, transparent)",
+                },
+                "50%": {
+                  boxShadow:
+                    "0 0 0 7px color-mix(in srgb, var(--ats-success) 22%, transparent), 0 0 32px color-mix(in srgb, var(--ats-success) 36%, transparent)",
+                },
+              },
             }}
           >
             <video
@@ -144,7 +166,9 @@ export const VideoPreviewArea = memo(function VideoPreviewArea({
               visible={isProctoringActive}
             />
           </Box>
-          {/* AI Avatar — fills column for classy full-panel look */}
+          {/* AI Avatar — fills column for classy full-panel look. Border glows indigo
+              while the avatar is delivering a question, matching the Meet-style speaking
+              ring on the user tile so the active speaker is always visually obvious. */}
           <Box
             sx={{
               flex: 1,
@@ -152,8 +176,28 @@ export const VideoPreviewArea = memo(function VideoPreviewArea({
               borderRadius: 2,
               overflow: "hidden",
               backgroundColor: "var(--interview-surface)",
-              border: "2px solid var(--border-default)",
+              border: "2px solid",
+              borderColor: isSpeaking
+                ? "var(--accent-indigo)"
+                : "var(--border-default)",
+              boxShadow: isSpeaking
+                ? "0 0 0 4px color-mix(in srgb, var(--accent-indigo) 32%, transparent), 0 0 24px color-mix(in srgb, var(--accent-indigo) 28%, transparent)"
+                : "none",
+              transition: "border-color 0.2s ease, box-shadow 0.2s ease",
               position: "relative",
+              animation: isSpeaking
+                ? "meet-ai-speaking-pulse 1.6s ease-in-out infinite"
+                : "none",
+              "@keyframes meet-ai-speaking-pulse": {
+                "0%, 100%": {
+                  boxShadow:
+                    "0 0 0 4px color-mix(in srgb, var(--accent-indigo) 32%, transparent), 0 0 24px color-mix(in srgb, var(--accent-indigo) 28%, transparent)",
+                },
+                "50%": {
+                  boxShadow:
+                    "0 0 0 7px color-mix(in srgb, var(--accent-indigo) 22%, transparent), 0 0 32px color-mix(in srgb, var(--accent-indigo) 36%, transparent)",
+                },
+              },
             }}
           >
             <AIAvatar

--- a/components/mock-interview/index.ts
+++ b/components/mock-interview/index.ts
@@ -12,6 +12,8 @@ export type { AnswerInputAreaProps } from "./AnswerInputArea";
 export { QuestionListSidebar } from "./QuestionListSidebar";
 export { FullscreenWarningDialog } from "./FullscreenWarningDialog";
 export { EndInterviewDialog } from "./EndInterviewDialog";
+export { CodingQuestionModal } from "./CodingQuestionModal";
+export { MCQQuestionModal } from "./MCQQuestionModal";
 export type { QuickStartFormData } from "./QuickStartForm";
 export type { ScheduleInterviewFormData } from "./ScheduleInterviewForm";
 

--- a/components/mock-interview/result/QuestionPerformance.tsx
+++ b/components/mock-interview/result/QuestionPerformance.tsx
@@ -4,6 +4,7 @@ import {
   Paper,
   Typography,
   Box,
+  Button,
   Chip,
   LinearProgress,
   Accordion,
@@ -12,13 +13,27 @@ import {
   Divider,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { memo } from "react";
+import { memo, useState, useCallback } from "react";
+import { StructuredQuestionViewModal } from "./StructuredQuestionViewModal";
 
 interface Question {
   id: number;
   type: string;
   question_text: string;
   expected_key_points: string[];
+  // Optional structured-question payloads stamped on `questions_for_interview` during the
+  // live interview. Present only for the turns where the AI inserted a coding question
+  // or an MCQ; consumed by the View-problem button below to re-render them.
+  coding_problem?: {
+    statement: string;
+    starter_code: string;
+    language: string;
+    sample_input?: string;
+    sample_output?: string;
+  };
+  mcq_options?: { id: string; text: string }[];
+  mcq_multi_select?: boolean;
+  mcq_correct_option_ids?: string[];
 }
 
 interface QuestionScore {
@@ -62,6 +77,20 @@ const QuestionPerformanceComponent = ({
   (responses || []).forEach((r) => {
     if (typeof r.question_id === "number") responseById.set(r.question_id, r);
   });
+
+  // Modal state for the "View problem" / "View MCQ" button on structured questions.
+  // Tracks the question id whose problem is being viewed (null = closed).
+  const [viewerQuestionId, setViewerQuestionId] = useState<number | null>(null);
+  const openViewer = useCallback((id: number) => setViewerQuestionId(id), []);
+  const closeViewer = useCallback(() => setViewerQuestionId(null), []);
+  const viewerQuestion =
+    viewerQuestionId !== null
+      ? questions.find((q) => q.id === viewerQuestionId) ?? null
+      : null;
+  const viewerAnswer =
+    viewerQuestionId !== null
+      ? responseById.get(viewerQuestionId)?.answer
+      : undefined;
   return (
     <Paper
       elevation={0}
@@ -159,6 +188,51 @@ const QuestionPerformanceComponent = ({
               </AccordionSummary>
               <AccordionDetails sx={{ pt: 0 }}>
                 <Divider sx={{ mb: 3 }} />
+
+                {/* "View problem" button — only renders for structured turns (coding
+                    or MCQ). Opens a read-only modal that re-renders the original problem
+                    statement + starter code (coding) or the option list with the correct
+                    answer highlighted (MCQ). The reviewer / candidate can revisit the
+                    exact payload that was shown during the live interview. */}
+                {(() => {
+                  const qtype = (question.type || "").toLowerCase();
+                  const hasCoding =
+                    qtype === "coding" && !!question.coding_problem?.statement;
+                  const hasMCQ =
+                    qtype === "mcq" && (question.mcq_options?.length ?? 0) >= 2;
+                  if (!hasCoding && !hasMCQ) return null;
+                  return (
+                    <Box sx={{ mb: 3 }}>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={
+                          <IconWrapper
+                            icon={
+                              hasCoding
+                                ? "mdi:code-braces"
+                                : "mdi:format-list-checks"
+                            }
+                            size={18}
+                          />
+                        }
+                        onClick={() => openViewer(question.id)}
+                        sx={{
+                          textTransform: "none",
+                          fontWeight: 600,
+                          borderColor: "var(--accent-indigo)",
+                          color: "var(--accent-indigo)",
+                          "&:hover": {
+                            backgroundColor: "var(--surface-indigo-light)",
+                            borderColor: "var(--accent-indigo-dark)",
+                          },
+                        }}
+                      >
+                        {hasCoding ? "View coding problem" : "View MCQ"}
+                      </Button>
+                    </Box>
+                  );
+                })()}
 
                 {/* Candidate's actual answer (what the user said in response to this
                     question). Pulled from interview_transcript.responses keyed by question id. */}
@@ -335,6 +409,12 @@ const QuestionPerformanceComponent = ({
           );
         })}
       </Box>
+      <StructuredQuestionViewModal
+        open={viewerQuestionId !== null}
+        onClose={closeViewer}
+        question={viewerQuestion}
+        candidateAnswer={viewerAnswer}
+      />
     </Paper>
   );
 };

--- a/components/mock-interview/result/ResultHeader.tsx
+++ b/components/mock-interview/result/ResultHeader.tsx
@@ -2,6 +2,7 @@
 
 import { Box, Container, Typography, Button, Chip } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { cleanInterviewTitle } from "@/lib/utils/mock-interview-title";
 import { memo } from "react";
 
 interface ResultHeaderProps {
@@ -22,13 +23,31 @@ const ResultHeaderComponent = ({
   topic,
   subtopic,
   difficulty,
-  duration_minutes,
+  duration_minutes: _duration_minutes,
   overall_percentage,
   performanceLabel,
   scoreColors,
   onBack,
   backLabel = "Back to Previous Interviews",
 }: ResultHeaderProps) => {
+  void _duration_minutes;
+
+  // The backend stamps `title` as "{topic} - {subtopic} Interview", which collapses to
+  // "System Design - System Design Interview" for quick-start interviews where the user
+  // didn't pick a distinct subtopic. `cleanInterviewTitle` strips that duplication so the
+  // header reads as "System Design Interview" / "Behavioral Questions Interview" etc.
+  // We fall back to `"{topic} Interview"` for safety in case the backend ever omits title.
+  const displayTitle =
+    cleanInterviewTitle(title) || (topic ? `${topic} Interview` : "Interview");
+
+  // Only render the subtopic chip when it actually adds information. Quick-start interviews
+  // set subtopic = topic, which would otherwise render an identical chip twice in the
+  // header.
+  const hasMeaningfulSubtopic = !!(
+    subtopic &&
+    subtopic.trim() &&
+    subtopic.trim().toLowerCase() !== topic.trim().toLowerCase()
+  );
   return (
     <Box
       sx={{
@@ -66,19 +85,10 @@ const ResultHeaderComponent = ({
                 fontSize: { xs: "1.5rem", md: "2rem" },
               }}
             >
-              {title}
+              {displayTitle}
             </Typography>
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 2 }}>
-              <Chip
-                label={topic}
-                size="small"
-                sx={{
-                  backgroundColor: "rgba(255, 255, 255, 0.2)",
-                  color: "#ffffff",
-                  fontWeight: 600,
-                }}
-              />
-              {subtopic && (
+              {hasMeaningfulSubtopic && (
                 <Chip
                   label={subtopic}
                   size="small"
@@ -91,18 +101,6 @@ const ResultHeaderComponent = ({
               )}
               <Chip
                 label={difficulty}
-                size="small"
-                sx={{
-                  backgroundColor: "rgba(255, 255, 255, 0.2)",
-                  color: "#ffffff",
-                  fontWeight: 600,
-                }}
-              />
-              <Chip
-                icon={
-                  <IconWrapper icon="mdi:clock-outline" size={14} color="#ffffff" />
-                }
-                label={`${duration_minutes} mins`}
                 size="small"
                 sx={{
                   backgroundColor: "rgba(255, 255, 255, 0.2)",
@@ -124,8 +122,8 @@ const ResultHeaderComponent = ({
           >
             <Box
               sx={{
-                width: 120,
-                height: 120,
+                width: 140,
+                height: 140,
                 borderRadius: "50%",
                 backgroundColor: "#ffffff",
                 display: "flex",
@@ -134,19 +132,40 @@ const ResultHeaderComponent = ({
                 justifyContent: "center",
                 boxShadow: "0 8px 24px rgba(0, 0, 0, 0.15)",
                 border: `6px solid ${scoreColors.main}`,
+                // Defensive: keep contents from spilling out of the circle when the
+                // percentage hits 100 with the inherited h3 font size.
+                overflow: "hidden",
+                px: 1,
               }}
             >
               <Typography
-                variant="h3"
-                sx={{ color: scoreColors.main, fontWeight: 800, lineHeight: 1 }}
+                sx={{
+                  color: scoreColors.main,
+                  fontWeight: 800,
+                  lineHeight: 1,
+                  // Scales with viewport so even very wide values fit inside the
+                  // circle on small screens. Caps at 2.25rem so the digits stay
+                  // legible on desktop without overflowing the 140px container.
+                  fontSize: "clamp(1.5rem, 4vw, 2.25rem)",
+                  whiteSpace: "nowrap",
+                  textAlign: "center",
+                }}
               >
-                {overall_percentage}%
+                {/* Round to an integer for a clean display. Defensive Math.round in
+                    case the backend ever returns 100.0 + tiny FP noise like 100.0001. */}
+                {Math.round(overall_percentage)}%
               </Typography>
               <Typography
                 variant="caption"
-                sx={{ color: "#6b7280", fontSize: "0.7rem", mt: 0.5 }}
+                sx={{
+                  color: "var(--font-secondary)",
+                  fontSize: "0.65rem",
+                  mt: 0.5,
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                }}
               >
-                OVERALL SCORE
+                Overall Score
               </Typography>
             </Box>
             <Chip

--- a/components/mock-interview/result/StructuredQuestionViewModal.tsx
+++ b/components/mock-interview/result/StructuredQuestionViewModal.tsx
@@ -1,0 +1,436 @@
+"use client";
+
+import { memo } from "react";
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Paper,
+  Typography,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export interface StructuredQuestionViewModalProps {
+  open: boolean;
+  onClose: () => void;
+  question:
+    | {
+        id: number;
+        type: string;
+        question_text: string;
+        coding_problem?: {
+          statement: string;
+          starter_code: string;
+          language: string;
+          sample_input?: string;
+          sample_output?: string;
+        };
+        mcq_options?: { id: string; text: string }[];
+        mcq_multi_select?: boolean;
+        mcq_correct_option_ids?: string[];
+      }
+    | null;
+  candidateAnswer?: string;
+}
+
+function parseCodingAnswer(answer: string | undefined): { code: string; language?: string } {
+  if (!answer) return { code: "" };
+  const match = answer.match(/^\[Coding answer\s*·\s*([^\]]+)\]\s*\n([\s\S]*)$/);
+  if (match) {
+    return { code: match[2], language: match[1].trim() };
+  }
+  return { code: answer };
+}
+
+function parseMCQAnswer(answer: string | undefined): string[] {
+  if (!answer) return [];
+  const match = answer.match(/\(ids:\s*([^)]*)\)/i);
+  if (!match) return [];
+  return match[1]
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s && s !== "—");
+}
+
+const StructuredQuestionViewModalComponent = ({
+  open,
+  onClose,
+  question,
+  candidateAnswer,
+}: StructuredQuestionViewModalProps) => {
+  if (!question) return null;
+  const qtype = (question.type || "").toLowerCase();
+  const isCoding = qtype === "coding" && !!question.coding_problem;
+  const isMCQ = qtype === "mcq" && (question.mcq_options?.length ?? 0) >= 2;
+
+  if (!isCoding && !isMCQ) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={isCoding ? "lg" : "sm"}
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          backgroundColor: "var(--card-bg)",
+          color: "var(--font-primary-dark)",
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 2,
+          borderBottom: "1px solid var(--border-default)",
+          backgroundColor: "var(--surface)",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
+          <IconWrapper
+            icon={isCoding ? "mdi:code-braces" : "mdi:format-list-checks"}
+            size={22}
+            color="var(--accent-indigo)"
+          />
+          <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+            {isCoding ? "Coding Question" : "Multiple Choice Question"}
+          </Typography>
+        </Box>
+        <IconButton onClick={onClose} aria-label="Close" size="small">
+          <IconWrapper icon="mdi:close" size={20} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 3 }}>
+        {question.question_text && (
+          <Paper
+            elevation={0}
+            sx={{
+              p: 1.5,
+              mb: 2.5,
+              backgroundColor: "var(--surface-indigo-light)",
+              border: "1px solid var(--accent-indigo)",
+              borderRadius: 2,
+            }}
+          >
+            <Typography
+              variant="caption"
+              sx={{
+                display: "block",
+                fontWeight: 700,
+                letterSpacing: "0.05em",
+                textTransform: "uppercase",
+                color: "var(--accent-indigo)",
+                mb: 0.5,
+              }}
+            >
+              Interviewer said
+            </Typography>
+            <Typography variant="body2" sx={{ lineHeight: 1.55 }}>
+              {question.question_text}
+            </Typography>
+          </Paper>
+        )}
+
+        {isCoding && question.coding_problem && (
+          <CodingProblemView
+            problem={question.coding_problem}
+            candidateAnswer={candidateAnswer}
+          />
+        )}
+
+        {isMCQ && question.mcq_options && (
+          <MCQView
+            options={question.mcq_options}
+            multiSelect={!!question.mcq_multi_select}
+            correctIds={question.mcq_correct_option_ids || []}
+            candidateSelectedIds={parseMCQAnswer(candidateAnswer)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+function CodingProblemView({
+  problem,
+  candidateAnswer,
+}: {
+  problem: NonNullable<StructuredQuestionViewModalProps["question"]>["coding_problem"];
+  candidateAnswer?: string;
+}) {
+  if (!problem) return null;
+  const submitted = parseCodingAnswer(candidateAnswer);
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <Section title="Problem">
+        <Typography
+          variant="body2"
+          sx={{ whiteSpace: "pre-wrap", lineHeight: 1.6 }}
+        >
+          {problem.statement}
+        </Typography>
+      </Section>
+
+      {problem.sample_input && (
+        <Section title="Sample Input">
+          <CodeBlock content={problem.sample_input} />
+        </Section>
+      )}
+      {problem.sample_output && (
+        <Section title="Sample Output">
+          <CodeBlock content={problem.sample_output} />
+        </Section>
+      )}
+
+      <Section
+        title={`Starter Code (${problem.language || "code"})`}
+        chip={problem.language ? problem.language.toUpperCase() : undefined}
+      >
+        <CodeBlock content={problem.starter_code} maxHeight={260} />
+      </Section>
+
+      {submitted.code && (
+        <Section
+          title="Candidate's Submission"
+          chip={submitted.language ? submitted.language.toUpperCase() : undefined}
+        >
+          <CodeBlock content={submitted.code} maxHeight={320} />
+        </Section>
+      )}
+    </Box>
+  );
+}
+
+function MCQView({
+  options,
+  multiSelect,
+  correctIds,
+  candidateSelectedIds,
+}: {
+  options: { id: string; text: string }[];
+  multiSelect: boolean;
+  correctIds: string[];
+  candidateSelectedIds: string[];
+}) {
+  const correctSet = new Set(correctIds);
+  const selectedSet = new Set(candidateSelectedIds);
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+      <Typography
+        variant="caption"
+        sx={{
+          display: "block",
+          fontWeight: 600,
+          letterSpacing: "0.05em",
+          textTransform: "uppercase",
+          color: "var(--font-secondary)",
+          mb: 0.25,
+        }}
+      >
+        {multiSelect ? "Multi-select" : "Single-select"} · Options
+      </Typography>
+      {options.map((opt) => {
+        const isCorrect = correctSet.has(opt.id);
+        const wasPicked = selectedSet.has(opt.id);
+        const borderColor = wasPicked
+          ? isCorrect
+            ? "var(--ats-success)"
+            : "var(--ats-error)"
+          : isCorrect
+            ? "var(--ats-success)"
+            : "var(--border-default)";
+        const bg = wasPicked
+          ? isCorrect
+            ? "color-mix(in srgb, var(--ats-success) 14%, var(--card-bg))"
+            : "color-mix(in srgb, var(--ats-error) 12%, var(--card-bg))"
+          : isCorrect
+            ? "color-mix(in srgb, var(--ats-success) 6%, var(--card-bg))"
+            : "var(--card-bg)";
+        return (
+          <Box
+            key={opt.id}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              px: 1.5,
+              py: 1.25,
+              borderRadius: 2,
+              border: "1px solid",
+              borderColor,
+              backgroundColor: bg,
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                width: 22,
+                height: 22,
+                borderRadius: "50%",
+                backgroundColor: isCorrect
+                  ? "var(--ats-success)"
+                  : "var(--surface)",
+                color: isCorrect ? "var(--font-light)" : "var(--font-secondary)",
+                fontWeight: 700,
+                fontSize: "0.7rem",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                textTransform: "uppercase",
+                flexShrink: 0,
+              }}
+            >
+              {opt.id}
+            </Box>
+            <Typography variant="body2" sx={{ flex: 1 }}>
+              {opt.text}
+            </Typography>
+            {isCorrect && (
+              <IconWrapper
+                icon="mdi:check-circle"
+                size={18}
+                color="var(--ats-success)"
+              />
+            )}
+            {wasPicked && !isCorrect && (
+              <IconWrapper
+                icon="mdi:close-circle"
+                size={18}
+                color="var(--ats-error)"
+              />
+            )}
+            {wasPicked && (
+              <Box
+                component="span"
+                sx={{
+                  px: 0.75,
+                  py: 0.15,
+                  borderRadius: 1,
+                  fontSize: "0.65rem",
+                  fontWeight: 700,
+                  letterSpacing: "0.05em",
+                  textTransform: "uppercase",
+                  backgroundColor: isCorrect
+                    ? "var(--ats-success)"
+                    : "var(--ats-error)",
+                  color: "var(--font-light)",
+                }}
+              >
+                Your pick
+              </Box>
+            )}
+          </Box>
+        );
+      })}
+      {candidateSelectedIds.length === 0 && (
+        <Typography
+          variant="caption"
+          sx={{ color: "var(--font-tertiary)", fontStyle: "italic", mt: 0.5 }}
+        >
+          No selection was recorded for this question.
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+function Section({
+  title,
+  chip,
+  children,
+}: {
+  title: string;
+  chip?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          mb: 0.75,
+        }}
+      >
+        <Typography
+          variant="caption"
+          sx={{
+            fontWeight: 700,
+            letterSpacing: "0.05em",
+            textTransform: "uppercase",
+            color: "var(--font-secondary)",
+          }}
+        >
+          {title}
+        </Typography>
+        {chip && (
+          <Box
+            component="span"
+            sx={{
+              px: 0.75,
+              py: 0.1,
+              borderRadius: 1,
+              fontSize: "0.6rem",
+              fontWeight: 700,
+              letterSpacing: "0.06em",
+              backgroundColor: "var(--surface-indigo-light)",
+              color: "var(--accent-indigo)",
+            }}
+          >
+            {chip}
+          </Box>
+        )}
+      </Box>
+      {children}
+    </Box>
+  );
+}
+
+function CodeBlock({
+  content,
+  maxHeight,
+}: {
+  content: string;
+  maxHeight?: number;
+}) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 1.5,
+        borderRadius: 2,
+        border: "1px solid var(--border-default)",
+        backgroundColor: "var(--surface)",
+        maxHeight,
+        overflow: maxHeight ? "auto" : "visible",
+      }}
+    >
+      <Box
+        component="pre"
+        sx={{
+          m: 0,
+          fontFamily:
+            "ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', monospace",
+          fontSize: "0.82rem",
+          lineHeight: 1.55,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          color: "var(--font-primary-dark)",
+        }}
+      >
+        {content}
+      </Box>
+    </Paper>
+  );
+}
+
+export const StructuredQuestionViewModal = memo(
+  StructuredQuestionViewModalComponent,
+);
+StructuredQuestionViewModal.displayName = "StructuredQuestionViewModal";

--- a/components/setup/steps/FeaturesStep.tsx
+++ b/components/setup/steps/FeaturesStep.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactElement } from "react";
 import { motion } from "framer-motion";
 import apiClient from "@/lib/services/api";
 import { WizardData } from "@/lib/setup/wizardData";
@@ -98,7 +98,7 @@ interface SectionConfig {
   description: string;
   iconBg: string;
   accent: string;
-  icon: JSX.Element;
+  icon: ReactElement;
 }
 
 const SECTIONS: SectionConfig[] = [

--- a/lib/hooks/useInterviewerVoice.ts
+++ b/lib/hooks/useInterviewerVoice.ts
@@ -370,6 +370,19 @@ export function useInterviewerVoice(
       cleanupAudio();
       utteranceRef.current = null;
       setAudioActive(false);
+      // If we already kicked off the utterance (didStart) but the effect is being torn
+      // down before `onend` fired — usually because the parent flipped `isSpeaking`
+      // to false (e.g., silence detector auto-advanced, new question replaced this one)
+      // — fire the complete callback explicitly. Without this the avatar's `isAnimating`
+      // would stay `true` and the lip-sync video would keep looping after the actual
+      // audio is already gone. This is the root cause of the "lip sync continues after
+      // voice stops" symptom.
+      if (didStart && !finishing) {
+        finishing = true;
+        try {
+          onSpeakCompleteRef.current?.();
+        } catch {}
+      }
     };
   }, [question, isSpeaking]);
 

--- a/lib/services/mock-interview.service.ts
+++ b/lib/services/mock-interview.service.ts
@@ -32,6 +32,13 @@ export interface MockInterviewDetail extends MockInterview {
   current_question?: InterviewQuestion | null;
   turn_number?: number;
   max_turns?: number;
+  /**
+   * Total accumulated bonus seconds across the interview (credited by past coding turns
+   * that fired the difficulty-scaled +5/+7/+10 min bump). The take page seeds its
+   * `interviewBonusSeconds` state from this when the page loads / re-loads mid-interview
+   * so the visible timer's effective budget stays correct across reloads.
+   */
+  bonus_seconds?: number;
 }
 
 export interface InterviewQuestion {
@@ -41,11 +48,43 @@ export interface InterviewQuestion {
   type: string;
   expected_key_points?: string[]; // Optional field
   follows_up_on?: string; // Dynamic-flow note: which prior answer this question builds on.
+
+  /**
+   * Present only when `type === "coding"`. The interviewer asks a code-writing question and
+   * the frontend opens a Monaco-editor modal sourced from this block. `question_text` is the
+   * spoken intro; the actual problem statement lives here. Auto-graded as text at submit
+   * time (no in-browser run button on purpose — see CodingQuestionModal).
+   */
+  coding_problem?: {
+    statement: string;
+    starter_code: string;
+    language: string;
+    sample_input?: string;
+    sample_output?: string;
+  };
+
+  /**
+   * Present only when `type === "mcq"`. Multiple-choice options shown in MCQQuestionModal.
+   * `mcq_multi_select` decides between radio (false) and checkbox (true) UX.
+   * `mcq_correct_option_ids` is included so the post-interview evaluator can score, but the
+   * frontend never reads it.
+   */
+  mcq_options?: { id: string; text: string }[];
+  mcq_multi_select?: boolean;
+  mcq_correct_option_ids?: string[];
 }
 
 export interface NextQuestionRequest {
   previous_question_id: number;
   candidate_answer: string;
+  /**
+   * Frontend signal that the candidate's VISIBLE timer hit zero — even if the backend's
+   * `wall_clock - started_at` math would say there's still time on the effective budget
+   * (which can happen when bonus_seconds from a coding turn doesn't perfectly equal the
+   * candidate's actual time in the modal). When true AND we have ≥2 prior responses, the
+   * backend skips the regular-question branch and returns the closing remark directly.
+   */
+  force_close?: boolean;
 }
 
 export interface NextQuestionResponse {
@@ -63,6 +102,19 @@ export interface NextQuestionResponse {
    */
   is_closing_remark?: boolean;
   closing_remark?: string;
+  /**
+   * Total accumulated `bonus_seconds` (across the whole interview) credited by coding
+   * turns. The on-screen interview timer adds this to its effective budget so wrap-up
+   * math stays in sync with the backend.
+   */
+  bonus_seconds?: number;
+  /**
+   * Seconds credited for THIS specific coding turn (5 / 7 / 10 min, scaled by interview
+   * difficulty). The CodingQuestionModal uses this to render its own per-question
+   * countdown so the candidate sees their remaining coding time, not just "TIMER PAUSED".
+   * Zero (or absent) for non-coding turns.
+   */
+  coding_time_budget_seconds?: number;
 }
 
 /**
@@ -86,6 +138,13 @@ export interface PendingCourseInterview {
 export interface InterviewResponse {
   question_id: number;
   answer: string;
+  /**
+   * Snapshot of the question text that this answer was given to. The backend serializer
+   * fills this in on /next-question/ records, and the take page now also stamps it on
+   * every locally-built response so the question-history UI can render the conversation
+   * without a separate lookup map.
+   */
+  question_text?: string;
   audio_url?: string;
 }
 

--- a/lib/utils/mock-interview-title.ts
+++ b/lib/utils/mock-interview-title.ts
@@ -1,0 +1,11 @@
+export function cleanInterviewTitle(title: string | null | undefined): string {
+  if (!title) return "";
+  const match = title.match(/^(.+?)\s*[-–—]\s*(.+?)\s+Interview\s*$/i);
+  if (!match) return title;
+  const left = match[1].trim();
+  const right = match[2].trim();
+  if (left.toLowerCase() === right.toLowerCase()) {
+    return `${left} Interview`;
+  }
+  return title;
+}


### PR DESCRIPTION
feat: clean up interview titles in PreviousInterviewsTable and ScheduledInterviewsTable

feat: enhance QuickStartForm to allow admin-specific interview durations

feat: improve VideoPreviewArea with speaking indicators for user and AI

feat: implement StructuredQuestionViewModal for displaying coding and MCQ questions

feat: add "View problem" button in QuestionPerformance for structured questions

fix: ensure interviewer voice cleanup triggers on end of speech

chore: update mock interview service to include bonus seconds and coding question details

refactor: create utility function to clean interview titles