### PR TITLE
feat(live-sessions): delete a webinar + editable email settings

### DIFF
--- a/components/admin/live-sessions/LiveSessionDetailDrawer.tsx
+++ b/components/admin/live-sessions/LiveSessionDetailDrawer.tsx
@@ -69,6 +69,8 @@ export function LiveSessionDetailDrawer({
   const [syncingRecording, setSyncingRecording] = useState(false);
   const [playerOpen, setPlayerOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deletingWebinar, setDeletingWebinar] = useState(false);
   const [tab, setTab] = useState(0);
 
   useEffect(() => {
@@ -137,6 +139,29 @@ export function LiveSessionDetailDrawer({
       showToast(getLiveSessionErrorMessage(error), "error");
     } finally {
       setEndingMeeting(false);
+    }
+  };
+
+  const handleDeleteWebinar = async () => {
+    if (liveClassId == null) return;
+    setDeleteConfirmOpen(false);
+    try {
+      setDeletingWebinar(true);
+      const result = await adminLiveActivitiesService.deleteWebinar(liveClassId);
+      if (result.status === "error") {
+        showToast(
+          getZoomApiErrorMessage(result.message) ||
+            t("adminLiveSessions.deleteWebinarFailed", "Failed to delete webinar"),
+          "error"
+        );
+        return;
+      }
+      showToast(result.message || t("adminLiveSessions.webinarDeleted", "Webinar deleted"), "success");
+      await refreshDetail();
+    } catch (error: unknown) {
+      showToast(getLiveSessionErrorMessage(error), "error");
+    } finally {
+      setDeletingWebinar(false);
     }
   };
 
@@ -345,6 +370,19 @@ export function LiveSessionDetailDrawer({
                       {t("adminLiveSessions.editWebinar", "Edit webinar")}
                     </Button>
                   )}
+                  {isWebinar && scheduledOrLive && !isCancelled && (
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      color="error"
+                      startIcon={deletingWebinar ? <CircularProgress size={16} color="inherit" /> : <IconWrapper icon="mdi:trash-can-outline" size={16} />}
+                      onClick={() => setDeleteConfirmOpen(true)}
+                      disabled={deletingWebinar}
+                      sx={{ textTransform: "none", alignSelf: "flex-start" }}
+                    >
+                      {t("adminLiveSessions.deleteWebinar", "Delete webinar")}
+                    </Button>
+                  )}
                   {!scheduledOrLive && !activity.zoom_password && (
                     <Typography variant="body2" sx={{ color: "var(--font-tertiary)" }}>
                       {t("adminLiveSessions.sessionFinished", "This session has finished.")}
@@ -415,7 +453,7 @@ export function LiveSessionDetailDrawer({
 
           {/* Webinar management tabs */}
           {isWebinar && tab === 4 && <WebinarInvitationsSection liveClassId={activity.id} />}
-          {isWebinar && tab === 5 && <WebinarEmailSection liveClassId={activity.id} />}
+          {isWebinar && tab === 5 && <WebinarEmailSection liveClassId={activity.id} editable={scheduledOrLive && !isCancelled} />}
           {isWebinar && tab === 6 && <WebinarBrandingSection liveClassId={activity.id} />}
         </Box>
       ) : null}
@@ -429,6 +467,24 @@ export function LiveSessionDetailDrawer({
           <Button onClick={() => setEndMeetingConfirmOpen(false)}>{t("adminLiveSessions.cancel")}</Button>
           <Button onClick={handleEndMeetingConfirm} color="error" variant="contained" disabled={endingMeeting}>
             {t("adminLiveSessions.endMeeting")}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={deleteConfirmOpen} onClose={() => setDeleteConfirmOpen(false)}>
+        <DialogTitle>{t("adminLiveSessions.deleteWebinarConfirmTitle", "Delete this webinar?")}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {t(
+              "adminLiveSessions.deleteWebinarConfirmDesc",
+              "This deletes the webinar in Zoom and marks it cancelled here. Zoom notifies registrants. Any recording and attendance already synced are kept. This can't be undone."
+            )}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirmOpen(false)}>{t("adminLiveSessions.cancel")}</Button>
+          <Button onClick={handleDeleteWebinar} color="error" variant="contained" disabled={deletingWebinar}>
+            {t("adminLiveSessions.deleteWebinar", "Delete webinar")}
           </Button>
         </DialogActions>
       </Dialog>

--- a/components/admin/live-sessions/WebinarEmailSection.tsx
+++ b/components/admin/live-sessions/WebinarEmailSection.tsx
@@ -1,16 +1,29 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Box, Typography, CircularProgress } from "@mui/material";
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Button,
+  TextField,
+  Switch,
+  FormControlLabel,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
 import {
   adminLiveActivitiesService,
   WebinarDetail,
 } from "@/lib/services/admin/admin-live-activities.service";
+import { getZoomApiErrorMessage } from "@/lib/utils/live-session-errors";
 import { SectionCard, InfoCallout } from "@/components/live-sessions/ui/LiveSessionUI";
 
 interface Props {
   liveClassId: number;
+  /** Editing pushes changes to Zoom; only sensible for scheduled/upcoming webinars. */
+  editable?: boolean;
 }
 
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
@@ -22,14 +35,35 @@ function Row({ label, value }: { label: string; value: React.ReactNode }) {
   );
 }
 
-/** Email tab — read-only mirror of the contact/email settings the template applied. */
-export function WebinarEmailSection({ liveClassId }: Props) {
+/** Email tab — contact/email settings mirrored from Zoom, editable in place when allowed. */
+export function WebinarEmailSection({ liveClassId, editable = false }: Props) {
   const { t } = useTranslation("common");
+  const { showToast } = useToast();
   const [detail, setDetail] = useState<WebinarDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Editable field state (seeded from detail when entering edit mode).
+  const [contactName, setContactName] = useState("");
+  const [contactEmail, setContactEmail] = useState("");
+  const [confirmationEmail, setConfirmationEmail] = useState(false);
+  const [registrationEmail, setRegistrationEmail] = useState(false);
+  const [registrationRequired, setRegistrationRequired] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const d = await adminLiveActivitiesService.getWebinarDetail(liveClassId);
+      setDetail(d);
+    } finally {
+      setLoading(false);
+    }
+  }, [liveClassId]);
 
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
     adminLiveActivitiesService
       .getWebinarDetail(liveClassId)
       .then((d) => {
@@ -42,6 +76,56 @@ export function WebinarEmailSection({ liveClassId }: Props) {
       cancelled = true;
     };
   }, [liveClassId]);
+
+  const startEdit = () => {
+    if (!detail) return;
+    setContactName(detail.contact_name ?? "");
+    setContactEmail(detail.contact_email ?? "");
+    setConfirmationEmail(detail.registrants_confirmation_email === true);
+    setRegistrationEmail(detail.registrants_email_notification === true);
+    setRegistrationRequired(detail.approval_type !== 2);
+    setEditing(true);
+  };
+
+  const handleSave = async () => {
+    if (!detail) return;
+    const input: {
+      contact_name?: string;
+      contact_email?: string;
+      registrants_confirmation_email?: boolean;
+      registrants_email_notification?: boolean;
+      approval_type?: number;
+    } = {};
+    if (contactName !== (detail.contact_name ?? "")) input.contact_name = contactName;
+    if (contactEmail !== (detail.contact_email ?? "")) input.contact_email = contactEmail;
+    if (confirmationEmail !== (detail.registrants_confirmation_email === true))
+      input.registrants_confirmation_email = confirmationEmail;
+    if (registrationEmail !== (detail.registrants_email_notification === true))
+      input.registrants_email_notification = registrationEmail;
+    const desiredApproval = registrationRequired ? 0 : 2;
+    if ((detail.approval_type !== 2) !== registrationRequired) input.approval_type = desiredApproval;
+
+    if (Object.keys(input).length === 0) {
+      showToast(t("adminLiveSessions.noChanges", "No changes to save"), "info");
+      setEditing(false);
+      return;
+    }
+    try {
+      setSaving(true);
+      const res = await adminLiveActivitiesService.editWebinar(liveClassId, input);
+      if (res.status === "error") {
+        showToast(getZoomApiErrorMessage(res.message), "error");
+        return;
+      }
+      showToast(t("adminLiveSessions.emailSettingsSaved", "Email settings updated"), "success");
+      setEditing(false);
+      await load();
+    } catch (e: unknown) {
+      showToast(getZoomApiErrorMessage(String(e)), "error");
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -58,21 +142,80 @@ export function WebinarEmailSection({ liveClassId }: Props) {
     <SectionCard title={t("adminLiveSessions.emailSettings", "Email settings")} icon="mdi:email-fast-outline">
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
         <InfoCallout icon="mdi:information-outline">
-          {t(
-            "adminLiveSessions.emailMirrorNote",
-            "Contact and email settings are inherited from the webinar template. Edit them in Zoom."
-          )}
+          {editable
+            ? t("adminLiveSessions.emailEditableNote", "Contact and email settings come from the webinar template. Edits here are pushed to Zoom.")
+            : t("adminLiveSessions.emailMirrorNote", "Contact and email settings are inherited from the webinar template. Edit them in Zoom.")}
         </InfoCallout>
-        <Box>
-          <Row label={t("adminLiveSessions.contactName", "Contact name")} value={detail?.contact_name || "—"} />
-          <Row label={t("adminLiveSessions.contactEmail", "Contact email")} value={detail?.contact_email || "—"} />
-          <Row label={t("adminLiveSessions.confirmationEmail", "Confirmation email")} value={yesNo(detail?.registrants_confirmation_email)} />
-          <Row label={t("adminLiveSessions.registrationEmail", "Registration email")} value={yesNo(detail?.registrants_email_notification)} />
-          <Row
-            label={t("adminLiveSessions.registrationRequiredLabel", "Registration required")}
-            value={detail?.approval_type === 2 ? t("adminLiveSessions.no", "No") : t("adminLiveSessions.yes", "Yes")}
-          />
-        </Box>
+
+        {!editing ? (
+          <>
+            <Box>
+              <Row label={t("adminLiveSessions.contactName", "Contact name")} value={detail?.contact_name || "—"} />
+              <Row label={t("adminLiveSessions.contactEmail", "Contact email")} value={detail?.contact_email || "—"} />
+              <Row label={t("adminLiveSessions.confirmationEmail", "Confirmation email")} value={yesNo(detail?.registrants_confirmation_email)} />
+              <Row label={t("adminLiveSessions.registrationEmail", "Registration email")} value={yesNo(detail?.registrants_email_notification)} />
+              <Row
+                label={t("adminLiveSessions.registrationRequiredLabel", "Registration required")}
+                value={detail?.approval_type === 2 ? t("adminLiveSessions.no", "No") : t("adminLiveSessions.yes", "Yes")}
+              />
+            </Box>
+            {editable && (
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<IconWrapper icon="mdi:pencil-outline" size={16} />}
+                onClick={startEdit}
+                sx={{ textTransform: "none", alignSelf: "flex-start", mt: 1 }}
+              >
+                {t("adminLiveSessions.editEmailSettings", "Edit email settings")}
+              </Button>
+            )}
+          </>
+        ) : (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+            <TextField
+              label={t("adminLiveSessions.contactName", "Contact name")}
+              value={contactName}
+              onChange={(e) => setContactName(e.target.value)}
+              fullWidth
+              size="small"
+            />
+            <TextField
+              label={t("adminLiveSessions.contactEmail", "Contact email")}
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              fullWidth
+              size="small"
+            />
+            <FormControlLabel
+              control={<Switch checked={confirmationEmail} onChange={(e) => setConfirmationEmail(e.target.checked)} />}
+              label={t("adminLiveSessions.confirmationEmail", "Confirmation email")}
+            />
+            <FormControlLabel
+              control={<Switch checked={registrationEmail} onChange={(e) => setRegistrationEmail(e.target.checked)} />}
+              label={t("adminLiveSessions.registrationEmail", "Registration email")}
+            />
+            <FormControlLabel
+              control={<Switch checked={registrationRequired} onChange={(e) => setRegistrationRequired(e.target.checked)} />}
+              label={t("adminLiveSessions.registrationRequiredLabel", "Registration required")}
+            />
+            <Box sx={{ display: "flex", gap: 1 }}>
+              <Button
+                variant="contained"
+                size="small"
+                onClick={handleSave}
+                disabled={saving}
+                sx={{ bgcolor: "var(--accent-indigo)", color: "var(--font-light)", "&:hover": { bgcolor: "var(--accent-indigo-dark)" } }}
+              >
+                {saving ? <CircularProgress size={18} color="inherit" /> : t("adminLiveSessions.save", "Save")}
+              </Button>
+              <Button size="small" onClick={() => setEditing(false)} disabled={saving}>
+                {t("adminLiveSessions.cancel", "Cancel")}
+              </Button>
+            </Box>
+          </Box>
+        )}
       </Box>
     </SectionCard>
   );

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -268,6 +268,10 @@ export interface WebinarEditInput {
   passcode?: string;
   approval_type?: number;
   alternative_hosts?: string;
+  contact_name?: string;
+  contact_email?: string;
+  registrants_confirmation_email?: boolean;
+  registrants_email_notification?: boolean;
 }
 
 /** Payload to assign an imported (unassigned) meeting to a course/instructor. */
@@ -481,6 +485,15 @@ export const adminLiveActivitiesService = {
     const response = await apiClient.patch<ZoomApiResponse<LiveActivity>>(
       `${BASE}/live-activities/${liveClassId}/webinar/edit/`,
       input
+    );
+    return response.data;
+  },
+
+  deleteWebinar: async (
+    liveClassId: number
+  ): Promise<ZoomApiResponse<LiveActivity>> => {
+    const response = await apiClient.delete<ZoomApiResponse<LiveActivity>>(
+      `${BASE}/live-activities/${liveClassId}/webinar/`
     );
     return response.data;
   },


### PR DESCRIPTION
Two admin-requested webinar features. Pairs with backend PR #272 (delete endpoint + editable contact/email PATCH).

## Delete a webinar from the LMS
There was no way to delete/cancel a webinar from the LMS. Adds a red **Delete webinar** action (with a confirm dialog) to the webinar detail drawer for scheduled/live webinars. It calls the new `DELETE …/webinar/` endpoint, which deletes it in Zoom and soft-cancels the local row; the drawer refreshes to the "Cancelled in Zoom" state. Synced recording/attendance are preserved.

## Editable email settings
The Email tab was read-only ("edit it in Zoom"). It's now editable in place — contact name/email, confirmation & registration email toggles, and "registration required" (`approval_type`) — saving back to Zoom via the webinar edit endpoint. Editing is gated to scheduled/upcoming webinars.

## Verification
- `tsc --noEmit` clean; eslint clean on changed files (3 warnings shown are pre-existing in untouched poll code).

> Requires backend PR #272 to be merged/deployed for the new DELETE method and the contact/email settings PATCH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)