### PR TITLE
feat(dashboard): gate MyCoursesSection on the `course` feature flag

### DIFF
--- a/components/dashboard/DashboardContent.tsx
+++ b/components/dashboard/DashboardContent.tsx
@@ -6,6 +6,7 @@ import { Course as CourseCardCourse } from "@/components/course/interfaces";
 import { ScorecardWidget } from "@/components/scorecard/dashboard/ScorecardWidget";
 import {
   useHideLeaderboardView,
+  useIsCourseEnabled,
   useIsScorecardEnabled,
 } from "@/lib/contexts/ClientInfoContext";
 
@@ -28,6 +29,7 @@ export const DashboardContent = ({
 }: DashboardContentProps) => {
   const hideLeaderboardView = useHideLeaderboardView();
   const scorecardEnabled = useIsScorecardEnabled();
+  const courseEnabled = useIsCourseEnabled();
   return (
     <Box
       sx={{
@@ -45,7 +47,7 @@ export const DashboardContent = ({
         <WelcomeMessage />
         <Box sx={{ mt: 3, width: hideLeaderboardView ? "70%" : "auto" }}>
           {scorecardEnabled && <ScorecardWidget />}
-          <MyCoursesSection courses={courses} loading={loading} />
+          {courseEnabled && <MyCoursesSection courses={courses} loading={loading} />}
         </Box>
       </Box>
       {!hideLeaderboardView && (


### PR DESCRIPTION
The `/courses` and `/courses/[id]` routes already redirect away when useIsCourseEnabled() returns false, and the sidebar entry is filtered by feature name. The dashboard, however, was still rendering the "My Courses" cards unconditionally — a tenant with `course` disabled saw an empty/duplicate course strip on /dashboard even though the actual course pages were unreachable.

Wrap <MyCoursesSection /> in the same useIsCourseEnabled() check we use elsewhere so it disappears alongside the rest of the course surface when a super-admin turns the feature off.

Audit on the dashboard found no other course-display surfaces:
- WelcomeMessage / WelcomeHeader: no course rendering
- DashboardSidebar: streak + leaderboard only
- WelcomeHeader's `courseId` prop is documented as deprecated/unused

Typecheck clean.