### PR TITLE
feat(scorecard): tighten UI — collapsible lists, skill distribution c…

### DIFF
--- a/components/scorecard/detailed/ActionPanelSection.tsx
+++ b/components/scorecard/detailed/ActionPanelSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Box, Typography } from "@mui/material";
 import { motion } from "framer-motion";
@@ -707,6 +707,19 @@ export function ActionPanelSection({ data }: ActionPanelSectionProps) {
     [data.pendingTasks],
   );
 
+  // Sub-section list collapses — each subsection caps at TASKS_PREVIEW etc.
+  // and shows a toggle when there's more. Keeps the Action Panel scannable
+  // when the backend returns a long list of recommended content / open loops.
+  const TASKS_PREVIEW = 5;
+  const UPCOMING_PREVIEW = 5;
+  const RECOMMENDED_PREVIEW = 6;
+  const [showAllTasks, setShowAllTasks] = useState(false);
+  const [showAllUpcoming, setShowAllUpcoming] = useState(false);
+  const [showAllRecommended, setShowAllRecommended] = useState(false);
+  const visibleTasks = showAllTasks ? data.pendingTasks : data.pendingTasks.slice(0, TASKS_PREVIEW);
+  const visibleUpcoming = showAllUpcoming ? data.upcomingAssessments : data.upcomingAssessments.slice(0, UPCOMING_PREVIEW);
+  const visibleRecommended = showAllRecommended ? data.recommendedContent : data.recommendedContent.slice(0, RECOMMENDED_PREVIEW);
+
   return (
     <Reveal as="section">
       <SectionShell
@@ -1082,10 +1095,19 @@ export function ActionPanelSection({ data }: ActionPanelSectionProps) {
                       viewport={{ once: true, amount: 0.1 }}
                       style={{ display: "grid", gap: 8 }}
                     >
-                      {data.pendingTasks.map((task, i) => (
+                      {visibleTasks.map((task, i) => (
                         <TaskRow key={task.id} task={task} index={i} />
                       ))}
                     </motion.div>
+                    {data.pendingTasks.length > TASKS_PREVIEW && (
+                      <ShowAllToggle
+                        expanded={showAllTasks}
+                        onToggle={() => setShowAllTasks((v) => !v)}
+                        total={data.pendingTasks.length}
+                        preview={TASKS_PREVIEW}
+                        label="tasks"
+                      />
+                    )}
                   </Box>
                 )}
 
@@ -1124,10 +1146,19 @@ export function ActionPanelSection({ data }: ActionPanelSectionProps) {
                       viewport={{ once: true, amount: 0.1 }}
                       style={{ display: "grid", gap: 8 }}
                     >
-                      {data.upcomingAssessments.map((row, i) => (
+                      {visibleUpcoming.map((row, i) => (
                         <UpcomingRow key={row.id} row={row} index={i} />
                       ))}
                     </motion.div>
+                    {data.upcomingAssessments.length > UPCOMING_PREVIEW && (
+                      <ShowAllToggle
+                        expanded={showAllUpcoming}
+                        onToggle={() => setShowAllUpcoming((v) => !v)}
+                        total={data.upcomingAssessments.length}
+                        preview={UPCOMING_PREVIEW}
+                        label="upcoming"
+                      />
+                    )}
                   </Box>
                 )}
               </Box>
@@ -1182,15 +1213,74 @@ export function ActionPanelSection({ data }: ActionPanelSectionProps) {
                     gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
                   }}
                 >
-                  {data.recommendedContent.map((item, i) => (
+                  {visibleRecommended.map((item, i) => (
                     <ContentCard key={item.id} item={item} index={i} />
                   ))}
                 </motion.div>
+                {data.recommendedContent.length > RECOMMENDED_PREVIEW && (
+                  <ShowAllToggle
+                    expanded={showAllRecommended}
+                    onToggle={() => setShowAllRecommended((v) => !v)}
+                    total={data.recommendedContent.length}
+                    preview={RECOMMENDED_PREVIEW}
+                    label="picks"
+                  />
+                )}
               </Box>
             )}
           </>
         )}
       </SectionShell>
     </Reveal>
+  );
+}
+
+/** Shared "Show all N / Show recent M" pill. Used by the three collapsible
+ *  subsections inside Action Panel so each list stays scannable. */
+function ShowAllToggle({
+  expanded,
+  onToggle,
+  total,
+  preview,
+  label,
+}: {
+  expanded: boolean;
+  onToggle: () => void;
+  total: number;
+  preview: number;
+  label: string;
+}) {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "center", mt: 1.5 }}>
+      <Box
+        component="button"
+        onClick={onToggle}
+        sx={{
+          appearance: "none",
+          border: `1px solid color-mix(in srgb, ${ACCENT} 28%, transparent)`,
+          backgroundColor: `color-mix(in srgb, ${ACCENT} 6%, transparent)`,
+          color: ACCENT_DARK,
+          fontWeight: 800,
+          fontSize: "0.72rem",
+          letterSpacing: "0.04em",
+          px: 1.75,
+          py: 0.6,
+          borderRadius: 999,
+          cursor: "pointer",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.5,
+          transition: "all 0.18s ease",
+          "&:hover": {
+            borderColor: ACCENT,
+            backgroundColor: `color-mix(in srgb, ${ACCENT} 12%, transparent)`,
+          },
+        }}
+        aria-expanded={expanded}
+      >
+        <IconWrapper icon={expanded ? "mdi:chevron-up" : "mdi:chevron-down"} size={14} />
+        {expanded ? `Show recent ${preview}` : `Show all ${total} ${label}`}
+      </Box>
+    </Box>
   );
 }

--- a/components/scorecard/detailed/AssessmentPerformanceSection.tsx
+++ b/components/scorecard/detailed/AssessmentPerformanceSection.tsx
@@ -580,6 +580,11 @@ function PerformanceRow({
 export function AssessmentPerformanceSection({ data }: AssessmentPerformanceSectionProps) {
   const entrance = useViewportEntrance();
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  // Timeline collapse: show the 10 most recent attempts by default. With a
+  // heavy test cycle the section can otherwise hit 30+ rows and dwarf the
+  // KPI rail above it. The full list is one click away.
+  const TIMELINE_PREVIEW = 10;
+  const [showAllAttempts, setShowAllAttempts] = useState(false);
 
   const summary = useMemo(() => {
     const scored = data.filter((d) => d.score != null) as (AssessmentPerformance & { score: number })[];
@@ -822,13 +827,14 @@ export function AssessmentPerformanceSection({ data }: AssessmentPerformanceSect
               viewport={{ once: true, amount: 0.05 }}
               style={{ display: "grid", gridTemplateColumns: "1fr", gap: 16 }}
             >
-              {data.map((row, idx) => {
+              {(showAllAttempts ? data : data.slice(0, TIMELINE_PREVIEW)).map((row, idx) => {
                 // Use the same key schema for React-key and expanded-state so two
                 // attempts of the same assessment can be toggled independently.
                 // Previously the expanded-state key dropped `dateAttempted`, so
                 // any duplicate `assessmentId` caused the second row's toggle
                 // to flip the first row's state.
                 const rowKey = `${row.assessmentId}-${row.dateAttempted ?? idx}`;
+                const visibleCount = showAllAttempts ? data.length : Math.min(TIMELINE_PREVIEW, data.length);
                 return (
                   <PerformanceRow
                     key={rowKey}
@@ -837,7 +843,7 @@ export function AssessmentPerformanceSection({ data }: AssessmentPerformanceSect
                     prevScore={summary.prevScoreByIdx.get(idx) ?? null}
                     isBest={!!summary.best && row === summary.best}
                     isLatest={!!summary.latest && row === summary.latest && summary.latest !== summary.best}
-                    isLast={idx === data.length - 1}
+                    isLast={idx === visibleCount - 1}
                     expanded={expandedId === rowKey}
                     onToggle={() =>
                       setExpandedId(expandedId === rowKey ? null : rowKey)
@@ -846,6 +852,46 @@ export function AssessmentPerformanceSection({ data }: AssessmentPerformanceSect
                 );
               })}
             </motion.div>
+
+            {/* "Show all" toggle for the timeline. Hides when the full list
+                already fits in the preview window. */}
+            {data.length > TIMELINE_PREVIEW && (
+              <Box sx={{ display: "flex", justifyContent: "center", mt: 2.5 }}>
+                <Box
+                  component="button"
+                  onClick={() => setShowAllAttempts((v) => !v)}
+                  sx={{
+                    appearance: "none",
+                    border: "1px solid color-mix(in srgb, var(--accent-indigo) 28%, transparent)",
+                    backgroundColor: "color-mix(in srgb, var(--accent-indigo) 6%, transparent)",
+                    color: "var(--accent-indigo-dark)",
+                    fontWeight: 800,
+                    fontSize: "0.78rem",
+                    letterSpacing: "0.04em",
+                    px: 2.25,
+                    py: 1,
+                    borderRadius: 999,
+                    cursor: "pointer",
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 0.75,
+                    transition: "all 0.18s ease",
+                    "&:hover": {
+                      borderColor: "var(--accent-indigo)",
+                      backgroundColor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
+                      transform: "translateY(-1px)",
+                    },
+                  }}
+                  aria-expanded={showAllAttempts}
+                  aria-label={showAllAttempts ? "Collapse the timeline" : `Show all ${data.length} attempts`}
+                >
+                  <IconWrapper icon={showAllAttempts ? "mdi:chevron-up" : "mdi:chevron-down"} size={16} />
+                  {showAllAttempts
+                    ? `Show recent ${TIMELINE_PREVIEW}`
+                    : `Show all ${data.length} attempts`}
+                </Box>
+              </Box>
+            )}
           </>
         )}
       </SectionShell>

--- a/components/scorecard/detailed/SkillScorecardSection.tsx
+++ b/components/scorecard/detailed/SkillScorecardSection.tsx
@@ -459,14 +459,38 @@ export function SkillScorecardSection({ data }: SkillScorecardSectionProps) {
   }, [data, sortMode, selectedCategory]);
 
   const summary = useMemo(() => {
-    if (!data.length) return { total: 0, avg: 0, strong: 0, interviewReady: 0, topThree: [] as Skill[] };
+    if (!data.length) return { total: 0, avg: 0, strong: 0, interviewReady: 0, topThree: [] as Skill[], distribution: [] as { label: string; count: number; color: string }[] };
     const total = data.length;
     const avg = Math.round(data.reduce((acc, s) => acc + (Number.isFinite(s.proficiencyScore) ? s.proficiencyScore : 0), 0) / total);
     const strong = data.filter((s) => s.strength === "Strong").length;
     const interviewReady = data.filter((s) => s.level === "Interview-Ready").length;
     const topThree = [...data].sort((a, b) => b.proficiencyScore - a.proficiencyScore).slice(0, 3);
-    return { total, avg, strong, interviewReady, topThree };
+    // Proficiency distribution buckets (0-20 / 20-40 / 40-60 / 60-80 / 80-100)
+    // so the section can show "where do my skills sit" without needing 35 rows.
+    const buckets = [
+      { label: "0–20", min: 0, max: 20, color: "#ef4444" },
+      { label: "20–40", min: 20, max: 40, color: "#f97316" },
+      { label: "40–60", min: 40, max: 60, color: "#f59e0b" },
+      { label: "60–80", min: 60, max: 80, color: "#10b981" },
+      { label: "80–100", min: 80, max: 100, color: "#0a66c2" },
+    ];
+    const distribution = buckets.map((b) => ({
+      label: b.label,
+      color: b.color,
+      count: data.filter((s) => s.proficiencyScore >= b.min && (b.max === 100 ? s.proficiencyScore <= 100 : s.proficiencyScore < b.max)).length,
+    }));
+    return { total, avg, strong, interviewReady, topThree, distribution };
   }, [data]);
+
+  // Collapse the list once it gets long. The top 8 stay visible by default;
+  // the rest sit behind a "Show all" toggle so the section doesn't sprawl
+  // into a 35-skill wall.
+  const SKILLS_PREVIEW_LIMIT = 8;
+  const [showAllSkills, setShowAllSkills] = useState(false);
+  const visibleSkills = useMemo(
+    () => (showAllSkills ? filteredAndSorted : filteredAndSorted.slice(0, SKILLS_PREVIEW_LIMIT)),
+    [filteredAndSorted, showAllSkills],
+  );
 
   if (data.length === 0) {
     return (
@@ -671,6 +695,107 @@ export function SkillScorecardSection({ data }: SkillScorecardSectionProps) {
           ))}
         </Box>
 
+        {/* Proficiency distribution — quick "where do my skills sit" read */}
+        {summary.distribution.length > 0 && summary.total >= 3 && (
+          <Box
+            component={motion.div}
+            variants={fadeRise}
+            {...entrance}
+            sx={{
+              p: { xs: 2, md: 2.5 },
+              borderRadius: 3,
+              border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+              bgcolor: "color-mix(in srgb, var(--card-bg) 92%, transparent)",
+              mb: { xs: 3, md: 4 },
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+              <IconWrapper icon="mdi:chart-bar" size={14} color="var(--accent-indigo-dark)" />
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 800,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  fontSize: "0.66rem",
+                  color: "var(--font-secondary)",
+                }}
+              >
+                Proficiency distribution
+              </Typography>
+              <Box
+                sx={{
+                  flex: 1,
+                  height: 1,
+                  ml: 0.5,
+                  background:
+                    "linear-gradient(90deg, color-mix(in srgb, var(--border-default) 70%, transparent) 0%, transparent 100%)",
+                }}
+              />
+            </Box>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: `repeat(${summary.distribution.length}, 1fr)`,
+                gap: { xs: 0.5, sm: 1 },
+                alignItems: "end",
+                height: { xs: 96, md: 112 },
+              }}
+            >
+              {(() => {
+                const maxCount = Math.max(1, ...summary.distribution.map((b) => b.count));
+                return summary.distribution.map((bucket) => {
+                  const pctHeight = (bucket.count / maxCount) * 100;
+                  return (
+                    <Box key={bucket.label} sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 0.75, minWidth: 0 }}>
+                      <Box
+                        sx={{
+                          width: "100%",
+                          height: `${Math.max(6, pctHeight)}%`,
+                          borderRadius: "8px 8px 4px 4px",
+                          background: `linear-gradient(180deg, ${bucket.color} 0%, color-mix(in srgb, ${bucket.color} 60%, transparent) 100%)`,
+                          boxShadow: `inset 0 -2px 6px color-mix(in srgb, ${bucket.color} 70%, transparent)`,
+                          transition: "height 0.6s ease",
+                          display: "flex",
+                          alignItems: "flex-start",
+                          justifyContent: "center",
+                          pt: 0.5,
+                        }}
+                      >
+                        {bucket.count > 0 && (
+                          <Typography
+                            sx={{
+                              fontWeight: 800,
+                              fontSize: "0.7rem",
+                              color: "#fff",
+                              fontVariantNumeric: "tabular-nums",
+                              textShadow: "0 1px 2px rgba(0,0,0,0.18)",
+                            }}
+                          >
+                            {bucket.count}
+                          </Typography>
+                        )}
+                      </Box>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          fontSize: "0.66rem",
+                          fontWeight: 700,
+                          color: "var(--font-secondary)",
+                          letterSpacing: "0.04em",
+                          fontVariantNumeric: "tabular-nums",
+                        }}
+                      >
+                        {bucket.label}%
+                      </Typography>
+                    </Box>
+                  );
+                });
+              })()}
+            </Box>
+          </Box>
+        )}
+
         {/* Filter + sort row */}
         <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1.5, mb: 2 }}>
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, alignItems: "center" }}>
@@ -734,7 +859,7 @@ export function SkillScorecardSection({ data }: SkillScorecardSectionProps) {
           viewport={{ once: true, amount: 0.05 }}
           style={{ display: "grid", gridTemplateColumns: "1fr", gap: 12 }}
         >
-          {filteredAndSorted.map((skill) => (
+          {visibleSkills.map((skill) => (
             <SkillCard
               key={skill.id}
               skill={skill}
@@ -743,6 +868,47 @@ export function SkillScorecardSection({ data }: SkillScorecardSectionProps) {
             />
           ))}
         </motion.div>
+
+        {/* "Show all" toggle — keeps the section scannable when there are
+            many tracked skills. Hides itself when the filter+sort already
+            yields ≤ preview limit. */}
+        {filteredAndSorted.length > SKILLS_PREVIEW_LIMIT && (
+          <Box sx={{ display: "flex", justifyContent: "center", mt: 2.5 }}>
+            <Box
+              component="button"
+              onClick={() => setShowAllSkills((v) => !v)}
+              sx={{
+                appearance: "none",
+                border: "1px solid color-mix(in srgb, var(--accent-indigo) 28%, transparent)",
+                backgroundColor: "color-mix(in srgb, var(--accent-indigo) 6%, transparent)",
+                color: "var(--accent-indigo-dark)",
+                fontWeight: 800,
+                fontSize: "0.78rem",
+                letterSpacing: "0.04em",
+                px: 2.25,
+                py: 1,
+                borderRadius: 999,
+                cursor: "pointer",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.75,
+                transition: "all 0.18s ease",
+                "&:hover": {
+                  borderColor: "var(--accent-indigo)",
+                  backgroundColor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
+                  transform: "translateY(-1px)",
+                },
+              }}
+              aria-expanded={showAllSkills}
+              aria-label={showAllSkills ? "Show fewer skills" : `Show all ${filteredAndSorted.length} skills`}
+            >
+              <IconWrapper icon={showAllSkills ? "mdi:chevron-up" : "mdi:chevron-down"} size={16} />
+              {showAllSkills
+                ? `Show top ${SKILLS_PREVIEW_LIMIT}`
+                : `Show all ${filteredAndSorted.length} skills`}
+            </Box>
+          </Box>
+        )}
       </SectionShell>
     </Reveal>
   );

--- a/components/scorecard/detailed/WeakAreasSection.tsx
+++ b/components/scorecard/detailed/WeakAreasSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Box, Chip, Tooltip, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 import { IconWrapper } from "@/components/common/IconWrapper";
@@ -89,6 +90,192 @@ function Breadcrumb({
           title={itemName}
         >
           — {itemName}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Skipped-questions card. Replaces the previous bare bullet list with a
+ * clean card-style layout that:
+ *   - shows up to PREVIEW questions by default (most-recent first per the
+ *     backend ordering)
+ *   - collapses extras behind a "Show all N" toggle so 50+ skipped items
+ *     don't sprawl the section
+ *   - puts each question in its own slim row with an index pill + truncation
+ */
+function SkippedQuestionsCard({ questions }: { questions: string[] }) {
+  const SKIPPED_PREVIEW = 6;
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? questions : questions.slice(0, SKIPPED_PREVIEW);
+  return (
+    <Box
+      component={motion.div}
+      variants={fadeRise}
+      sx={{
+        p: { xs: 2, md: 2.5 },
+        borderRadius: 3,
+        border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+        bgcolor: "color-mix(in srgb, var(--card-bg) 96%, transparent)",
+        gridColumn: { md: "1 / -1" },
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        aria-hidden
+        sx={{
+          position: "absolute",
+          top: -40,
+          right: -40,
+          width: 160,
+          height: 160,
+          borderRadius: "50%",
+          background:
+            "radial-gradient(circle, color-mix(in srgb, var(--accent-indigo) 14%, transparent) 0%, transparent 70%)",
+          filter: "blur(20px)",
+          pointerEvents: "none",
+        }}
+      />
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.75, position: "relative" }}>
+        <Box
+          sx={{
+            width: 32,
+            height: 32,
+            borderRadius: 1.5,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)",
+            color: "#fff",
+            boxShadow: "0 8px 16px -8px color-mix(in srgb, var(--accent-indigo) 60%, transparent)",
+          }}
+        >
+          <IconWrapper icon="mdi:skip-next-outline" size={16} color="#fff" />
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "var(--accent-indigo-dark)",
+              fontSize: "0.62rem",
+              fontWeight: 800,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              display: "block",
+              lineHeight: 1.2,
+            }}
+          >
+            Recently skipped
+          </Typography>
+          <Typography
+            sx={{ fontWeight: 800, color: "var(--font-primary)", letterSpacing: "-0.01em", fontSize: "1rem", lineHeight: 1.2 }}
+          >
+            Questions you didn&apos;t answer
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 0.5,
+            px: 1,
+            py: 0.4,
+            borderRadius: 999,
+            bgcolor: "color-mix(in srgb, var(--accent-indigo) 10%, transparent)",
+            color: "var(--accent-indigo-dark)",
+            fontSize: "0.68rem",
+            fontWeight: 800,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          <IconWrapper icon="mdi:counter" size={11} />
+          {questions.length}
+        </Box>
+      </Box>
+      <Box sx={{ display: "grid", gap: 0.75, position: "relative" }}>
+        {visible.map((q, idx) => (
+          <Box
+            key={`${q.slice(0, 32)}-${idx}`}
+            sx={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 1.25,
+              p: 1.25,
+              borderRadius: 2,
+              border: "1px solid color-mix(in srgb, var(--border-default) 60%, transparent)",
+              bgcolor: "var(--card-bg)",
+              transition: "border-color 0.18s ease, transform 0.18s ease",
+              "&:hover": {
+                borderColor: "color-mix(in srgb, var(--accent-indigo) 35%, transparent)",
+                transform: "translateX(2px)",
+              },
+            }}
+          >
+            <Box
+              sx={{
+                flexShrink: 0,
+                width: 24,
+                height: 24,
+                borderRadius: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
+                color: "var(--accent-indigo-dark)",
+                fontSize: "0.7rem",
+                fontWeight: 800,
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              {idx + 1}
+            </Box>
+            <Typography
+              sx={{
+                fontSize: "0.84rem",
+                lineHeight: 1.5,
+                color: "var(--font-primary)",
+                minWidth: 0,
+                wordBreak: "break-word",
+              }}
+            >
+              {q}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+      {questions.length > SKIPPED_PREVIEW && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 1.5, position: "relative" }}>
+          <Box
+            component="button"
+            onClick={() => setExpanded((v) => !v)}
+            sx={{
+              appearance: "none",
+              border: "1px solid color-mix(in srgb, var(--accent-indigo) 28%, transparent)",
+              backgroundColor: "color-mix(in srgb, var(--accent-indigo) 6%, transparent)",
+              color: "var(--accent-indigo-dark)",
+              fontWeight: 800,
+              fontSize: "0.72rem",
+              letterSpacing: "0.04em",
+              px: 1.75,
+              py: 0.6,
+              borderRadius: 999,
+              cursor: "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+              transition: "all 0.18s ease",
+              "&:hover": {
+                borderColor: "var(--accent-indigo)",
+                backgroundColor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
+              },
+            }}
+            aria-expanded={expanded}
+          >
+            <IconWrapper icon={expanded ? "mdi:chevron-up" : "mdi:chevron-down"} size={14} />
+            {expanded ? `Show recent ${SKIPPED_PREVIEW}` : `Show all ${questions.length} skipped`}
+          </Box>
         </Box>
       )}
     </Box>
@@ -469,31 +656,7 @@ export function WeakAreasSection({ data }: WeakAreasSectionProps) {
               )}
 
               {skippedQuestions.length > 0 && (
-                <Box
-                  component={motion.div}
-                  variants={fadeRise}
-                  sx={{
-                    p: 2,
-                    borderRadius: 3,
-                    border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
-                    bgcolor: "color-mix(in srgb, var(--card-bg) 96%, transparent)",
-                    gridColumn: { md: "1 / -1" },
-                  }}
-                >
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
-                    <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "var(--accent-indigo)", boxShadow: "0 0 0 4px color-mix(in srgb, var(--accent-indigo) 18%, transparent)" }} />
-                    <Typography variant="subtitle2" sx={{ fontWeight: 800, color: "var(--font-primary)", letterSpacing: "-0.01em" }}>
-                      Questions you skipped recently
-                    </Typography>
-                  </Box>
-                  <Box component="ul" sx={{ pl: 2.25, m: 0, display: "grid", gap: 0.5, color: "var(--font-primary)", fontSize: "0.85rem" }}>
-                    {skippedQuestions.map((q, idx) => (
-                      <Box component="li" key={`${q}-${idx}`} sx={{ lineHeight: 1.5 }}>
-                        {q}
-                      </Box>
-                    ))}
-                  </Box>
-                </Box>
+                <SkippedQuestionsCard questions={skippedQuestions} />
               )}
             </Box>
           </>


### PR DESCRIPTION
…hart

Polish pass on Skill Scorecard, Weak Areas, Assessment Performance, and Action Panel so the heavier sections stop sprawling when there's a lot of data, and match the Chapter 02 / Learning Consumption visual idiom the rest of the scorecard already uses.

Skill Scorecard (Chapter 04)
- New proficiency-distribution mini chart between the KPI rail and the filter row: 5 buckets (0-20 / 20-40 / 40-60 / 60-80 / 80-100), bar height scaled to the bucket count, color-coded by band. Gives a one-glance read on "where do my 35 skills sit" without scrolling the whole list.
- Long skill list is now collapsible. Top 8 cards stay visible by default; the rest sit behind a "Show all N skills" pill that toggles back to "Show top 8". Hides itself when the filter+sort already yields ≤ 8.

Weak Areas (Chapter 05)
- "Questions you skipped recently" was a plain <ul> with raw question text. Replaced with a card-style list: header row with icon-on- gradient badge, eyebrow + title, count chip, indexed slim rows for each question with hover affordance and word-break for long text. Shows 6 by default with a "Show all N skipped" toggle.

Assessment Performance (Chapter 06)
- Timeline now shows the 10 most-recent attempts by default with a "Show all N attempts" toggle for the rest. Heavy test cycles otherwise produced 30+ rows that dwarfed the KPI rail above. Most- recent-first ordering is preserved (already date-sorted).

Action Panel (Chapter 11)
- Three subsection collapses with a new shared ShowAllToggle helper: pending tasks (5 visible), upcoming assessments (5 visible), recommended content (6 visible). Same toggle visual as Skills / Assessments / Weak Areas, scoped to the Action Panel's accent color.

Typecheck clean across all edited files.