### PR TITLE
feat(scorecard): Phase 6 frontend — Behavioral & Consistency

### DIFF
--- a/app/admin/scorecard/page.tsx
+++ b/app/admin/scorecard/page.tsx
@@ -26,6 +26,7 @@ import { useToast } from "@/components/common/Toast";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { ActivityHeatmap } from "@/components/profile/ActivityHeatmap";
 import { AssessmentPerformanceSection } from "@/components/scorecard/detailed/AssessmentPerformanceSection";
+import { BehavioralMetricsSection } from "@/components/scorecard/detailed/BehavioralMetricsSection";
 import { LearningConsumptionSection } from "@/components/scorecard/detailed/LearningConsumptionSection";
 import { MockInterviewSection } from "@/components/scorecard/detailed/MockInterviewSection";
 import { PerformanceTrendsSection } from "@/components/scorecard/detailed/PerformanceTrendsSection";
@@ -50,6 +51,7 @@ const MODULE_OPTIONS = [
   { id: "weak_areas", label: "Weak Areas" },
   { id: "assessment_performance", label: "Assessment Performance" },
   { id: "mock_interview", label: "Mock Interview" },
+  { id: "behavioral_metrics", label: "Behavioral & Consistency" },
 ] as const;
 
 const ALLOWED_MODULE_IDS: string[] = MODULE_OPTIONS.map((m) => m.id);
@@ -771,6 +773,14 @@ export default function AdminScorecardPage() {
                             <MockInterviewSection
                               key={sectionId}
                               data={scorecardData.mockInterviewPerformance}
+                            />
+                          );
+                        case "behavioral_metrics":
+                          if (!scorecardData.behavioralMetrics) return null;
+                          return (
+                            <BehavioralMetricsSection
+                              key={sectionId}
+                              data={scorecardData.behavioralMetrics}
                             />
                           );
                         default:

--- a/app/user/scorecard/page.tsx
+++ b/app/user/scorecard/page.tsx
@@ -16,6 +16,7 @@ import { MainLayout } from "@/components/layout/MainLayout";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { ActivityHeatmap } from "@/components/profile/ActivityHeatmap";
 import { AssessmentPerformanceSection } from "@/components/scorecard/detailed/AssessmentPerformanceSection";
+import { BehavioralMetricsSection } from "@/components/scorecard/detailed/BehavioralMetricsSection";
 import { LearningConsumptionSection } from "@/components/scorecard/detailed/LearningConsumptionSection";
 import { MockInterviewSection } from "@/components/scorecard/detailed/MockInterviewSection";
 import { PerformanceTrendsSection } from "@/components/scorecard/detailed/PerformanceTrendsSection";
@@ -35,6 +36,7 @@ const SECTION_ORDER = [
   "weak_areas",
   "assessment_performance",
   "mock_interview",
+  "behavioral_metrics",
 ] as const;
 
 /** Soft editorial backdrop — radial gradient mesh that picks up theme accents. */
@@ -356,6 +358,14 @@ export default function ScorecardPage() {
                       <MockInterviewSection
                         key={sectionId}
                         data={data.mockInterviewPerformance}
+                      />
+                    );
+                  case "behavioral_metrics":
+                    if (!data.behavioralMetrics) return null;
+                    return (
+                      <BehavioralMetricsSection
+                        key={sectionId}
+                        data={data.behavioralMetrics}
                       />
                     );
                   default:

--- a/components/scorecard/detailed/BehavioralMetricsSection.tsx
+++ b/components/scorecard/detailed/BehavioralMetricsSection.tsx
@@ -1,0 +1,422 @@
+"use client";
+
+import { useMemo } from "react";
+import { Box, LinearProgress, Tooltip, Typography } from "@mui/material";
+import { motion } from "framer-motion";
+import {
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+  BarChart,
+  Bar,
+} from "recharts";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { CountUp, Reveal, gridStagger } from "@/components/scorecard/shared";
+import type { BehavioralMetrics, StudyTimeDistribution } from "@/lib/types/scorecard.types";
+
+interface BehavioralMetricsSectionProps {
+  data: BehavioralMetrics;
+}
+
+function formatWeekLabel(iso: string): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleDateString(undefined, { day: "numeric", month: "short" });
+  } catch {
+    return iso;
+  }
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "—";
+    const ms = Date.now() - d.getTime();
+    if (ms < 0) return "today";
+    const days = Math.floor(ms / (1000 * 60 * 60 * 24));
+    if (days <= 0) return "today";
+    if (days === 1) return "yesterday";
+    if (days < 7) return `${days} days ago`;
+    if (days < 30) return `${Math.floor(days / 7)} weeks ago`;
+    return d.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
+  } catch {
+    return "—";
+  }
+}
+
+function MiniBarChart({ data, dataKey, color }: { data: any[]; dataKey: string; color: string }) {
+  if (!data.length) {
+    return (
+      <Box
+        sx={{
+          height: 120,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "var(--font-secondary)",
+          fontSize: "0.78rem",
+          borderRadius: 2,
+          border: "1px dashed color-mix(in srgb, var(--border-default) 80%, transparent)",
+        }}
+      >
+        No data yet
+      </Box>
+    );
+  }
+  return (
+    <Box sx={{ height: 140, width: "100%" }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 4, left: -16, bottom: 0 }}>
+          <CartesianGrid
+            strokeDasharray="3 4"
+            stroke="color-mix(in srgb, var(--border-default) 70%, transparent)"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="label"
+            tick={{ fill: "var(--font-secondary)", fontSize: 10 }}
+            tickLine={false}
+            axisLine={{ stroke: "color-mix(in srgb, var(--border-default) 60%, transparent)" }}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            tick={{ fill: "var(--font-secondary)", fontSize: 10 }}
+            tickLine={false}
+            axisLine={false}
+            width={28}
+          />
+          <RechartsTooltip
+            contentStyle={{
+              background: "var(--card-bg)",
+              border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+              borderRadius: 8,
+              fontSize: 11,
+              boxShadow: "0 12px 32px -16px rgba(15, 23, 42, 0.18)",
+            }}
+            labelStyle={{ color: "var(--font-primary)", fontWeight: 700 }}
+          />
+          <Bar dataKey={dataKey} fill={color} radius={[4, 4, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </Box>
+  );
+}
+
+function StudyTimeDistributionBars({ data }: { data: StudyTimeDistribution[] }) {
+  const max = useMemo(() => data.reduce((acc, d) => Math.max(acc, d.hours), 0), [data]);
+  if (!data.length) return null;
+  return (
+    <Box sx={{ display: "grid", gap: 0.75 }}>
+      {data.map((row) => {
+        const pct = max > 0 ? (row.hours / max) * 100 : 0;
+        return (
+          <Box key={row.day}>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                mb: 0.25,
+              }}
+            >
+              <Typography variant="caption" sx={{ fontWeight: 700, color: "var(--font-primary)", fontSize: "0.7rem" }}>
+                {row.day}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 800,
+                  color: "var(--accent-indigo-dark)",
+                  fontVariantNumeric: "tabular-nums",
+                  fontSize: "0.7rem",
+                }}
+              >
+                {row.hours.toFixed(1)}h
+              </Typography>
+            </Box>
+            <LinearProgress
+              variant="determinate"
+              value={Math.max(0, Math.min(100, pct))}
+              sx={{
+                height: 5,
+                borderRadius: 3,
+                bgcolor: "color-mix(in srgb, var(--border-default) 45%, transparent)",
+                "& .MuiLinearProgress-bar": {
+                  borderRadius: 3,
+                  background: "linear-gradient(90deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)",
+                },
+              }}
+            />
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+export function BehavioralMetricsSection({ data }: BehavioralMetricsSectionProps) {
+  const consistencyAccent =
+    data.consistencyScore >= 80
+      ? "#10b981"
+      : data.consistencyScore >= 60
+      ? "var(--accent-indigo)"
+      : data.consistencyScore >= 40
+      ? "#f59e0b"
+      : "#ef4444";
+
+  const loginChartData = useMemo(
+    () =>
+      data.loginFrequency.map((d) => ({
+        label: formatWeekLabel(d.week),
+        active: d.loginCount,
+      })),
+    [data.loginFrequency],
+  );
+
+  const studyChartData = useMemo(
+    () =>
+      data.studyTimeByWeek.map((d) => ({
+        label: formatWeekLabel(d.week),
+        hours: d.hours,
+      })),
+    [data.studyTimeByWeek],
+  );
+
+  return (
+    <Reveal as="section">
+      <Box
+        sx={{
+          position: "relative",
+          borderRadius: 4,
+          overflow: "hidden",
+          border:
+            "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+          backgroundColor: "var(--card-bg)",
+          boxShadow:
+            "0 1px 0 color-mix(in srgb, var(--border-default) 60%, transparent), 0 30px 60px -30px rgba(15, 23, 42, 0.18)",
+          backdropFilter: "blur(6px)",
+        }}
+      >
+        <Box
+          aria-hidden
+          sx={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0.4,
+            backgroundImage: [
+              "radial-gradient(55% 70% at 0% 0%, color-mix(in srgb, var(--accent-cyan) 16%, transparent), transparent 60%)",
+              "radial-gradient(45% 60% at 100% 100%, color-mix(in srgb, var(--accent-indigo) 12%, transparent), transparent 60%)",
+            ].join(", "),
+            pointerEvents: "none",
+          }}
+        />
+
+        <Box sx={{ position: "relative", p: { xs: 2.5, sm: 3.5, md: 4.5 } }}>
+          <Box
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 2,
+              alignItems: { xs: "flex-start", sm: "center" },
+              justifyContent: "space-between",
+              pb: { xs: 2.5, md: 3 },
+              mb: { xs: 2.5, md: 3 },
+              borderBottom:
+                "1px dashed color-mix(in srgb, var(--border-default) 80%, transparent)",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, minWidth: 0 }}>
+              <Box
+                sx={{
+                  width: 44,
+                  height: 44,
+                  borderRadius: 2,
+                  background: "linear-gradient(135deg, var(--accent-cyan, #06b6d4) 0%, #0891b2 100%)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  boxShadow:
+                    "0 12px 24px -12px color-mix(in srgb, var(--accent-cyan, #06b6d4) 60%, transparent)",
+                  flexShrink: 0,
+                }}
+              >
+                <IconWrapper icon="mdi:calendar-clock-outline" size={22} color="#fff" />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant="h6"
+                  sx={{
+                    fontWeight: 800,
+                    color: "var(--font-primary)",
+                    fontSize: { xs: "1.05rem", sm: "1.2rem" },
+                    lineHeight: 1.25,
+                  }}
+                >
+                  Behavioral & Consistency
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ fontSize: "0.85rem", mt: 0.25 }}>
+                  Activity rhythm, study-time patterns, and consistency index.
+                </Typography>
+              </Box>
+            </Box>
+
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "repeat(2, minmax(0, 1fr))", sm: "repeat(3, auto)" },
+                gap: { xs: 1, sm: 1.5 },
+              }}
+            >
+              {[
+                {
+                  label: "Consistency",
+                  value: `${Math.round(data.consistencyScore)}%`,
+                  color: consistencyAccent,
+                  numeric: true,
+                  numericValue: data.consistencyScore,
+                },
+                {
+                  label: "Last active",
+                  value: formatRelative(data.lastActiveDate),
+                  color: "var(--accent-cyan, #06b6d4)",
+                },
+                {
+                  label: "Missed",
+                  value: data.missedDeadlinesCount,
+                  color: data.missedDeadlinesCount > 0 ? "#ef4444" : "var(--font-secondary)",
+                  numeric: true,
+                  numericValue: data.missedDeadlinesCount,
+                },
+              ].map((stat) => (
+                <Box
+                  key={stat.label}
+                  sx={{
+                    px: 1.5,
+                    py: 0.75,
+                    borderRadius: 2,
+                    bgcolor:
+                      "color-mix(in srgb, var(--border-default) 30%, transparent)",
+                    display: "flex",
+                    flexDirection: "column",
+                    minWidth: 78,
+                  }}
+                >
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ fontWeight: 600, letterSpacing: 0.3, textTransform: "uppercase", fontSize: "0.65rem" }}
+                  >
+                    {stat.label}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontWeight: 800,
+                      color: stat.color,
+                      fontSize: "1.05rem",
+                      lineHeight: 1.2,
+                      fontVariantNumeric: "tabular-nums",
+                    }}
+                  >
+                    {stat.numeric && typeof stat.numericValue === "number" ? (
+                      <CountUp value={stat.numericValue} duration={0.8} />
+                    ) : (
+                      stat.value
+                    )}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+
+          <motion.div
+            variants={gridStagger}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.1 }}
+            style={{
+              display: "grid",
+              gap: 16,
+              gridTemplateColumns: "1fr",
+            }}
+          >
+            <Box
+              sx={{
+                display: "grid",
+                gap: 2,
+                gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+              }}
+            >
+              <Box
+                sx={{
+                  p: { xs: 1.75, sm: 2 },
+                  borderRadius: 2.5,
+                  border:
+                    "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+                  bgcolor: "var(--card-bg)",
+                }}
+              >
+                <Tooltip
+                  title="Distinct days you opened content per week — proxy for login frequency."
+                  arrow
+                  placement="top"
+                >
+                  <Typography
+                    variant="subtitle2"
+                    sx={{
+                      fontWeight: 800,
+                      color: "var(--font-primary)",
+                      mb: 1,
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                    }}
+                  >
+                    Active days / week
+                    <IconWrapper icon="mdi:information-outline" size={14} color="var(--font-secondary)" />
+                  </Typography>
+                </Tooltip>
+                <MiniBarChart data={loginChartData} dataKey="active" color="var(--accent-cyan, #06b6d4)" />
+              </Box>
+              <Box
+                sx={{
+                  p: { xs: 1.75, sm: 2 },
+                  borderRadius: 2.5,
+                  border:
+                    "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+                  bgcolor: "var(--card-bg)",
+                }}
+              >
+                <Typography variant="subtitle2" sx={{ fontWeight: 800, color: "var(--font-primary)", mb: 1 }}>
+                  Study hours / week
+                </Typography>
+                <MiniBarChart data={studyChartData} dataKey="hours" color="var(--accent-indigo)" />
+              </Box>
+            </Box>
+
+            {data.studyTimeDistribution.length > 0 && (
+              <Box
+                sx={{
+                  p: { xs: 1.75, sm: 2 },
+                  borderRadius: 2.5,
+                  border:
+                    "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+                  bgcolor: "var(--card-bg)",
+                }}
+              >
+                <Typography variant="subtitle2" sx={{ fontWeight: 800, color: "var(--font-primary)", mb: 1 }}>
+                  When you study — by day of week
+                </Typography>
+                <StudyTimeDistributionBars data={data.studyTimeDistribution} />
+              </Box>
+            )}
+          </motion.div>
+        </Box>
+      </Box>
+    </Reveal>
+  );
+}

--- a/lib/services/scorecard.service.ts
+++ b/lib/services/scorecard.service.ts
@@ -4,6 +4,7 @@ import { profileService } from "./profile.service";
 import { scorecardFromApiPayload, type ScorecardApiPayload } from "./scorecard/build-scorecard";
 import {
   mapAssessmentPerformanceFromApi,
+  mapBehavioralMetricsFromApi,
   mapMockInterviewPerformanceFromApi,
   mapPerformanceTrendsFromApi,
   mapSkillsFromApi,
@@ -11,6 +12,7 @@ import {
 } from "./scorecard/mappers";
 import type {
   AssessmentPerformance,
+  BehavioralMetrics,
   MockInterviewPerformance,
   PerformanceTrends,
   Skill,
@@ -96,6 +98,14 @@ export const scorecardService = {
       `/api/scorecard/clients/${clientId}/student/scorecard/mock-interviews/`,
     );
     return mapMockInterviewPerformanceFromApi(response.data);
+  },
+
+  getBehavioralMetrics: async (): Promise<BehavioralMetrics> => {
+    const clientId = config.clientId;
+    const response = await apiClient.get<Record<string, unknown>>(
+      `/api/scorecard/clients/${clientId}/student/scorecard/behavioral/`,
+    );
+    return mapBehavioralMetricsFromApi(response.data);
   },
 
   exportScorecardPdf: async (): Promise<Blob> => {

--- a/lib/services/scorecard/build-scorecard.ts
+++ b/lib/services/scorecard/build-scorecard.ts
@@ -1,6 +1,7 @@
 import type { ScorecardData } from "@/lib/types/scorecard.types";
 import {
   mapAssessmentPerformanceFromApi,
+  mapBehavioralMetricsFromApi,
   mapLearningConsumptionFromApi,
   mapMockInterviewPerformanceFromApi,
   mapOverviewFromApi,
@@ -22,6 +23,7 @@ export type ScorecardApiPayload = {
   weak_areas?: unknown;
   assessment_performance?: unknown;
   mock_interview_performance?: unknown;
+  behavioral_metrics?: unknown;
 };
 
 export function scorecardFromApiPayload(data: ScorecardApiPayload | undefined | null): ScorecardData {
@@ -66,6 +68,10 @@ export function scorecardFromApiPayload(data: ScorecardApiPayload | undefined | 
 
   if (data?.mock_interview_performance != null && typeof data.mock_interview_performance === "object") {
     result.mockInterviewPerformance = mapMockInterviewPerformanceFromApi(data.mock_interview_performance);
+  }
+
+  if (data?.behavioral_metrics != null && typeof data.behavioral_metrics === "object") {
+    result.behavioralMetrics = mapBehavioralMetricsFromApi(data.behavioral_metrics);
   }
 
   return result;

--- a/lib/services/scorecard/mappers.ts
+++ b/lib/services/scorecard/mappers.ts
@@ -1,6 +1,7 @@
 import type {
   AssessmentDifficultyBreakdown,
   AssessmentPerformance,
+  BehavioralMetrics,
   ContentCompletionOverview,
   InterviewParameter,
   LearningConsumption,
@@ -531,6 +532,60 @@ export function mapMockInterviewPerformanceFromApi(api: unknown): MockInterviewP
     interviewReadinessIndex: num(raw.interview_readiness_index),
     improvementSinceFirst: num(raw.improvement_since_first),
     interviews,
+  };
+}
+
+export function mapBehavioralMetricsFromApi(api: unknown): BehavioralMetrics {
+  if (!api || typeof api !== "object") {
+    return getEmptyBehavioralMetrics();
+  }
+  const raw = api as Record<string, unknown>;
+  const loginFrequency = Array.isArray(raw.login_frequency)
+    ? (raw.login_frequency as Record<string, unknown>[]).map((r) => ({
+        week: (r.week as string) ?? "",
+        loginCount: num(r.login_count),
+      }))
+    : [];
+  const studyTimeByWeek = Array.isArray(raw.study_time_by_week)
+    ? (raw.study_time_by_week as Record<string, unknown>[]).map((r) => ({
+        week: (r.week as string) ?? "",
+        hours: num(r.hours),
+      }))
+    : [];
+  const studyTimeDistribution = Array.isArray(raw.study_time_distribution)
+    ? (raw.study_time_distribution as Record<string, unknown>[]).map((r) => ({
+        day: (r.day as string) ?? "",
+        hours: num(r.hours),
+      }))
+    : [];
+  const activityCalendarRaw =
+    raw.activity_calendar && typeof raw.activity_calendar === "object"
+      ? (raw.activity_calendar as Record<string, unknown>)
+      : {};
+  const activityCalendar: Record<string, number> = {};
+  for (const [key, value] of Object.entries(activityCalendarRaw)) {
+    activityCalendar[key] = num(value);
+  }
+  return {
+    loginFrequency,
+    studyTimeByWeek,
+    studyTimeDistribution,
+    missedDeadlinesCount: num(raw.missed_deadlines_count),
+    lastActiveDate: (raw.last_active_date as string) || null,
+    consistencyScore: num(raw.consistency_score),
+    activityCalendar,
+  };
+}
+
+export function getEmptyBehavioralMetrics(): BehavioralMetrics {
+  return {
+    loginFrequency: [],
+    studyTimeByWeek: [],
+    studyTimeDistribution: [],
+    missedDeadlinesCount: 0,
+    lastActiveDate: null,
+    consistencyScore: 0,
+    activityCalendar: {},
   };
 }
 

--- a/lib/types/scorecard.types.ts
+++ b/lib/types/scorecard.types.ts
@@ -304,6 +304,32 @@ export interface MockInterviewPerformance {
   interviews: MockInterview[];
 }
 
+// Behavioral & Consistency (Phase 6)
+export interface LoginFrequency {
+  week: string;
+  loginCount: number;
+}
+
+export interface StudyTimeByWeek {
+  week: string;
+  hours: number;
+}
+
+export interface StudyTimeDistribution {
+  day: string;
+  hours: number;
+}
+
+export interface BehavioralMetrics {
+  loginFrequency: LoginFrequency[];
+  studyTimeByWeek: StudyTimeByWeek[];
+  studyTimeDistribution: StudyTimeDistribution[];
+  missedDeadlinesCount: number;
+  lastActiveDate: string | null;
+  consistencyScore: number;
+  activityCalendar: Record<string, number>;
+}
+
 export interface ScorecardData {
   scorecardConfig?: ScorecardConfig;
   overview: StudentOverview;
@@ -313,4 +339,5 @@ export interface ScorecardData {
   weakAreas?: WeakAreas;
   assessmentPerformance?: AssessmentPerformance[];
   mockInterviewPerformance?: MockInterviewPerformance;
+  behavioralMetrics?: BehavioralMetrics;
 }


### PR DESCRIPTION
## Summary

Two Recharts bar charts side-by-side (active days per week + study hours per week) and a weekday distribution LinearProgress strip showing when the learner studies. Cyan-tinted radial mesh.

**New file:** `components/scorecard/detailed/BehavioralMetricsSection.tsx`

Header: Consistency / Last active / Missed deadlines chips.

## Test plan
- [ ] User with 4+ weeks activity: bars populate
- [ ] Day-of-week distribution shows reasonable bars
- [ ] Last active shows relative time ("3 days ago")
- [ ] Missed deadlines count is red when > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)