### PR TITLE
feat(scorecard): Phase 9 frontend — Action Panel (final section)

### DIFF
--- a/app/admin/scorecard/page.tsx
+++ b/app/admin/scorecard/page.tsx
@@ -28,6 +28,7 @@ import { ActivityHeatmap } from "@/components/profile/ActivityHeatmap";
 import { AssessmentPerformanceSection } from "@/components/scorecard/detailed/AssessmentPerformanceSection";
 import { BehavioralMetricsSection } from "@/components/scorecard/detailed/BehavioralMetricsSection";
 import { AchievementsSection } from "@/components/scorecard/detailed/AchievementsSection";
+import { ActionPanelSection } from "@/components/scorecard/detailed/ActionPanelSection";
 import { ComparativeInsightsSection } from "@/components/scorecard/detailed/ComparativeInsightsSection";
 import { LearningConsumptionSection } from "@/components/scorecard/detailed/LearningConsumptionSection";
 import { MockInterviewSection } from "@/components/scorecard/detailed/MockInterviewSection";
@@ -56,6 +57,7 @@ const MODULE_OPTIONS = [
   { id: "behavioral_metrics", label: "Behavioral & Consistency" },
   { id: "comparative_insights", label: "Comparative Insights" },
   { id: "achievements", label: "Achievements" },
+  { id: "action_panel", label: "Action Panel" },
 ] as const;
 
 const ALLOWED_MODULE_IDS: string[] = MODULE_OPTIONS.map((m) => m.id);
@@ -801,6 +803,14 @@ export default function AdminScorecardPage() {
                             <AchievementsSection
                               key={sectionId}
                               data={scorecardData.achievements}
+                            />
+                          );
+                        case "action_panel":
+                          if (!scorecardData.actionPanel) return null;
+                          return (
+                            <ActionPanelSection
+                              key={sectionId}
+                              data={scorecardData.actionPanel}
                             />
                           );
                         default:

--- a/app/user/scorecard/page.tsx
+++ b/app/user/scorecard/page.tsx
@@ -18,6 +18,7 @@ import { ActivityHeatmap } from "@/components/profile/ActivityHeatmap";
 import { AssessmentPerformanceSection } from "@/components/scorecard/detailed/AssessmentPerformanceSection";
 import { BehavioralMetricsSection } from "@/components/scorecard/detailed/BehavioralMetricsSection";
 import { AchievementsSection } from "@/components/scorecard/detailed/AchievementsSection";
+import { ActionPanelSection } from "@/components/scorecard/detailed/ActionPanelSection";
 import { ComparativeInsightsSection } from "@/components/scorecard/detailed/ComparativeInsightsSection";
 import { LearningConsumptionSection } from "@/components/scorecard/detailed/LearningConsumptionSection";
 import { MockInterviewSection } from "@/components/scorecard/detailed/MockInterviewSection";
@@ -41,6 +42,7 @@ const SECTION_ORDER = [
   "behavioral_metrics",
   "comparative_insights",
   "achievements",
+  "action_panel",
 ] as const;
 
 /** Soft editorial backdrop — radial gradient mesh that picks up theme accents. */
@@ -386,6 +388,14 @@ export default function ScorecardPage() {
                       <AchievementsSection
                         key={sectionId}
                         data={data.achievements}
+                      />
+                    );
+                  case "action_panel":
+                    if (!data.actionPanel) return null;
+                    return (
+                      <ActionPanelSection
+                        key={sectionId}
+                        data={data.actionPanel}
                       />
                     );
                   default:

--- a/components/scorecard/detailed/ActionPanelSection.tsx
+++ b/components/scorecard/detailed/ActionPanelSection.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import Link from "next/link";
+import { Box, Chip, Typography } from "@mui/material";
+import { motion } from "framer-motion";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { Reveal, gridStagger } from "@/components/scorecard/shared";
+import type {
+  ActionPanel,
+  PendingTask,
+  PriorityAction,
+  RecommendedContentItem,
+  UpcomingAssessment,
+} from "@/lib/types/scorecard.types";
+
+interface ActionPanelSectionProps {
+  data: ActionPanel;
+}
+
+const PRIORITY_ICON: Record<string, string> = {
+  mcq: "mdi:format-list-checks",
+  revise: "mdi:book-open-page-variant",
+  video: "mdi:play-circle-outline",
+  interview: "mdi:account-voice",
+  assessment: "mdi:clipboard-check",
+};
+
+const PRIORITY_ACCENT: Record<string, string> = {
+  mcq: "var(--accent-indigo)",
+  revise: "#f59e0b",
+  video: "#10b981",
+  interview: "#a855f7",
+  assessment: "#0a66c2",
+};
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "—";
+    const ms = d.getTime() - Date.now();
+    if (ms < 0) return "overdue";
+    const days = Math.ceil(ms / (1000 * 60 * 60 * 24));
+    if (days === 0) return "today";
+    if (days === 1) return "tomorrow";
+    if (days < 7) return `in ${days} days`;
+    if (days < 30) return `in ${Math.floor(days / 7)} weeks`;
+    return d.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
+  } catch {
+    return "—";
+  }
+}
+
+function ActionCard({ action }: { action: PriorityAction }) {
+  const accent = PRIORITY_ACCENT[action.type] ?? "var(--accent-indigo)";
+  const icon = PRIORITY_ICON[action.type] ?? "mdi:flash-outline";
+  const isLink = !!action.actionUrl;
+  return (
+    <motion.div
+      variants={{
+        hidden: { opacity: 0, y: 10 },
+        visible: { opacity: 1, y: 0, transition: { duration: 0.45, ease: [0.16, 1, 0.3, 1] as const } },
+      }}
+    >
+      <Box
+        component={isLink ? Link : "div"}
+        {...(isLink && action.actionUrl ? { href: action.actionUrl } : {})}
+        sx={{
+          position: "relative",
+          display: "block",
+          p: { xs: 1.5, sm: 1.75 },
+          borderRadius: 2.5,
+          border: `1px solid color-mix(in srgb, ${accent} 28%, transparent)`,
+          background: `linear-gradient(135deg, color-mix(in srgb, ${accent} 8%, transparent) 0%, transparent 100%)`,
+          textDecoration: "none",
+          color: "inherit",
+          cursor: isLink ? "pointer" : "default",
+          transition: "transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease",
+          ...(isLink && {
+            "&:hover": {
+              transform: "translateY(-1px)",
+              borderColor: `color-mix(in srgb, ${accent} 55%, transparent)`,
+              boxShadow: `0 18px 40px -24px color-mix(in srgb, ${accent} 40%, transparent)`,
+            },
+          }),
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.75 }}>
+          <Box
+            sx={{
+              width: 30,
+              height: 30,
+              borderRadius: 1.5,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              bgcolor: `color-mix(in srgb, ${accent} 18%, transparent)`,
+              color: accent,
+            }}
+          >
+            <IconWrapper icon={icon} size={16} />
+          </Box>
+          <Typography
+            variant="subtitle2"
+            sx={{ fontWeight: 800, color: "var(--font-primary)", fontSize: "0.9rem" }}
+          >
+            {action.title}
+          </Typography>
+        </Box>
+        <Typography variant="body2" color="text.secondary" sx={{ fontSize: "0.82rem", lineHeight: 1.45 }}>
+          {action.description}
+        </Typography>
+      </Box>
+    </motion.div>
+  );
+}
+
+function ContentCard({ item }: { item: RecommendedContentItem }) {
+  const icon = PRIORITY_ICON[item.type] ?? "mdi:bookmark-outline";
+  const accent = PRIORITY_ACCENT[item.type] ?? "var(--accent-indigo)";
+  const isLink = !!item.url;
+  return (
+    <motion.div
+      variants={{
+        hidden: { opacity: 0, y: 8 },
+        visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: [0.16, 1, 0.3, 1] as const } },
+      }}
+    >
+      <Box
+        component={isLink ? Link : "div"}
+        {...(isLink && item.url ? { href: item.url } : {})}
+        sx={{
+          display: "block",
+          p: 1.5,
+          borderRadius: 2,
+          border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+          bgcolor: "var(--card-bg)",
+          textDecoration: "none",
+          color: "inherit",
+          cursor: isLink ? "pointer" : "default",
+          transition: "border-color 0.18s ease, transform 0.18s ease",
+          ...(isLink && {
+            "&:hover": {
+              borderColor: `color-mix(in srgb, ${accent} 40%, transparent)`,
+              transform: "translateY(-1px)",
+            },
+          }),
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+          <Box sx={{ color: accent }}>
+            <IconWrapper icon={icon} size={14} />
+          </Box>
+          <Chip
+            size="small"
+            label={item.type.toUpperCase()}
+            sx={{
+              height: 18,
+              fontSize: "0.62rem",
+              fontWeight: 700,
+              bgcolor: `color-mix(in srgb, ${accent} 14%, transparent)`,
+              color: accent,
+            }}
+          />
+        </Box>
+        <Typography variant="body2" sx={{ fontWeight: 700, color: "var(--font-primary)", fontSize: "0.85rem", lineHeight: 1.3, mb: 0.25 }}>
+          {item.title}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.72rem" }}>
+          {item.reason}
+        </Typography>
+      </Box>
+    </motion.div>
+  );
+}
+
+function PendingTaskRow({ task }: { task: PendingTask }) {
+  const isOverdue = task.dueDate ? new Date(task.dueDate).getTime() < Date.now() : false;
+  return (
+    <Box
+      component={task.url ? Link : "div"}
+      {...(task.url ? { href: task.url } : {})}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        p: 1.25,
+        borderRadius: 1.5,
+        border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+        bgcolor: "var(--card-bg)",
+        textDecoration: "none",
+        color: "inherit",
+        ...(task.url && {
+          "&:hover": { borderColor: "color-mix(in srgb, var(--accent-indigo) 40%, transparent)" },
+        }),
+      }}
+    >
+      <Box sx={{ color: isOverdue ? "#ef4444" : "var(--accent-indigo)" }}>
+        <IconWrapper icon={isOverdue ? "mdi:alert-circle-outline" : "mdi:clock-outline"} size={16} />
+      </Box>
+      <Typography
+        variant="body2"
+        sx={{
+          fontWeight: 700,
+          color: "var(--font-primary)",
+          fontSize: "0.85rem",
+          flex: 1,
+          minWidth: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {task.title}
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{
+          fontWeight: 700,
+          color: isOverdue ? "#ef4444" : "var(--font-secondary)",
+          fontSize: "0.72rem",
+        }}
+      >
+        {formatRelative(task.dueDate)}
+      </Typography>
+    </Box>
+  );
+}
+
+function UpcomingRow({ row }: { row: UpcomingAssessment }) {
+  return (
+    <Box
+      component={row.url ? Link : "div"}
+      {...(row.url ? { href: row.url } : {})}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        p: 1.25,
+        borderRadius: 1.5,
+        border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+        bgcolor: "var(--card-bg)",
+        textDecoration: "none",
+        color: "inherit",
+        ...(row.url && {
+          "&:hover": { borderColor: "color-mix(in srgb, var(--accent-cyan, #06b6d4) 40%, transparent)" },
+        }),
+      }}
+    >
+      <Box sx={{ color: "var(--accent-cyan, #06b6d4)" }}>
+        <IconWrapper icon="mdi:calendar-star" size={16} />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          variant="body2"
+          sx={{
+            fontWeight: 700,
+            color: "var(--font-primary)",
+            fontSize: "0.85rem",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {row.name}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.72rem" }}>
+          {row.duration > 0 ? `${row.duration} min` : "—"}
+        </Typography>
+      </Box>
+      <Typography variant="caption" sx={{ fontWeight: 700, color: "var(--accent-cyan, #0891b2)", fontSize: "0.72rem" }}>
+        {formatRelative(row.date)}
+      </Typography>
+    </Box>
+  );
+}
+
+export function ActionPanelSection({ data }: ActionPanelSectionProps) {
+  const isEmpty =
+    data.priorityActions.length === 0 &&
+    data.recommendedContent.length === 0 &&
+    data.pendingTasks.length === 0 &&
+    data.upcomingAssessments.length === 0;
+
+  return (
+    <Reveal as="section">
+      <Box
+        sx={{
+          position: "relative",
+          borderRadius: 4,
+          overflow: "hidden",
+          border:
+            "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+          backgroundColor: "var(--card-bg)",
+          boxShadow:
+            "0 1px 0 color-mix(in srgb, var(--border-default) 60%, transparent), 0 30px 60px -30px rgba(15, 23, 42, 0.18)",
+          backdropFilter: "blur(6px)",
+        }}
+      >
+        <Box
+          aria-hidden
+          sx={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0.45,
+            backgroundImage: [
+              "radial-gradient(55% 70% at 100% 0%, color-mix(in srgb, var(--accent-indigo) 18%, transparent), transparent 60%)",
+              "radial-gradient(45% 60% at 0% 100%, color-mix(in srgb, var(--accent-cyan, #06b6d4) 14%, transparent), transparent 60%)",
+            ].join(", "),
+            pointerEvents: "none",
+          }}
+        />
+
+        <Box sx={{ position: "relative", p: { xs: 2.5, sm: 3.5, md: 4.5 } }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              pb: { xs: 2.5, md: 3 },
+              mb: { xs: 2.5, md: 3 },
+              borderBottom:
+                "1px dashed color-mix(in srgb, var(--border-default) 80%, transparent)",
+            }}
+          >
+            <Box
+              sx={{
+                width: 44,
+                height: 44,
+                borderRadius: 2,
+                background:
+                  "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                boxShadow:
+                  "0 12px 24px -12px color-mix(in srgb, var(--accent-indigo) 60%, transparent)",
+                flexShrink: 0,
+              }}
+            >
+              <IconWrapper icon="mdi:lightning-bolt-outline" size={22} color="#fff" />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 800,
+                  color: "var(--font-primary)",
+                  fontSize: { xs: "1.05rem", sm: "1.2rem" },
+                  lineHeight: 1.25,
+                }}
+              >
+                Action Panel
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ fontSize: "0.85rem", mt: 0.25 }}>
+                Your next moves — pulled from weak areas, pending tasks, and upcoming assessments.
+              </Typography>
+            </Box>
+          </Box>
+
+          {isEmpty ? (
+            <Box
+              sx={{
+                py: { xs: 4, sm: 5 },
+                textAlign: "center",
+                borderRadius: 2,
+                border: "1px dashed color-mix(in srgb, var(--border-default) 80%, transparent)",
+                color: "var(--font-secondary)",
+              }}
+            >
+              <IconWrapper icon="mdi:lightning-bolt-outline" size={42} color="var(--font-secondary)" />
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+                Nothing urgent right now. Keep up the momentum on your course path.
+              </Typography>
+            </Box>
+          ) : (
+            <Box sx={{ display: "grid", gap: 2.5 }}>
+              {data.priorityActions.length > 0 && (
+                <Box>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 800, color: "var(--font-primary)", mb: 1.25 }}>
+                    Priority actions
+                  </Typography>
+                  <motion.div
+                    variants={gridStagger}
+                    initial="hidden"
+                    whileInView="visible"
+                    viewport={{ once: true, amount: 0.1 }}
+                    style={{
+                      display: "grid",
+                      gap: 10,
+                      gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                    }}
+                  >
+                    {data.priorityActions.map((a) => (
+                      <ActionCard key={a.id} action={a} />
+                    ))}
+                  </motion.div>
+                </Box>
+              )}
+
+              {data.recommendedContent.length > 0 && (
+                <Box>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 800, color: "var(--font-primary)", mb: 1.25 }}>
+                    Recommended content
+                  </Typography>
+                  <motion.div
+                    variants={gridStagger}
+                    initial="hidden"
+                    whileInView="visible"
+                    viewport={{ once: true, amount: 0.1 }}
+                    style={{
+                      display: "grid",
+                      gap: 10,
+                      gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                    }}
+                  >
+                    {data.recommendedContent.map((item) => (
+                      <ContentCard key={item.id} item={item} />
+                    ))}
+                  </motion.div>
+                </Box>
+              )}
+
+              {data.pendingTasks.length > 0 && (
+                <Box>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 800, color: "var(--font-primary)", mb: 1.25 }}>
+                    Pending tasks
+                  </Typography>
+                  <Box sx={{ display: "grid", gap: 8 / 8 }}>
+                    {data.pendingTasks.map((task) => (
+                      <PendingTaskRow key={task.id} task={task} />
+                    ))}
+                  </Box>
+                </Box>
+              )}
+
+              {data.upcomingAssessments.length > 0 && (
+                <Box>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 800, color: "var(--font-primary)", mb: 1.25 }}>
+                    Upcoming assessments
+                  </Typography>
+                  <Box sx={{ display: "grid", gap: 1 }}>
+                    {data.upcomingAssessments.map((row) => (
+                      <UpcomingRow key={row.id} row={row} />
+                    ))}
+                  </Box>
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Reveal>
+  );
+}

--- a/lib/services/scorecard.service.ts
+++ b/lib/services/scorecard.service.ts
@@ -4,6 +4,7 @@ import { profileService } from "./profile.service";
 import { scorecardFromApiPayload, type ScorecardApiPayload } from "./scorecard/build-scorecard";
 import {
   mapAchievementsFromApi,
+  mapActionPanelFromApi,
   mapAssessmentPerformanceFromApi,
   mapBehavioralMetricsFromApi,
   mapComparativeInsightsFromApi,
@@ -14,6 +15,7 @@ import {
 } from "./scorecard/mappers";
 import type {
   Achievements,
+  ActionPanel,
   AssessmentPerformance,
   BehavioralMetrics,
   ComparativeInsights,
@@ -126,6 +128,14 @@ export const scorecardService = {
       `/api/scorecard/clients/${clientId}/student/scorecard/achievements/`,
     );
     return mapAchievementsFromApi(response.data);
+  },
+
+  getActionPanel: async (): Promise<ActionPanel> => {
+    const clientId = config.clientId;
+    const response = await apiClient.get<Record<string, unknown>>(
+      `/api/scorecard/clients/${clientId}/student/scorecard/action-panel/`,
+    );
+    return mapActionPanelFromApi(response.data);
   },
 
   exportScorecardPdf: async (): Promise<Blob> => {

--- a/lib/services/scorecard/build-scorecard.ts
+++ b/lib/services/scorecard/build-scorecard.ts
@@ -1,6 +1,7 @@
 import type { ScorecardData } from "@/lib/types/scorecard.types";
 import {
   mapAchievementsFromApi,
+  mapActionPanelFromApi,
   mapAssessmentPerformanceFromApi,
   mapBehavioralMetricsFromApi,
   mapComparativeInsightsFromApi,
@@ -28,6 +29,7 @@ export type ScorecardApiPayload = {
   behavioral_metrics?: unknown;
   comparative_insights?: unknown;
   achievements?: unknown;
+  action_panel?: unknown;
 };
 
 export function scorecardFromApiPayload(data: ScorecardApiPayload | undefined | null): ScorecardData {
@@ -84,6 +86,10 @@ export function scorecardFromApiPayload(data: ScorecardApiPayload | undefined | 
 
   if (data?.achievements != null && typeof data.achievements === "object") {
     result.achievements = mapAchievementsFromApi(data.achievements);
+  }
+
+  if (data?.action_panel != null && typeof data.action_panel === "object") {
+    result.actionPanel = mapActionPanelFromApi(data.action_panel);
   }
 
   return result;

--- a/lib/services/scorecard/mappers.ts
+++ b/lib/services/scorecard/mappers.ts
@@ -1,5 +1,6 @@
 import type {
   Achievements,
+  ActionPanel,
   AssessmentDifficultyBreakdown,
   AssessmentPerformance,
   BadgeEarned,
@@ -13,13 +14,17 @@ import type {
   LearningConsumption,
   MockInterview,
   MockInterviewPerformance,
+  PendingTask,
   PerformanceTrends,
+  PriorityAction,
+  RecommendedContentItem,
   ScorecardData,
   Skill,
   SkillBreakdownItem,
   SkillBreakdownItems,
   StudentOverview,
   TopicIncorrect,
+  UpcomingAssessment,
   WeakArea,
   WeakAreaRecommendation,
   WeakAreas,
@@ -660,6 +665,65 @@ export function mapAchievementsFromApi(api: unknown): Achievements {
     totalPoints: num(raw.total_points),
     badgesEarnedCount: num(raw.badges_earned_count),
     badgesAvailableCount: num(raw.badges_available_count),
+  };
+}
+
+export function mapActionPanelFromApi(api: unknown): ActionPanel {
+  if (!api || typeof api !== "object") {
+    return getEmptyActionPanel();
+  }
+  const raw = api as Record<string, unknown>;
+
+  const priorityActions: PriorityAction[] = Array.isArray(raw.priority_actions)
+    ? (raw.priority_actions as Record<string, unknown>[]).map((p) => ({
+        id: String(p.id ?? ""),
+        title: (p.title as string) ?? "",
+        description: (p.description as string) ?? "",
+        priority: num(p.priority),
+        type: ((p.type as PriorityAction["type"]) ?? "mcq") as PriorityAction["type"],
+        actionUrl: (p.action_url as string) || null,
+      }))
+    : [];
+
+  const recommendedContent: RecommendedContentItem[] = Array.isArray(raw.recommended_content)
+    ? (raw.recommended_content as Record<string, unknown>[]).map((r) => ({
+        id: String(r.id ?? ""),
+        title: (r.title as string) ?? "",
+        type: (r.type as string) ?? "",
+        reason: (r.reason as string) ?? "",
+        url: (r.url as string) || null,
+      }))
+    : [];
+
+  const pendingTasks: PendingTask[] = Array.isArray(raw.pending_tasks)
+    ? (raw.pending_tasks as Record<string, unknown>[]).map((t) => ({
+        id: String(t.id ?? ""),
+        title: (t.title as string) ?? "",
+        dueDate: (t.due_date as string) || null,
+        type: (t.type as string) ?? "",
+        url: (t.url as string) || null,
+      }))
+    : [];
+
+  const upcomingAssessments: UpcomingAssessment[] = Array.isArray(raw.upcoming_assessments)
+    ? (raw.upcoming_assessments as Record<string, unknown>[]).map((u) => ({
+        id: String(u.id ?? ""),
+        name: (u.name as string) ?? "",
+        date: (u.date as string) || null,
+        duration: num(u.duration),
+        url: (u.url as string) || null,
+      }))
+    : [];
+
+  return { priorityActions, recommendedContent, pendingTasks, upcomingAssessments };
+}
+
+export function getEmptyActionPanel(): ActionPanel {
+  return {
+    priorityActions: [],
+    recommendedContent: [],
+    pendingTasks: [],
+    upcomingAssessments: [],
   };
 }
 

--- a/lib/types/scorecard.types.ts
+++ b/lib/types/scorecard.types.ts
@@ -391,6 +391,47 @@ export interface Achievements {
   badgesAvailableCount: number;
 }
 
+// Action Panel (Phase 9)
+export interface PriorityAction {
+  id: string;
+  title: string;
+  description: string;
+  priority: number;
+  type: "mcq" | "video" | "interview" | "assessment" | "revise" | string;
+  actionUrl?: string | null;
+}
+
+export interface RecommendedContentItem {
+  id: string;
+  title: string;
+  type: string;
+  reason: string;
+  url?: string | null;
+}
+
+export interface PendingTask {
+  id: string;
+  title: string;
+  dueDate: string | null;
+  type: string;
+  url?: string | null;
+}
+
+export interface UpcomingAssessment {
+  id: string;
+  name: string;
+  date: string | null;
+  duration: number;
+  url?: string | null;
+}
+
+export interface ActionPanel {
+  priorityActions: PriorityAction[];
+  recommendedContent: RecommendedContentItem[];
+  pendingTasks: PendingTask[];
+  upcomingAssessments: UpcomingAssessment[];
+}
+
 export interface ScorecardData {
   scorecardConfig?: ScorecardConfig;
   overview: StudentOverview;
@@ -403,4 +444,5 @@ export interface ScorecardData {
   behavioralMetrics?: BehavioralMetrics;
   comparativeInsights?: ComparativeInsights;
   achievements?: Achievements;
+  actionPanel?: ActionPanel;
 }


### PR DESCRIPTION
## Summary

The final section. Four sub-panels rendered as motion-staggered grids:
- **Priority actions**: tinted gradient cards (indigo/amber/green/purple/blue per type) with hover lift
- **Recommended content**: type-chip + reason cards (next lesson, weak-skill video, recent article)
- **Pending tasks**: compact rows with relative-time labels ("in 3 days", "overdue")
- **Upcoming assessments**: scheduled in next 14 days

**New file:** `components/scorecard/detailed/ActionPanelSection.tsx`

Clickable cards link out where actionUrl is present.

## Test plan
- [ ] Learner with weak skills + pending assessment: both surface as priority actions
- [ ] Action URLs route correctly when clicked
- [ ] Overdue assessment shows red "overdue" badge
- [ ] Empty learner sees calm "nothing urgent" empty state

🤖 All 10 scorecard modules now live across both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)