### PR TITLE
feat(courses): hide non-enrolled courses for students when tenant 

### DIFF
--- a/app/admin/course-builder/page.tsx
+++ b/app/admin/course-builder/page.tsx
@@ -12,6 +12,9 @@ import {
   DialogContentText,
   DialogActions,
   Button,
+  Switch,
+  FormControlLabel,
+  Typography,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -36,6 +39,11 @@ import { SearchResultsInfo } from "@/components/admin/course-builder/SearchResul
 import { EmptyState } from "@/components/admin/course-builder/EmptyState";
 import { useAuth } from "@/lib/auth/auth-context";
 import { isCourseManagerRole } from "@/lib/auth/auth-utils";
+import {
+  useHideAvailableCourses,
+  updateHideAvailableCourses,
+} from "@/lib/admin/courseVisibility";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 
 export default function CourseBuilderPage() {
   const { showToast } = useToast();
@@ -43,6 +51,32 @@ export default function CourseBuilderPage() {
   const router = useRouter();
   const { user } = useAuth();
   const isCourseManager = isCourseManagerRole(user?.role);
+  const hideAvailableCourses = useHideAvailableCourses();
+  const { refreshClientInfo } = useClientInfo();
+  const [savingVisibility, setSavingVisibility] = useState(false);
+
+  const handleToggleHideAvailable = async (next: boolean) => {
+    try {
+      setSavingVisibility(true);
+      await updateHideAvailableCourses(next);
+      await refreshClientInfo();
+      showToast(
+        next
+          ? "Available courses are now hidden from students."
+          : "Available courses are now visible to students.",
+        "success"
+      );
+    } catch (error: any) {
+      showToast(
+        error?.response?.data?.error ||
+          error?.message ||
+          "Failed to update course visibility.",
+        "error"
+      );
+    } finally {
+      setSavingVisibility(false);
+    }
+  };
   const [courses, setCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
@@ -215,6 +249,68 @@ export default function CourseBuilderPage() {
     <MainLayout>
       <Box sx={{ p: { xs: 2, sm: 3 } }}>
         <CourseBuilderHeader />
+
+        {!isCourseManager && (
+          <Paper
+            sx={{
+              p: { xs: 2, sm: 2.5 },
+              mb: 2,
+              borderRadius: 2,
+              border: "1px solid var(--border-default)",
+              backgroundColor: "var(--card-bg)",
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: { xs: "column", sm: "row" },
+                justifyContent: "space-between",
+                alignItems: { xs: "flex-start", sm: "center" },
+                gap: 2,
+              }}
+            >
+              <Box>
+                <Typography
+                  variant="subtitle1"
+                  fontWeight={600}
+                  sx={{ color: "var(--font-primary-dark)" }}
+                >
+                  Student course visibility
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mt: 0.5 }}
+                >
+                  When on, the student course module only shows enrolled
+                  courses — the "Available Courses" tab is hidden. Applies to
+                  every student of this tenant.
+                </Typography>
+              </Box>
+              <FormControlLabel
+                sx={{ flexShrink: 0, m: 0 }}
+                control={
+                  <Switch
+                    checked={hideAvailableCourses}
+                    onChange={(e) => handleToggleHideAvailable(e.target.checked)}
+                    disabled={savingVisibility}
+                    color="primary"
+                  />
+                }
+                label={
+                  <Typography variant="body2" fontWeight={600}>
+                    {savingVisibility
+                      ? "Saving…"
+                      : hideAvailableCourses
+                        ? "Available courses hidden"
+                        : "Available courses visible"}
+                  </Typography>
+                }
+                labelPlacement="start"
+              />
+            </Box>
+          </Paper>
+        )}
 
         <Paper
           sx={{

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -32,6 +32,7 @@ import { usePayment } from "@/hooks/usePayment";
 import type { Course as CourseCardCourse } from "@/components/course/interfaces";
 import { PaymentType } from "@/lib/services/payment.service";
 import { useIsCourseEnabled, useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import { useHideAvailableCourses } from "@/lib/admin/courseVisibility";
 
 const ITEMS_PER_PAGE = 12;
 
@@ -43,6 +44,7 @@ export default function CoursesPage() {
   const router = useRouter();
   const isCourseEnabled = useIsCourseEnabled();
   const { loading: clientLoading } = useClientInfo();
+  const hideAvailableCourses = useHideAvailableCourses();
   const [courses, setCourses] = useState<CourseCardCourse[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
@@ -75,6 +77,16 @@ export default function CoursesPage() {
     hasLoadedRef.current = true;
     loadCourses();
   }, []);
+
+  // If the admin flips on "hide available courses" while the user is sitting
+  // on the Available tab, snap them back to "all" so they aren't stuck on an
+  // empty view.
+  useEffect(() => {
+    if (hideAvailableCourses && filter === "available") {
+      setFilter("all");
+      setPage(1);
+    }
+  }, [hideAvailableCourses, filter]);
 
   const loadCourses = async () => {
     try {
@@ -135,21 +147,33 @@ export default function CoursesPage() {
 
   const categoryOptions = useMemo(() => {
     const set = new Set<string>();
-    courses.forEach((c) =>
+    const source = hideAvailableCourses
+      ? courses.filter((c) => c.is_enrolled)
+      : courses;
+    source.forEach((c) =>
       (c.tags || []).forEach((tag) => {
         const t = tag.trim();
         if (t) set.add(t);
       })
     );
     return Array.from(set).sort((a, b) => a.localeCompare(b));
-  }, [courses]);
+  }, [courses, hideAvailableCourses]);
 
-  const totalCount = courses.length;
-  const enrolledCount = courses.filter((c) => c.is_enrolled).length;
-  const availableCount = courses.filter((c) => !c.is_enrolled).length;
+  // When the admin has hidden "available" courses tenant-wide, drop
+  // non-enrolled courses from the working set entirely. This makes the
+  // counts, the "All" tab, search, and pagination all reflect enrolled-only.
+  const visibleCourses = useMemo(
+    () =>
+      hideAvailableCourses ? courses.filter((c) => c.is_enrolled) : courses,
+    [courses, hideAvailableCourses]
+  );
+
+  const totalCount = visibleCourses.length;
+  const enrolledCount = visibleCourses.filter((c) => c.is_enrolled).length;
+  const availableCount = visibleCourses.filter((c) => !c.is_enrolled).length;
 
   const filteredCourses = useMemo(() => {
-    let result = courses.filter(
+    let result = visibleCourses.filter(
       (course) =>
         course.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
         course.description?.toLowerCase().includes(searchTerm.toLowerCase())
@@ -185,7 +209,7 @@ export default function CoursesPage() {
       }
       return 0;
     });
-  }, [courses, searchTerm, filter, filters, sortBy]);
+  }, [visibleCourses, searchTerm, filter, filters, sortBy]);
 
   const paginatedCourses = useMemo(() => {
     const start = (page - 1) * pageSize;
@@ -305,7 +329,7 @@ export default function CoursesPage() {
             display: "grid",
             gridTemplateColumns: {
               xs: "1fr",
-              sm: "repeat(3, 1fr)",
+              sm: hideAvailableCourses ? "repeat(2, 1fr)" : "repeat(3, 1fr)",
             },
             gap: 2,
             mb: 3,
@@ -386,39 +410,41 @@ export default function CoursesPage() {
               </Box>
             </Box>
           </Paper>
-          <Paper
-            elevation={0}
-            sx={{
-              p: 2.5,
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              backgroundColor: "var(--card-bg)",
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-              <Box
-                sx={{
-                  width: 48,
-                  height: 48,
-                  borderRadius: 2,
-                  backgroundColor: "var(--surface-blue-light)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-              >
-                <IconWrapper icon="mdi:play-circle" size={24} color="var(--accent-blue-light)" />
+          {!hideAvailableCourses && (
+            <Paper
+              elevation={0}
+              sx={{
+                p: 2.5,
+                border: "1px solid var(--border-default)",
+                borderRadius: 2,
+                backgroundColor: "var(--card-bg)",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                <Box
+                  sx={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 2,
+                    backgroundColor: "var(--surface-blue-light)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <IconWrapper icon="mdi:play-circle" size={24} color="var(--accent-blue-light)" />
+                </Box>
+                <Box>
+                  <Typography variant="h4" fontWeight={700} color="var(--font-primary-dark)">
+                    {availableCount}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {t("courses.allAvailable")}
+                  </Typography>
+                </Box>
               </Box>
-              <Box>
-                <Typography variant="h4" fontWeight={700} color="var(--font-primary-dark)">
-                  {availableCount}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {t("courses.allAvailable")}
-                </Typography>
-              </Box>
-            </Box>
-          </Paper>
+            </Paper>
+          )}
         </Box>
 
         <Paper
@@ -456,7 +482,9 @@ export default function CoursesPage() {
           >
             <Tab label={`${t("courses.all")} (${totalCount})`} value="all" />
             <Tab label={`${t("courses.enrolledTab")} (${enrolledCount})`} value="enrolled" />
-            <Tab label={`${t("courses.availableTab")} (${availableCount})`} value="available" />
+            {!hideAvailableCourses && (
+              <Tab label={`${t("courses.availableTab")} (${availableCount})`} value="available" />
+            )}
           </Tabs>
 
           <Box

--- a/lib/admin/courseVisibility.ts
+++ b/lib/admin/courseVisibility.ts
@@ -1,0 +1,43 @@
+"use client";
+
+// Tenant-wide toggle for hiding "Available" (non-enrolled) courses from the
+// student course module. Backed by the Client model field
+// `hide_available_courses_from_students` and exposed via:
+//   - GET via the existing /api/clients/<id>/client-info/ endpoint
+//     (consumed through ClientInfoContext)
+//   - PATCH via /admin-dashboard/api/clients/<id>/course-settings/
+//     (tenant admins or superadmins only)
+//
+// Flipping the toggle in the admin course builder updates the backend; the
+// student courses page reads it from ClientInfoContext, so every student gets
+// the change on their next client-info refresh.
+
+import apiClient from "@/lib/services/api";
+import { config } from "@/lib/config";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+
+const clientId = () => Number(config.clientId);
+
+interface CourseSettingsResponse {
+  hide_available_courses_from_students: boolean;
+  message?: string;
+}
+
+/** Reactive read of the tenant flag, sourced from ClientInfoContext. */
+export function useHideAvailableCourses(): boolean {
+  const { clientInfo } = useClientInfo();
+  return Boolean(clientInfo?.hide_available_courses_from_students);
+}
+
+/** Persist the new value on the server. Caller is responsible for refreshing
+ *  ClientInfoContext afterwards (e.g. via `refreshClientInfo()`) so the UI
+ *  picks up the change without a hard reload. */
+export async function updateHideAvailableCourses(
+  next: boolean
+): Promise<boolean> {
+  const { data } = await apiClient.patch<CourseSettingsResponse>(
+    `/admin-dashboard/api/clients/${clientId()}/course-settings/`,
+    { hide_available_courses_from_students: next }
+  );
+  return data.hide_available_courses_from_students;
+}

--- a/lib/services/client.service.ts
+++ b/lib/services/client.service.ts
@@ -107,6 +107,8 @@ export interface ClientInfo {
   allow_instructor_self_signup?: boolean;
   /** Enables admin live proctoring/monitoring features in UI. */
   live_proctoring_enabled?: boolean;
+  /** When true, students only see enrolled courses; the "Available Courses" UI is hidden. */
+  hide_available_courses_from_students?: boolean;
   /** Optional assets for learner-facing certificates */
   certificate_signature_url?: string | null;
   certificate_signatory_name?: string | null;


### PR DESCRIPTION
Adds useHideAvailableCourses() sourced from ClientInfoContext and updateHideAvailableCourses() that PATCHes the new
/admin-dashboard/api/clients/<id>/course-settings/ endpoint. The student /courses page filters non-enrolled out of the working set and hides the Available stat card + tab when the flag is on. Admin course builder gets a Switch (admin/superadmin only) that calls the API, refreshes client-info, and toasts the result.