### PR TITLE
feat(navigation): instant sidebar nav with route-level shimmers

### DIFF
--- a/app/admin/admin-mock-interview/loading.tsx
+++ b/app/admin/admin-mock-interview/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" rows={5} />;
+}

--- a/app/admin/ai-course-builder/loading.tsx
+++ b/app/admin/ai-course-builder/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" rows={5} />;
+}

--- a/app/admin/assessment/loading.tsx
+++ b/app/admin/assessment/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/admin/attendance/loading.tsx
+++ b/app/admin/attendance/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" rows={5} />;
+}

--- a/app/admin/branding/loading.tsx
+++ b/app/admin/branding/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/admin/certificates/loading.tsx
+++ b/app/admin/certificates/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/admin/course-builder/loading.tsx
+++ b/app/admin/course-builder/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" rows={5} />;
+}

--- a/app/admin/dashboard/loading.tsx
+++ b/app/admin/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/admin/emails/loading.tsx
+++ b/app/admin/emails/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/admin/instructors/loading.tsx
+++ b/app/admin/instructors/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/admin/jobs-v2/loading.tsx
+++ b/app/admin/jobs-v2/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/admin/live-sessions/loading.tsx
+++ b/app/admin/live-sessions/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={5} />;
+}

--- a/app/admin/loading.tsx
+++ b/app/admin/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" />;
+}

--- a/app/admin/manage-students/loading.tsx
+++ b/app/admin/manage-students/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={8} />;
+}

--- a/app/admin/mock-interview/loading.tsx
+++ b/app/admin/mock-interview/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" rows={5} />;
+}

--- a/app/admin/notifications/loading.tsx
+++ b/app/admin/notifications/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/admin/pending-instructors/loading.tsx
+++ b/app/admin/pending-instructors/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/admin/profile/loading.tsx
+++ b/app/admin/profile/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/admin/scorecard/loading.tsx
+++ b/app/admin/scorecard/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/admin/tickets/loading.tsx
+++ b/app/admin/tickets/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={8} />;
+}

--- a/app/admin/verify-content/loading.tsx
+++ b/app/admin/verify-content/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/assessments/loading.tsx
+++ b/app/assessments/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/attendance/loading.tsx
+++ b/app/attendance/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" />;
+}

--- a/app/community/loading.tsx
+++ b/app/community/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/courses/[id]/page.tsx
+++ b/app/courses/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { Box, Typography, Fab, Tooltip, CircularProgress } from "@mui/material";
+import dynamic from "next/dynamic";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
   coursesService,
@@ -19,7 +20,15 @@ import { CourseOverview } from "@/components/course/CourseOverview";
 import { ProgressDashboard } from "@/components/course/ProgressDashboard";
 import { CourseLeaderboard } from "@/components/course/CourseLeaderboard";
 import { InstructorCard } from "@/components/course/InstructorCard";
-import { CertificateButtons } from "@/components/course/CertificateButtons";
+// Lazy: CertificateButtons drags in jspdf + html-to-image (~500KB gz). Only
+// needed when a course is certifiable, so defer it off the initial bundle.
+const CertificateButtons = dynamic(
+  () =>
+    import("@/components/course/CertificateButtons").then((m) => ({
+      default: m.CertificateButtons,
+    })),
+  { ssr: false }
+);
 import { usePayment } from "@/hooks/usePayment";
 import { PaymentType } from "@/lib/services/payment.service";
 import { useHideLeaderboardView, useIsCourseEnabled, useClientInfo } from "@/lib/contexts/ClientInfoContext";

--- a/app/courses/loading.tsx
+++ b/app/courses/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/jobs-v2/loading.tsx
+++ b/app/jobs-v2/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/jobs/loading.tsx
+++ b/app/jobs/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/app/live-sessions/loading.tsx
+++ b/app/live-sessions/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={5} />;
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" />;
+}

--- a/app/mock-interview/loading.tsx
+++ b/app/mock-interview/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="rows" />;
+}

--- a/app/profile/loading.tsx
+++ b/app/profile/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/tickets/loading.tsx
+++ b/app/tickets/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" rows={6} />;
+}

--- a/components/common/PageShimmer.tsx
+++ b/components/common/PageShimmer.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Box, Skeleton, Stack } from "@mui/material";
+
+interface PageShimmerProps {
+  /** Number of card rows to render. Defaults to 4. */
+  rows?: number;
+  /** Show a grid of cards instead of horizontal rows. */
+  variant?: "rows" | "grid" | "list" | "detail";
+  /** Hide the page header (title + subtitle). */
+  hideHeader?: boolean;
+}
+
+/**
+ * Generic shimmer placeholder for full-page route transitions. Rendered by
+ * each segment's `loading.tsx` so the new page appears instantly while its
+ * data loads, keeping perceived navigation latency near zero.
+ */
+export function PageShimmer({
+  rows = 4,
+  variant = "rows",
+  hideHeader = false,
+}: PageShimmerProps) {
+  return (
+    <Box
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      sx={{ width: "100%" }}
+    >
+      {!hideHeader && (
+        <Stack spacing={1.25} sx={{ mb: 3 }}>
+          <Skeleton
+            variant="rounded"
+            width={260}
+            height={32}
+            sx={{ borderRadius: 1 }}
+          />
+          <Skeleton
+            variant="rounded"
+            width={420}
+            height={18}
+            sx={{ borderRadius: 1, maxWidth: "70%" }}
+          />
+        </Stack>
+      )}
+
+      {variant === "grid" && (
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: {
+              xs: "1fr",
+              sm: "repeat(2, 1fr)",
+              md: "repeat(3, 1fr)",
+              lg: "repeat(4, 1fr)",
+            },
+          }}
+        >
+          {Array.from({ length: Math.max(rows * 2, 6) }).map((_, i) => (
+            <Skeleton
+              key={i}
+              variant="rounded"
+              height={180}
+              sx={{ borderRadius: 2 }}
+            />
+          ))}
+        </Box>
+      )}
+
+      {variant === "rows" && (
+        <Stack spacing={1.5}>
+          {Array.from({ length: rows }).map((_, i) => (
+            <Skeleton
+              key={i}
+              variant="rounded"
+              height={84}
+              sx={{ borderRadius: 2 }}
+            />
+          ))}
+        </Stack>
+      )}
+
+      {variant === "list" && (
+        <Stack spacing={1}>
+          {Array.from({ length: rows + 4 }).map((_, i) => (
+            <Box
+              key={i}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+                py: 1.25,
+                px: 1.5,
+                borderRadius: 1.5,
+              }}
+            >
+              <Skeleton variant="circular" width={40} height={40} />
+              <Stack spacing={0.75} sx={{ flex: 1 }}>
+                <Skeleton
+                  variant="rounded"
+                  width="40%"
+                  height={16}
+                  sx={{ borderRadius: 1 }}
+                />
+                <Skeleton
+                  variant="rounded"
+                  width="70%"
+                  height={12}
+                  sx={{ borderRadius: 1 }}
+                />
+              </Stack>
+              <Skeleton
+                variant="rounded"
+                width={80}
+                height={28}
+                sx={{ borderRadius: 1 }}
+              />
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      {variant === "detail" && (
+        <Stack spacing={2.5}>
+          <Skeleton variant="rounded" height={220} sx={{ borderRadius: 2 }} />
+          <Box
+            sx={{
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: { xs: "1fr", md: "2fr 1fr" },
+            }}
+          >
+            <Stack spacing={1.25}>
+              {Array.from({ length: rows }).map((_, i) => (
+                <Skeleton
+                  key={i}
+                  variant="rounded"
+                  height={i === 0 ? 28 : 16}
+                  width={i === 0 ? "60%" : `${100 - i * 6}%`}
+                  sx={{ borderRadius: 1 }}
+                />
+              ))}
+            </Stack>
+            <Skeleton variant="rounded" height={260} sx={{ borderRadius: 2 }} />
+          </Box>
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+export default PageShimmer;

--- a/components/common/PageShimmerLayout.tsx
+++ b/components/common/PageShimmerLayout.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { MainLayout } from "@/components/layout/MainLayout";
+import { PageShimmer } from "@/components/common/PageShimmer";
+
+interface PageShimmerLayoutProps {
+  rows?: number;
+  variant?: "rows" | "grid" | "list" | "detail";
+  hideHeader?: boolean;
+}
+
+/**
+ * Drop-in loading screen rendered by `loading.tsx` route files. Keeps the
+ * sidebar + app bar visible by wrapping the shimmer in `MainLayout`, so
+ * clicks on nav items appear to swap pages instantly while real data loads.
+ */
+export default function PageShimmerLayout(props: PageShimmerLayoutProps) {
+  return (
+    <MainLayout>
+      <PageShimmer {...props} />
+    </MainLayout>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -45,6 +45,91 @@ import { resolveClientLogoUrl } from "@/lib/utils/resolveClientLogoUrl";
 const DRAWER_WIDTH = 240;
 const DRAWER_WIDTH_COLLAPSED = 64;
 
+function SidebarNavButton({
+  icon,
+  label,
+  isActive,
+  collapsed,
+  rtl,
+  shell,
+}: {
+  icon: string;
+  label: string;
+  isActive: boolean;
+  collapsed: boolean;
+  rtl: boolean;
+  shell: ReturnType<typeof useTenantShellTheme>;
+}) {
+  return (
+    <ListItemButton
+      sx={{
+        borderRadius: 1.5,
+        backgroundColor: isActive ? shell.activeBg : "transparent",
+        color: isActive ? shell.activeText : shell.navMuted,
+        py: 1,
+        px: collapsed ? 1.25 : 1.5,
+        justifyContent: collapsed ? "center" : rtl ? "flex-end" : "flex-start",
+        flexDirection: rtl && !collapsed ? "row-reverse" : "row",
+        minHeight: 40,
+        position: "relative",
+        "&::before": isActive
+          ? {
+              content: '""',
+              position: "absolute",
+              ...(rtl ? { right: 0, left: "auto" } : { left: 0, right: "auto" }),
+              top: "50%",
+              transform: "translateY(-50%)",
+              width: 3,
+              height: "50%",
+              backgroundColor: shell.p500,
+              borderRadius: rtl ? "3px 0 0 3px" : "0 3px 3px 0",
+            }
+          : {},
+        "&:hover": {
+          backgroundColor: isActive ? shell.activeBgHover : shell.navHoverBg,
+          color: isActive ? shell.activeText : shell.nav,
+          "& .MuiListItemIcon-root svg": {
+            transform: "translateY(-2px) scale(1.1)",
+            filter: shell.dropHover,
+          },
+        },
+      }}
+    >
+      <ListItemIcon
+        sx={{
+          minWidth: collapsed ? 0 : 36,
+          color: "inherit",
+          justifyContent: "center",
+          position: "relative",
+          ...(rtl && !collapsed && { marginRight: 0, marginLeft: 1 }),
+          "& svg": {
+            filter: isActive
+              ? shell.dropIconActive
+              : "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2))",
+            transform: isActive
+              ? "translateY(-1px) scale(1.05)"
+              : "translateY(0) scale(1)",
+            transition: "all 0.2s ease",
+          },
+        }}
+      >
+        <IconWrapper icon={icon} size={18} />
+      </ListItemIcon>
+      {!collapsed && (
+        <ListItemText
+          primary={label}
+          slotProps={{
+            primary: {
+              fontSize: "1rem",
+              fontWeight: isActive ? 600 : 500,
+            },
+          }}
+        />
+      )}
+    </ListItemButton>
+  );
+}
+
 interface NavigationItem {
   label: string;
   labelKey: string;
@@ -588,74 +673,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
                     style={{ textDecoration: "none", color: "inherit", width: "100%" }}
                     onClick={() => handleNavigation(item)}
                   >
-                    <ListItemButton
-                      sx={{
-                        borderRadius: 1.5,
-                        backgroundColor: isActive
-                          ? shell.activeBg
-                          : "transparent",
-                        color: isActive ? shell.activeText : shell.navMuted,
-                        py: 1,
-                        px: collapsed ? 1.25 : 1.5,
-                        justifyContent: collapsed ? "center" : rtl ? "flex-end" : "flex-start",
-                        flexDirection: rtl && !collapsed ? "row-reverse" : "row",
-                        minHeight: 40,
-                        position: "relative",
-                        "&::before": isActive
-                          ? {
-                              content: '""',
-                              position: "absolute",
-                              ...(rtl ? { right: 0, left: "auto" } : { left: 0, right: "auto" }),
-                              top: "50%",
-                              transform: "translateY(-50%)",
-                              width: 3,
-                              height: "50%",
-                              backgroundColor: shell.p500,
-                              borderRadius: rtl ? "3px 0 0 3px" : "0 3px 3px 0",
-                            }
-                          : {},
-                        "&:hover": {
-                          backgroundColor: isActive
-                            ? shell.activeBgHover
-                            : shell.navHoverBg,
-                          color: isActive ? shell.activeText : shell.nav,
-                          "& .MuiListItemIcon-root svg": {
-                            transform: "translateY(-2px) scale(1.1)",
-                            filter: shell.dropHover,
-                          },
-                        },
-                      }}
-                    >
-                    <ListItemIcon
-                      sx={{
-                        minWidth: collapsed ? 0 : 36,
-                        color: "inherit",
-                        justifyContent: "center",
-                        position: "relative",
-                        ...(rtl && !collapsed && { marginRight: 0, marginLeft: 1 }),
-                        "& svg": {
-                          filter: isActive
-                            ? shell.dropIconActive
-                            : "drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2))",
-                          transform: isActive
-                            ? "translateY(-1px) scale(1.05)"
-                            : "translateY(0) scale(1)",
-                          transition: "all 0.2s ease",
-                        },
-                      }}
-                    >
-                      <IconWrapper icon={item.icon} size={18} />
-                    </ListItemIcon>
-                    {!collapsed && (
-                      <ListItemText
-                        primary={t(item.labelKey)}
-                        primaryTypographyProps={{
-                          fontSize: "1rem",
-                          fontWeight: isActive ? 600 : 500,
-                        }}
-                      />
-                    )}
-                  </ListItemButton>
+                    <SidebarNavButton
+                      icon={item.icon}
+                      label={t(item.labelKey)}
+                      isActive={!!isActive}
+                      collapsed={collapsed}
+                      rtl={rtl}
+                      shell={shell}
+                    />
                   </Link>
                 </ListItem>
               );


### PR DESCRIPTION
Sidebar clicks now feel instant: every authenticated route has a loading.tsx that renders a shimmer the moment Next.js starts the transition, so the new URL is shown immediately while the page's data is still loading. PageShimmer ships four variants (rows, grid, list, detail) so each route's placeholder roughly matches its real shape, and PageShimmerLayout keeps the sidebar + app bar visible during the transition.

Sidebar pending-state UI removed (no spinner) — the URL change and shimmer page are sufficient feedback.

Also lazy-loads CertificateButtons on /courses/[id] via next/dynamic to drop jspdf + html-to-image (~500KB gz) out of that route's initial bundle.