### PR TITLE
feat(live-sessions): Zoom templates/presets, inbox & virtual backgrounds

### DIFF
--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Container,
@@ -21,6 +21,12 @@ import { LiveSessionDetailDrawer } from "@/components/admin/live-sessions/LiveSe
 import { ZoomCredentialsDialog } from "@/components/admin/live-sessions/ZoomCredentialsDialog";
 import { ZoomSetupCard, ZoomSetupStatus } from "@/components/admin/live-sessions/ZoomSetupCard";
 import {
+  ImportedMeetingsInbox,
+  ImportedMeetingsInboxHandle,
+} from "@/components/admin/live-sessions/ImportedMeetingsInbox";
+import { MeetingPresetsDialog } from "@/components/admin/live-sessions/MeetingPresetsDialog";
+import { VirtualBackgroundsDialog } from "@/components/admin/live-sessions/VirtualBackgroundsDialog";
+import {
   SessionsPageHeader,
   SessionStatCard,
   SessionFilterChips,
@@ -32,9 +38,12 @@ const PAST = new Set(["ended", "expired"]);
 export default function AdminLiveSessionsPage() {
   const { t } = useTranslation("common");
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
+  const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
+  const [backgroundsDialogOpen, setBackgroundsDialogOpen] = useState(false);
   const [hasCheckedCredentials, setHasCheckedCredentials] = useState(false);
   const [webhookConfigured, setWebhookConfigured] = useState(false);
   const [filter, setFilter] = useState("all");
+  const inboxRef = useRef<ImportedMeetingsInboxHandle>(null);
   const [zoomStatus, setZoomStatus] = useState<ZoomSetupStatus>({
     loading: true,
     configured: false,
@@ -177,18 +186,42 @@ export default function AdminLiveSessionsPage() {
           title={t("adminLiveSessions.title")}
           subtitle={t("adminLiveSessions.subtitle")}
           actions={
-            <Button
-              variant="contained"
-              startIcon={<IconWrapper icon="mdi:plus" size={20} />}
-              onClick={() => setCreateDialogOpen(true)}
-              sx={{ bgcolor: "var(--accent-indigo)", color: "var(--font-light)", "&:hover": { bgcolor: "var(--accent-indigo-dark)" } }}
-            >
-              {t("adminLiveSessions.createLiveSession")}
-            </Button>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", justifyContent: "flex-end" }}>
+              <Button
+                variant="outlined"
+                startIcon={<IconWrapper icon="mdi:tune-variant" size={18} />}
+                onClick={() => setPresetsDialogOpen(true)}
+                sx={{ color: "var(--font-secondary)", borderColor: "var(--border-default)" }}
+              >
+                {t("adminLiveSessions.presets", "Presets")}
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<IconWrapper icon="mdi:image-outline" size={18} />}
+                onClick={() => setBackgroundsDialogOpen(true)}
+                sx={{ color: "var(--font-secondary)", borderColor: "var(--border-default)" }}
+              >
+                {t("adminLiveSessions.backgrounds", "Backgrounds")}
+              </Button>
+              <Button
+                variant="contained"
+                startIcon={<IconWrapper icon="mdi:plus" size={20} />}
+                onClick={() => setCreateDialogOpen(true)}
+                sx={{ bgcolor: "var(--accent-indigo)", color: "var(--font-light)", "&:hover": { bgcolor: "var(--accent-indigo-dark)" } }}
+              >
+                {t("adminLiveSessions.createLiveSession")}
+              </Button>
+            </Box>
           }
         />
 
         <ZoomSetupCard status={zoomStatus} onConfigure={() => setCredentialsDialogOpen(true)} />
+
+        <ImportedMeetingsInbox
+          ref={inboxRef}
+          formatDateTime={formatDateTime}
+          onAssigned={loadSessions}
+        />
 
         {sessions.length === 0 ? (
           <AdminLiveSessionsEmptyState onCreate={() => setCreateDialogOpen(true)} />
@@ -257,6 +290,16 @@ export default function AdminLiveSessionsPage() {
             setCredentialsDialogOpen(false);
             refreshZoomStatus(false);
           }}
+        />
+
+        <MeetingPresetsDialog
+          open={presetsDialogOpen}
+          onClose={() => setPresetsDialogOpen(false)}
+        />
+
+        <VirtualBackgroundsDialog
+          open={backgroundsDialogOpen}
+          onClose={() => setBackgroundsDialogOpen(false)}
         />
       </Container>
     </MainLayout>

--- a/components/admin/live-sessions/AssignMeetingDialog.tsx
+++ b/components/admin/live-sessions/AssignMeetingDialog.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Box,
+  Typography,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  IconButton,
+  CircularProgress,
+  MenuItem,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminLiveActivitiesService,
+  LiveActivity,
+} from "@/lib/services/admin/admin-live-activities.service";
+import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
+import { getZoomApiErrorMessage } from "@/lib/utils/live-session-errors";
+
+interface AssignMeetingDialogProps {
+  meeting: LiveActivity | null;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/** Assign an imported (unassigned) Zoom meeting to a course/instructor. */
+export function AssignMeetingDialog({
+  meeting,
+  open,
+  onClose,
+  onSuccess,
+}: AssignMeetingDialogProps) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [topicName, setTopicName] = useState("");
+  const [instructor, setInstructor] = useState("");
+  const [courseId, setCourseId] = useState<number | null>(null);
+  const [courses, setCourses] = useState<{ id: number; title: string }[]>([]);
+  const [loadingCourses, setLoadingCourses] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open || !meeting) return;
+    setTopicName(meeting.topic_name ?? "");
+    setInstructor(
+      typeof meeting.instructor === "string" ? meeting.instructor : ""
+    );
+    setCourseId(meeting.course ?? null);
+  }, [open, meeting]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setLoadingCourses(true);
+    adminCoursesService
+      .getCourses({ limit: 1000 })
+      .then((data: unknown) => {
+        if (cancelled) return;
+        const list = Array.isArray(data)
+          ? data
+          : (data as { results?: unknown[] })?.results ?? [];
+        setCourses(
+          list
+            .filter(
+              (c: unknown) =>
+                c && typeof c === "object" && "id" in c && "title" in c
+            )
+            .map((c: unknown) => ({
+              id: (c as { id: number }).id,
+              title: (c as { title: string }).title,
+            }))
+        );
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoadingCourses(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const handleAssign = async () => {
+    if (!meeting) return;
+    try {
+      setSaving(true);
+      const result = await adminLiveActivitiesService.assignMeeting(meeting.id, {
+        course_id: courseId,
+        instructor: instructor.trim(),
+        topic_name: topicName.trim() || undefined,
+      });
+      if (result.status === "error") {
+        showToast(getZoomApiErrorMessage(result.message), "error");
+        return;
+      }
+      showToast(
+        t("adminLiveSessions.meetingAssigned", "Meeting assigned"),
+        "success"
+      );
+      onSuccess();
+      onClose();
+    } catch (error: unknown) {
+      showToast(getZoomApiErrorMessage(String(error)), "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {t("adminLiveSessions.assignMeetingTitle", "Assign imported meeting")}
+          </Typography>
+          <IconButton onClick={onClose} size="small">
+            <IconWrapper icon="mdi:close" size={20} />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+            {t(
+              "adminLiveSessions.assignMeetingHint",
+              "This Zoom meeting was created directly in Zoom. Assign it to a course so enrolled students see it and get notified."
+            )}
+          </Typography>
+          <TextField
+            label={t("adminLiveSessions.topicName")}
+            value={topicName}
+            onChange={(e) => setTopicName(e.target.value)}
+            fullWidth
+            size="small"
+          />
+          <TextField
+            select
+            label={t("adminLiveSessions.courseOptional")}
+            value={courseId ?? ""}
+            onChange={(e) =>
+              setCourseId(e.target.value === "" ? null : Number(e.target.value))
+            }
+            fullWidth
+            size="small"
+            disabled={loadingCourses}
+          >
+            <MenuItem value="">{t("adminLiveSessions.none")}</MenuItem>
+            {courses.map((c) => (
+              <MenuItem key={c.id} value={c.id}>
+                {c.title}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label={t("adminLiveSessions.instructorOptional", "Instructor (optional)")}
+            value={instructor}
+            onChange={(e) => setInstructor(e.target.value)}
+            fullWidth
+            size="small"
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose}>{t("adminLiveSessions.cancel")}</Button>
+        <Button
+          variant="contained"
+          onClick={handleAssign}
+          disabled={saving}
+          sx={{
+            bgcolor: "var(--accent-indigo)",
+            color: "var(--font-light)",
+            "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+          }}
+        >
+          {saving ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            t("adminLiveSessions.assign", "Assign")
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/live-sessions/CreateLiveSessionDialog.tsx
+++ b/components/admin/live-sessions/CreateLiveSessionDialog.tsx
@@ -18,7 +18,11 @@ import {
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { liveClassService, LiveClassSession } from "@/lib/services/live-class.service";
-import { adminLiveActivitiesService } from "@/lib/services/admin/admin-live-activities.service";
+import {
+  adminLiveActivitiesService,
+  MeetingPreset,
+  MeetingTemplate,
+} from "@/lib/services/admin/admin-live-activities.service";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
 import {
   getLiveSessionErrorMessage,
@@ -69,6 +73,11 @@ export function CreateLiveSessionDialog({
   const [courseId, setCourseId] = useState<number | null>(null);
   const [courses, setCourses] = useState<{ id: number; title: string }[]>([]);
   const [loadingCourses, setLoadingCourses] = useState(false);
+  // Optional Zoom preset / native template applied when creating the meeting.
+  const [presets, setPresets] = useState<MeetingPreset[]>([]);
+  const [templates, setTemplates] = useState<MeetingTemplate[]>([]);
+  const [selectedPresetId, setSelectedPresetId] = useState<number | "">("");
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
 
   useEffect(() => {
     if (!open) return;
@@ -92,6 +101,27 @@ export function CreateLiveSessionDialog({
     return () => { cancelled = true; };
   }, [open]);
 
+  // Load presets + native templates once the session exists and we're on the Zoom step.
+  useEffect(() => {
+    if (step !== "create-zoom") return;
+    let cancelled = false;
+    Promise.allSettled([
+      adminLiveActivitiesService.listPresets(),
+      adminLiveActivitiesService.getMeetingTemplates(),
+    ]).then(([presetRes, templateRes]) => {
+      if (cancelled) return;
+      if (presetRes.status === "fulfilled") {
+        setPresets(presetRes.value);
+        const def = presetRes.value.find((p) => p.is_default);
+        if (def) setSelectedPresetId(def.id);
+      }
+      if (templateRes.status === "fulfilled") setTemplates(templateRes.value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [step]);
+
   const getValidInstructorId = (): number | undefined => {
     const trimmed = instructorId.trim();
     if (!trimmed) return undefined;
@@ -114,6 +144,10 @@ export function CreateLiveSessionDialog({
     setMeetLink("");
     setInstructorId("");
     setCourseId(null);
+    setPresets([]);
+    setTemplates([]);
+    setSelectedPresetId("");
+    setSelectedTemplateId("");
   };
 
   const handleCreateSession = async () => {
@@ -221,7 +255,11 @@ export function CreateLiveSessionDialog({
     try {
       setCreatingZoom(true);
       const result = await adminLiveActivitiesService.createZoom(
-        createdSession.id
+        createdSession.id,
+        {
+          preset_id: selectedPresetId === "" ? undefined : selectedPresetId,
+          template_id: selectedTemplateId || undefined,
+        }
       );
       if (result.status === "error") {
         const msg = (result.message || "").toLowerCase();
@@ -504,6 +542,49 @@ export function CreateLiveSessionDialog({
                 {t("adminLiveSessions.createZoomHint", "Creating the meeting emails the join link to all enrolled students and turns on automatic attendance, recording and transcript sync.")}
               </InfoCallout>
             </Box>
+            {(presets.length > 0 || templates.length > 0) && (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mb: 2 }}>
+                {presets.length > 0 && (
+                  <TextField
+                    select
+                    label={t("adminLiveSessions.meetingPreset", "Settings preset (optional)")}
+                    value={selectedPresetId}
+                    onChange={(e) =>
+                      setSelectedPresetId(e.target.value === "" ? "" : Number(e.target.value))
+                    }
+                    fullWidth
+                    size="small"
+                    helperText={t("adminLiveSessions.meetingPresetHelper", "Reusable Zoom settings applied to this meeting.")}
+                  >
+                    <MenuItem value="">{t("adminLiveSessions.none")}</MenuItem>
+                    {presets.map((p) => (
+                      <MenuItem key={p.id} value={p.id}>
+                        {p.name}
+                        {p.is_default ? ` (${t("adminLiveSessions.default", "default")})` : ""}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                )}
+                {templates.length > 0 && (
+                  <TextField
+                    select
+                    label={t("adminLiveSessions.meetingTemplate", "Zoom template (optional)")}
+                    value={selectedTemplateId}
+                    onChange={(e) => setSelectedTemplateId(e.target.value)}
+                    fullWidth
+                    size="small"
+                    helperText={t("adminLiveSessions.meetingTemplateHelper", "Apply settings from a saved Zoom meeting template.")}
+                  >
+                    <MenuItem value="">{t("adminLiveSessions.none")}</MenuItem>
+                    {templates.map((tpl) => (
+                      <MenuItem key={tpl.id} value={tpl.id}>
+                        {tpl.name}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              </Box>
+            )}
             <Button
               variant="contained"
               onClick={handleCreateZoom}

--- a/components/admin/live-sessions/ImportedMeetingsInbox.tsx
+++ b/components/admin/live-sessions/ImportedMeetingsInbox.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState, useEffect, useCallback, useImperativeHandle, forwardRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Box, Typography, Button, Chip, Divider } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  adminLiveActivitiesService,
+  LiveActivity,
+} from "@/lib/services/admin/admin-live-activities.service";
+import { AssignMeetingDialog } from "./AssignMeetingDialog";
+
+export interface ImportedMeetingsInboxHandle {
+  refresh: () => void;
+}
+
+interface ImportedMeetingsInboxProps {
+  /** Called after a meeting is assigned, so the parent can refresh the main list. */
+  onAssigned?: () => void;
+  formatDateTime: (dateString: string) => string;
+}
+
+/**
+ * Inbox of meetings created directly in Zoom (imported via webhook/backfill) that
+ * are not yet assigned to a course. Renders nothing when the inbox is empty.
+ */
+export const ImportedMeetingsInbox = forwardRef<
+  ImportedMeetingsInboxHandle,
+  ImportedMeetingsInboxProps
+>(function ImportedMeetingsInbox({ onAssigned, formatDateTime }, ref) {
+  const { t } = useTranslation("common");
+  const [meetings, setMeetings] = useState<LiveActivity[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<LiveActivity | null>(null);
+  const [assignOpen, setAssignOpen] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    adminLiveActivitiesService
+      .getUnassigned()
+      .then((data) => setMeetings(Array.isArray(data) ? data : []))
+      .catch(() => setMeetings([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useImperativeHandle(ref, () => ({ refresh: load }), [load]);
+
+  if (!loading && meetings.length === 0) return null;
+
+  return (
+    <Box
+      sx={{
+        mb: 3,
+        p: 2,
+        borderRadius: 2,
+        border: "1px solid var(--border-default)",
+        bgcolor: "color-mix(in srgb, var(--accent-indigo) 5%, var(--surface) 95%)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}>
+        <IconWrapper icon="mdi:inbox-arrow-down" size={20} />
+        <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+          {t("adminLiveSessions.importedInboxTitle", "Imported from Zoom")}
+        </Typography>
+        <Chip size="small" label={meetings.length} sx={{ ml: 0.5 }} />
+      </Box>
+      <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 1.5 }}>
+        {t(
+          "adminLiveSessions.importedInboxHint",
+          "These meetings were created directly in Zoom. Assign each one to a course so students see it."
+        )}
+      </Typography>
+
+      <Box sx={{ display: "flex", flexDirection: "column" }}>
+        {meetings.map((m, idx) => (
+          <Box key={m.id}>
+            {idx > 0 && <Divider />}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 2,
+                py: 1.25,
+                flexWrap: "wrap",
+              }}
+            >
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant="body2"
+                  sx={{ fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
+                >
+                  {m.topic_name}
+                  {m.zoom_meeting_type === "webinar" && (
+                    <Chip size="small" label={t("adminLiveSessions.webinar", "Webinar")} sx={{ ml: 1 }} />
+                  )}
+                </Typography>
+                <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                  {m.class_datetime ? formatDateTime(m.class_datetime) : "—"}
+                  {typeof m.duration_minutes === "number" ? ` · ${m.duration_minutes} min` : ""}
+                </Typography>
+              </Box>
+              <Box sx={{ display: "flex", gap: 1 }}>
+                {m.zoom_join_url && (
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => window.open(m.zoom_join_url!, "_blank")}
+                    startIcon={<IconWrapper icon="mdi:link-variant" size={16} />}
+                  >
+                    {t("adminLiveSessions.joinLink", "Join link")}
+                  </Button>
+                )}
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={() => {
+                    setSelected(m);
+                    setAssignOpen(true);
+                  }}
+                  sx={{
+                    bgcolor: "var(--accent-indigo)",
+                    color: "var(--font-light)",
+                    "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+                  }}
+                >
+                  {t("adminLiveSessions.assign", "Assign")}
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+        ))}
+      </Box>
+
+      <AssignMeetingDialog
+        meeting={selected}
+        open={assignOpen}
+        onClose={() => setAssignOpen(false)}
+        onSuccess={() => {
+          load();
+          onAssigned?.();
+        }}
+      />
+    </Box>
+  );
+});

--- a/components/admin/live-sessions/MeetingPresetsDialog.tsx
+++ b/components/admin/live-sessions/MeetingPresetsDialog.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Box,
+  Typography,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  IconButton,
+  CircularProgress,
+  MenuItem,
+  List,
+  ListItem,
+  ListItemText,
+  FormControlLabel,
+  Checkbox,
+  Divider,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminLiveActivitiesService,
+  MeetingPreset,
+  MeetingTemplate,
+} from "@/lib/services/admin/admin-live-activities.service";
+import { getZoomApiErrorMessage } from "@/lib/utils/live-session-errors";
+import { InfoCallout } from "@/components/live-sessions/ui/LiveSessionUI";
+
+interface MeetingPresetsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SETTINGS_PLACEHOLDER = `{
+  "waiting_room": true,
+  "mute_upon_entry": true,
+  "join_before_host": false
+}`;
+
+/** Manage reusable Zoom meeting-setting presets for this client. */
+export function MeetingPresetsDialog({ open, onClose }: MeetingPresetsDialogProps) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [presets, setPresets] = useState<MeetingPreset[]>([]);
+  const [templates, setTemplates] = useState<MeetingTemplate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+
+  // New-preset form
+  const [name, setName] = useState("");
+  const [templateId, setTemplateId] = useState("");
+  const [isDefault, setIsDefault] = useState(false);
+  const [settingsJson, setSettingsJson] = useState("");
+  const [jsonError, setJsonError] = useState(false);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    Promise.allSettled([
+      adminLiveActivitiesService.listPresets(),
+      adminLiveActivitiesService.getMeetingTemplates(),
+    ])
+      .then(([p, tpl]) => {
+        if (p.status === "fulfilled") setPresets(p.value);
+        if (tpl.status === "fulfilled") setTemplates(tpl.value);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (open) load();
+  }, [open, load]);
+
+  const resetForm = () => {
+    setName("");
+    setTemplateId("");
+    setIsDefault(false);
+    setSettingsJson("");
+    setJsonError(false);
+  };
+
+  const handleCreate = async () => {
+    if (!name.trim()) {
+      showToast(t("adminLiveSessions.presetNameRequired", "Preset name is required"), "error");
+      return;
+    }
+    let settings: Record<string, unknown> = {};
+    if (settingsJson.trim()) {
+      try {
+        settings = JSON.parse(settingsJson);
+        setJsonError(false);
+      } catch {
+        setJsonError(true);
+        showToast(t("adminLiveSessions.invalidJson", "Settings must be valid JSON"), "error");
+        return;
+      }
+    }
+    try {
+      setSaving(true);
+      await adminLiveActivitiesService.createPreset({
+        name: name.trim(),
+        settings,
+        template_id: templateId || undefined,
+        is_default: isDefault,
+      });
+      showToast(t("adminLiveSessions.presetCreated", "Preset created"), "success");
+      resetForm();
+      load();
+    } catch (e: unknown) {
+      showToast(getZoomApiErrorMessage(String(e)), "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      setDeletingId(id);
+      await adminLiveActivitiesService.deletePreset(id);
+      showToast(t("adminLiveSessions.presetDeleted", "Preset deleted"), "success");
+      load();
+    } catch (e: unknown) {
+      showToast(getZoomApiErrorMessage(String(e)), "error");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {t("adminLiveSessions.presetsTitle", "Meeting presets")}
+          </Typography>
+          <IconButton onClick={onClose} size="small">
+            <IconWrapper icon="mdi:close" size={20} />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ mb: 2 }}>
+          <InfoCallout icon="mdi:information-outline">
+            {t(
+              "adminLiveSessions.presetsHint",
+              "Presets are reusable Zoom settings you can apply when creating a meeting. Cloud recording stays on regardless, so attendance and transcripts keep working."
+            )}
+          </InfoCallout>
+        </Box>
+
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+            <CircularProgress />
+          </Box>
+        ) : presets.length === 0 ? (
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)", py: 1 }}>
+            {t("adminLiveSessions.noPresets", "No presets yet.")}
+          </Typography>
+        ) : (
+          <List dense>
+            {presets.map((p) => (
+              <ListItem
+                key={p.id}
+                secondaryAction={
+                  <IconButton
+                    edge="end"
+                    onClick={() => handleDelete(p.id)}
+                    disabled={deletingId === p.id}
+                    aria-label="delete"
+                  >
+                    {deletingId === p.id ? (
+                      <CircularProgress size={18} />
+                    ) : (
+                      <IconWrapper icon="mdi:delete-outline" size={20} />
+                    )}
+                  </IconButton>
+                }
+              >
+                <ListItemText
+                  primary={`${p.name}${p.is_default ? ` (${t("adminLiveSessions.default", "default")})` : ""}`}
+                  secondary={
+                    p.template_id
+                      ? `${t("adminLiveSessions.meetingTemplate", "Zoom template")}: ${p.template_id}`
+                      : undefined
+                  }
+                />
+              </ListItem>
+            ))}
+          </List>
+        )}
+
+        <Divider sx={{ my: 2 }} />
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1.5 }}>
+          {t("adminLiveSessions.newPreset", "New preset")}
+        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <TextField
+            label={t("adminLiveSessions.presetName", "Preset name")}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            size="small"
+            required
+          />
+          {templates.length > 0 && (
+            <TextField
+              select
+              label={t("adminLiveSessions.meetingTemplate", "Zoom template (optional)")}
+              value={templateId}
+              onChange={(e) => setTemplateId(e.target.value)}
+              fullWidth
+              size="small"
+            >
+              <MenuItem value="">{t("adminLiveSessions.none")}</MenuItem>
+              {templates.map((tpl) => (
+                <MenuItem key={tpl.id} value={tpl.id}>
+                  {tpl.name}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+          <TextField
+            label={t("adminLiveSessions.presetSettingsJson", "Settings (JSON, optional)")}
+            value={settingsJson}
+            onChange={(e) => {
+              setSettingsJson(e.target.value);
+              if (jsonError) setJsonError(false);
+            }}
+            placeholder={SETTINGS_PLACEHOLDER}
+            multiline
+            rows={5}
+            fullWidth
+            size="small"
+            error={jsonError}
+            helperText={
+              jsonError
+                ? t("adminLiveSessions.invalidJson", "Settings must be valid JSON")
+                : t("adminLiveSessions.presetSettingsHelper", "Raw Zoom meeting settings object.")
+            }
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isDefault}
+                onChange={(e) => setIsDefault(e.target.checked)}
+              />
+            }
+            label={t("adminLiveSessions.makeDefaultPreset", "Pre-select this preset by default")}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose}>{t("adminLiveSessions.close", "Close")}</Button>
+        <Button
+          variant="contained"
+          onClick={handleCreate}
+          disabled={saving || !name.trim()}
+          sx={{
+            bgcolor: "var(--accent-indigo)",
+            color: "var(--font-light)",
+            "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+          }}
+        >
+          {saving ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            t("adminLiveSessions.createPreset", "Create preset")
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/live-sessions/VirtualBackgroundsDialog.tsx
+++ b/components/admin/live-sessions/VirtualBackgroundsDialog.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Box,
+  Typography,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  CircularProgress,
+  List,
+  ListItem,
+  ListItemText,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminLiveActivitiesService,
+  VirtualBackground,
+} from "@/lib/services/admin/admin-live-activities.service";
+import { getZoomApiErrorMessage } from "@/lib/utils/live-session-errors";
+import { InfoCallout } from "@/components/live-sessions/ui/LiveSessionUI";
+
+interface VirtualBackgroundsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/** Manage account-level Zoom virtual backgrounds (applies account-wide, not per-meeting). */
+export function VirtualBackgroundsDialog({
+  open,
+  onClose,
+}: VirtualBackgroundsDialogProps) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [backgrounds, setBackgrounds] = useState<VirtualBackground[]>([]);
+  const [note, setNote] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    adminLiveActivitiesService
+      .listVirtualBackgrounds()
+      .then((data) => {
+        setBackgrounds(data.virtual_backgrounds ?? []);
+        setNote(data.note ?? "");
+      })
+      .catch((e) => showToast(getZoomApiErrorMessage(String(e)), "error"))
+      .finally(() => setLoading(false));
+  }, [showToast]);
+
+  useEffect(() => {
+    if (open) load();
+  }, [open, load]);
+
+  const handleUpload = async (file: File) => {
+    try {
+      setUploading(true);
+      const result = await adminLiveActivitiesService.uploadVirtualBackground(file);
+      if (result.status === "error") {
+        showToast(getZoomApiErrorMessage(result.message), "error");
+        return;
+      }
+      showToast(t("adminLiveSessions.backgroundUploaded", "Background uploaded"), "success");
+      load();
+    } catch (e: unknown) {
+      showToast(getZoomApiErrorMessage(String(e)), "error");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      setDeletingId(id);
+      await adminLiveActivitiesService.deleteVirtualBackground(id);
+      showToast(t("adminLiveSessions.backgroundDeleted", "Background deleted"), "success");
+      load();
+    } catch (e: unknown) {
+      showToast(getZoomApiErrorMessage(String(e)), "error");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {t("adminLiveSessions.virtualBackgroundsTitle", "Virtual backgrounds")}
+          </Typography>
+          <IconButton onClick={onClose} size="small">
+            <IconWrapper icon="mdi:close" size={20} />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ mb: 2 }}>
+          <InfoCallout icon="mdi:information-outline">
+            {note ||
+              t(
+                "adminLiveSessions.virtualBackgroundsNote",
+                "Virtual backgrounds are managed at the Zoom account level and apply account-wide; Zoom provides no per-meeting virtual background API."
+              )}
+          </InfoCallout>
+        </Box>
+
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : backgrounds.length === 0 ? (
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)", py: 2 }}>
+            {t("adminLiveSessions.noBackgrounds", "No virtual backgrounds uploaded yet.")}
+          </Typography>
+        ) : (
+          <List dense>
+            {backgrounds.map((bg) => (
+              <ListItem
+                key={bg.id}
+                secondaryAction={
+                  <IconButton
+                    edge="end"
+                    onClick={() => handleDelete(bg.id)}
+                    disabled={deletingId === bg.id}
+                    aria-label="delete"
+                  >
+                    {deletingId === bg.id ? (
+                      <CircularProgress size={18} />
+                    ) : (
+                      <IconWrapper icon="mdi:delete-outline" size={20} />
+                    )}
+                  </IconButton>
+                }
+              >
+                <ListItemText
+                  primary={bg.name || bg.id}
+                  secondary={bg.type}
+                />
+              </ListItem>
+            ))}
+          </List>
+        )}
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handleUpload(f);
+            e.target.value = "";
+          }}
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose}>{t("adminLiveSessions.close", "Close")}</Button>
+        <Button
+          variant="contained"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          startIcon={
+            uploading ? (
+              <CircularProgress size={18} color="inherit" />
+            ) : (
+              <IconWrapper icon="mdi:upload" size={18} />
+            )
+          }
+          sx={{
+            bgcolor: "var(--accent-indigo)",
+            color: "var(--font-light)",
+            "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+          }}
+        >
+          {t("adminLiveSessions.uploadBackground", "Upload image")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -34,6 +34,9 @@ export interface LiveActivity {
   is_google_meet?: boolean;
   zoom_meeting_type?: "meeting" | "webinar" | null;
   closes_at?: string | null;
+  zoom_source?: "platform" | "imported" | null;
+  is_unassigned?: boolean;
+  zoom_host_id?: string | null;
   zoom_meeting_id?: string | null;
   zoom_meeting_uuid?: string | null;
   zoom_start_url?: string | null;
@@ -148,6 +151,51 @@ export interface SyncAttendanceResponse {
   data: SyncAttendanceData | null;
 }
 
+/** Native Zoom meeting template (GET zoom/templates/). */
+export interface MeetingTemplate {
+  id: string;
+  name: string;
+  type?: number;
+}
+
+/** Platform-side reusable meeting-setting preset (zoom/presets/ CRUD). */
+export interface MeetingPreset {
+  id: number;
+  name: string;
+  settings: Record<string, unknown>;
+  template_id: string;
+  is_default: boolean;
+  created_at?: string;
+}
+
+export interface MeetingPresetInput {
+  name: string;
+  settings?: Record<string, unknown>;
+  template_id?: string;
+  is_default?: boolean;
+}
+
+/** Account-level virtual background file (zoom/virtual-backgrounds/). */
+export interface VirtualBackground {
+  id: string;
+  name?: string;
+  type?: string;
+  is_default?: boolean;
+}
+
+/** Optional preset/template to apply when creating the Zoom meeting. */
+export interface CreateZoomOptions {
+  preset_id?: number;
+  template_id?: string;
+}
+
+/** Payload to assign an imported (unassigned) meeting to a course/instructor. */
+export interface AssignMeetingInput {
+  course_id?: number | null;
+  instructor?: string;
+  topic_name?: string;
+}
+
 export const adminLiveActivitiesService = {
   getLiveActivities: async (): Promise<LiveActivity[]> => {
     const response = await apiClient.get<LiveActivity[]>(
@@ -166,10 +214,12 @@ export const adminLiveActivitiesService = {
   },
 
   createZoom: async (
-    liveClassId: number
+    liveClassId: number,
+    options?: CreateZoomOptions
   ): Promise<ZoomApiResponse<ZoomCreateSuccessData>> => {
     const response = await apiClient.post<ZoomApiResponse<ZoomCreateSuccessData>>(
-      `${BASE}/live-activities/${liveClassId}/zoom/create/`
+      `${BASE}/live-activities/${liveClassId}/zoom/create/`,
+      options ?? {}
     );
     return response.data;
   },
@@ -233,6 +283,97 @@ export const adminLiveActivitiesService = {
   ): Promise<LiveSessionTranscriptResponse> => {
     const response = await apiClient.get<LiveSessionTranscriptResponse>(
       `${BASE}/live-activities/${liveClassId}/zoom/transcript/`
+    );
+    return response.data;
+  },
+
+  // ── Native Zoom meeting templates ──────────────────────────────────────────
+  getMeetingTemplates: async (): Promise<MeetingTemplate[]> => {
+    const response = await apiClient.get<
+      ZoomApiResponse<{ templates: MeetingTemplate[] }>
+    >(`${BASE}/zoom/templates/`);
+    return response.data.data?.templates ?? [];
+  },
+
+  // ── Platform-side meeting presets ──────────────────────────────────────────
+  listPresets: async (): Promise<MeetingPreset[]> => {
+    const response = await apiClient.get<
+      ZoomApiResponse<{ presets: MeetingPreset[] }>
+    >(`${BASE}/zoom/presets/`);
+    return response.data.data?.presets ?? [];
+  },
+
+  createPreset: async (input: MeetingPresetInput): Promise<MeetingPreset> => {
+    const response = await apiClient.post<ZoomApiResponse<MeetingPreset>>(
+      `${BASE}/zoom/presets/`,
+      input
+    );
+    return response.data.data as MeetingPreset;
+  },
+
+  updatePreset: async (
+    presetId: number,
+    input: Partial<MeetingPresetInput>
+  ): Promise<MeetingPreset> => {
+    const response = await apiClient.put<ZoomApiResponse<MeetingPreset>>(
+      `${BASE}/zoom/presets/${presetId}/`,
+      input
+    );
+    return response.data.data as MeetingPreset;
+  },
+
+  deletePreset: async (presetId: number): Promise<void> => {
+    await apiClient.delete(`${BASE}/zoom/presets/${presetId}/`);
+  },
+
+  // ── Account-level virtual backgrounds (applies account-wide) ───────────────
+  listVirtualBackgrounds: async (): Promise<{
+    virtual_backgrounds: VirtualBackground[];
+    note: string;
+  }> => {
+    const response = await apiClient.get<
+      ZoomApiResponse<{ virtual_backgrounds: VirtualBackground[]; note: string }>
+    >(`${BASE}/zoom/virtual-backgrounds/`);
+    return (
+      response.data.data ?? { virtual_backgrounds: [], note: "" }
+    );
+  },
+
+  uploadVirtualBackground: async (
+    file: File
+  ): Promise<ZoomApiResponse<{ file: VirtualBackground; note: string }>> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await apiClient.post<
+      ZoomApiResponse<{ file: VirtualBackground; note: string }>
+    >(`${BASE}/zoom/virtual-backgrounds/`, formData);
+    return response.data;
+  },
+
+  deleteVirtualBackground: async (
+    fileIds: string | string[]
+  ): Promise<void> => {
+    const ids = Array.isArray(fileIds) ? fileIds.join(",") : fileIds;
+    await apiClient.delete(`${BASE}/zoom/virtual-backgrounds/`, {
+      params: { file_ids: ids },
+    });
+  },
+
+  // ── Inbound sync: imported (unassigned) meetings inbox + assign ────────────
+  getUnassigned: async (): Promise<LiveActivity[]> => {
+    const response = await apiClient.get<LiveActivity[]>(
+      `${BASE}/live-activities/unassigned/`
+    );
+    return response.data;
+  },
+
+  assignMeeting: async (
+    liveClassId: number,
+    input: AssignMeetingInput
+  ): Promise<ZoomApiResponse<LiveActivity>> => {
+    const response = await apiClient.post<ZoomApiResponse<LiveActivity>>(
+      `${BASE}/live-activities/${liveClassId}/assign/`,
+      input
     );
     return response.data;
   },


### PR DESCRIPTION
Wire the admin live-sessions UI to the new backend Zoom endpoints:
- Create dialog: optional settings-preset + native Zoom-template pickers, passed to zoom/create/ (default preset pre-selected).
- Imported-meetings inbox: lists meetings created directly in Zoom (is_unassigned) with an Assign-to-course dialog; auto-refreshes the main list on assign.
- Presets manager (name + raw settings JSON + template + default) and account-level virtual-backgrounds manager (upload/delete, with the account-wide caveat surfaced in the UI).
- admin-live-activities.service: typed methods for templates, presets CRUD, virtual backgrounds, unassigned list, assign; createZoom takes an optional {preset_id, template_id} body; LiveActivity gains zoom_source/is_unassigned.