### PR TITLE
fix(config): make clientId throw lazy so Netlify build can collect pages

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,3 +1,23 @@
+/**
+ * Resolve the tenant id, throwing if it's not set in the build env.
+ *
+ * Kept as a getter on the config object (rather than an IIFE that runs at
+ * module load) so Next.js's page-data collection step can import this
+ * module during `next build` even when the env var is provided only at
+ * runtime. The throw still fires the first time real application code
+ * reads `config.clientId`, so we never silently fall back to a hardcoded
+ * prod tenant — which is the whole reason this guard exists.
+ */
+function resolveClientId(): string {
+  const v = process.env.NEXT_PUBLIC_CLIENT_ID;
+  if (!v) {
+    throw new Error(
+      "NEXT_PUBLIC_CLIENT_ID must be set — refusing to fall back to a hardcoded tenant id (would risk cross-tenant data leak).",
+    );
+  }
+  return v;
+}
+
 export const config = {
   /**
    * Canonical origin of this LMS web app (e.g. https://your-app.netlify.app).
@@ -8,15 +28,9 @@ export const config = {
     process.env.NEXT_PUBLIC_API_BASE_URL ||
     (process.env.NODE_ENV === "development" ? "http://localhost:8000" : "")
   ).replace(/\/$/, ""),
-  clientId: (() => {
-    const v = process.env.NEXT_PUBLIC_CLIENT_ID;
-    if (!v) {
-      throw new Error(
-        "NEXT_PUBLIC_CLIENT_ID must be set — refusing to fall back to a hardcoded tenant id (would risk cross-tenant data leak).",
-      );
-    }
-    return v;
-  })(),
+  get clientId(): string {
+    return resolveClientId();
+  },
   googleClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
   /**
    * Tenant slug (subdomain) — passed to the central auth proxy so it can route


### PR DESCRIPTION
Netlify's deploy preview build was failing in the page-data collection step:

  Error: Failed to collect page data for /_not-found
    [cause]: Error: NEXT_PUBLIC_CLIENT_ID must be set — refusing to
    fall back to a hardcoded tenant id (would risk cross-tenant data
    leak).

The previous IIFE on `config.clientId` fired the throw at module import time. Next.js loads every page module during `next build` so it can compute static configuration (including for /_not-found), which means the build crashed even on previews whose env var is only provided at runtime.

Convert the field to a getter that calls a `resolveClientId()` helper:
  - Module import succeeds (build's page-data collection passes).
  - Reading `config.clientId` still throws when the env var isn't set, so we keep the original guarantee that we never silently fall back to a hardcoded prod tenant (the original P0 fix).

Verified in isolation: with NEXT_PUBLIC_CLIENT_ID unset, the module loads cleanly, `config.appUrl` reads as `""`, and the first read of `config.clientId` throws the same error message.