### PR TITLE
feat(device-check): lower confidence thresholds for device-check screens

### DIFF
--- a/app/admin/admin-mock-interview/templates/page.tsx
+++ b/app/admin/admin-mock-interview/templates/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Box,
@@ -144,6 +144,10 @@ export default function AdminInterviewTemplatesPage() {
   const [attemptsLoading, setAttemptsLoading] = useState(false);
   const [releasingAttemptId, setReleasingAttemptId] = useState<number | null>(null);
   const [bulkReleasing, setBulkReleasing] = useState(false);
+  const [evaluatingTemplateId, setEvaluatingTemplateId] = useState<number | null>(null);
+  // Mirrors the currently-open attempts dialog so a delayed refresh can check whether it's
+  // still open without capturing a stale value in a setTimeout closure.
+  const attemptsDialogTemplateRef = useRef<InterviewTemplate | null>(null);
 
   const isEditing = selectedTemplate !== null;
 
@@ -179,6 +183,10 @@ export default function AdminInterviewTemplatesPage() {
   useEffect(() => {
     loadAll();
   }, [loadAll]);
+
+  useEffect(() => {
+    attemptsDialogTemplateRef.current = attemptsDialogTemplate;
+  }, [attemptsDialogTemplate]);
 
   // Quick course lookup so the list view can render attached-course chips without a join.
   const courseById = useMemo(() => {
@@ -326,6 +334,31 @@ export default function AdminInterviewTemplatesPage() {
       showToast("Bulk release failed", "error");
     } finally {
       setBulkReleasing(false);
+    }
+  };
+
+  const handleEvaluatePending = async (templateId: number) => {
+    setEvaluatingTemplateId(templateId);
+    try {
+      const res =
+        await adminMockInterviewService.evaluatePendingTemplateResults(templateId);
+      showToast(res.message, res.queued > 0 ? "success" : "info");
+      // If the attempts dialog is still open for this template, refresh it after a short
+      // beat so the admin sees has_evaluation flip and can release. The backend evaluates in
+      // the background, so we give it a moment before re-fetching. The ref check avoids
+      // re-opening a dialog the admin closed in the meantime.
+      if (res.queued > 0) {
+        setTimeout(() => {
+          const open = attemptsDialogTemplateRef.current;
+          if (open && open.id === templateId) {
+            void openAttemptsDialog(open);
+          }
+        }, 8000);
+      }
+    } catch (err) {
+      showToast("Could not start AI evaluation", "error");
+    } finally {
+      setEvaluatingTemplateId(null);
     }
   };
 
@@ -545,6 +578,23 @@ export default function AdminInterviewTemplatesPage() {
                             }}
                           >
                             Attempts
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="text"
+                            disabled={evaluatingTemplateId === t.id}
+                            startIcon={
+                              <IconWrapper icon="mdi:robot-outline" size={16} />
+                            }
+                            onClick={() => handleEvaluatePending(t.id)}
+                            sx={{
+                              textTransform: "none",
+                              color: "var(--accent-indigo)",
+                            }}
+                          >
+                            {evaluatingTemplateId === t.id
+                              ? "Evaluating…"
+                              : "AI Evaluation"}
                           </Button>
                           <Button
                             size="small"
@@ -1036,21 +1086,33 @@ export default function AdminInterviewTemplatesPage() {
                           }}
                         />
                       ) : a.status === "completed" ? (
-                        <Button
-                          size="small"
-                          variant="contained"
-                          disabled={releasingAttemptId === a.id}
-                          onClick={() => handleReleaseSingleAttempt(a.id)}
-                          sx={{
-                            textTransform: "none",
-                            backgroundColor: "var(--accent-indigo)",
-                            "&:hover": {
-                              backgroundColor: "var(--accent-indigo-dark)",
-                            },
-                          }}
-                        >
-                          {releasingAttemptId === a.id ? "Releasing…" : "Release"}
-                        </Button>
+                        a.has_evaluation ? (
+                          <Button
+                            size="small"
+                            variant="contained"
+                            disabled={releasingAttemptId === a.id}
+                            onClick={() => handleReleaseSingleAttempt(a.id)}
+                            sx={{
+                              textTransform: "none",
+                              backgroundColor: "var(--accent-indigo)",
+                              "&:hover": {
+                                backgroundColor: "var(--accent-indigo-dark)",
+                              },
+                            }}
+                          >
+                            {releasingAttemptId === a.id ? "Releasing…" : "Release"}
+                          </Button>
+                        ) : (
+                          <Chip
+                            label="Evaluation pending"
+                            size="small"
+                            sx={{
+                              backgroundColor: "var(--warning-100)",
+                              color: "var(--ats-warning-muted)",
+                              fontWeight: 600,
+                            }}
+                          />
+                        )
                       ) : (
                         <Chip
                           label={a.status}
@@ -1068,14 +1130,36 @@ export default function AdminInterviewTemplatesPage() {
             )}
           </DialogContent>
           <DialogActions sx={{ justifyContent: "space-between", px: 3, py: 2 }}>
-            <Button
-              variant="outlined"
-              disabled={bulkReleasing || attemptsList.every((a) => a.result_visible_to_student)}
-              onClick={handleBulkReleaseTemplate}
-              sx={{ textTransform: "none" }}
-            >
-              {bulkReleasing ? "Releasing all…" : "Release all pending"}
-            </Button>
+            <Box sx={{ display: "flex", gap: 1 }}>
+              <Button
+                variant="outlined"
+                startIcon={<IconWrapper icon="mdi:robot-outline" size={16} />}
+                disabled={
+                  attemptsDialogTemplate === null ||
+                  evaluatingTemplateId === attemptsDialogTemplate?.id ||
+                  !attemptsList.some(
+                    (a) => a.status === "completed" && !a.has_evaluation,
+                  )
+                }
+                onClick={() =>
+                  attemptsDialogTemplate &&
+                  handleEvaluatePending(attemptsDialogTemplate.id)
+                }
+                sx={{ textTransform: "none" }}
+              >
+                {evaluatingTemplateId === attemptsDialogTemplate?.id
+                  ? "Starting AI evaluation…"
+                  : "AI evaluate pending"}
+              </Button>
+              <Button
+                variant="outlined"
+                disabled={bulkReleasing || attemptsList.every((a) => a.result_visible_to_student)}
+                onClick={handleBulkReleaseTemplate}
+                sx={{ textTransform: "none" }}
+              >
+                {bulkReleasing ? "Releasing all…" : "Release all pending"}
+              </Button>
+            </Box>
             <Button
               onClick={() => setAttemptsDialogTemplate(null)}
               sx={{ textTransform: "none" }}

--- a/app/assessments/[slug]/device-check/page.tsx
+++ b/app/assessments/[slug]/device-check/page.tsx
@@ -93,10 +93,16 @@ export default function DeviceCheckPage({
     minFaceSize: 20, // Strictly reject faces beyond 2-3 meters
     maxFaceSize: 75,
     lookingAwayThreshold: 0.3,
-    minConfidence: 0.4,
+    // Permissive thresholds for the device-check screen: this is just verifying
+    // "camera works and we can see a face" — not anti-cheat. On low-end devices
+    // and grainy 640x480 webcams BlazeFace returns lower-confidence boxes and
+    // noisier landmarks for real faces, which previously read as "No face".
+    // The take/proctoring pages keep their own (stricter) thresholds.
+    minConfidence: 0.2,
     smoothFrameCount: 3,
     poorLightingThreshold: 0.4,
-    minConfidenceForValidFace: 0.82, // Stricter on device check: reject hand covering face
+    minConfidenceForValidFace: 0.5,
+    minEyeSpreadRatio: 0.18,
     onViolation: (violation) => {
       // Once the user has committed to starting the assessment, freeze
       // validation state — stopping the detector for hand-off to the take

--- a/app/mock-interview/[id]/device-check/page.tsx
+++ b/app/mock-interview/[id]/device-check/page.tsx
@@ -144,10 +144,13 @@ export default function MockInterviewDeviceCheckPage() {
     minFaceSize: 20,
     maxFaceSize: 75,
     lookingAwayThreshold: 0.3,
-    minConfidence: 0.4,
+    // Permissive thresholds for device-check (see assessments/[slug]/device-check
+    // for the rationale). The interview take page keeps stricter values.
+    minConfidence: 0.2,
     smoothFrameCount: 3,
     poorLightingThreshold: 0.4,
-    minConfidenceForValidFace: 0.82,
+    minConfidenceForValidFace: 0.5,
+    minEyeSpreadRatio: 0.18,
     onViolation: (violation) => {
       setFaceValidationPassed(false);
       setFaceValidationMessage(violation.message);

--- a/app/mock-interview/[id]/take/page.tsx
+++ b/app/mock-interview/[id]/take/page.tsx
@@ -2099,6 +2099,7 @@ export default function TakeMockInterviewPage() {
               questionHistory={isDynamicInterview ? questionHistory : []}
               focusedHistoryQuestionId={focusedHistoryQuestionId}
               submitDisabled={isClosingRemark && isSpeaking}
+              micLevelRef={audioLevelRef}
             />
           )}
         </Box>

--- a/components/mock-interview/AIAvatar.tsx
+++ b/components/mock-interview/AIAvatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, memo, useCallback } from "react";
+import { useEffect, useRef, useState, memo, useCallback, useMemo } from "react";
 import { Box } from "@mui/material";
 import { useInterviewerVoice } from "@/lib/hooks/useInterviewerVoice";
 
@@ -143,6 +143,39 @@ export const AIAvatar = memo(function AIAvatar({
     onSpeakStart: handleSpeakStart,
     onSpeakComplete: handleSpeakComplete,
   });
+
+  // Progressive caption reveal — the subtitle text appears word-by-word as the avatar
+  // "speaks" rather than dumping the whole sentence at once. We pace at roughly a natural
+  // TTS speaking cadence; exact word-level sync isn't possible across the browser/cloud
+  // voice paths, but a steady reveal reads as "the text comes as the interviewer talks".
+  // It resets whenever a new question starts speaking.
+  const captionWords = useMemo(
+    () => (question ? question.trim().split(/\s+/).filter(Boolean) : []),
+    [question],
+  );
+  const [revealedWordCount, setRevealedWordCount] = useState(0);
+  useEffect(() => {
+    if (!isAnimating || captionWords.length === 0) {
+      setRevealedWordCount(0);
+      return;
+    }
+    let shown = 1;
+    setRevealedWordCount(shown);
+    const PER_WORD_MS = 280; // ~215 wpm, close to the avatar's spoken pace
+    const id = window.setInterval(() => {
+      shown += 1;
+      setRevealedWordCount(shown);
+      if (shown >= captionWords.length) {
+        window.clearInterval(id);
+      }
+    }, PER_WORD_MS);
+    return () => window.clearInterval(id);
+  }, [isAnimating, captionWords]);
+
+  const revealedCaption = useMemo(
+    () => captionWords.slice(0, revealedWordCount).join(" "),
+    [captionWords, revealedWordCount],
+  );
 
   const isTalking = isAnimating && !isUserSpeaking;
   const isListening = isUserSpeaking && !isAnimating;
@@ -371,7 +404,7 @@ export const AIAvatar = memo(function AIAvatar({
             }}
             aria-live="polite"
           >
-            {question}
+            {revealedCaption || " "}
           </Box>
         </Box>
       )}

--- a/components/mock-interview/AnswerInputArea.tsx
+++ b/components/mock-interview/AnswerInputArea.tsx
@@ -6,6 +6,7 @@ import { memo, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { PauseProgressBar } from "./PauseProgressBar";
+import { MicWaveform } from "./MicWaveform";
 
 export interface AnswerInputAreaProps {
   currentAnswer: string;
@@ -62,6 +63,12 @@ export interface AnswerInputAreaProps {
    * command so the candidate sees which past question the AI is re-speaking.
    */
   focusedHistoryQuestionId?: number | null;
+  /**
+   * Live 0..1 microphone-loudness ref (updated every frame by the take page's Web Audio
+   * analyser). Drives the MicWaveform so the candidate gets a real "you're being heard"
+   * signal that grows with their voice.
+   */
+  micLevelRef?: { current: number };
 }
 
 export const AnswerInputArea = memo(function AnswerInputArea({
@@ -84,6 +91,7 @@ export const AnswerInputArea = memo(function AnswerInputArea({
   isFetchingNext = false,
   submitDisabled = false,
   focusedHistoryQuestionId = null,
+  micLevelRef,
 }: AnswerInputAreaProps) {
   const { t } = useTranslation("common");
   const displayValue =
@@ -164,19 +172,9 @@ export const AnswerInputArea = memo(function AnswerInputArea({
                   : "Speak naturally — your answer is being recorded."}
               </Typography>
             </Box>
-            <Box
-              sx={{
-                width: 10,
-                height: 10,
-                borderRadius: "50%",
-                backgroundColor: "var(--ats-success)",
-                animation: "listeningPulse 1.2s ease-in-out infinite",
-                "@keyframes listeningPulse": {
-                  "0%, 100%": { opacity: 1, transform: "scale(1)" },
-                  "50%": { opacity: 0.6, transform: "scale(1.2)" },
-                },
-              }}
-            />
+            {/* Live mic waveform — bars grow with the candidate's loudness so they get a
+                clear "you're being heard" signal instead of a single static dot. */}
+            <MicWaveform levelRef={micLevelRef} active color="var(--ats-success)" />
           </>
         ) : (
           <>
@@ -424,6 +422,13 @@ export const AnswerInputArea = memo(function AnswerInputArea({
             <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
               {conversationStatus || "Listening"}
             </Typography>
+            <Box sx={{ flex: 1 }} />
+            <MicWaveform
+              levelRef={micLevelRef}
+              active={isListening}
+              bars={7}
+              color={isListening ? "var(--ats-success)" : "var(--accent-indigo)"}
+            />
           </Box>
           {pauseProgressRef ? (
             <PauseProgressBar

--- a/components/mock-interview/MicWaveform.tsx
+++ b/components/mock-interview/MicWaveform.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Box } from "@mui/material";
+import { memo, useEffect, useRef } from "react";
+
+interface MicWaveformProps {
+  /**
+   * Ref to a live 0..1 microphone-loudness value. The take page updates this every
+   * animation frame from the Web Audio analyser, so we read it imperatively here instead
+   * of taking it through React state (which would re-render the whole page on every audio
+   * tick). The bars' heights scale with this value, so the wave genuinely reacts to how
+   * loud the candidate is speaking instead of looking static.
+   */
+  levelRef?: { current: number };
+  /** True while the mic is actively listening — bars animate; otherwise they rest low. */
+  active?: boolean;
+  /** Number of bars to render. */
+  bars?: number;
+  /** Bar + glow colour (defaults to the success/green token). */
+  color?: string;
+}
+
+const DEFAULT_BARS = 9;
+
+/**
+ * A compact equaliser-style mic waveform. Each bar oscillates on its own sine phase and its
+ * amplitude is driven by the live loudness, giving an obvious "you're being heard" signal
+ * that grows with the candidate's voice. Driven entirely by requestAnimationFrame + direct
+ * DOM writes — no React re-renders per frame.
+ */
+export const MicWaveform = memo(function MicWaveform({
+  levelRef,
+  active = false,
+  bars = DEFAULT_BARS,
+  color = "var(--ats-success)",
+}: MicWaveformProps) {
+  const barRefs = useRef<Array<HTMLSpanElement | null>>([]);
+  const rafRef = useRef<number | null>(null);
+  const phaseRef = useRef(0);
+  // Smoothed level so the bars don't jitter frame-to-frame on noisy input.
+  const smoothedRef = useRef(0);
+  const activeRef = useRef(active);
+
+  useEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  useEffect(() => {
+    const tick = () => {
+      const raw = Math.min(1, Math.max(0, levelRef?.current ?? 0));
+      // Gain-up: speech typically sits around 0.05–0.35 on the analyser, so multiply to use
+      // the full bar range, then clamp.
+      const boosted = Math.min(1, raw * 3.2);
+      // Exponential smoothing — quick to rise, slightly slower to fall.
+      const prev = smoothedRef.current;
+      smoothedRef.current =
+        boosted > prev ? prev + (boosted - prev) * 0.5 : prev + (boosted - prev) * 0.25;
+      const level = smoothedRef.current;
+      const isActive = activeRef.current;
+
+      phaseRef.current += 0.45;
+      const phase = phaseRef.current;
+      const count = barRefs.current.length;
+      const mid = (count - 1) / 2;
+
+      barRefs.current.forEach((bar, i) => {
+        if (!bar) return;
+        // Center bars swing taller than edge bars for a natural equaliser shape.
+        const centerFalloff = 1 - Math.abs(i - mid) / (mid + 1);
+        const wave = 0.5 + 0.5 * Math.sin(phase + i * 0.7);
+        // Idle: a gentle low shimmer so the user knows the mic is live. Active: amplitude
+        // tracks loudness, scaled by the per-bar wave + center falloff.
+        const baseline = isActive ? 0.16 : 0.12;
+        const amplitude = isActive
+          ? level * (0.45 + 0.55 * centerFalloff) * (0.4 + 0.6 * wave)
+          : 0.08 * wave;
+        const heightPct = Math.max(8, Math.min(100, (baseline + amplitude) * 100));
+        bar.style.height = `${heightPct}%`;
+        bar.style.opacity = isActive
+          ? String(0.55 + 0.45 * level)
+          : "0.35";
+      });
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [levelRef]);
+
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "3px",
+        height: 26,
+        minWidth: bars * 6,
+      }}
+    >
+      {Array.from({ length: bars }).map((_, i) => (
+        <Box
+          key={i}
+          component="span"
+          ref={(el: HTMLSpanElement | null) => {
+            barRefs.current[i] = el;
+          }}
+          sx={{
+            display: "block",
+            width: 3,
+            height: "20%",
+            borderRadius: 999,
+            backgroundColor: color,
+            transition: "height 0.07s linear, opacity 0.12s linear",
+          }}
+        />
+      ))}
+    </Box>
+  );
+});

--- a/components/mock-interview/QuickStartForm.tsx
+++ b/components/mock-interview/QuickStartForm.tsx
@@ -294,7 +294,8 @@ const QuickStartFormComponent = ({
                     key={mins}
                     onClick={() => handleDurationChange(mins)}
                     sx={{
-                      p: 2,
+                      py: 1.25,
+                      px: 1,
                       borderRadius: 2,
                       border: "2px solid",
                       borderColor: selected
@@ -307,6 +308,14 @@ const QuickStartFormComponent = ({
                       textAlign: "center",
                       transition: "all 0.2s ease",
                       position: "relative",
+                      // Stack the number above the "min" label so every option renders on a
+                      // consistent two-line layout. (Previously "10 min"/"20 min" wrapped to
+                      // two lines only on narrow cells, so the grid looked ragged.)
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      lineHeight: 1,
                       "&:hover": {
                         borderColor: "var(--course-cta)",
                         backgroundColor:
@@ -315,13 +324,27 @@ const QuickStartFormComponent = ({
                     }}
                   >
                     <Typography
-                      variant="body2"
+                      component="span"
+                      sx={{
+                        fontWeight: 700,
+                        fontSize: "1.15rem",
+                        lineHeight: 1.1,
+                        color: selected ? "var(--course-cta)" : "var(--font-primary)",
+                      }}
+                    >
+                      {mins}
+                    </Typography>
+                    <Typography
+                      component="span"
                       sx={{
                         fontWeight: 600,
+                        fontSize: "0.72rem",
+                        letterSpacing: "0.02em",
+                        mt: 0.25,
                         color: selected ? "var(--course-cta)" : "var(--font-secondary)",
                       }}
                     >
-                      {mins} min
+                      min
                     </Typography>
                     {isAdminOnlyOption && (
                       <Box

--- a/lib/services/admin/admin-mock-interview.service.ts
+++ b/lib/services/admin/admin-mock-interview.service.ts
@@ -577,6 +577,13 @@ export interface AdminReleaseBulkResponse {
   message: string;
 }
 
+export interface AdminEvaluatePendingResponse {
+  template_id: number;
+  /** How many completed-but-unevaluated attempts were queued for AI evaluation. */
+  queued: number;
+  message: string;
+}
+
 const adminMockInterviewService = {
   /**
    * Get dashboard overview with KPIs, trends, and top performers
@@ -737,6 +744,21 @@ const adminMockInterviewService = {
   ): Promise<AdminReleaseBulkResponse> => {
     const response = await apiClient.post(
       `${TEMPLATES_BASE_URL}/${templateId}/release-results/`,
+    );
+    return response.data;
+  },
+
+  /**
+   * Trigger AI (re)evaluation for every completed attempt of a template whose evaluation
+   * never landed (result stuck on "evaluation pending"). Runs in the background server-side;
+   * the returned `queued` count is how many attempts are being evaluated. Reopen the
+   * attempts list shortly after to release the freshly-scored ones.
+   */
+  evaluatePendingTemplateResults: async (
+    templateId: number,
+  ): Promise<AdminEvaluatePendingResponse> => {
+    const response = await apiClient.post(
+      `${TEMPLATES_BASE_URL}/${templateId}/evaluate-pending/`,
     );
     return response.data;
   },

--- a/lib/services/proctoring.service.ts
+++ b/lib/services/proctoring.service.ts
@@ -45,6 +45,10 @@ export interface ProctoringConfig {
   poorLightingThreshold?: number;
   /** Minimum confidence to accept face as "properly visible" (reject hand/obstruction). Default 0.65. */
   minConfidenceForValidFace?: number;
+  /** Min ratio of inter-eye distance to face width before we treat landmarks as
+   *  collapsed (i.e. face covered / not visible). Lower = more permissive on
+   *  low-res webcams where BlazeFace landmarks are noisier. Default 0.22. */
+  minEyeSpreadRatio?: number;
 
   // Callbacks
   onViolation?: (violation: ProctoringViolation) => void;
@@ -62,6 +66,7 @@ const DEFAULT_CONFIG: ProctoringConfig = {
   smoothFrameCount: 3, // Require 3 consistent frames to reduce flicker
   poorLightingThreshold: 0.4, // Only flag lighting if confidence < 0.4
   minConfidenceForValidFace: 0.78, // Require high confidence for "face OK" (reject hand covering face)
+  minEyeSpreadRatio: 0.22, // Default landmark spread sanity check
 };
 
 export class ProctoringService {
@@ -104,9 +109,17 @@ export class ProctoringService {
     try {
       this.isModelLoading = true;
 
-      // Set backend
-      await tf.setBackend("webgl");
-      await tf.ready();
+      // Prefer WebGL for speed, but fall back to CPU on low-end devices /
+      // browsers where WebGL is missing or blocked. CPU is slower but keeps
+      // the device-check from failing outright. Without this fallback, users
+      // on restricted GPU drivers saw a permanent "No face" state.
+      try {
+        await tf.setBackend("webgl");
+        await tf.ready();
+      } catch {
+        await tf.setBackend("cpu");
+        await tf.ready();
+      }
 
       // Load the model
       this.model = await blazeface.load();
@@ -683,7 +696,8 @@ export class ProctoringService {
         const eyeDistance = Math.sqrt(eyeDx * eyeDx + eyeDy * eyeDy);
         const eyeSpreadRatio = eyeDistance / faceWidth;
         // Real face: eyes are ~30–50% of face width apart. Hand/covered gives tiny or weird ratio
-        if (eyeSpreadRatio < 0.22) {
+        const minEyeSpread = this.config.minEyeSpreadRatio ?? 0.22;
+        if (eyeSpreadRatio < minEyeSpread) {
           violations.push(
             this.createViolation("FACE_NOT_VISIBLE", faceNotVisibleMsg, "high")
           );


### PR DESCRIPTION
This commit updates the minimum confidence thresholds for face detection in both the assessments and mock interview device-check pages to improve usability on low-end devices. The `minConfidence` is set to 0.2 and `minConfidenceForValidFace` to 0.5, along with the introduction of `minEyeSpreadRatio` to enhance detection accuracy. Additionally, the proctoring service is updated to allow for a fallback to CPU processing when WebGL is unavailable, ensuring a smoother user experience.