### PR TITLE
feat(adaptive-courses): revamp generate — cleaner form + CSV-upload c…

### DIFF
--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -2,74 +2,69 @@
 
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import {
-  Box,
-  ButtonBase,
-  Container,
-  FormControlLabel,
-  Switch,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, ButtonBase, Container, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import { GenerateModeToggle } from "@/components/adaptive-quiz/generate/GenerateModeToggle";
+import { DescribeModePanel } from "@/components/adaptive-quiz/generate/DescribeModePanel";
+import { CsvUploadPanel } from "@/components/adaptive-quiz/generate/CsvUploadPanel";
+import { EditableCsvPlanPreview } from "@/components/adaptive-quiz/generate/EditableCsvPlanPreview";
+import { SharedGenerationConfig } from "@/components/adaptive-quiz/generate/SharedGenerationConfig";
+import {
+  ALL_CONTENT_TYPES,
+  ALL_DIFFICULTIES,
+  withRowUids,
+  type ContentType,
+  type Difficulty,
+  type GenerateMode,
+  type ParsedCsv,
+} from "@/components/adaptive-quiz/generate/types";
 import {
   adminAdaptiveCourseService,
   type AdaptiveCourseGenConfig,
+  type CsvCoursePlan,
 } from "@/lib/services/admin/admin-adaptive-course.service";
-
-type Difficulty = "Easy" | "Medium" | "Hard";
-const ALL_DIFFICULTIES: Difficulty[] = ["Easy", "Medium", "Hard"];
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 export default function GenerateAdaptiveCoursePage() {
   const router = useRouter();
   const { showToast } = useToast();
 
+  const [mode, setMode] = useState<GenerateMode>("describe");
+
+  // --- Describe mode ---
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
-  const [targetAudience, setTargetAudience] = useState("");
   const [durationWeeks, setDurationWeeks] = useState(8);
+
+  // --- CSV mode ---
+  const [csvTitle, setCsvTitle] = useState("");
+  const [parsed, setParsed] = useState<ParsedCsv | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [hint, setHint] = useState("");
+  const [plan, setPlan] = useState<CsvCoursePlan | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+
+  // --- Shared generation config ---
   const [difficulties, setDifficulties] = useState<Difficulty[]>(["Easy", "Medium", "Hard"]);
   const [questionsPerCell, setQuestionsPerCell] = useState(3);
   const [minQuestions, setMinQuestions] = useState(8);
   const [maxQuestions, setMaxQuestions] = useState(20);
   const [confidence, setConfidence] = useState(true);
-  const [contentTypes, setContentTypes] = useState<Array<"quiz" | "article" | "coding" | "video">>(["quiz", "article"]);
+  const [contentTypes, setContentTypes] = useState<ContentType[]>(["quiz", "article"]);
   const [codingClipboard, setCodingClipboard] = useState(false);
+
   const [submitting, setSubmitting] = useState(false);
 
-  const canSubmit =
-    title.trim().length > 1 && description.trim().length > 4 && difficulties.length > 0 && contentTypes.length > 0;
-
-  function toggleContentType(t: "quiz" | "article" | "coding" | "video") {
+  function toggleContentType(t: ContentType) {
     setContentTypes((prev) => {
       const next = prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t];
-      return (["quiz", "article", "coding", "video"] as const).filter((x) => next.includes(x));
+      return ALL_CONTENT_TYPES.filter((x) => next.includes(x));
     });
   }
-
-  // Rough preview — outline picks ~3 submodules/module; bank ≈ submodules ×
-  // ~3 sub-skills × difficulties × questions/cell.
-  const preview = useMemo(() => {
-    const modules = Math.max(1, Math.round(durationWeeks * 0.75));
-    const submodules = modules * 3;
-    const bankPerQuiz = 3 * difficulties.length * questionsPerCell;
-    const hasQuiz = contentTypes.includes("quiz");
-    const hasCoding = contentTypes.includes("coding");
-    return {
-      modules,
-      submodules,
-      hasQuiz,
-      hasCoding,
-      quizzes: hasQuiz ? submodules : 0,
-      bankItems: hasQuiz ? submodules * bankPerQuiz : 0,
-      // Coding generates ~2 problems per difficulty tier per submodule (see builder).
-      codingProblems: hasCoding ? submodules * difficulties.length * 2 : 0,
-    };
-  }, [durationWeeks, difficulties.length, questionsPerCell, contentTypes]);
 
   function toggleDifficulty(d: Difficulty) {
     setDifficulties((prev) => {
@@ -78,10 +73,71 @@ export default function GenerateAdaptiveCoursePage() {
     });
   }
 
-  async function handleSubmit() {
-    if (!canSubmit || submitting) return;
-    setSubmitting(true);
-    const config: AdaptiveCourseGenConfig = {
+  // Mirror the backend serializer's requirements so editing to an invalid plan
+  // disables Generate (with a hint) instead of bouncing off a nested 400.
+  const planReady =
+    !!plan &&
+    plan.modules.length > 0 &&
+    plan.modules.every(
+      (m) =>
+        m.title.trim().length > 0 &&
+        m.submodules.length > 0 &&
+        m.submodules.every((s) => s.title.trim().length > 0),
+    );
+
+  const canSubmit =
+    difficulties.length > 0 &&
+    contentTypes.length > 0 &&
+    (mode === "describe"
+      ? title.trim().length > 1 && description.trim().length > 4
+      : csvTitle.trim().length > 1 && planReady);
+
+  // Rough preview — describe mode estimates from duration; CSV mode uses the exact
+  // parsed counts (and per-submodule key_concepts) so the bento matches what builds.
+  const preview = useMemo(() => {
+    const hasQuiz = contentTypes.includes("quiz");
+    const hasCoding = contentTypes.includes("coding");
+    if (mode === "csv" && plan) {
+      const modules = plan.modules.length;
+      const submodules = plan.modules.reduce((n, m) => n + m.submodules.length, 0);
+      const bankItems = hasQuiz
+        ? plan.modules.reduce(
+            (n, m) =>
+              n +
+              m.submodules.reduce(
+                (s, sub) =>
+                  s + Math.min(Math.max(sub.key_concepts.length, 1), 4) * difficulties.length * questionsPerCell,
+                0,
+              ),
+            0,
+          )
+        : 0;
+      return {
+        modules,
+        submodules,
+        hasQuiz,
+        hasCoding,
+        quizzes: hasQuiz ? submodules : 0,
+        bankItems,
+        codingProblems: hasCoding ? submodules * difficulties.length * 2 : 0,
+      };
+    }
+    const modules = Math.max(1, Math.round(durationWeeks * 0.75));
+    const submodules = modules * 3;
+    const bankPerQuiz = 3 * difficulties.length * questionsPerCell;
+    return {
+      modules,
+      submodules,
+      hasQuiz,
+      hasCoding,
+      quizzes: hasQuiz ? submodules : 0,
+      bankItems: hasQuiz ? submodules * bankPerQuiz : 0,
+      codingProblems: hasCoding ? submodules * difficulties.length * 2 : 0,
+    };
+  }, [mode, plan, durationWeeks, difficulties, questionsPerCell, contentTypes]);
+
+  function buildConfig(): AdaptiveCourseGenConfig {
+    return {
       difficulty_levels: difficulties,
       difficulty_level: difficulties.includes("Medium") ? "Medium" : difficulties[0],
       questions_per_cell: questionsPerCell,
@@ -93,21 +149,60 @@ export default function GenerateAdaptiveCoursePage() {
         ? { coding_problems_per_submodule: 2, coding_language: "Python", coding_allow_clipboard: codingClipboard }
         : {}),
     };
+  }
+
+  async function handleAnalyze() {
+    if (!parsed || analyzing) return;
+    setAnalyzing(true);
     try {
-      const job = await adminAdaptiveCourseService.generateCourse({
-        title: title.trim(),
-        description: description.trim(),
-        target_audience: targetAudience.trim() || undefined,
-        duration_weeks: durationWeeks,
-        config,
+      const result = await adminAdaptiveCourseService.parseCsv({
+        title: csvTitle.trim() || undefined,
+        columns: parsed.columns,
+        rows: parsed.rows,
+        hint: hint.trim() || undefined,
       });
+      setPlan(withRowUids(result));
+      if (!result.modules?.length) {
+        showToast("The AI couldn't find any topics in that CSV. Try a clearer file or hint.", "error");
+      } else {
+        const weeks = result.modules.length;
+        showToast(`Parsed ${weeks} ${weeks === 1 ? "week" : "weeks"} — review and generate.`, "success");
+      }
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, "Couldn't analyze the CSV."), "error");
+    } finally {
+      setAnalyzing(false);
+    }
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit || submitting) return;
+    setSubmitting(true);
+    const config = buildConfig();
+    try {
+      const job =
+        mode === "describe"
+          ? await adminAdaptiveCourseService.generateCourse({
+              title: title.trim(),
+              description: description.trim(),
+              duration_weeks: durationWeeks,
+              config,
+            })
+          : await adminAdaptiveCourseService.generateFromPlan({
+              title: csvTitle.trim(),
+              modules: plan!.modules,
+              config,
+            });
       showToast("Generation started.", "success");
       router.push(`/admin/adaptive-courses/jobs/${job.job_id}`);
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't start generation.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't start generation."), "error");
       setSubmitting(false);
     }
   }
+
+  const showGenerate = mode === "describe" || !!plan;
+  const showEstimate = mode === "describe" || (mode === "csv" && !!plan);
 
   return (
     <MainLayout>
@@ -123,8 +218,8 @@ export default function GenerateAdaptiveCoursePage() {
         <AdaptiveSectionShell>
           <AdaptiveSectionHero
             chapter="Generate · Adaptive"
-            title="Generate adaptive course from description"
-            subtitle="Describe the course once — we generate modules, submodules, and a full adaptive quiz (IRT bank, branching, confidence capture) for every submodule."
+            title="Generate adaptive course"
+            subtitle="Describe a course in prose, or upload a curriculum CSV and let AI map it — either way we generate modules, submodules, and a full adaptive quiz (IRT bank, branching, confidence capture) for every submodule."
             icon="mdi:auto-fix"
             accent="purple"
           />
@@ -138,175 +233,86 @@ export default function GenerateAdaptiveCoursePage() {
             }}
           >
             {/* Form */}
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-              <TextField
-                label="Course title"
-                required
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                fullWidth
-              />
-              <TextField
-                label="Course description"
-                required
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                fullWidth
-                multiline
-                minRows={4}
-              />
-              <TextField
-                label="Target audience (optional)"
-                value={targetAudience}
-                onChange={(e) => setTargetAudience(e.target.value)}
-                fullWidth
-              />
-              <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-                <TextField
-                  label="Duration (weeks)"
-                  type="number"
-                  value={durationWeeks}
-                  onChange={(e) => setDurationWeeks(clamp(Number(e.target.value), 1, 52))}
-                  sx={{ width: 160 }}
-                />
-                <TextField
-                  label="Questions per skill cell"
-                  type="number"
-                  value={questionsPerCell}
-                  onChange={(e) => setQuestionsPerCell(clamp(Number(e.target.value), 1, 10))}
-                  sx={{ width: 220 }}
-                />
-              </Box>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+              <GenerateModeToggle mode={mode} onChange={setMode} />
 
-              <Box>
-                <Typography sx={{ fontWeight: 800, fontSize: "0.85rem", mb: 1 }}>
-                  Content types (per submodule)
-                </Typography>
-                <Box sx={{ display: "flex", gap: 1 }}>
-                  {([
-                    ["article", "Adaptive Article", "mdi:book-open-variant"],
-                    ["quiz", "Adaptive Quiz", "mdi:tune-vertical"],
-                    ["coding", "AI Coding Mentor", "mdi:robot-happy-outline"],
-                    ["video", "Video Companion", "mdi:play-circle-outline"],
-                  ] as const).map(([key, label, icon]) => {
-                    const active = contentTypes.includes(key);
-                    return (
-                      <ButtonBase
-                        key={key}
-                        onClick={() => toggleContentType(key)}
-                        sx={{
-                          px: 2, py: 0.85, borderRadius: 999, fontWeight: 800, fontSize: "0.82rem", gap: 0.5,
-                          color: active ? "white" : "text.primary",
-                          background: active
-                            ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
-                            : "color-mix(in srgb, var(--card-bg) 60%, transparent)",
-                          border: active ? "1px solid transparent" : "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
-                        }}
-                      >
-                        <Icon icon={icon} width={15} />
-                        {label}
-                      </ButtonBase>
-                    );
-                  })}
-                </Box>
-                {contentTypes.includes("coding") && (
-                  <Box
-                    component="button"
-                    onClick={() => setCodingClipboard((v) => !v)}
-                    sx={{
-                      all: "unset", cursor: "pointer", mt: 1.25, display: "inline-flex", alignItems: "center", gap: 0.75,
-                      fontSize: "0.82rem", fontWeight: 700, color: "text.secondary",
+              {mode === "describe" ? (
+                <DescribeModePanel
+                  title={title}
+                  onTitleChange={setTitle}
+                  description={description}
+                  onDescriptionChange={setDescription}
+                  durationWeeks={durationWeeks}
+                  onDurationWeeksChange={setDurationWeeks}
+                />
+              ) : (
+                <>
+                  <CsvUploadPanel
+                    csvTitle={csvTitle}
+                    onCsvTitleChange={setCsvTitle}
+                    parsed={parsed}
+                    onParsed={(p) => {
+                      setParsed(p);
+                      setPlan(null); // a new file invalidates the previous AI plan
                     }}
-                  >
-                    <Icon icon={codingClipboard ? "mdi:checkbox-marked" : "mdi:checkbox-blank-outline"} width={18} style={{ color: codingClipboard ? "#6366f1" : undefined }} />
-                    Allow copy-paste in the coding editor
-                    <Typography component="span" sx={{ fontSize: "0.74rem", color: "text.disabled" }}>
-                      (off = anti-paste hardening; changeable per set later)
-                    </Typography>
-                  </Box>
-                )}
-                {contentTypes.includes("video") && (
-                  <Typography sx={{ mt: 1.25, fontSize: "0.78rem", color: "text.secondary", display: "flex", gap: 0.5, alignItems: "center" }}>
-                    <Icon icon="mdi:information-outline" width={16} />
-                    We AI-match a transcribed Vimeo video per submodule from your catalog (review &amp; swap after). Sync the catalog first if it&apos;s empty.
-                  </Typography>
-                )}
-              </Box>
+                    parseError={parseError}
+                    onParseError={setParseError}
+                    hint={hint}
+                    onHintChange={setHint}
+                    analyzing={analyzing}
+                    onAnalyze={() => void handleAnalyze()}
+                    hasPlan={!!plan}
+                  />
+                  {plan && (
+                    <EditableCsvPlanPreview plan={plan} onChange={setPlan} contentTypes={contentTypes} />
+                  )}
+                </>
+              )}
 
-              <Box>
-                <Typography sx={{ fontWeight: 800, fontSize: "0.85rem", mb: 1 }}>
-                  Difficulty tiers (quizzes span these)
-                </Typography>
-                <Box sx={{ display: "flex", gap: 1 }}>
-                  {ALL_DIFFICULTIES.map((d) => {
-                    const active = difficulties.includes(d);
-                    return (
-                      <ButtonBase
-                        key={d}
-                        onClick={() => toggleDifficulty(d)}
-                        sx={{
-                          px: 2,
-                          py: 0.85,
-                          borderRadius: 999,
-                          fontWeight: 800,
-                          fontSize: "0.82rem",
-                          color: active ? "white" : "text.primary",
-                          background: active
-                            ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
-                            : "color-mix(in srgb, var(--card-bg) 60%, transparent)",
-                          border: active
-                            ? "1px solid transparent"
-                            : "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
-                        }}
-                      >
-                        {d}
-                      </ButtonBase>
-                    );
-                  })}
-                </Box>
-              </Box>
-
-              <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-                <TextField
-                  label="Min questions / quiz"
-                  type="number"
-                  value={minQuestions}
-                  onChange={(e) => setMinQuestions(clamp(Number(e.target.value), 1, 50))}
-                  sx={{ width: 200 }}
-                />
-                <TextField
-                  label="Max questions / quiz"
-                  type="number"
-                  value={maxQuestions}
-                  onChange={(e) => setMaxQuestions(clamp(Number(e.target.value), 1, 100))}
-                  sx={{ width: 200 }}
-                />
-              </Box>
-
-              <FormControlLabel
-                control={<Switch checked={confidence} onChange={(e) => setConfidence(e.target.checked)} />}
-                label="Confidence capture (Guess / Unsure / Sure / Certain under each question)"
+              <SharedGenerationConfig
+                contentTypes={contentTypes}
+                onToggleContentType={toggleContentType}
+                difficulties={difficulties}
+                onToggleDifficulty={toggleDifficulty}
+                questionsPerCell={questionsPerCell}
+                onQuestionsPerCellChange={setQuestionsPerCell}
+                minQuestions={minQuestions}
+                onMinQuestionsChange={setMinQuestions}
+                maxQuestions={maxQuestions}
+                onMaxQuestionsChange={setMaxQuestions}
+                confidence={confidence}
+                onConfidenceChange={setConfidence}
+                codingClipboard={codingClipboard}
+                onCodingClipboardChange={setCodingClipboard}
               />
 
-              <ButtonBase
-                onClick={() => void handleSubmit()}
-                disabled={!canSubmit || submitting}
-                sx={{
-                  alignSelf: "flex-start",
-                  px: 3.5,
-                  py: 1.4,
-                  borderRadius: 999,
-                  fontWeight: 800,
-                  color: "white",
-                  gap: 0.75,
-                  opacity: !canSubmit || submitting ? 0.5 : 1,
-                  background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
-                  boxShadow: "0 18px 36px -16px rgba(168, 85, 247, 0.55)",
-                }}
-              >
-                <Icon icon={submitting ? "mdi:loading" : "mdi:auto-fix"} width={18} className={submitting ? "spin" : ""} />
-                {submitting ? "Starting…" : "Generate adaptive course"}
-              </ButtonBase>
+              {showGenerate && (
+                <ButtonBase
+                  onClick={() => void handleSubmit()}
+                  disabled={!canSubmit || submitting}
+                  sx={{
+                    alignSelf: "flex-start",
+                    px: 3.5,
+                    py: 1.4,
+                    borderRadius: 999,
+                    fontWeight: 800,
+                    color: "white",
+                    gap: 0.75,
+                    opacity: !canSubmit || submitting ? 0.5 : 1,
+                    background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
+                    boxShadow: "0 18px 36px -16px rgba(168, 85, 247, 0.55)",
+                  }}
+                >
+                  <Icon icon={submitting ? "mdi:loading" : "mdi:auto-fix"} width={18} className={submitting ? "spin" : ""} />
+                  {submitting ? "Starting…" : "Generate adaptive course"}
+                </ButtonBase>
+              )}
+              {mode === "csv" && plan && !planReady && (
+                <Typography sx={{ fontSize: "0.78rem", color: "#b45309", display: "flex", gap: 0.5, alignItems: "center", mt: -1 }}>
+                  <Icon icon="mdi:alert-outline" width={15} />
+                  Every week and topic needs a title before you can generate.
+                </Typography>
+              )}
             </Box>
 
             {/* Live preview */}
@@ -321,21 +327,31 @@ export default function GenerateAdaptiveCoursePage() {
                 top: 16,
               }}
             >
-              <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
-                <Icon icon="mdi:sparkles" width={20} />
-                <Typography sx={{ fontWeight: 800 }}>{"What you'll get"}</Typography>
-              </Box>
-              <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 1.5 }}>
-                <PreviewStat value={`~${preview.modules}`} label="Modules" />
-                <PreviewStat value={`~${preview.submodules}`} label="Submodules" />
-                {preview.hasQuiz && <PreviewStat value={`~${preview.quizzes}`} label="Adaptive quizzes" />}
-                {preview.hasQuiz && <PreviewStat value={`~${preview.bankItems}`} label="Calibrated quiz items" />}
-                {preview.hasCoding && <PreviewStat value={`~${preview.codingProblems}`} label="Coding problems" />}
-              </Box>
-              <Typography sx={{ mt: 2.5, fontSize: "0.82rem", opacity: 0.92, lineHeight: 1.5 }}>
-                Every submodule ships a branching IRT quiz that picks each next question by
-                performance. Estimates update as you change the form.
-              </Typography>
+              {showEstimate ? (
+                <>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+                    <Icon icon="mdi:sparkles" width={20} />
+                    <Typography sx={{ fontWeight: 800 }}>{"What you'll get"}</Typography>
+                  </Box>
+                  <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 1.5 }}>
+                    <PreviewStat value={`~${preview.modules}`} label="Modules" />
+                    <PreviewStat value={`~${preview.submodules}`} label="Submodules" />
+                    {preview.hasQuiz && <PreviewStat value={`~${preview.quizzes}`} label="Adaptive quizzes" />}
+                    {preview.hasQuiz && <PreviewStat value={`~${preview.bankItems}`} label="Calibrated quiz items" />}
+                    {preview.hasCoding && (
+                      <PreviewStat value={`~${preview.codingProblems}`} label="Coding problems" />
+                    )}
+                  </Box>
+                  <Typography sx={{ mt: 2.5, fontSize: "0.82rem", opacity: 0.92, lineHeight: 1.5 }}>
+                    Every submodule ships a branching IRT quiz that picks each next question by performance.
+                    {mode === "csv"
+                      ? " Estimates reflect your edited plan."
+                      : " Estimates update as you change the form."}
+                  </Typography>
+                </>
+              ) : (
+                <CsvHowItWorks />
+              )}
             </Box>
           </Box>
         </AdaptiveSectionShell>
@@ -353,7 +369,44 @@ function PreviewStat({ value, label }: { value: string; label: string }) {
   );
 }
 
-function clamp(n: number, min: number, max: number): number {
-  if (Number.isNaN(n)) return min;
-  return Math.min(max, Math.max(min, n));
+function CsvHowItWorks() {
+  const steps: Array<{ icon: string; text: string }> = [
+    { icon: "mdi:tray-arrow-up", text: "Upload a curriculum CSV — any column names work." },
+    { icon: "mdi:sparkles", text: "AI maps your columns into weeks, topics, and skills." },
+    { icon: "mdi:pencil-outline", text: "Review and edit the plan — rename, delete, or add rows." },
+    { icon: "mdi:auto-fix", text: "Generate — an adaptive quiz, article & more per topic." },
+  ];
+  return (
+    <>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+        <Icon icon="mdi:file-delimited-outline" width={20} />
+        <Typography sx={{ fontWeight: 800 }}>How CSV upload works</Typography>
+      </Box>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        {steps.map((s, i) => (
+          <Box key={i} sx={{ display: "flex", gap: 1.25, alignItems: "flex-start" }}>
+            <Box
+              sx={{
+                flexShrink: 0,
+                width: 28,
+                height: 28,
+                borderRadius: 2,
+                display: "grid",
+                placeItems: "center",
+                bgcolor: "rgba(255,255,255,0.18)",
+                fontWeight: 900,
+                fontSize: "0.8rem",
+              }}
+            >
+              {i + 1}
+            </Box>
+            <Box sx={{ display: "flex", gap: 0.75, alignItems: "center" }}>
+              <Icon icon={s.icon} width={18} />
+              <Typography sx={{ fontSize: "0.85rem", opacity: 0.95, lineHeight: 1.4 }}>{s.text}</Typography>
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
 }

--- a/components/adaptive-quiz/generate/CsvAnalyzingProgress.tsx
+++ b/components/adaptive-quiz/generate/CsvAnalyzingProgress.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, LinearProgress, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+
+// The AI mapping is a single (multi-second) call we can't get sub-progress from,
+// so we narrate the work in stages. The stages advance on a timer and the last
+// one stays active until the response lands — so the wait reads as "working",
+// never frozen.
+const STAGES: Array<{ icon: string; label: string }> = [
+  { icon: "mdi:file-table-outline", label: "Reading your rows" },
+  { icon: "mdi:table-column", label: "Identifying week, topic & description columns" },
+  { icon: "mdi:calendar-week-begin", label: "Grouping topics into weekly modules" },
+  { icon: "mdi:lightbulb-on-outline", label: "Deriving the skills each topic teaches" },
+  { icon: "mdi:check-decagram-outline", label: "Finalizing your course plan" },
+];
+
+const STEP_MS = 2200;
+
+export function CsvAnalyzingProgress({
+  rowCount,
+  columnCount,
+}: {
+  rowCount: number;
+  columnCount: number;
+}) {
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      // Hold on the final stage — it completes only when the plan arrives (unmount).
+      setActive((i) => Math.min(i + 1, STAGES.length - 1));
+    }, STEP_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <Box
+      sx={{
+        borderRadius: 4,
+        p: 2.5,
+        bgcolor: "color-mix(in srgb, #6366f1 7%, var(--card-bg))",
+        border: "1px solid color-mix(in srgb, #6366f1 30%, transparent)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+        <Icon icon="mdi:sparkles" width={20} style={{ color: "#a855f7" }} />
+        <Typography sx={{ fontWeight: 800 }}>Analyzing with AI…</Typography>
+      </Box>
+      <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mb: 1.5 }}>
+        Reading {rowCount} {rowCount === 1 ? "row" : "rows"} across {columnCount}{" "}
+        {columnCount === 1 ? "column" : "columns"} — this usually takes a few seconds.
+      </Typography>
+
+      <LinearProgress
+        sx={{
+          height: 6,
+          borderRadius: 999,
+          mb: 2,
+          bgcolor: "color-mix(in srgb, #6366f1 18%, transparent)",
+          "& .MuiLinearProgress-bar": {
+            background: "linear-gradient(90deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
+          },
+        }}
+      />
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        {STAGES.map((stage, i) => {
+          const done = i < active;
+          const current = i === active;
+          return (
+            <Box key={stage.label} sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Box sx={{ width: 20, height: 20, display: "grid", placeItems: "center", flexShrink: 0 }}>
+                {done ? (
+                  <Icon icon="mdi:check-circle" width={18} style={{ color: "#10b981" }} />
+                ) : current ? (
+                  <Box
+                    sx={{
+                      display: "inline-flex",
+                      animation: "csv-analyze-spin 0.9s linear infinite",
+                      "@keyframes csv-analyze-spin": { to: { transform: "rotate(360deg)" } },
+                    }}
+                  >
+                    <Icon icon="mdi:loading" width={18} style={{ color: "#6366f1" }} />
+                  </Box>
+                ) : (
+                  <Icon icon={stage.icon} width={16} style={{ color: "var(--border-default)" }} />
+                )}
+              </Box>
+              <Typography
+                sx={{
+                  fontSize: "0.84rem",
+                  fontWeight: done || current ? 700 : 500,
+                  color: done ? "text.secondary" : current ? "text.primary" : "text.disabled",
+                  transition: "color 200ms ease",
+                }}
+              >
+                {stage.label}
+              </Typography>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/components/adaptive-quiz/generate/CsvUploadPanel.tsx
+++ b/components/adaptive-quiz/generate/CsvUploadPanel.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Box, ButtonBase, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { CsvAnalyzingProgress } from "./CsvAnalyzingProgress";
+import { CSV_ROW_CAP, type ParsedCsv } from "./types";
+
+/**
+ * The "Upload CSV" creation path. Parses the file in the browser (header mode) so
+ * the admin gets instant "detected N columns, M rows" feedback, then hands the
+ * rows to the AI mapper via the page's onAnalyze. Column names can be anything —
+ * the AI figures out which is week / topic / description.
+ */
+export function CsvUploadPanel({
+  csvTitle,
+  onCsvTitleChange,
+  parsed,
+  onParsed,
+  parseError,
+  onParseError,
+  hint,
+  onHintChange,
+  analyzing,
+  onAnalyze,
+  hasPlan,
+}: {
+  csvTitle: string;
+  onCsvTitleChange: (v: string) => void;
+  parsed: ParsedCsv | null;
+  onParsed: (p: ParsedCsv | null) => void;
+  parseError: string | null;
+  onParseError: (v: string | null) => void;
+  hint: string;
+  onHintChange: (v: string) => void;
+  analyzing: boolean;
+  onAnalyze: () => void;
+  hasPlan: boolean;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  async function handleFile(file: File | undefined) {
+    if (!file) return;
+    onParseError(null);
+    if (!/\.csv$/i.test(file.name) && file.type && !file.type.includes("csv")) {
+      onParseError("That doesn't look like a CSV. Export your sheet as .csv and try again.");
+      onParsed(null);
+      return;
+    }
+    try {
+      const text = await file.text();
+      const { default: Papa } = await import("papaparse");
+      const result = Papa.parse<Record<string, string>>(text, {
+        header: true,
+        skipEmptyLines: true,
+      });
+      const fields = (result.meta.fields || []).map((f) => (f || "").trim()).filter(Boolean);
+      const allRows = (result.data || []).filter(
+        (r) => r && typeof r === "object" && Object.values(r).some((v) => String(v ?? "").trim()),
+      );
+      if (!fields.length || !allRows.length) {
+        onParseError("Couldn't find a header row and data in that file. Make sure row 1 has column names.");
+        onParsed(null);
+        return;
+      }
+      const rows = allRows.slice(0, CSV_ROW_CAP);
+      const firstErr = result.errors?.[0];
+      onParsed({
+        fileName: file.name,
+        columns: fields,
+        rows,
+        totalRows: allRows.length,
+        truncated: allRows.length > CSV_ROW_CAP,
+        parseWarning: firstErr ? `Row ${firstErr.row ?? "?"}: ${firstErr.message}` : null,
+      });
+      // Seed the course title from the filename if the admin hasn't typed one.
+      if (!csvTitle.trim()) {
+        onCsvTitleChange(file.name.replace(/\.csv$/i, "").replace(/[_-]+/g, " ").trim());
+      }
+    } catch {
+      onParseError("Couldn't read that file. Try re-exporting it as a UTF-8 CSV.");
+      onParsed(null);
+    }
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <TextField
+        label="Course title"
+        required
+        value={csvTitle}
+        onChange={(e) => onCsvTitleChange(e.target.value)}
+        fullWidth
+        placeholder="e.g. Backend Engineering Bootcamp"
+      />
+
+      {/* Dropzone */}
+      <Box>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".csv,text/csv"
+          hidden
+          onChange={(e) => {
+            void handleFile(e.target.files?.[0]);
+            e.target.value = ""; // allow re-selecting the same file
+          }}
+        />
+        <Box
+          onClick={() => inputRef.current?.click()}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragging(true);
+          }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDragging(false);
+            void handleFile(e.dataTransfer.files?.[0]);
+          }}
+          sx={{
+            cursor: "pointer",
+            borderRadius: 4,
+            p: 3,
+            textAlign: "center",
+            border: "1.5px dashed",
+            borderColor: dragging
+              ? "#6366f1"
+              : "color-mix(in srgb, var(--border-default) 90%, transparent)",
+            bgcolor: dragging
+              ? "color-mix(in srgb, #6366f1 8%, transparent)"
+              : "color-mix(in srgb, var(--card-bg) 55%, transparent)",
+            transition: "border-color 120ms ease, background 120ms ease",
+          }}
+        >
+          <Icon
+            icon={parsed ? "mdi:file-check-outline" : "mdi:tray-arrow-up"}
+            width={34}
+            style={{ color: "#a855f7" }}
+          />
+          {parsed ? (
+            <>
+              <Typography sx={{ fontWeight: 800, mt: 1 }}>{parsed.fileName}</Typography>
+              <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", mt: 0.25 }}>
+                Detected {parsed.columns.length} columns ·{" "}
+                {parsed.truncated ? `first ${parsed.rows.length} of ${parsed.totalRows}` : parsed.rows.length}{" "}
+                rows · click to replace
+              </Typography>
+            </>
+          ) : (
+            <>
+              <Typography sx={{ fontWeight: 800, mt: 1 }}>
+                Drop your curriculum CSV here, or click to browse
+              </Typography>
+              <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", mt: 0.25 }}>
+                Any columns work — a week/module column, a topic column, and a description help most.
+              </Typography>
+            </>
+          )}
+        </Box>
+
+        {parsed && (
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, mt: 1.25 }}>
+            {parsed.columns.map((c) => (
+              <Box
+                key={c}
+                component="span"
+                sx={{
+                  px: 1, py: 0.25, borderRadius: 999, fontSize: "0.72rem", fontWeight: 700,
+                  color: "text.secondary",
+                  bgcolor: "color-mix(in srgb, var(--card-bg) 70%, transparent)",
+                  border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+                }}
+              >
+                {c}
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        {parsed?.truncated && (
+          <Note icon="mdi:information-outline" color="#f59e0b">
+            Only the first {CSV_ROW_CAP} rows will be analyzed.
+          </Note>
+        )}
+        {parsed?.parseWarning && (
+          <Note icon="mdi:alert-outline" color="#f59e0b">
+            Parser note — {parsed.parseWarning}
+          </Note>
+        )}
+        {parseError && (
+          <Note icon="mdi:alert-circle-outline" color="#ef4444">
+            {parseError}
+          </Note>
+        )}
+      </Box>
+
+      <TextField
+        label="Anything the AI should know? (optional)"
+        value={hint}
+        onChange={(e) => onHintChange(e.target.value)}
+        fullWidth
+        multiline
+        minRows={2}
+        placeholder='e.g. "Treat the Module column as weeks" or "Ignore the Notes column"'
+      />
+
+      {analyzing ? (
+        <CsvAnalyzingProgress
+          rowCount={parsed?.rows.length ?? 0}
+          columnCount={parsed?.columns.length ?? 0}
+        />
+      ) : (
+        <ButtonBase
+          onClick={onAnalyze}
+          disabled={!parsed}
+          sx={{
+            alignSelf: "flex-start",
+            px: 3,
+            py: 1.2,
+            borderRadius: 999,
+            fontWeight: 800,
+            gap: 0.75,
+            color: "white",
+            opacity: !parsed ? 0.5 : 1,
+            background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
+            boxShadow: "0 16px 32px -16px rgba(168, 85, 247, 0.55)",
+          }}
+        >
+          <Icon icon="mdi:sparkles" width={18} />
+          {hasPlan ? "Re-analyze" : "Analyze with AI"}
+        </ButtonBase>
+      )}
+    </Box>
+  );
+}
+
+function Note({ icon, color, children }: { icon: string; color: string; children: React.ReactNode }) {
+  return (
+    <Typography
+      sx={{ mt: 1, fontSize: "0.78rem", color, display: "flex", gap: 0.5, alignItems: "center", fontWeight: 600 }}
+    >
+      <Icon icon={icon} width={16} />
+      {children}
+    </Typography>
+  );
+}

--- a/components/adaptive-quiz/generate/DescribeModePanel.tsx
+++ b/components/adaptive-quiz/generate/DescribeModePanel.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Box, TextField } from "@mui/material";
+
+/**
+ * The "Describe" creation path: a title, a free-text description the engine plans
+ * the whole course from, and the duration that seeds the module count. The IRT /
+ * content knobs live in the shared config below, so this panel stays minimal.
+ */
+export function DescribeModePanel({
+  title,
+  onTitleChange,
+  description,
+  onDescriptionChange,
+  durationWeeks,
+  onDurationWeeksChange,
+}: {
+  title: string;
+  onTitleChange: (v: string) => void;
+  description: string;
+  onDescriptionChange: (v: string) => void;
+  durationWeeks: number;
+  onDurationWeeksChange: (v: number) => void;
+}) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      <TextField
+        label="Course title"
+        required
+        value={title}
+        onChange={(e) => onTitleChange(e.target.value)}
+        fullWidth
+      />
+      <TextField
+        label="Course description"
+        required
+        value={description}
+        onChange={(e) => onDescriptionChange(e.target.value)}
+        fullWidth
+        multiline
+        minRows={4}
+        helperText="Tip: paste a week-wise plan and the engine will follow your structure."
+      />
+      <TextField
+        label="Duration (weeks)"
+        type="number"
+        value={durationWeeks}
+        onChange={(e) => onDurationWeeksChange(clamp(Number(e.target.value), 1, 52))}
+        sx={{ width: 160 }}
+      />
+    </Box>
+  );
+}
+
+function clamp(n: number, min: number, max: number): number {
+  if (Number.isNaN(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}

--- a/components/adaptive-quiz/generate/EditableCsvPlanPreview.tsx
+++ b/components/adaptive-quiz/generate/EditableCsvPlanPreview.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { Box, ButtonBase, IconButton, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type {
+  CsvCoursePlan,
+  CsvPlanModule,
+  CsvPlanSubmodule,
+} from "@/lib/services/admin/admin-adaptive-course.service";
+import { makeRowUid, type ContentType } from "./types";
+
+const CONTENT_ICON: Record<ContentType, { icon: string; label: string }> = {
+  article: { icon: "mdi:book-open-variant", label: "Article" },
+  quiz: { icon: "mdi:tune-vertical", label: "Quiz" },
+  coding: { icon: "mdi:robot-happy-outline", label: "Coding" },
+  video: { icon: "mdi:play-circle-outline", label: "Video" },
+};
+
+const ROLE_LABEL: Record<string, string> = {
+  week: "Week",
+  topic: "Topic",
+  description: "Description",
+  key_concepts: "Skills",
+};
+
+/**
+ * Editable preview of an AI-parsed CSV plan. The admin vets exactly what will be
+ * built — weeks, topics, the skills each topic teaches, and which content each
+ * gets — and can rename, delete, or add modules/submodules before generating.
+ * Every edit emits the full updated plan upward so the live estimate stays in sync.
+ */
+export function EditableCsvPlanPreview({
+  plan,
+  onChange,
+  contentTypes,
+}: {
+  plan: CsvCoursePlan;
+  onChange: (plan: CsvCoursePlan) => void;
+  contentTypes: ContentType[];
+}) {
+  const setModules = (modules: CsvPlanModule[]) => onChange({ ...plan, modules });
+
+  const updateModule = (mi: number, patch: Partial<CsvPlanModule>) =>
+    setModules(plan.modules.map((m, i) => (i === mi ? { ...m, ...patch } : m)));
+
+  const deleteModule = (mi: number) =>
+    setModules(plan.modules.filter((_, i) => i !== mi).map((m, i) => ({ ...m, week: i + 1 })));
+
+  const addModule = () =>
+    setModules([
+      ...plan.modules,
+      {
+        week: plan.modules.length + 1,
+        title: `Week ${plan.modules.length + 1}`,
+        submodules: [{ title: "New topic", description: "", key_concepts: [], _uid: makeRowUid() }],
+        _uid: makeRowUid(),
+      },
+    ]);
+
+  const updateSub = (mi: number, si: number, patch: Partial<CsvPlanSubmodule>) =>
+    updateModule(mi, {
+      submodules: plan.modules[mi].submodules.map((s, i) => (i === si ? { ...s, ...patch } : s)),
+    });
+
+  const deleteSub = (mi: number, si: number) =>
+    updateModule(mi, { submodules: plan.modules[mi].submodules.filter((_, i) => i !== si) });
+
+  const addSub = (mi: number) =>
+    updateModule(mi, {
+      submodules: [
+        ...plan.modules[mi].submodules,
+        { title: "New topic", description: "", key_concepts: [], _uid: makeRowUid() },
+      ],
+    });
+
+  const totalTopics = plan.modules.reduce((n, m) => n + m.submodules.length, 0);
+  const mapping = Object.entries(plan.column_mapping || {}).filter(([, v]) => v);
+  const activeContent = contentTypes.filter((c) => CONTENT_ICON[c]);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>Review &amp; edit the course plan</Typography>
+        <Box component="span" sx={chipSx("#6366f1")}>
+          {plan.modules.length} {plan.modules.length === 1 ? "week" : "weeks"}
+        </Box>
+        <Box component="span" sx={chipSx("#a855f7")}>
+          {totalTopics} {totalTopics === 1 ? "topic" : "topics"}
+        </Box>
+      </Box>
+
+      {/* Column mapping */}
+      {mapping.length > 0 && (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, alignItems: "center" }}>
+          <Typography sx={{ fontSize: "0.76rem", color: "text.secondary", fontWeight: 700 }}>
+            AI column mapping:
+          </Typography>
+          {mapping.map(([role, col]) => (
+            <Box key={role} component="span" sx={chipSx("#10b981")}>
+              {ROLE_LABEL[role] ?? role} ← {col}
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {/* Warnings */}
+      {(plan.warnings || []).length > 0 && (
+        <Box
+          sx={{
+            borderRadius: 3,
+            p: 1.5,
+            bgcolor: "color-mix(in srgb, #f59e0b 10%, transparent)",
+            border: "1px solid color-mix(in srgb, #f59e0b 35%, transparent)",
+          }}
+        >
+          {plan.warnings.map((w, i) => (
+            <Typography
+              key={i}
+              sx={{ fontSize: "0.78rem", color: "#b45309", display: "flex", gap: 0.5, alignItems: "flex-start" }}
+            >
+              <Icon icon="mdi:alert-outline" width={15} style={{ marginTop: 2, flexShrink: 0 }} />
+              {w}
+            </Typography>
+          ))}
+        </Box>
+      )}
+
+      {/* Modules */}
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        {plan.modules.map((mod, mi) => (
+          <Box
+            key={mod._uid ?? mi}
+            sx={{
+              borderRadius: 4,
+              p: 2,
+              bgcolor: "color-mix(in srgb, var(--card-bg) 70%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Box
+                component="span"
+                sx={{
+                  flexShrink: 0, px: 1, py: 0.4, borderRadius: 2, fontSize: "0.7rem", fontWeight: 900,
+                  color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
+                }}
+              >
+                W{mod.week}
+              </Box>
+              <TextField
+                variant="standard"
+                value={mod.title}
+                onChange={(e) => updateModule(mi, { title: e.target.value })}
+                fullWidth
+                InputProps={{ disableUnderline: true, sx: { fontWeight: 800, fontSize: "0.95rem" } }}
+              />
+              <IconButton
+                size="small"
+                aria-label="Delete week"
+                onClick={() => deleteModule(mi)}
+                sx={{ color: "#ef4444" }}
+              >
+                <Icon icon="mdi:trash-can-outline" width={18} />
+              </IconButton>
+            </Box>
+
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mt: 1 }}>
+              {mod.submodules.map((sub, si) => (
+                <Box
+                  key={sub._uid ?? si}
+                  sx={{
+                    borderRadius: 3,
+                    p: 1.25,
+                    bgcolor: "color-mix(in srgb, var(--card-bg) 55%, transparent)",
+                    border: "1px solid color-mix(in srgb, var(--border-default) 60%, transparent)",
+                  }}
+                >
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                    <Icon icon="mdi:circle-small" width={20} style={{ color: "#a855f7", flexShrink: 0 }} />
+                    <TextField
+                      variant="standard"
+                      value={sub.title}
+                      onChange={(e) => updateSub(mi, si, { title: e.target.value })}
+                      fullWidth
+                      placeholder="Topic title"
+                      InputProps={{ disableUnderline: true, sx: { fontWeight: 700, fontSize: "0.86rem" } }}
+                    />
+                    <IconButton
+                      size="small"
+                      aria-label="Delete topic"
+                      onClick={() => deleteSub(mi, si)}
+                      sx={{ color: "#ef4444", flexShrink: 0 }}
+                    >
+                      <Icon icon="mdi:close" width={16} />
+                    </IconButton>
+                  </Box>
+                  <TextField
+                    variant="standard"
+                    value={sub.description}
+                    onChange={(e) => updateSub(mi, si, { description: e.target.value })}
+                    fullWidth
+                    placeholder="Short description (optional)"
+                    multiline
+                    InputProps={{
+                      disableUnderline: true,
+                      sx: { fontSize: "0.78rem", color: "text.secondary", pl: 2.5 },
+                    }}
+                  />
+                  {(sub.key_concepts || []).length > 0 && (
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.5, pl: 2.5 }}>
+                      {sub.key_concepts.map((c, ci) => (
+                        <Box key={ci} component="span" sx={chipSx("#6366f1", true)}>
+                          {c}
+                        </Box>
+                      ))}
+                    </Box>
+                  )}
+                  {activeContent.length > 0 && (
+                    <Box sx={{ display: "flex", gap: 1, mt: 0.75, pl: 2.5, flexWrap: "wrap" }}>
+                      {activeContent.map((c) => (
+                        <Box
+                          key={c}
+                          sx={{ display: "inline-flex", alignItems: "center", gap: 0.3, color: "text.disabled" }}
+                        >
+                          <Icon icon={CONTENT_ICON[c].icon} width={13} />
+                          <Typography component="span" sx={{ fontSize: "0.68rem", fontWeight: 700 }}>
+                            {CONTENT_ICON[c].label}
+                          </Typography>
+                        </Box>
+                      ))}
+                    </Box>
+                  )}
+                </Box>
+              ))}
+              <ButtonBase
+                onClick={() => addSub(mi)}
+                sx={{
+                  alignSelf: "flex-start", gap: 0.4, fontSize: "0.78rem", fontWeight: 700, color: "#6366f1",
+                  px: 1, py: 0.5, borderRadius: 2,
+                }}
+              >
+                <Icon icon="mdi:plus" width={16} /> Add topic
+              </ButtonBase>
+            </Box>
+          </Box>
+        ))}
+      </Box>
+
+      <ButtonBase
+        onClick={addModule}
+        sx={{
+          alignSelf: "flex-start", gap: 0.5, fontSize: "0.82rem", fontWeight: 800, color: "#6366f1",
+          px: 1.5, py: 0.75, borderRadius: 999,
+          border: "1px dashed color-mix(in srgb, #6366f1 45%, transparent)",
+        }}
+      >
+        <Icon icon="mdi:plus" width={17} /> Add week
+      </ButtonBase>
+    </Box>
+  );
+}
+
+function chipSx(color: string, soft = false) {
+  return {
+    px: 1,
+    py: 0.25,
+    borderRadius: 999,
+    fontSize: soft ? "0.7rem" : "0.74rem",
+    fontWeight: 700,
+    color,
+    bgcolor: `color-mix(in srgb, ${color} ${soft ? 12 : 14}%, transparent)`,
+    border: `1px solid color-mix(in srgb, ${color} 30%, transparent)`,
+    whiteSpace: "nowrap" as const,
+  };
+}

--- a/components/adaptive-quiz/generate/GenerateModeToggle.tsx
+++ b/components/adaptive-quiz/generate/GenerateModeToggle.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Box, ButtonBase } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { GenerateMode } from "./types";
+
+const TABS: Array<{ key: GenerateMode; label: string; icon: string }> = [
+  { key: "describe", label: "Describe", icon: "mdi:text-box-edit-outline" },
+  { key: "csv", label: "Upload CSV", icon: "mdi:file-delimited-outline" },
+];
+
+/**
+ * Segmented control that switches the Generate page between describing a course
+ * in prose and uploading a curriculum CSV. The shared generation config below it
+ * is untouched by the switch, so settings carry across modes.
+ */
+export function GenerateModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: GenerateMode;
+  onChange: (mode: GenerateMode) => void;
+}) {
+  return (
+    <Box
+      role="tablist"
+      aria-label="Course creation method"
+      sx={{
+        display: "inline-flex",
+        gap: 0.5,
+        p: 0.5,
+        borderRadius: 999,
+        bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+        alignSelf: "flex-start",
+      }}
+    >
+      {TABS.map((tab) => {
+        const active = mode === tab.key;
+        return (
+          <ButtonBase
+            key={tab.key}
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(tab.key)}
+            sx={{
+              px: 2.25,
+              py: 0.9,
+              borderRadius: 999,
+              fontWeight: 800,
+              fontSize: "0.85rem",
+              gap: 0.6,
+              color: active ? "white" : "text.secondary",
+              background: active
+                ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
+                : "transparent",
+              transition: "color 120ms ease, background 120ms ease",
+            }}
+          >
+            <Icon icon={tab.icon} width={17} />
+            {tab.label}
+          </ButtonBase>
+        );
+      })}
+    </Box>
+  );
+}

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { Box, ButtonBase, Collapse, FormControlLabel, Switch, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { ALL_CONTENT_TYPES, ALL_DIFFICULTIES, type ContentType, type Difficulty } from "./types";
+
+const CONTENT_META: Record<ContentType, { label: string; icon: string }> = {
+  article: { label: "Adaptive Article", icon: "mdi:book-open-variant" },
+  quiz: { label: "Adaptive Quiz", icon: "mdi:tune-vertical" },
+  coding: { label: "AI Coding Mentor", icon: "mdi:robot-happy-outline" },
+  video: { label: "Video Companion", icon: "mdi:play-circle-outline" },
+};
+
+/**
+ * Generation settings shared by both creation modes (describe + CSV): which
+ * content types to build per submodule, the difficulty span, questions per skill
+ * cell, and an Advanced drawer (collapsed by default) for the IRT length bounds,
+ * confidence capture, the coding copy-paste toggle, and the Vimeo match note.
+ * Lives below the mode panels so switching modes never resets these.
+ */
+export function SharedGenerationConfig({
+  contentTypes,
+  onToggleContentType,
+  difficulties,
+  onToggleDifficulty,
+  questionsPerCell,
+  onQuestionsPerCellChange,
+  minQuestions,
+  onMinQuestionsChange,
+  maxQuestions,
+  onMaxQuestionsChange,
+  confidence,
+  onConfidenceChange,
+  codingClipboard,
+  onCodingClipboardChange,
+}: {
+  contentTypes: ContentType[];
+  onToggleContentType: (t: ContentType) => void;
+  difficulties: Difficulty[];
+  onToggleDifficulty: (d: Difficulty) => void;
+  questionsPerCell: number;
+  onQuestionsPerCellChange: (v: number) => void;
+  minQuestions: number;
+  onMinQuestionsChange: (v: number) => void;
+  maxQuestions: number;
+  onMaxQuestionsChange: (v: number) => void;
+  confidence: boolean;
+  onConfidenceChange: (v: boolean) => void;
+  codingClipboard: boolean;
+  onCodingClipboardChange: (v: boolean) => void;
+}) {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const hasCoding = contentTypes.includes("coding");
+  const hasVideo = contentTypes.includes("video");
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+      {/* Content types */}
+      <Box>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.85rem", mb: 1 }}>
+          Content types (per submodule)
+        </Typography>
+        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+          {ALL_CONTENT_TYPES.map((key) => (
+            <Pill
+              key={key}
+              active={contentTypes.includes(key)}
+              onClick={() => onToggleContentType(key)}
+              icon={CONTENT_META[key].icon}
+            >
+              {CONTENT_META[key].label}
+            </Pill>
+          ))}
+        </Box>
+      </Box>
+
+      {/* Difficulty tiers */}
+      <Box>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.85rem", mb: 1 }}>
+          Difficulty tiers (quizzes span these)
+        </Typography>
+        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+          {ALL_DIFFICULTIES.map((d) => (
+            <Pill key={d} active={difficulties.includes(d)} onClick={() => onToggleDifficulty(d)}>
+              {d}
+            </Pill>
+          ))}
+        </Box>
+      </Box>
+
+      <TextField
+        label="Questions per skill cell"
+        type="number"
+        value={questionsPerCell}
+        onChange={(e) => onQuestionsPerCellChange(clamp(Number(e.target.value), 1, 10))}
+        sx={{ width: 220 }}
+      />
+
+      {/* Advanced options */}
+      <Box>
+        <ButtonBase
+          onClick={() => setAdvancedOpen((v) => !v)}
+          sx={{ gap: 0.5, fontWeight: 800, fontSize: "0.85rem", color: "text.primary", py: 0.5 }}
+        >
+          <Icon icon={advancedOpen ? "mdi:chevron-down" : "mdi:chevron-right"} width={20} />
+          Advanced options
+        </ButtonBase>
+        <Collapse in={advancedOpen} unmountOnExit>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+              mt: 1.5,
+              pl: 1.5,
+              borderLeft: "2px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+            }}
+          >
+            <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+              <TextField
+                label="Min questions / quiz"
+                type="number"
+                value={minQuestions}
+                onChange={(e) => onMinQuestionsChange(clamp(Number(e.target.value), 1, 50))}
+                sx={{ width: 200 }}
+              />
+              <TextField
+                label="Max questions / quiz"
+                type="number"
+                value={maxQuestions}
+                onChange={(e) => onMaxQuestionsChange(clamp(Number(e.target.value), 1, 100))}
+                sx={{ width: 200 }}
+              />
+            </Box>
+
+            <FormControlLabel
+              control={<Switch checked={confidence} onChange={(e) => onConfidenceChange(e.target.checked)} />}
+              label="Confidence capture (Guess / Unsure / Sure / Certain under each question)"
+            />
+
+            {hasCoding && (
+              <Box
+                component="button"
+                onClick={() => onCodingClipboardChange(!codingClipboard)}
+                sx={{
+                  all: "unset", cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 0.75,
+                  fontSize: "0.82rem", fontWeight: 700, color: "text.secondary",
+                }}
+              >
+                <Icon
+                  icon={codingClipboard ? "mdi:checkbox-marked" : "mdi:checkbox-blank-outline"}
+                  width={18}
+                  style={{ color: codingClipboard ? "#6366f1" : undefined }}
+                />
+                Allow copy-paste in the coding editor
+                <Typography component="span" sx={{ fontSize: "0.74rem", color: "text.disabled" }}>
+                  (off = anti-paste hardening; changeable per set later)
+                </Typography>
+              </Box>
+            )}
+
+            {hasVideo && (
+              <Typography
+                sx={{ fontSize: "0.78rem", color: "text.secondary", display: "flex", gap: 0.5, alignItems: "center" }}
+              >
+                <Icon icon="mdi:information-outline" width={16} />
+                We AI-match a transcribed Vimeo video per submodule from your catalog (review &amp; swap after). Sync
+                the catalog first if it&apos;s empty.
+              </Typography>
+            )}
+          </Box>
+        </Collapse>
+      </Box>
+    </Box>
+  );
+}
+
+function Pill({
+  active,
+  onClick,
+  icon,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <ButtonBase
+      onClick={onClick}
+      sx={{
+        px: 2, py: 0.85, borderRadius: 999, fontWeight: 800, fontSize: "0.82rem", gap: 0.5,
+        color: active ? "white" : "text.primary",
+        background: active
+          ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
+          : "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+        border: active
+          ? "1px solid transparent"
+          : "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+      }}
+    >
+      {icon && <Icon icon={icon} width={15} />}
+      {children}
+    </ButtonBase>
+  );
+}
+
+function clamp(n: number, min: number, max: number): number {
+  if (Number.isNaN(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}

--- a/components/adaptive-quiz/generate/types.ts
+++ b/components/adaptive-quiz/generate/types.ts
@@ -1,0 +1,54 @@
+// Shared types + constants for the Adaptive Course "Generate" surface. Kept in
+// one place so the page orchestrator and the mode panels never drift on the
+// canonical content-type / difficulty ordering.
+
+import type { CsvCoursePlan } from "@/lib/services/admin/admin-adaptive-course.service";
+
+export type Difficulty = "Easy" | "Medium" | "Hard";
+export type ContentType = "quiz" | "article" | "coding" | "video";
+
+export const ALL_DIFFICULTIES: Difficulty[] = ["Easy", "Medium", "Hard"];
+// Canonical generation order shared with the backend (quiz → article → coding → video).
+export const ALL_CONTENT_TYPES: ContentType[] = ["quiz", "article", "coding", "video"];
+
+export type GenerateMode = "describe" | "csv";
+
+/** Result of a client-side header-mode CSV parse, before AI analysis. */
+export interface ParsedCsv {
+  fileName: string;
+  columns: string[];
+  rows: Array<Record<string, string>>;
+  /** Total data rows in the file (before the client-side cap). */
+  totalRows: number;
+  /** True when more rows existed than we kept (rows is capped). */
+  truncated: boolean;
+  /** First non-fatal parser warning, if any. */
+  parseWarning: string | null;
+}
+
+/** Max rows sent to the backend — the AI re-caps, the serializer hard-caps too. */
+export const CSV_ROW_CAP = 500;
+
+// --- Stable row keys for the editable plan -----------------------------------
+// Modules/submodules have no server id at preview time, so we tag each row with a
+// monotonic client uid. This keeps React keys stable across delete/add (an index
+// key reuses the wrong DOM node on a mid-list delete → focus/cursor jumps). The
+// backend serializer ignores the extra `_uid` field, so it's safe to send.
+
+let _rowSeq = 0;
+export function makeRowUid(): string {
+  _rowSeq += 1;
+  return `row-${_rowSeq}`;
+}
+
+/** Tag every module/submodule in a freshly-parsed plan with a stable uid. */
+export function withRowUids(plan: CsvCoursePlan): CsvCoursePlan {
+  return {
+    ...plan,
+    modules: plan.modules.map((m) => ({
+      ...m,
+      _uid: m._uid ?? makeRowUid(),
+      submodules: m.submodules.map((s) => ({ ...s, _uid: s._uid ?? makeRowUid() })),
+    })),
+  };
+}

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -33,6 +33,51 @@ export interface GenerateAdaptiveCoursePayload {
   config?: AdaptiveCourseGenConfig;
 }
 
+/** One topic row in a CSV-derived plan → becomes an adaptive submodule. */
+export interface CsvPlanSubmodule {
+  title: string;
+  description: string;
+  /** Sub-skills the submodule teaches — drive quiz/article skill tags. */
+  key_concepts: string[];
+  /** Client-only stable React key (ignored by the backend serializer). */
+  _uid?: string;
+}
+
+/** One week/module in a CSV-derived plan. */
+export interface CsvPlanModule {
+  week: number;
+  title: string;
+  submodules: CsvPlanSubmodule[];
+  /** Client-only stable React key (ignored by the backend serializer). */
+  _uid?: string;
+}
+
+/** Result of AI-mapping an uploaded curriculum CSV (preview, no DB writes). */
+export interface CsvCoursePlan {
+  modules: CsvPlanModule[];
+  /** Which source column the AI mapped to each role (or null). Preview only. */
+  column_mapping: Record<string, string | null>;
+  warnings: string[];
+}
+
+export interface ParseCsvPayload {
+  title?: string;
+  /** Detected CSV headers. */
+  columns: string[];
+  /** Header→cell row objects from a client-side header-mode parse. */
+  rows: Array<Record<string, string>>;
+  /** Free-text guidance for the AI (e.g. "treat Module column as weeks"). */
+  hint?: string;
+}
+
+export interface GenerateFromPlanPayload {
+  title: string;
+  description?: string;
+  /** The (possibly admin-edited) module/submodule structure to build. */
+  modules: CsvPlanModule[];
+  config?: AdaptiveCourseGenConfig;
+}
+
 export type AdaptiveCourseJobStatus =
   | "pending"
   | "generating_outline"
@@ -241,6 +286,24 @@ export const adminAdaptiveCourseService = {
   async generateCourse(payload: GenerateAdaptiveCoursePayload): Promise<AdaptiveCourseJobDetail> {
     const { data } = await apiClient.post<AdaptiveCourseJobDetail>(
       `${BASE}/courses/generate/`,
+      payload,
+    );
+    return data;
+  },
+
+  /** AI-map an uploaded curriculum CSV into an editable course plan (no job). */
+  async parseCsv(payload: ParseCsvPayload): Promise<CsvCoursePlan> {
+    const { data } = await apiClient.post<CsvCoursePlan>(
+      `${BASE}/courses/parse-csv/`,
+      payload,
+    );
+    return data;
+  },
+
+  /** Build an adaptive course from an edited CSV plan — returns the started job. */
+  async generateFromPlan(payload: GenerateFromPlanPayload): Promise<AdaptiveCourseJobDetail> {
+    const { data } = await apiClient.post<AdaptiveCourseJobDetail>(
+      `${BASE}/courses/generate-from-plan/`,
       payload,
     );
     return data;


### PR DESCRIPTION
…reation

Part 1 — declutter the Describe form: drop Target audience, and move min/max questions, confidence capture, the coding copy-paste toggle and the Vimeo note into a collapsed Advanced options drawer (defaults unchanged).

Part 2 — new "Upload CSV" path via a [Describe | Upload CSV] toggle that shares the content-type / difficulty / advanced config:
- parse the CSV client-side (papaparse, header mode, 500-row cap)
- "Analyze with AI" maps arbitrary columns into an editable week->topic plan with per-topic skills, column-mapping chips and warnings
- rename / add / delete weeks & topics; stable row keys so editing never jumps the cursor; blank-title guard disables Generate with a hint
- live "What you'll get" estimate uses the exact parsed/edited counts
- a staged, real-time progress panel while analyzing so the wait never looks stuck

Adds components/adaptive-quiz/generate/* and the parseCsv / generateFromPlan service methods.