### PR TITLE
feat(scorecard): Phase 1 frontend — Accuracy & Performance Trends (staging design)

### DIFF
--- a/app/admin/scorecard/page.tsx
+++ b/app/admin/scorecard/page.tsx
@@ -26,6 +26,7 @@ import { useToast } from "@/components/common/Toast";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { ActivityHeatmap } from "@/components/profile/ActivityHeatmap";
 import { LearningConsumptionSection } from "@/components/scorecard/detailed/LearningConsumptionSection";
+import { PerformanceTrendsSection } from "@/components/scorecard/detailed/PerformanceTrendsSection";
 import { StudentOverviewSection } from "@/components/scorecard/detailed/StudentOverviewSection";
 import { adminStudentService, type Student } from "@/lib/services/admin/admin-student.service";
 import {
@@ -40,6 +41,7 @@ const MODULE_OPTIONS = [
   { id: "overview", label: "Student Overview" },
   { id: "activity_heatmap", label: "Activity Heatmap" },
   { id: "learning_consumption", label: "Learning Consumption" },
+  { id: "performance_trends", label: "Performance Trends" },
 ] as const;
 
 const ALLOWED_MODULE_IDS: string[] = MODULE_OPTIONS.map((m) => m.id);
@@ -732,6 +734,15 @@ export default function AdminScorecardPage() {
                           );
                         case "learning_consumption":
                           return <LearningConsumptionSection key={sectionId} data={scorecardData.learningConsumption} />;
+                        case "performance_trends":
+                          if (!scorecardData.performanceTrends) return null;
+                          return (
+                            <PerformanceTrendsSection
+                              key={sectionId}
+                              initialData={scorecardData.performanceTrends}
+                              readOnly
+                            />
+                          );
                         default:
                           return null;
                       }

--- a/app/user/scorecard/page.tsx
+++ b/app/user/scorecard/page.tsx
@@ -16,12 +16,18 @@ import { MainLayout } from "@/components/layout/MainLayout";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { ActivityHeatmap } from "@/components/profile/ActivityHeatmap";
 import { LearningConsumptionSection } from "@/components/scorecard/detailed/LearningConsumptionSection";
+import { PerformanceTrendsSection } from "@/components/scorecard/detailed/PerformanceTrendsSection";
 import { StudentOverviewSection } from "@/components/scorecard/detailed/StudentOverviewSection";
 import { profileService, type HeatmapData } from "@/lib/services/profile.service";
 import { scorecardService } from "@/lib/services/scorecard.service";
 import type { ScorecardData } from "@/lib/types/scorecard.types";
 
-const SECTION_ORDER = ["overview", "activity_heatmap", "learning_consumption"] as const;
+const SECTION_ORDER = [
+  "overview",
+  "activity_heatmap",
+  "learning_consumption",
+  "performance_trends",
+] as const;
 
 /** Soft editorial backdrop — radial gradient mesh that picks up theme accents. */
 function PageBackdrop() {
@@ -309,6 +315,17 @@ export default function ScorecardPage() {
                       <LearningConsumptionSection
                         key={sectionId}
                         data={data.learningConsumption}
+                      />
+                    );
+                  case "performance_trends":
+                    // performanceTrends is optional on ScorecardData — earlier
+                    // backend deploys may not return it; render the section
+                    // only when the umbrella payload included it.
+                    if (!data.performanceTrends) return null;
+                    return (
+                      <PerformanceTrendsSection
+                        key={sectionId}
+                        initialData={data.performanceTrends}
                       />
                     );
                   default:

--- a/components/scorecard/charts/PerformanceLineChart.tsx
+++ b/components/scorecard/charts/PerformanceLineChart.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+export interface PerformanceLineChartSeries {
+  key: string;
+  label: string;
+  color: string;
+}
+
+export interface PerformanceLineChartProps<TData extends Record<string, unknown>> {
+  data: TData[];
+  xKey: keyof TData & string;
+  series: PerformanceLineChartSeries[];
+  height?: number;
+  title?: string;
+  emptyHint?: string;
+}
+
+/**
+ * Recharts line chart used by the Performance Trends section.
+ *
+ * Designed for the staging revamp surface: transparent background, dashed
+ * grid in `var(--border-default)`, axis labels in `var(--font-secondary)`,
+ * tooltip card in `var(--card-bg)` with the same border style as the
+ * surrounding section cards. Multi-series with up to 4 metrics.
+ */
+export function PerformanceLineChart<TData extends Record<string, unknown>>({
+  data,
+  xKey,
+  series,
+  height = 280,
+  title,
+  emptyHint,
+}: PerformanceLineChartProps<TData>) {
+  const isEmpty = !data || data.length === 0;
+
+  return (
+    <Box>
+      {title && (
+        <Typography
+          variant="subtitle2"
+          sx={{
+            fontWeight: 700,
+            color: "var(--font-primary)",
+            mb: 1.5,
+            letterSpacing: 0.2,
+          }}
+        >
+          {title}
+        </Typography>
+      )}
+      <Box
+        sx={{
+          width: "100%",
+          height,
+          position: "relative",
+          borderRadius: 2,
+          bgcolor:
+            "color-mix(in srgb, var(--surface-subtle, rgba(15,23,42,0.04)) 100%, transparent)",
+          p: 1.5,
+        }}
+      >
+        {isEmpty ? (
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexDirection: "column",
+              gap: 0.5,
+              color: "var(--font-secondary)",
+            }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              {emptyHint ?? "No data yet."}
+            </Typography>
+          </Box>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 8, right: 16, left: -12, bottom: 0 }}>
+              <CartesianGrid
+                strokeDasharray="3 4"
+                stroke="color-mix(in srgb, var(--border-default) 70%, transparent)"
+                vertical={false}
+              />
+              <XAxis
+                dataKey={xKey}
+                tick={{ fill: "var(--font-secondary)", fontSize: 11 }}
+                tickLine={false}
+                axisLine={{
+                  stroke: "color-mix(in srgb, var(--border-default) 60%, transparent)",
+                }}
+              />
+              <YAxis
+                domain={[0, 100]}
+                tick={{ fill: "var(--font-secondary)", fontSize: 11 }}
+                tickLine={false}
+                axisLine={false}
+                width={32}
+              />
+              <Tooltip
+                cursor={{
+                  stroke: "color-mix(in srgb, var(--accent-indigo) 30%, transparent)",
+                  strokeWidth: 1,
+                }}
+                contentStyle={{
+                  background: "var(--card-bg)",
+                  border:
+                    "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+                  borderRadius: 8,
+                  fontSize: 12,
+                  boxShadow:
+                    "0 12px 32px -16px rgba(15, 23, 42, 0.18)",
+                }}
+                labelStyle={{ color: "var(--font-primary)", fontWeight: 700 }}
+                itemStyle={{ color: "var(--font-primary)" }}
+              />
+              <Legend
+                verticalAlign="top"
+                align="right"
+                iconType="circle"
+                iconSize={8}
+                wrapperStyle={{ paddingBottom: 6, fontSize: 11 }}
+              />
+              {series.map((s) => (
+                <Line
+                  key={s.key}
+                  type="monotone"
+                  dataKey={s.key}
+                  name={s.label}
+                  stroke={s.color}
+                  strokeWidth={2}
+                  dot={{ r: 3, strokeWidth: 0 }}
+                  activeDot={{ r: 5, strokeWidth: 0 }}
+                  isAnimationActive
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/scorecard/charts/SkillAccuracyBars.tsx
+++ b/components/scorecard/charts/SkillAccuracyBars.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { Box, LinearProgress, Tooltip, Typography } from "@mui/material";
+import { proficiencyBandColor } from "@/lib/utils/scorecard-visual";
+
+export interface SkillAccuracyBarsRow {
+  skillName: string;
+  accuracy: number;
+  attemptCount: number;
+  confidenceScore: number;
+}
+
+export interface SkillAccuracyBarsProps {
+  data: SkillAccuracyBarsRow[];
+  title?: string;
+  /** Cap on number of rows rendered before showing a "+N more" line. */
+  maxRows?: number;
+  /** When the dataset is sparse, hint at what's needed to populate the chart. */
+  emptyHint?: string;
+}
+
+/**
+ * Skill-wise accuracy chart for the Performance Trends section.
+ *
+ * Linear progress bars rather than a recharts bar chart so dense skill lists
+ * stay readable and the value labels (accuracy %, attempts, confidence)
+ * can sit inline. Color follows proficiencyBandColor so it matches the
+ * existing overview score palette.
+ */
+export function SkillAccuracyBars({
+  data,
+  title,
+  maxRows = 8,
+  emptyHint,
+}: SkillAccuracyBarsProps) {
+  const rows = (data ?? []).slice(0, maxRows);
+  const overflow = (data?.length ?? 0) - rows.length;
+
+  return (
+    <Box>
+      {title && (
+        <Typography
+          variant="subtitle2"
+          sx={{
+            fontWeight: 700,
+            color: "var(--font-primary)",
+            mb: 1.5,
+            letterSpacing: 0.2,
+          }}
+        >
+          {title}
+        </Typography>
+      )}
+      {rows.length === 0 ? (
+        <Box
+          sx={{
+            p: 3,
+            borderRadius: 2,
+            border:
+              "1px dashed color-mix(in srgb, var(--border-default) 80%, transparent)",
+            textAlign: "center",
+            color: "var(--font-secondary)",
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            {emptyHint ??
+              "Tag content with skills (admin) and complete quizzes to populate the per-skill accuracy chart."}
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ display: "grid", gap: 1.25 }}>
+          {rows.map((row) => {
+            const accent = proficiencyBandColor(row.accuracy);
+            return (
+              <Box key={row.skillName}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 1,
+                    mb: 0.5,
+                  }}
+                >
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: 600,
+                      color: "var(--font-primary)",
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                    title={row.skillName}
+                  >
+                    {row.skillName}
+                  </Typography>
+                  <Tooltip
+                    title={`${row.attemptCount} attempt${row.attemptCount === 1 ? "" : "s"} · confidence ${row.confidenceScore}%`}
+                    arrow
+                    placement="top"
+                  >
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontVariantNumeric: "tabular-nums",
+                        fontWeight: 700,
+                        color: accent,
+                      }}
+                    >
+                      {row.accuracy.toFixed(0)}%
+                    </Typography>
+                  </Tooltip>
+                </Box>
+                <LinearProgress
+                  variant="determinate"
+                  value={Math.max(0, Math.min(100, row.accuracy))}
+                  sx={{
+                    height: 8,
+                    borderRadius: 4,
+                    bgcolor:
+                      "color-mix(in srgb, var(--border-default) 50%, transparent)",
+                    "& .MuiLinearProgress-bar": {
+                      borderRadius: 4,
+                      backgroundColor: accent,
+                    },
+                  }}
+                />
+              </Box>
+            );
+          })}
+          {overflow > 0 && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mt: 0.5 }}
+            >
+              + {overflow} more skill{overflow === 1 ? "" : "s"} not shown
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/scorecard/detailed/PerformanceTrendsSection.tsx
+++ b/components/scorecard/detailed/PerformanceTrendsSection.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Box, ToggleButton, ToggleButtonGroup, Typography, CircularProgress } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { Reveal, useStaticRender } from "@/components/scorecard/shared";
+import { scorecardService, type PerformanceTrendsGranularity } from "@/lib/services/scorecard.service";
+import type { PerformanceTrends } from "@/lib/types/scorecard.types";
+import { PerformanceLineChart } from "@/components/scorecard/charts/PerformanceLineChart";
+import { SkillAccuracyBars } from "@/components/scorecard/charts/SkillAccuracyBars";
+
+interface PerformanceTrendsSectionProps {
+  initialData: PerformanceTrends;
+  /**
+   * When true (admin view / PDF render) granularity switching is disabled.
+   * Avoids client-side fetches that wouldn't carry the admin's user_id
+   * context, and keeps PDFs deterministic.
+   */
+  readOnly?: boolean;
+}
+
+const GRANULARITY_OPTIONS: PerformanceTrendsGranularity[] = ["weekly", "bimonthly", "monthly"];
+
+const SERIES = [
+  { key: "mcqAccuracy", label: "MCQ accuracy", color: "var(--accent-indigo)" },
+  { key: "subjectiveScore", label: "Subjective", color: "#10b981" },
+  { key: "assessmentScore", label: "Assessment", color: "#f59e0b" },
+  { key: "interviewScore", label: "Interview", color: "#a855f7" },
+];
+
+export function PerformanceTrendsSection({
+  initialData,
+  readOnly = false,
+}: PerformanceTrendsSectionProps) {
+  const staticRender = useStaticRender();
+  const [granularity, setGranularity] = useState<PerformanceTrendsGranularity>(
+    initialData.granularity ?? "weekly",
+  );
+  const [data, setData] = useState<PerformanceTrends>(initialData);
+  const [loading, setLoading] = useState(false);
+  const cacheRef = useRef<Partial<Record<PerformanceTrendsGranularity, PerformanceTrends>>>({});
+  const fetchIdRef = useRef(0);
+
+  useEffect(() => {
+    setData(initialData);
+    if (initialData.granularity) {
+      cacheRef.current[initialData.granularity] = initialData;
+    }
+  }, [initialData]);
+
+  const handleGranularityChange = useCallback(
+    async (next: PerformanceTrendsGranularity) => {
+      if (next === granularity || loading || readOnly || staticRender) return;
+      const cached = cacheRef.current[next];
+      if (cached) {
+        setGranularity(next);
+        setData(cached);
+        return;
+      }
+      const fetchId = ++fetchIdRef.current;
+      setGranularity(next);
+      setLoading(true);
+      try {
+        const fresh = await scorecardService.getPerformanceTrends(next);
+        if (fetchId === fetchIdRef.current) {
+          cacheRef.current[next] = fresh;
+          setData(fresh);
+        }
+      } catch (err) {
+        console.warn("PerformanceTrends fetch failed:", err);
+      } finally {
+        if (fetchId === fetchIdRef.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [granularity, loading, readOnly, staticRender],
+  );
+
+  const hasWeekly = data.weeklyData.length > 0;
+  const hasSkill = data.skillWiseAccuracy.length > 0;
+  const isEmpty = !hasWeekly && !hasSkill;
+
+  return (
+    <Reveal as="section">
+      <Box
+        sx={{
+          position: "relative",
+          borderRadius: 4,
+          overflow: "hidden",
+          border:
+            "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+          backgroundColor: "var(--card-bg)",
+          boxShadow:
+            "0 1px 0 color-mix(in srgb, var(--border-default) 60%, transparent), 0 30px 60px -30px rgba(15, 23, 42, 0.18)",
+          backdropFilter: "blur(6px)",
+        }}
+      >
+        {/* Decorative radial gradient mesh — matches StudentOverviewSection accent style. */}
+        <Box
+          aria-hidden
+          sx={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0.45,
+            backgroundImage: [
+              "radial-gradient(55% 70% at 0% 0%, color-mix(in srgb, var(--accent-indigo) 18%, transparent), transparent 60%)",
+              "radial-gradient(45% 60% at 100% 0%, color-mix(in srgb, var(--accent-cyan) 14%, transparent), transparent 60%)",
+            ].join(", "),
+            pointerEvents: "none",
+          }}
+        />
+
+        <Box sx={{ position: "relative", p: { xs: 2.5, sm: 3.5, md: 4.5 } }}>
+          {/* Header */}
+          <Box
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 2,
+              alignItems: { xs: "flex-start", sm: "center" },
+              justifyContent: "space-between",
+              pb: { xs: 2.5, md: 3 },
+              mb: { xs: 2.5, md: 3 },
+              borderBottom:
+                "1px dashed color-mix(in srgb, var(--border-default) 80%, transparent)",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, minWidth: 0 }}>
+              <Box
+                sx={{
+                  width: 44,
+                  height: 44,
+                  borderRadius: 2,
+                  background:
+                    "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  boxShadow:
+                    "0 12px 24px -12px color-mix(in srgb, var(--accent-indigo) 60%, transparent)",
+                  flexShrink: 0,
+                }}
+              >
+                <IconWrapper icon="mdi:chart-line" size={22} color="#fff" />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant="h6"
+                  sx={{
+                    fontWeight: 800,
+                    color: "var(--font-primary)",
+                    fontSize: { xs: "1.05rem", sm: "1.2rem" },
+                    lineHeight: 1.25,
+                  }}
+                >
+                  Accuracy & Performance Trends
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ fontSize: "0.85rem", mt: 0.25 }}
+                >
+                  Track how your scores evolve across quizzes, assessments, and interviews.
+                </Typography>
+              </Box>
+            </Box>
+
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <ToggleButtonGroup
+                value={granularity}
+                exclusive
+                onChange={(_, value) => value && handleGranularityChange(value)}
+                disabled={loading || readOnly || staticRender}
+                size="small"
+                sx={{
+                  bgcolor:
+                    "color-mix(in srgb, var(--border-default) 35%, transparent)",
+                  borderRadius: 999,
+                  p: 0.5,
+                  "& .MuiToggleButtonGroup-grouped": {
+                    border: 0,
+                    borderRadius: 999,
+                    px: 1.5,
+                    py: 0.5,
+                    textTransform: "capitalize",
+                    fontWeight: 600,
+                    fontSize: "0.75rem",
+                    color: "var(--font-secondary)",
+                    "&.Mui-selected": {
+                      bgcolor: "var(--card-bg)",
+                      color: "var(--font-primary)",
+                      boxShadow:
+                        "0 4px 12px -6px color-mix(in srgb, var(--accent-indigo) 35%, transparent)",
+                      "&:hover": { bgcolor: "var(--card-bg)" },
+                    },
+                    "&:hover": {
+                      bgcolor:
+                        "color-mix(in srgb, var(--accent-indigo) 6%, transparent)",
+                    },
+                  },
+                }}
+              >
+                {GRANULARITY_OPTIONS.map((opt) => (
+                  <ToggleButton key={opt} value={opt} aria-label={opt}>
+                    {opt}
+                  </ToggleButton>
+                ))}
+              </ToggleButtonGroup>
+              <Box sx={{ width: 22, display: "flex", justifyContent: "center" }}>
+                {loading && <CircularProgress size={16} thickness={5} />}
+              </Box>
+            </Box>
+          </Box>
+
+          {isEmpty ? (
+            <Box
+              sx={{
+                py: { xs: 4, sm: 6 },
+                textAlign: "center",
+                borderRadius: 2,
+                border:
+                  "1px dashed color-mix(in srgb, var(--border-default) 80%, transparent)",
+                color: "var(--font-secondary)",
+              }}
+            >
+              <IconWrapper icon="mdi:chart-timeline-variant" size={40} color="var(--font-secondary)" />
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+                No performance data yet. Complete quizzes, assessments, and interviews to start the trend.
+              </Typography>
+            </Box>
+          ) : (
+            <Box
+              sx={{
+                display: "grid",
+                gap: { xs: 3, md: 4 },
+                gridTemplateColumns: {
+                  xs: "1fr",
+                  md: "minmax(0, 1.4fr) minmax(0, 1fr)",
+                },
+              }}
+            >
+              <PerformanceLineChart
+                data={data.weeklyData as unknown as Record<string, unknown>[]}
+                xKey="weekLabel"
+                series={SERIES}
+                title="Score over time"
+                emptyHint="Once you attempt content over multiple weeks, the lines populate here."
+              />
+              <SkillAccuracyBars
+                data={data.skillWiseAccuracy}
+                title="Skill-wise accuracy"
+                emptyHint="Skill bars appear once mapped MCQs / coding problems have ≥3 attempts."
+              />
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Reveal>
+  );
+}

--- a/lib/services/scorecard.service.ts
+++ b/lib/services/scorecard.service.ts
@@ -2,9 +2,12 @@ import apiClient from "./api";
 import { config } from "@/lib/config";
 import { profileService } from "./profile.service";
 import { scorecardFromApiPayload, type ScorecardApiPayload } from "./scorecard/build-scorecard";
+import { mapPerformanceTrendsFromApi } from "./scorecard/mappers";
+import type { PerformanceTrends } from "@/lib/types/scorecard.types";
 
 export { formatTimeSpent } from "./scorecard/mappers";
 export type { ScorecardApiPayload };
+export type PerformanceTrendsGranularity = "weekly" | "bimonthly" | "monthly";
 
 async function mergeProfilePicture<T extends { overview: { profilePicUrl?: string } }>(result: T): Promise<T> {
   try {
@@ -38,6 +41,17 @@ export const scorecardService = {
     if (!res.ok) throw new Error("Invalid or expired PDF link");
     const data = (await res.json()) as ScorecardApiPayload;
     return scorecardFromApiPayload(data);
+  },
+
+  getPerformanceTrends: async (
+    granularity: PerformanceTrendsGranularity = "weekly",
+  ): Promise<PerformanceTrends> => {
+    const clientId = config.clientId;
+    const response = await apiClient.get<Record<string, unknown>>(
+      `/api/scorecard/clients/${clientId}/student/scorecard/performance-trends/`,
+      { params: { granularity } },
+    );
+    return mapPerformanceTrendsFromApi(response.data);
   },
 
   exportScorecardPdf: async (): Promise<Blob> => {

--- a/lib/services/scorecard/build-scorecard.ts
+++ b/lib/services/scorecard/build-scorecard.ts
@@ -2,6 +2,7 @@ import type { ScorecardData } from "@/lib/types/scorecard.types";
 import {
   mapLearningConsumptionFromApi,
   mapOverviewFromApi,
+  mapPerformanceTrendsFromApi,
   getEmptyLearningConsumption,
   getEmptyOverview,
   getEmptyScorecardData,
@@ -12,6 +13,7 @@ export type ScorecardApiPayload = {
   scorecard_config?: { enabled_modules?: string[]; enabled_content_types_for_skills?: string[] };
   overview?: Record<string, unknown>;
   learning_consumption?: unknown;
+  performance_trends?: unknown;
 };
 
 export function scorecardFromApiPayload(data: ScorecardApiPayload | undefined | null): ScorecardData {
@@ -34,6 +36,13 @@ export function scorecardFromApiPayload(data: ScorecardApiPayload | undefined | 
     data?.learning_consumption != null && typeof data.learning_consumption === "object"
       ? mapLearningConsumptionFromApi(data.learning_consumption as Record<string, unknown>)
       : getEmptyLearningConsumption();
+
+  // Only set performanceTrends when the backend actually sent it. Leaving it
+  // undefined lets pages render older deploys (Phase 0 backend) without
+  // crashing on missing data — the section component renders an empty state.
+  if (data?.performance_trends != null && typeof data.performance_trends === "object") {
+    result.performanceTrends = mapPerformanceTrendsFromApi(data.performance_trends);
+  }
 
   return result;
 }

--- a/lib/services/scorecard/mappers.ts
+++ b/lib/services/scorecard/mappers.ts
@@ -1,6 +1,7 @@
 import type {
   ContentCompletionOverview,
   LearningConsumption,
+  PerformanceTrends,
   ScorecardData,
   StudentOverview,
 } from "@/lib/types/scorecard.types";
@@ -238,6 +239,44 @@ export function getEmptyLearningConsumption(): LearningConsumption {
       assessmentsMissed: 0,
     },
   };
+}
+
+export function mapPerformanceTrendsFromApi(api: unknown): PerformanceTrends {
+  if (!api || typeof api !== "object") {
+    return getEmptyPerformanceTrends();
+  }
+  const raw = api as Record<string, unknown>;
+  const weeklyData = Array.isArray(raw.weekly_data)
+    ? (raw.weekly_data as Record<string, unknown>[]).map((w) => ({
+        week: num(w.week),
+        weekLabel: (w.week_label as string) ?? "",
+        mcqAccuracy: num(w.mcq_accuracy),
+        subjectiveScore: num(w.subjective_score),
+        assessmentScore: num(w.assessment_score),
+        interviewScore: num(w.interview_score),
+      }))
+    : [];
+  const skillWiseAccuracy = Array.isArray(raw.skill_wise_accuracy)
+    ? (raw.skill_wise_accuracy as Record<string, unknown>[]).map((s) => ({
+        skillName: (s.skill_name as string) ?? "",
+        accuracy: num(s.accuracy),
+        attemptCount: num(s.attempt_count),
+        confidenceScore: num(s.confidence_score),
+      }))
+    : [];
+  const granularity = raw.granularity;
+  const allowed = new Set(["weekly", "bimonthly", "monthly"] as const);
+  return {
+    granularity: typeof granularity === "string" && allowed.has(granularity as "weekly")
+      ? (granularity as "weekly" | "bimonthly" | "monthly")
+      : "weekly",
+    weeklyData,
+    skillWiseAccuracy,
+  };
+}
+
+export function getEmptyPerformanceTrends(): PerformanceTrends {
+  return { granularity: "weekly", weeklyData: [], skillWiseAccuracy: [] };
 }
 
 export function getEmptyScorecardData(): ScorecardData {

--- a/lib/types/scorecard.types.ts
+++ b/lib/types/scorecard.types.ts
@@ -110,8 +110,34 @@ export interface ScorecardConfig {
   enabledModules: string[];
 }
 
+// Performance Trends (Phase 1) — added incrementally as new modules land.
+// Older mockup branch had these in a single big drop; on stagging they're
+// introduced one section at a time so each phase merges cleanly.
+export interface WeeklyPerformance {
+  week: number;
+  weekLabel: string;
+  mcqAccuracy: number;
+  subjectiveScore: number;
+  assessmentScore: number;
+  interviewScore: number;
+}
+
+export interface SkillAccuracy {
+  skillName: string;
+  accuracy: number; // 0-100
+  attemptCount: number;
+  confidenceScore: number; // 0-100
+}
+
+export interface PerformanceTrends {
+  granularity?: "weekly" | "bimonthly" | "monthly";
+  weeklyData: WeeklyPerformance[];
+  skillWiseAccuracy: SkillAccuracy[];
+}
+
 export interface ScorecardData {
   scorecardConfig?: ScorecardConfig;
   overview: StudentOverview;
   learningConsumption: LearningConsumption;
+  performanceTrends?: PerformanceTrends;
 }


### PR DESCRIPTION
## Summary

Adds Performance Trends section as a fresh build on top of the current stagging revamp (Reveal wrapper, radial gradient mesh, `var(--card-bg)` / `var(--accent-indigo)` tokens). Does NOT depend on feature/scorecard-implementation's older mockup components.

**New files:**
- `components/scorecard/charts/PerformanceLineChart.tsx`: Recharts wrapper
- `components/scorecard/charts/SkillAccuracyBars.tsx`: linear-progress layout for dense skill lists
- `components/scorecard/detailed/PerformanceTrendsSection.tsx`: section card with granularity pill switcher

Wired into /user/scorecard and /admin/scorecard. Renders nothing when the backend hasn't sent performance_trends yet — old-deploy fallback safe.

## Test plan
- [ ] After backend Phase 1 deploys, section appears on `/user/scorecard`
- [ ] Granularity toggle (weekly / bimonthly / monthly) refetches and renders new data
- [ ] No console errors when backend response is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)