### PR TITLE
feat(adaptive-journey): course certificate admin page + LinkedIn share

### DIFF
--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Box, ButtonBase, Container, Typography } from "@mui/material";
+import { Box, Container, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
   adaptiveCourseService,
@@ -13,6 +13,8 @@ import { MainLayout } from "@/components/layout/MainLayout";
 import { KpiRail, Reveal } from "@/components/scorecard/shared";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
+import { CoursesNavTabs } from "@/components/courses/CoursesNavTabs";
 
 export default function AdaptiveCourseListPage() {
   const router = useRouter();
@@ -72,6 +74,7 @@ export default function AdaptiveCourseListPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        <CoursesNavTabs active="adaptive" />
         <AdaptiveSectionShell meshOpacity={0.18}>
           <AdaptiveSectionHero
             chapter="Library · Adaptive Engine"
@@ -117,7 +120,7 @@ export default function AdaptiveCourseListPage() {
             >
               {items.map((course, idx) => (
                 <Reveal key={course.id} delay={Math.min(idx, 8) * 0.06}>
-                  <CourseCard
+                  <AdaptiveCourseCard
                     course={course}
                     onOpen={() => router.push(`/adaptive-courses/${course.id}`)}
                   />
@@ -128,138 +131,6 @@ export default function AdaptiveCourseListPage() {
         </AdaptiveSectionShell>
       </Box>
     </MainLayout>
-  );
-}
-
-function CourseCard({
-  course,
-  onOpen,
-}: {
-  course: AdaptiveCourseListItem;
-  onOpen: () => void;
-}) {
-  return (
-    <ButtonBase
-      onClick={onOpen}
-      sx={{
-        width: "100%",
-        height: "100%",
-        textAlign: "left",
-        display: "block",
-        borderRadius: 3,
-        p: 2.5,
-        bgcolor: "var(--card-bg, #fff)",
-        border: "1px solid var(--border-default, #ececf1)",
-        boxShadow: "0 1px 2px rgba(16,24,40,0.04), 0 10px 26px -22px rgba(16,24,40,0.18)",
-        transition: "transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease",
-        "&:hover": {
-          transform: "translateY(-3px)",
-          borderColor: "color-mix(in srgb, #6366f1 40%, transparent)",
-          boxShadow: "0 20px 40px -26px rgba(99, 102, 241, 0.45)",
-        },
-      }}
-    >
-      {course.card_image_url && (
-        <Box
-          sx={{
-            width: "100%",
-            aspectRatio: "16 / 9",
-            borderRadius: 2.5,
-            overflow: "hidden",
-            mb: 1.5,
-            bgcolor: "color-mix(in srgb, #6366f1 8%, transparent)",
-          }}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={course.card_image_url}
-            alt={course.title}
-            loading="lazy"
-            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
-          />
-        </Box>
-      )}
-
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.5 }}>
-        <Box
-          sx={{
-            width: 44,
-            height: 44,
-            borderRadius: 3,
-            display: "grid",
-            placeItems: "center",
-            color: "white",
-            background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
-            boxShadow: "0 14px 26px -14px rgba(168, 85, 247, 0.6)",
-          }}
-        >
-          <Icon icon="mdi:book-education-outline" width={22} />
-        </Box>
-        <Box
-          component="span"
-          sx={{
-            px: 1,
-            py: 0.3,
-            borderRadius: 999,
-            fontSize: "0.65rem",
-            fontWeight: 800,
-            letterSpacing: 0.4,
-            textTransform: "uppercase",
-            color: "#a855f7",
-            bgcolor: "color-mix(in srgb, #a855f7 14%, transparent)",
-          }}
-        >
-          Adaptive
-        </Box>
-      </Box>
-
-      <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3 }}>
-        {course.title}
-      </Typography>
-      {course.description && (
-        <Typography
-          sx={{
-            color: "text.secondary",
-            mt: 0.75,
-            fontSize: "0.86rem",
-            lineHeight: 1.5,
-            display: "-webkit-box",
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
-          }}
-        >
-          {course.description}
-        </Typography>
-      )}
-
-      <Box sx={{ display: "flex", gap: 2, mt: 2, flexWrap: "wrap" }}>
-        <Metric icon="mdi:view-module-outline" label="modules" value={course.module_count} />
-        <Metric icon="mdi:file-tree-outline" label="submodules" value={course.submodule_count} />
-        <Metric icon="mdi:book-open-variant" label="articles" value={course.article_count} />
-        <Metric icon="mdi:tune-vertical" label="quizzes" value={course.quiz_count} />
-        {(course.coding_count ?? 0) > 0 && (
-          <Metric icon="mdi:robot-happy-outline" label="coding" value={course.coding_count ?? 0} />
-        )}
-        {(course.video_count ?? 0) > 0 && (
-          <Metric icon="mdi:play-circle-outline" label="videos" value={course.video_count ?? 0} />
-        )}
-      </Box>
-    </ButtonBase>
-  );
-}
-
-function Metric({ icon, label, value }: { icon: string; label: string; value: number }) {
-  return (
-    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6 }}>
-      <Icon icon={icon} width={16} style={{ color: "#6366f1" }} />
-      <Typography component="span" sx={{ fontWeight: 800, fontSize: "0.85rem" }}>
-        {value}
-      </Typography>
-      <Typography component="span" sx={{ color: "text.secondary", fontSize: "0.78rem" }}>
-        {label}
-      </Typography>
-    </Box>
   );
 }
 

--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -2,7 +2,17 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Box, Container, Typography } from "@mui/material";
+import {
+  Box,
+  Chip,
+  Container,
+  InputAdornment,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
   adaptiveCourseService,
@@ -22,6 +32,9 @@ export default function AdaptiveCourseListPage() {
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<AdaptiveCourseListItem[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [difficulty, setDifficulty] = useState<string>("all");
+  const [sort, setSort] = useState<"recent" | "title" | "content">("recent");
 
   useEffect(() => {
     if (!featureOn) {
@@ -55,6 +68,34 @@ export default function AdaptiveCourseListPage() {
     }
     return { courses: items.length, modules, quizzes, articles };
   }, [items]);
+
+  // Difficulty chips are derived from whatever the catalog actually uses.
+  const difficultyOptions = useMemo(() => {
+    const s = new Set<string>();
+    items.forEach((c) => (c.difficulty_levels || []).forEach((d) => d && s.add(d)));
+    return Array.from(s);
+  }, [items]);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = items.filter((c) => {
+      const matchesQuery =
+        !q ||
+        c.title.toLowerCase().includes(q) ||
+        (c.description || "").toLowerCase().includes(q) ||
+        (c.target_audience || "").toLowerCase().includes(q);
+      const matchesDifficulty =
+        difficulty === "all" || (c.difficulty_levels || []).includes(difficulty);
+      return matchesQuery && matchesDifficulty;
+    });
+    const contentScore = (c: AdaptiveCourseListItem) =>
+      c.module_count + c.quiz_count + c.article_count + (c.coding_count ?? 0) + (c.video_count ?? 0);
+    return [...filtered].sort((a, b) => {
+      if (sort === "title") return a.title.localeCompare(b.title);
+      if (sort === "content") return contentScore(b) - contentScore(a);
+      return (b.updated_at || "").localeCompare(a.updated_at || "");
+    });
+  }, [items, query, difficulty, sort]);
 
   if (!featureOn) {
     return (
@@ -109,7 +150,75 @@ export default function AdaptiveCourseListPage() {
 
           {!loading && !error && items.length === 0 && <EmptyState />}
 
-          {!loading && items.length > 0 && (
+          {!loading && !error && items.length > 0 && (
+            <Box sx={{ mb: 2.5 }}>
+              <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems={{ md: "center" }}>
+                <TextField
+                  size="small"
+                  placeholder="Search adaptive courses…"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <Icon icon="mdi:magnify" width={18} />
+                      </InputAdornment>
+                    ),
+                  }}
+                  sx={{ flex: 1, minWidth: { xs: "100%", md: 280 }, bgcolor: "var(--card-bg, #fff)", borderRadius: 2 }}
+                />
+                <Select
+                  size="small"
+                  value={sort}
+                  onChange={(e) => setSort(e.target.value as "recent" | "title" | "content")}
+                  sx={{ minWidth: 190, bgcolor: "var(--card-bg, #fff)" }}
+                >
+                  <MenuItem value="recent">Recently updated</MenuItem>
+                  <MenuItem value="title">Title (A–Z)</MenuItem>
+                  <MenuItem value="content">Most content</MenuItem>
+                </Select>
+              </Stack>
+
+              {difficultyOptions.length > 0 && (
+                <Stack direction="row" sx={{ mt: 1.5, flexWrap: "wrap", gap: 1 }}>
+                  {[{ key: "all", label: "All levels" }, ...difficultyOptions.map((d) => ({ key: d, label: d }))].map((opt) => {
+                    const selected = difficulty === opt.key;
+                    return (
+                      <Chip
+                        key={opt.key}
+                        label={opt.label}
+                        onClick={() => setDifficulty(opt.key)}
+                        sx={{
+                          fontWeight: 700,
+                          color: selected ? "white" : "text.primary",
+                          background: selected ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" : "transparent",
+                          border: selected ? "1px solid transparent" : "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+                          "&:hover": { background: selected ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" : "color-mix(in srgb, #6366f1 8%, transparent)" },
+                        }}
+                      />
+                    );
+                  })}
+                </Stack>
+              )}
+            </Box>
+          )}
+
+          {!loading && !error && items.length > 0 && visible.length === 0 && (
+            <Box sx={{ p: { xs: 3, md: 5 }, borderRadius: 4, textAlign: "center", bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)", border: "1px dashed color-mix(in srgb, var(--border-default) 90%, transparent)" }}>
+              <Icon icon="mdi:magnify-close" width={44} style={{ color: "#a855f7" }} />
+              <Typography sx={{ fontWeight: 800, mt: 1.5, fontSize: "1.05rem" }}>No adaptive courses match your search.</Typography>
+              <Chip
+                label="Clear search & filters"
+                onClick={() => {
+                  setQuery("");
+                  setDifficulty("all");
+                }}
+                sx={{ mt: 1.75, fontWeight: 700, cursor: "pointer" }}
+              />
+            </Box>
+          )}
+
+          {!loading && visible.length > 0 && (
             <Box
               sx={{
                 display: "grid",
@@ -118,7 +227,7 @@ export default function AdaptiveCourseListPage() {
                 alignItems: "stretch",
               }}
             >
-              {items.map((course, idx) => (
+              {visible.map((course, idx) => (
                 <Reveal key={course.id} delay={Math.min(idx, 8) * 0.06}>
                   <AdaptiveCourseCard
                     course={course}

--- a/app/admin/adaptive-courses/[courseId]/calibration/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/calibration/page.tsx
@@ -1,46 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Avatar, Box, ButtonBase, Chip, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { CalibrationAdminSection } from "@/components/admin/adaptive-course/CalibrationAdminSection";
-import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
-import type {
-  CalibrationSubmissionRow,
-  CalibrationSubmissionsResponse,
-} from "@/lib/types/adaptive-journey";
-
-const TIER_COLOR: Record<string, string> = {
-  beginner: "#f59e0b",
-  intermediate: "#3b82f6",
-  advanced: "#16a34a",
-};
+import { CalibrationResultsSection } from "@/components/admin/adaptive-course/CalibrationResultsSection";
 
 export default function AdminCalibrationPage() {
   const router = useRouter();
   const courseId = Number(useParams().courseId);
-  const [data, setData] = useState<CalibrationSubmissionsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!Number.isFinite(courseId)) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const d = await adaptiveJourneyService.getCalibrationSubmissions(courseId);
-        if (!cancelled) setData(d);
-      } catch {
-        /* surfaced as empty state */
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [courseId]);
 
   return (
     <MainLayout fullWidthContent>
@@ -57,76 +26,16 @@ export default function AdminCalibrationPage() {
             <Icon icon="mdi:shield-half-full" width={22} />
           </Box>
           <Box>
-            <Typography sx={{ fontWeight: 900, fontSize: "1.3rem" }}>Calibration assessment</Typography>
+            <Typography sx={{ fontWeight: 900, fontSize: "1.3rem" }}>Calibration</Typography>
             <Typography sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
-              Generate &amp; edit the test, then review submissions and each student&apos;s AI profile.
+              Generate &amp; edit the test, set the schedule, then review submissions and each student&apos;s AI profile.
             </Typography>
           </Box>
         </Stack>
 
         <CalibrationAdminSection courseId={courseId} />
-
-        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5, mt: 1 }}>
-          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Submissions &amp; student model</Typography>
-          {data && <Chip label={`${data.submission_count} submitted`} size="small" sx={{ fontWeight: 700 }} />}
-        </Stack>
-
-        {loading ? (
-          <Box sx={{ display: "grid", placeItems: "center", py: 5 }}>
-            <CircularProgress sx={{ color: "#6366f1" }} />
-          </Box>
-        ) : !data || data.submissions.length === 0 ? (
-          <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default, #ececf1)" }}>
-            <Icon icon="mdi:inbox-outline" width={36} style={{ opacity: 0.4 }} />
-            <Typography sx={{ color: "text.secondary", mt: 1 }}>No calibration submissions yet.</Typography>
-          </Box>
-        ) : (
-          <Stack spacing={1.25}>
-            {data.submissions.map((s) => (
-              <SubmissionRow key={s.submission_id} s={s} />
-            ))}
-          </Stack>
-        )}
+        <CalibrationResultsSection courseId={courseId} />
       </Box>
     </MainLayout>
-  );
-}
-
-function SubmissionRow({ s }: { s: CalibrationSubmissionRow }) {
-  return (
-    <Box sx={{ p: 2, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
-      <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems={{ md: "center" }} justifyContent="space-between">
-        <Stack direction="row" spacing={1.5} alignItems="center" sx={{ minWidth: 0 }}>
-          <Avatar src={s.profile_pic_url || undefined} sx={{ width: 38, height: 38 }}>{s.name?.[0]}</Avatar>
-          <Box sx={{ minWidth: 0 }}>
-            <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }}>{s.name}</Typography>
-            <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }}>
-              {s.email || "—"}
-              {s.submitted_at ? ` · ${new Date(s.submitted_at).toLocaleDateString()}` : ""}
-            </Typography>
-          </Box>
-        </Stack>
-        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ gap: 1 }}>
-          {s.level_label && (
-            <Chip label={s.level_label} size="small" sx={{ fontWeight: 800, color: "white", bgcolor: TIER_COLOR[s.field_tier || "intermediate"] }} />
-          )}
-          {s.ability_index != null && <Chip label={`Ability ${Math.round(s.ability_index)}`} size="small" variant="outlined" />}
-          {s.pace && <Chip label={`Pace: ${s.pace}`} size="small" variant="outlined" />}
-        </Stack>
-      </Stack>
-      {s.summary && (
-        <Typography sx={{ mt: 1, fontSize: "0.85rem", color: "text.secondary", lineHeight: 1.5 }}>{s.summary}</Typography>
-      )}
-      {(s.strengths.length > 0 || s.growth_areas.length > 0) && (
-        <Stack direction="row" flexWrap="wrap" sx={{ mt: 1, gap: 0.75 }}>
-          {s.strengths.map((x) => (
-            <Chip key={`s-${x.dimension}`} size="small" label={x.dimension} sx={{ bgcolor: "#dcfce7", color: "#15803d", fontWeight: 700 }} />
-          ))}
-          {s.growth_areas.map((x) => (
-            <Chip key={`g-${x.dimension}`} size="small" label={x.dimension} sx={{ bgcolor: "#fef3c7", color: "#b45309", fontWeight: 700 }} />
-          ))}
-        </Stack>
-      )}
-    </Box>
   );
 }

--- a/app/admin/adaptive-courses/[courseId]/calibration/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/calibration/page.tsx
@@ -28,7 +28,7 @@ export default function AdminCalibrationPage() {
           <Box>
             <Typography sx={{ fontWeight: 900, fontSize: "1.3rem" }}>Calibration</Typography>
             <Typography sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
-              Generate &amp; edit the test, set the schedule, then review submissions and each student&apos;s AI profile.
+              Generate &amp; edit the test, then review submissions and each student&apos;s AI profile.
             </Typography>
           </Box>
         </Stack>

--- a/app/admin/adaptive-courses/[courseId]/certificate/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/certificate/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import {
+  Box,
+  ButtonBase,
+  Chip,
+  CircularProgress,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { AdminCertificateUploadCard } from "@/components/admin/certificates/AdminCertificateUploadCard";
+import { useToast } from "@/components/common/Toast";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type { AdminCertificateConfig } from "@/lib/types/adaptive-journey";
+
+export default function AdminAdaptiveCertificatePage() {
+  const router = useRouter();
+  const courseId = Number(useParams().courseId);
+  const { showToast } = useToast();
+
+  const [config, setConfig] = useState<AdminCertificateConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Local editable copies of the criteria.
+  const [enabled, setEnabled] = useState(false);
+  const [minCompletion, setMinCompletion] = useState(80);
+  const [title, setTitle] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Template upload state.
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const hydrate = (c: AdminCertificateConfig) => {
+    setConfig(c);
+    setEnabled(c.enabled);
+    setMinCompletion(c.min_completion_percent);
+    setTitle(c.title);
+  };
+
+  useEffect(() => {
+    if (!Number.isFinite(courseId)) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const c = await adaptiveJourneyService.getCertificateConfig(courseId);
+        if (!cancelled) hydrate(c);
+      } catch {
+        /* surfaced as empty state */
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setUploading(true);
+    try {
+      const c = await adaptiveJourneyService.uploadCertificateTemplate(courseId, file);
+      hydrate(c);
+      setFile(null);
+      showToast("Certificate template uploaded.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Failed to upload template.", "error");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const c = await adaptiveJourneyService.updateCertificateConfig(courseId, {
+        enabled,
+        min_completion_percent: minCompletion,
+        title: title.trim(),
+      });
+      hydrate(c);
+      showToast("Certificate settings saved.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Failed to save settings.", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const dirty =
+    !!config &&
+    (enabled !== config.enabled ||
+      minCompletion !== config.min_completion_percent ||
+      title.trim() !== config.title);
+
+  const clampPct = (v: number) => Math.max(0, Math.min(100, Math.round(v)));
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1100, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 4 } }}>
+        <ButtonBase
+          onClick={() => router.push(`/admin/adaptive-courses/${courseId}`)}
+          sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
+        >
+          <Icon icon="mdi:arrow-left" width={18} /> Back to course
+        </ButtonBase>
+
+        <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 2.5 }}>
+          <Box sx={{ width: 42, height: 42, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)" }}>
+            <Icon icon="mdi:certificate" width={22} />
+          </Box>
+          <Box>
+            <Typography sx={{ fontWeight: 900, fontSize: "1.3rem" }}>Course certificate</Typography>
+            <Typography sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
+              Upload the certificate template and set when learners can download &amp; share it on LinkedIn.
+            </Typography>
+          </Box>
+        </Stack>
+
+        {loading ? (
+          <Box sx={{ display: "grid", placeItems: "center", py: 6 }}>
+            <CircularProgress sx={{ color: "#6366f1" }} />
+          </Box>
+        ) : (
+          <Stack spacing={3}>
+            {/* Criteria */}
+            <Box sx={{ p: { xs: 2.5, md: 3 }, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+                <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Unlock criteria</Typography>
+                {config?.configured ? (
+                  <Chip size="small" color="success" variant="outlined" label="Template uploaded" sx={{ fontWeight: 700 }} />
+                ) : (
+                  <Chip size="small" color="warning" variant="outlined" label="No template yet" sx={{ fontWeight: 700 }} />
+                )}
+              </Stack>
+
+              <FormControlLabel
+                control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+                label={
+                  <Box>
+                    <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }}>Certificate enabled</Typography>
+                    <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
+                      Learners see the certificate card and can claim it once they meet the threshold.
+                    </Typography>
+                  </Box>
+                }
+                sx={{ alignItems: "flex-start", mb: 2, ml: 0 }}
+              />
+
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                <TextField
+                  label="Minimum completion %"
+                  type="number"
+                  value={minCompletion}
+                  onChange={(e) => setMinCompletion(clampPct(Number(e.target.value)))}
+                  inputProps={{ min: 0, max: 100 }}
+                  helperText="Course completion required to unlock (0–100)."
+                  sx={{ width: { xs: "100%", sm: 220 } }}
+                />
+                <TextField
+                  label="Certificate title (optional)"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="e.g. Data Science Professional"
+                  helperText="Shown as the credential name on LinkedIn."
+                  sx={{ flex: 1 }}
+                />
+              </Stack>
+
+              <Box sx={{ mt: 2.5 }}>
+                <LoadingButton
+                  variant="contained"
+                  onClick={handleSave}
+                  loading={saving}
+                  disabled={!dirty}
+                  sx={{ backgroundColor: "#6366f1", "&:hover": { backgroundColor: "#4f46e5" } }}
+                >
+                  Save settings
+                </LoadingButton>
+              </Box>
+            </Box>
+
+            {/* Template upload */}
+            <Box>
+              <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", mb: 0.5 }}>Certificate template</Typography>
+              <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", mb: 2 }}>
+                Upload a background image (PNG/JPG). The learner&apos;s name and details are drawn on top when they
+                download or share. Leave empty to use the default branded certificate.
+              </Typography>
+
+              {config?.template_url && (
+                <Box sx={{ mb: 2, borderRadius: 2, overflow: "hidden", border: "1px solid var(--border-default, #ececf1)", maxWidth: 520 }}>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={config.template_url} alt="Certificate template" style={{ width: "100%", height: "auto", display: "block" }} />
+                </Box>
+              )}
+
+              <AdminCertificateUploadCard
+                selectedFile={file}
+                onSelectFile={setFile}
+                onUpload={handleUpload}
+                uploading={uploading}
+                lastUrl={config?.template_url ?? null}
+              />
+            </Box>
+          </Stack>
+        )}
+      </Box>
+    </MainLayout>
+  );
+}

--- a/app/admin/adaptive-courses/[courseId]/certificate/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/certificate/page.tsx
@@ -16,10 +16,57 @@ import {
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { LoadingButton } from "@/components/common/LoadingButton";
+import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
+import { Reveal, SectionHero } from "@/components/scorecard/shared";
 import { AdminCertificateUploadCard } from "@/components/admin/certificates/AdminCertificateUploadCard";
 import { useToast } from "@/components/common/Toast";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { AdminCertificateConfig } from "@/lib/types/adaptive-journey";
+
+// Certificate identity accent — amber → orange, matching the course-hub launcher
+// card and the learner certificate card.
+const AMBER_TOP = "#f59e0b";
+const AMBER_BOTTOM = "#f97316";
+const AMBER_GRADIENT = `linear-gradient(135deg, ${AMBER_TOP} 0%, ${AMBER_BOTTOM} 100%)`;
+// Primary CTA gradient shared across the adaptive admin surfaces.
+const INDIGO_GRADIENT = "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)";
+
+/** A section panel header: gradient icon tile + title + helper, with an optional right slot. */
+function PanelHeader({
+  icon,
+  gradient,
+  title,
+  sub,
+  right,
+}: {
+  icon: string;
+  gradient: string;
+  title: string;
+  sub: string;
+  right?: React.ReactNode;
+}) {
+  return (
+    <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1.5} sx={{ mb: 2 }}>
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ minWidth: 0 }}>
+        <Box sx={{ width: 38, height: 38, borderRadius: 2.25, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: gradient }}>
+          <Icon icon={icon} width={20} />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.2 }}>{title}</Typography>
+          <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>{sub}</Typography>
+        </Box>
+      </Stack>
+      {right}
+    </Stack>
+  );
+}
+
+const panelSx = {
+  p: { xs: 2.25, md: 3 },
+  borderRadius: 4,
+  bgcolor: "color-mix(in srgb, var(--card-bg) 92%, transparent)",
+  border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+} as const;
 
 export default function AdminAdaptiveCertificatePage() {
   const router = useRouter();
@@ -104,6 +151,33 @@ export default function AdminAdaptiveCertificatePage() {
 
   const clampPct = (v: number) => Math.max(0, Math.min(100, Math.round(v)));
 
+  const statusChips = config && (
+    <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+      <Chip
+        size="small"
+        icon={<Icon icon={config.enabled ? "mdi:check-circle" : "mdi:pause-circle-outline"} width={15} />}
+        label={config.enabled ? "Live" : "Off"}
+        sx={{
+          fontWeight: 800, height: 24,
+          color: config.enabled ? "#15803d" : "#64748b",
+          bgcolor: config.enabled ? "#dcfce7" : "#f1f5f9",
+          "& .MuiChip-icon": { color: "inherit" },
+        }}
+      />
+      <Chip
+        size="small"
+        icon={<Icon icon={config.configured ? "mdi:image-check" : "mdi:image-off-outline"} width={15} />}
+        label={config.configured ? "Template uploaded" : "No template"}
+        sx={{
+          fontWeight: 700, height: 24,
+          color: config.configured ? "#b45309" : "#64748b",
+          bgcolor: config.configured ? "#fef3c7" : "#f1f5f9",
+          "& .MuiChip-icon": { color: "inherit" },
+        }}
+      />
+    </Stack>
+  );
+
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1100, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 4 } }}>
@@ -114,106 +188,129 @@ export default function AdminAdaptiveCertificatePage() {
           <Icon icon="mdi:arrow-left" width={18} /> Back to course
         </ButtonBase>
 
-        <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 2.5 }}>
-          <Box sx={{ width: 42, height: 42, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)" }}>
-            <Icon icon="mdi:certificate" width={22} />
-          </Box>
-          <Box>
-            <Typography sx={{ fontWeight: 900, fontSize: "1.3rem" }}>Course certificate</Typography>
-            <Typography sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
-              Upload the certificate template and set when learners can download &amp; share it on LinkedIn.
-            </Typography>
-          </Box>
-        </Stack>
+        <AdaptiveSectionShell>
+          {loading ? (
+            <Box sx={{ display: "grid", placeItems: "center", py: 8 }}>
+              <CircularProgress sx={{ color: "#f59e0b" }} />
+            </Box>
+          ) : (
+            <>
+              <SectionHero
+                chapter={config?.enabled ? "Live · Certificate" : "Setup · Certificate"}
+                title="Course certificate"
+                subtitle="Upload the certificate template and decide when learners can download it and share to LinkedIn."
+                accentTop={AMBER_TOP}
+                accentBottom={AMBER_BOTTOM}
+                iconBadge={{
+                  icon: "mdi:certificate",
+                  gradient: AMBER_GRADIENT,
+                  shadow: `0 18px 32px -16px color-mix(in srgb, ${AMBER_TOP} 60%, transparent)`,
+                }}
+                rightSlot={statusChips}
+              />
 
-        {loading ? (
-          <Box sx={{ display: "grid", placeItems: "center", py: 6 }}>
-            <CircularProgress sx={{ color: "#6366f1" }} />
-          </Box>
-        ) : (
-          <Stack spacing={3}>
-            {/* Criteria */}
-            <Box sx={{ p: { xs: 2.5, md: 3 }, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
-                <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Unlock criteria</Typography>
-                {config?.configured ? (
-                  <Chip size="small" color="success" variant="outlined" label="Template uploaded" sx={{ fontWeight: 700 }} />
-                ) : (
-                  <Chip size="small" color="warning" variant="outlined" label="No template yet" sx={{ fontWeight: 700 }} />
-                )}
-              </Stack>
+              <Stack spacing={2.5}>
+                {/* Unlock criteria */}
+                <Reveal>
+                  <Box sx={panelSx}>
+                    <PanelHeader
+                      icon="mdi:flag-checkered"
+                      gradient={INDIGO_GRADIENT}
+                      title="Unlock criteria"
+                      sub="When learners can claim the certificate."
+                    />
 
-              <FormControlLabel
-                control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
-                label={
-                  <Box>
-                    <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }}>Certificate enabled</Typography>
-                    <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
-                      Learners see the certificate card and can claim it once they meet the threshold.
-                    </Typography>
+                    <FormControlLabel
+                      control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+                      label={
+                        <Box>
+                          <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }}>Certificate enabled</Typography>
+                          <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
+                            Learners see the certificate card and can claim it once they meet the threshold.
+                          </Typography>
+                        </Box>
+                      }
+                      sx={{ alignItems: "flex-start", mb: 2.5, ml: 0 }}
+                    />
+
+                    <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+                      <TextField
+                        label="Minimum completion %"
+                        type="number"
+                        value={minCompletion}
+                        onChange={(e) => setMinCompletion(clampPct(Number(e.target.value)))}
+                        inputProps={{ min: 0, max: 100 }}
+                        helperText="Course completion required to unlock (0–100)."
+                        sx={{ width: { xs: "100%", sm: 240 } }}
+                      />
+                      <TextField
+                        label="Certificate title (optional)"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        placeholder="e.g. Data Science Professional"
+                        helperText="Shown as the credential name on LinkedIn."
+                        sx={{ flex: 1 }}
+                      />
+                    </Stack>
+
+                    <Box sx={{ mt: 2.5 }}>
+                      <LoadingButton
+                        variant="contained"
+                        onClick={handleSave}
+                        loading={saving}
+                        disabled={!dirty}
+                        sx={{
+                          textTransform: "none", fontWeight: 700, borderRadius: 2, px: 2.5,
+                          background: INDIGO_GRADIENT,
+                          "&.Mui-disabled": { background: "#e2e8f0", color: "#94a3b8" },
+                        }}
+                      >
+                        Save settings
+                      </LoadingButton>
+                    </Box>
                   </Box>
-                }
-                sx={{ alignItems: "flex-start", mb: 2, ml: 0 }}
-              />
+                </Reveal>
 
-              <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-                <TextField
-                  label="Minimum completion %"
-                  type="number"
-                  value={minCompletion}
-                  onChange={(e) => setMinCompletion(clampPct(Number(e.target.value)))}
-                  inputProps={{ min: 0, max: 100 }}
-                  helperText="Course completion required to unlock (0–100)."
-                  sx={{ width: { xs: "100%", sm: 220 } }}
-                />
-                <TextField
-                  label="Certificate title (optional)"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  placeholder="e.g. Data Science Professional"
-                  helperText="Shown as the credential name on LinkedIn."
-                  sx={{ flex: 1 }}
-                />
+                {/* Certificate template */}
+                <Reveal delay={0.06}>
+                  <Box sx={panelSx}>
+                    <PanelHeader
+                      icon="mdi:image-outline"
+                      gradient={AMBER_GRADIENT}
+                      title="Certificate template"
+                      sub="The background image the learner's name is drawn onto."
+                      right={
+                        config?.configured ? (
+                          <Chip size="small" color="success" variant="outlined" label="Uploaded" sx={{ fontWeight: 700 }} />
+                        ) : undefined
+                      }
+                    />
+
+                    <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", mb: 2 }}>
+                      Upload a PNG or JPG. The learner&apos;s name and details are drawn on top when they download or
+                      share. Leave empty to use the default branded certificate.
+                    </Typography>
+
+                    {config?.template_url && (
+                      <Box sx={{ mb: 2, borderRadius: 3, overflow: "hidden", border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)", maxWidth: 540 }}>
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src={config.template_url} alt="Certificate template" style={{ width: "100%", height: "auto", display: "block" }} />
+                      </Box>
+                    )}
+
+                    <AdminCertificateUploadCard
+                      selectedFile={file}
+                      onSelectFile={setFile}
+                      onUpload={handleUpload}
+                      uploading={uploading}
+                      lastUrl={config?.template_url ?? null}
+                    />
+                  </Box>
+                </Reveal>
               </Stack>
-
-              <Box sx={{ mt: 2.5 }}>
-                <LoadingButton
-                  variant="contained"
-                  onClick={handleSave}
-                  loading={saving}
-                  disabled={!dirty}
-                  sx={{ backgroundColor: "#6366f1", "&:hover": { backgroundColor: "#4f46e5" } }}
-                >
-                  Save settings
-                </LoadingButton>
-              </Box>
-            </Box>
-
-            {/* Template upload */}
-            <Box>
-              <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", mb: 0.5 }}>Certificate template</Typography>
-              <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", mb: 2 }}>
-                Upload a background image (PNG/JPG). The learner&apos;s name and details are drawn on top when they
-                download or share. Leave empty to use the default branded certificate.
-              </Typography>
-
-              {config?.template_url && (
-                <Box sx={{ mb: 2, borderRadius: 2, overflow: "hidden", border: "1px solid var(--border-default, #ececf1)", maxWidth: 520 }}>
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={config.template_url} alt="Certificate template" style={{ width: "100%", height: "auto", display: "block" }} />
-                </Box>
-              )}
-
-              <AdminCertificateUploadCard
-                selectedFile={file}
-                onSelectFile={setFile}
-                onUpload={handleUpload}
-                uploading={uploading}
-                lastUrl={config?.template_url ?? null}
-              />
-            </Box>
-          </Stack>
-        )}
+            </>
+          )}
+        </AdaptiveSectionShell>
       </Box>
     </MainLayout>
   );

--- a/app/admin/adaptive-courses/[courseId]/certificate/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/certificate/page.tsx
@@ -1,182 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import {
-  Box,
-  ButtonBase,
-  Chip,
-  CircularProgress,
-  FormControlLabel,
-  Stack,
-  Switch,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Box, ButtonBase } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { LoadingButton } from "@/components/common/LoadingButton";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
-import { Reveal, SectionHero } from "@/components/scorecard/shared";
-import { AdminCertificateUploadCard } from "@/components/admin/certificates/AdminCertificateUploadCard";
-import { useToast } from "@/components/common/Toast";
-import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
-import type { AdminCertificateConfig } from "@/lib/types/adaptive-journey";
+import { SectionHero } from "@/components/scorecard/shared";
+import { CertificateAdminSection } from "@/components/admin/adaptive-course/CertificateAdminSection";
 
-// Certificate identity accent — amber → orange, matching the course-hub launcher
-// card and the learner certificate card.
 const AMBER_TOP = "#f59e0b";
 const AMBER_BOTTOM = "#f97316";
-const AMBER_GRADIENT = `linear-gradient(135deg, ${AMBER_TOP} 0%, ${AMBER_BOTTOM} 100%)`;
-// Primary CTA gradient shared across the adaptive admin surfaces.
-const INDIGO_GRADIENT = "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)";
-
-/** A section panel header: gradient icon tile + title + helper, with an optional right slot. */
-function PanelHeader({
-  icon,
-  gradient,
-  title,
-  sub,
-  right,
-}: {
-  icon: string;
-  gradient: string;
-  title: string;
-  sub: string;
-  right?: React.ReactNode;
-}) {
-  return (
-    <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1.5} sx={{ mb: 2 }}>
-      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ minWidth: 0 }}>
-        <Box sx={{ width: 38, height: 38, borderRadius: 2.25, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: gradient }}>
-          <Icon icon={icon} width={20} />
-        </Box>
-        <Box sx={{ minWidth: 0 }}>
-          <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.2 }}>{title}</Typography>
-          <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>{sub}</Typography>
-        </Box>
-      </Stack>
-      {right}
-    </Stack>
-  );
-}
-
-const panelSx = {
-  p: { xs: 2.25, md: 3 },
-  borderRadius: 4,
-  bgcolor: "color-mix(in srgb, var(--card-bg) 92%, transparent)",
-  border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
-} as const;
 
 export default function AdminAdaptiveCertificatePage() {
   const router = useRouter();
   const courseId = Number(useParams().courseId);
-  const { showToast } = useToast();
-
-  const [config, setConfig] = useState<AdminCertificateConfig | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  // Local editable copies of the criteria.
-  const [enabled, setEnabled] = useState(false);
-  const [minCompletion, setMinCompletion] = useState(80);
-  const [title, setTitle] = useState("");
-  const [saving, setSaving] = useState(false);
-
-  // Template upload state.
-  const [file, setFile] = useState<File | null>(null);
-  const [uploading, setUploading] = useState(false);
-
-  const hydrate = (c: AdminCertificateConfig) => {
-    setConfig(c);
-    setEnabled(c.enabled);
-    setMinCompletion(c.min_completion_percent);
-    setTitle(c.title);
-  };
-
-  useEffect(() => {
-    if (!Number.isFinite(courseId)) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const c = await adaptiveJourneyService.getCertificateConfig(courseId);
-        if (!cancelled) hydrate(c);
-      } catch {
-        /* surfaced as empty state */
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [courseId]);
-
-  const handleUpload = async () => {
-    if (!file) return;
-    setUploading(true);
-    try {
-      const c = await adaptiveJourneyService.uploadCertificateTemplate(courseId, file);
-      hydrate(c);
-      setFile(null);
-      showToast("Certificate template uploaded.", "success");
-    } catch (e) {
-      showToast(e instanceof Error ? e.message : "Failed to upload template.", "error");
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      const c = await adaptiveJourneyService.updateCertificateConfig(courseId, {
-        enabled,
-        min_completion_percent: minCompletion,
-        title: title.trim(),
-      });
-      hydrate(c);
-      showToast("Certificate settings saved.", "success");
-    } catch (e) {
-      showToast(e instanceof Error ? e.message : "Failed to save settings.", "error");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const dirty =
-    !!config &&
-    (enabled !== config.enabled ||
-      minCompletion !== config.min_completion_percent ||
-      title.trim() !== config.title);
-
-  const clampPct = (v: number) => Math.max(0, Math.min(100, Math.round(v)));
-
-  const statusChips = config && (
-    <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
-      <Chip
-        size="small"
-        icon={<Icon icon={config.enabled ? "mdi:check-circle" : "mdi:pause-circle-outline"} width={15} />}
-        label={config.enabled ? "Live" : "Off"}
-        sx={{
-          fontWeight: 800, height: 24,
-          color: config.enabled ? "#15803d" : "#64748b",
-          bgcolor: config.enabled ? "#dcfce7" : "#f1f5f9",
-          "& .MuiChip-icon": { color: "inherit" },
-        }}
-      />
-      <Chip
-        size="small"
-        icon={<Icon icon={config.configured ? "mdi:image-check" : "mdi:image-off-outline"} width={15} />}
-        label={config.configured ? "Template uploaded" : "No template"}
-        sx={{
-          fontWeight: 700, height: 24,
-          color: config.configured ? "#b45309" : "#64748b",
-          bgcolor: config.configured ? "#fef3c7" : "#f1f5f9",
-          "& .MuiChip-icon": { color: "inherit" },
-        }}
-      />
-    </Stack>
-  );
 
   return (
     <MainLayout fullWidthContent>
@@ -189,127 +26,19 @@ export default function AdminAdaptiveCertificatePage() {
         </ButtonBase>
 
         <AdaptiveSectionShell>
-          {loading ? (
-            <Box sx={{ display: "grid", placeItems: "center", py: 8 }}>
-              <CircularProgress sx={{ color: "#f59e0b" }} />
-            </Box>
-          ) : (
-            <>
-              <SectionHero
-                chapter={config?.enabled ? "Live · Certificate" : "Setup · Certificate"}
-                title="Course certificate"
-                subtitle="Upload the certificate template and decide when learners can download it and share to LinkedIn."
-                accentTop={AMBER_TOP}
-                accentBottom={AMBER_BOTTOM}
-                iconBadge={{
-                  icon: "mdi:certificate",
-                  gradient: AMBER_GRADIENT,
-                  shadow: `0 18px 32px -16px color-mix(in srgb, ${AMBER_TOP} 60%, transparent)`,
-                }}
-                rightSlot={statusChips}
-              />
-
-              <Stack spacing={2.5}>
-                {/* Unlock criteria */}
-                <Reveal>
-                  <Box sx={panelSx}>
-                    <PanelHeader
-                      icon="mdi:flag-checkered"
-                      gradient={INDIGO_GRADIENT}
-                      title="Unlock criteria"
-                      sub="When learners can claim the certificate."
-                    />
-
-                    <FormControlLabel
-                      control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
-                      label={
-                        <Box>
-                          <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }}>Certificate enabled</Typography>
-                          <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
-                            Learners see the certificate card and can claim it once they meet the threshold.
-                          </Typography>
-                        </Box>
-                      }
-                      sx={{ alignItems: "flex-start", mb: 2.5, ml: 0 }}
-                    />
-
-                    <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-                      <TextField
-                        label="Minimum completion %"
-                        type="number"
-                        value={minCompletion}
-                        onChange={(e) => setMinCompletion(clampPct(Number(e.target.value)))}
-                        inputProps={{ min: 0, max: 100 }}
-                        helperText="Course completion required to unlock (0–100)."
-                        sx={{ width: { xs: "100%", sm: 240 } }}
-                      />
-                      <TextField
-                        label="Certificate title (optional)"
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                        placeholder="e.g. Data Science Professional"
-                        helperText="Shown as the credential name on LinkedIn."
-                        sx={{ flex: 1 }}
-                      />
-                    </Stack>
-
-                    <Box sx={{ mt: 2.5 }}>
-                      <LoadingButton
-                        variant="contained"
-                        onClick={handleSave}
-                        loading={saving}
-                        disabled={!dirty}
-                        sx={{
-                          textTransform: "none", fontWeight: 700, borderRadius: 2, px: 2.5,
-                          background: INDIGO_GRADIENT,
-                          "&.Mui-disabled": { background: "#e2e8f0", color: "#94a3b8" },
-                        }}
-                      >
-                        Save settings
-                      </LoadingButton>
-                    </Box>
-                  </Box>
-                </Reveal>
-
-                {/* Certificate template */}
-                <Reveal delay={0.06}>
-                  <Box sx={panelSx}>
-                    <PanelHeader
-                      icon="mdi:image-outline"
-                      gradient={AMBER_GRADIENT}
-                      title="Certificate template"
-                      sub="The background image the learner's name is drawn onto."
-                      right={
-                        config?.configured ? (
-                          <Chip size="small" color="success" variant="outlined" label="Uploaded" sx={{ fontWeight: 700 }} />
-                        ) : undefined
-                      }
-                    />
-
-                    <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", mb: 2 }}>
-                      Upload a PNG or JPG. The learner&apos;s name and details are drawn on top when they download or
-                      share. Leave empty to use the default branded certificate.
-                    </Typography>
-
-                    {config?.template_url && (
-                      <Box sx={{ mb: 2, borderRadius: 3, overflow: "hidden", border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)", maxWidth: 540 }}>
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img src={config.template_url} alt="Certificate template" style={{ width: "100%", height: "auto", display: "block" }} />
-                      </Box>
-                    )}
-
-                    <AdminCertificateUploadCard
-                      selectedFile={file}
-                      onSelectFile={setFile}
-                      onUpload={handleUpload}
-                      uploading={uploading}
-                      lastUrl={config?.template_url ?? null}
-                    />
-                  </Box>
-                </Reveal>
-              </Stack>
-            </>
-          )}
+          <SectionHero
+            chapter="Course certificate"
+            title="Course certificate"
+            subtitle="Upload the certificate template and decide when learners can download it and share to LinkedIn."
+            accentTop={AMBER_TOP}
+            accentBottom={AMBER_BOTTOM}
+            iconBadge={{
+              icon: "mdi:certificate",
+              gradient: `linear-gradient(135deg, ${AMBER_TOP} 0%, ${AMBER_BOTTOM} 100%)`,
+              shadow: `0 18px 32px -16px color-mix(in srgb, ${AMBER_TOP} 60%, transparent)`,
+            }}
+          />
+          <CertificateAdminSection courseId={courseId} />
         </AdaptiveSectionShell>
       </Box>
     </MainLayout>

--- a/app/admin/adaptive-courses/[courseId]/mock-interview/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/mock-interview/page.tsx
@@ -1,68 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Avatar, Box, Button, ButtonBase, Chip, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { useToast } from "@/components/common/Toast";
-import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
-import type {
-  CalibrationInterviewStatus,
-  CourseInterviewAttempt,
-  CourseInterviewTemplate,
-  CourseInterviewsResponse,
-} from "@/lib/types/adaptive-journey";
-
-const STATUS_CHIP: Record<string, { color: string; bg: string }> = {
-  completed: { color: "#15803d", bg: "#dcfce7" },
-  in_progress: { color: "#4338ca", bg: "#e0e7ff" },
-  scheduled: { color: "#b45309", bg: "#fef3c7" },
-  cancelled: { color: "#64748b", bg: "#f1f5f9" },
-  failed: { color: "#b91c1c", bg: "#fee2e2" },
-};
+import { MockInterviewAdminSection } from "@/components/admin/adaptive-course/MockInterviewAdminSection";
 
 export default function AdminMockInterviewPage() {
   const router = useRouter();
-  const { showToast } = useToast();
   const courseId = Number(useParams().courseId);
-  const [data, setData] = useState<CourseInterviewsResponse | null>(null);
-  const [calib, setCalib] = useState<CalibrationInterviewStatus | null>(null);
-  const [generating, setGenerating] = useState(false);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!Number.isFinite(courseId)) return;
-    let cancelled = false;
-    (async () => {
-      const [d, c] = await Promise.allSettled([
-        adaptiveJourneyService.getCourseInterviews(courseId),
-        adaptiveJourneyService.getCalibrationInterview(courseId),
-      ]);
-      if (cancelled) return;
-      if (d.status === "fulfilled") setData(d.value);
-      if (c.status === "fulfilled") setCalib(c.value);
-      setLoading(false);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [courseId]);
-
-  const generate = async () => {
-    setGenerating(true);
-    try {
-      const res = await adaptiveJourneyService.createCalibrationInterview(courseId);
-      setCalib(res);
-      const refreshed = await adaptiveJourneyService.getCourseInterviews(courseId);
-      setData(refreshed);
-      showToast("Calibration interview created.", "success");
-    } catch {
-      showToast("Couldn't create the calibration interview.", "error");
-    } finally {
-      setGenerating(false);
-    }
-  };
 
   return (
     <MainLayout fullWidthContent>
@@ -86,128 +32,8 @@ export default function AdminMockInterviewPage() {
           </Box>
         </Stack>
 
-        {!loading && (
-          <Box sx={{ p: 2, mb: 2.5, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
-            <Stack direction="row" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={1.5}>
-              <Box sx={{ minWidth: 0 }}>
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <Typography sx={{ fontWeight: 800 }}>Calibration interview</Typography>
-                  <Chip
-                    label={calib?.exists ? "Ready" : "Not set up"}
-                    size="small"
-                    sx={{ height: 20, fontWeight: 800, fontSize: "0.66rem", color: calib?.exists ? "#15803d" : "#64748b", bgcolor: calib?.exists ? "#dcfce7" : "#f1f5f9" }}
-                  />
-                </Stack>
-                <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>
-                  {calib?.exists
-                    ? `Live entry level-gauge (~${calib.duration_minutes ?? 10} min) — seeds each student's AI Student Model. New courses get this automatically.`
-                    : "AI conversational level-gauge that seeds the Student Model. New courses get this automatically; create it here for older courses."}
-                </Typography>
-              </Box>
-              {!calib?.exists && (
-                <Button
-                  variant="contained"
-                  disabled={generating}
-                  onClick={generate}
-                  startIcon={generating ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:auto-fix" width={18} />}
-                  sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2, background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
-                >
-                  {generating ? "Creating…" : "Generate calibration interview (AI)"}
-                </Button>
-              )}
-            </Stack>
-          </Box>
-        )}
-
-        {loading ? (
-          <Box sx={{ display: "grid", placeItems: "center", py: 6 }}>
-            <CircularProgress sx={{ color: "#6366f1" }} />
-          </Box>
-        ) : (
-          <>
-            <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", mb: 1.25 }}>Interview rounds</Typography>
-            {!data || data.templates.length === 0 ? (
-              <Box sx={{ p: 3, mb: 3, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default, #ececf1)" }}>
-                <Typography sx={{ color: "text.secondary" }}>
-                  No interview rounds in this course yet — add an interview node to the journey.
-                </Typography>
-              </Box>
-            ) : (
-              <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 1.25, mb: 3 }}>
-                {data.templates.map((t) => (
-                  <TemplateCard key={t.id} t={t} />
-                ))}
-              </Box>
-            )}
-
-            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.25 }}>
-              <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Student attempts &amp; feedback</Typography>
-              {data && <Chip label={`${data.attempt_count} attempts`} size="small" sx={{ fontWeight: 700 }} />}
-            </Stack>
-            {!data || data.attempts.length === 0 ? (
-              <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default, #ececf1)" }}>
-                <Icon icon="mdi:inbox-outline" width={36} style={{ opacity: 0.4 }} />
-                <Typography sx={{ color: "text.secondary", mt: 1 }}>No interview attempts yet.</Typography>
-              </Box>
-            ) : (
-              <Stack spacing={1.25}>
-                {data.attempts.map((a) => (
-                  <AttemptRow key={a.interview_id} a={a} />
-                ))}
-              </Stack>
-            )}
-          </>
-        )}
+        <MockInterviewAdminSection courseId={courseId} />
       </Box>
     </MainLayout>
-  );
-}
-
-function TemplateCard({ t }: { t: CourseInterviewTemplate }) {
-  return (
-    <Box sx={{ p: 2, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
-      <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>{t.title}</Typography>
-        {t.is_level_gauge && <Chip label="Level gauge" size="small" sx={{ height: 20, fontSize: "0.62rem", fontWeight: 800, color: "#6d28d9", bgcolor: "#ede9fe" }} />}
-      </Stack>
-      <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>{t.topic}{t.subtopic ? ` · ${t.subtopic}` : ""}</Typography>
-      <Stack direction="row" spacing={0.75} sx={{ mt: 1, gap: 0.75 }} flexWrap="wrap">
-        <Chip size="small" variant="outlined" label={t.difficulty} />
-        <Chip size="small" variant="outlined" label={`${t.duration_minutes} min`} />
-        <Chip size="small" variant="outlined" label={`Release: ${t.result_release_mode}`} />
-      </Stack>
-    </Box>
-  );
-}
-
-function AttemptRow({ a }: { a: CourseInterviewAttempt }) {
-  const sc = STATUS_CHIP[a.status] ?? STATUS_CHIP.scheduled;
-  return (
-    <Box sx={{ p: 2, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
-      <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems={{ md: "center" }} justifyContent="space-between">
-        <Stack direction="row" spacing={1.5} alignItems="center" sx={{ minWidth: 0 }}>
-          <Avatar src={a.profile_pic_url || undefined} sx={{ width: 38, height: 38 }}>{a.name?.[0]}</Avatar>
-          <Box sx={{ minWidth: 0 }}>
-            <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }}>{a.name}</Typography>
-            <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }}>
-              {a.template_title || a.topic}
-              {a.submitted_at ? ` · ${new Date(a.submitted_at).toLocaleDateString()}` : ""}
-            </Typography>
-          </Box>
-        </Stack>
-        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ gap: 1 }}>
-          {a.overall_percentage != null && (
-            <Chip label={`${Math.round(a.overall_percentage)}%`} size="small" sx={{ fontWeight: 800, color: "#0f172a", bgcolor: "#f1f5f9" }} />
-          )}
-          <Chip label={a.status.replace("_", " ")} size="small" sx={{ fontWeight: 700, color: sc.color, bgcolor: sc.bg, textTransform: "capitalize" }} />
-          <Chip
-            size="small"
-            variant="outlined"
-            icon={<Icon icon={a.result_visible_to_student ? "mdi:eye-outline" : "mdi:eye-off-outline"} width={14} />}
-            label={a.result_visible_to_student ? "Result shown" : "Result hidden"}
-          />
-        </Stack>
-      </Stack>
-    </Box>
   );
 }

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -33,6 +33,7 @@ import { MatchedVideoReview } from "@/components/adaptive-video/admin/MatchedVid
 import { CourseStudentsPanel } from "@/components/admin/adaptive-course/CourseStudentsPanel";
 import { CourseCoverArtPanel } from "@/components/admin/adaptive-course/CourseCoverArtPanel";
 import { CalibrationAdminSection } from "@/components/admin/adaptive-course/CalibrationAdminSection";
+import { CohortScheduleSection } from "@/components/admin/adaptive-course/CohortScheduleSection";
 import { CalibrationResultsSection } from "@/components/admin/adaptive-course/CalibrationResultsSection";
 import { MockInterviewAdminSection } from "@/components/admin/adaptive-course/MockInterviewAdminSection";
 import { CertificateAdminSection } from "@/components/admin/adaptive-course/CertificateAdminSection";
@@ -380,6 +381,8 @@ export default function AdminAdaptiveCourseDetailPage() {
               {tab === "mock" && <MockInterviewAdminSection courseId={course.id} />}
 
               {tab === "certificate" && <CertificateAdminSection courseId={course.id} />}
+
+              {tab === "content" && <CohortScheduleSection courseId={course.id} />}
 
               {tab === "content" && course.skills.length > 0 && (
                 <Box sx={{

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -327,6 +327,14 @@ export default function AdminAdaptiveCourseDetailPage() {
                       accent: "#a855f7",
                       href: `/admin/adaptive-courses/${course.id}/mock-interview`,
                     },
+                    {
+                      key: "certificate",
+                      title: "Certificate",
+                      sub: "Upload the template + set the completion criteria",
+                      icon: "mdi:certificate",
+                      accent: "#f59e0b",
+                      href: `/admin/adaptive-courses/${course.id}/certificate`,
+                    },
                   ] as const).map((c) => (
                     <ButtonBase
                       key={c.key}

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -6,10 +6,12 @@ import {
   Box,
   Button,
   ButtonBase,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
+  Stack,
   TextField,
   Typography,
 } from "@mui/material";
@@ -68,6 +70,12 @@ export default function AdminAdaptiveCourseDetailPage() {
   const [expandedArticle, setExpandedArticle] = useState<number | null>(null);
   const [expandedCoding, setExpandedCoding] = useState<number | null>(null);
   const [tab, setTab] = useState<"content" | "students" | "cover">("content");
+  // Edit course title + description (with AI-drafted description).
+  const [editOpen, setEditOpen] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [savingDetails, setSavingDetails] = useState(false);
+  const [genDesc, setGenDesc] = useState(false);
 
   function handleQuizSaved(configId: number, mcqCount: number) {
     setCourse((prev) =>
@@ -183,6 +191,50 @@ export default function AdminAdaptiveCourseDetailPage() {
     }
   }
 
+  function openEditDetails() {
+    if (!course) return;
+    setEditTitle(course.title);
+    setEditDescription(course.description ?? "");
+    setEditOpen(true);
+  }
+
+  async function handleGenerateDescription() {
+    if (!course || genDesc) return;
+    setGenDesc(true);
+    try {
+      const description = await adminAdaptiveCourseService.generateCourseDescription(course.id);
+      if (description) setEditDescription(description);
+      showToast("Description drafted — review and save.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't generate a description.", "error");
+    } finally {
+      setGenDesc(false);
+    }
+  }
+
+  async function handleSaveDetails() {
+    if (!course || savingDetails) return;
+    const title = editTitle.trim();
+    if (!title) {
+      showToast("Title can't be empty.", "error");
+      return;
+    }
+    setSavingDetails(true);
+    try {
+      const updated = await adminAdaptiveCourseService.updateCourse(course.id, {
+        title,
+        description: editDescription.trim(),
+      });
+      setCourse(updated);
+      setEditOpen(false);
+      showToast("Course details saved.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't save.", "error");
+    } finally {
+      setSavingDetails(false);
+    }
+  }
+
   async function handleDialogSubmit() {
     if (!dialog || !course || topic.trim().length < 2 || difficulties.length === 0 || contentTypes.length === 0 || submitting) return;
     setSubmitting(true);
@@ -247,7 +299,11 @@ export default function AdminAdaptiveCourseDetailPage() {
                 icon="mdi:book-cog-outline"
                 accent="indigo"
                 rightSlot={
-                  <Box sx={{ display: "flex", gap: 1 }}>
+                  <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                    <ButtonBase onClick={openEditDetails} sx={pillBtnSx("outline")}>
+                      <Icon icon="mdi:pencil-outline" width={16} />
+                      Edit details
+                    </ButtonBase>
                     <ButtonBase
                       onClick={() => openDialog({ kind: "module" })}
                       sx={pillBtnSx("outline")}
@@ -663,6 +719,57 @@ export default function AdminAdaptiveCourseDetailPage() {
           )}
         </AdaptiveSectionShell>
       </Box>
+
+      <Dialog open={editOpen} onClose={() => setEditOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle sx={{ fontWeight: 800 }}>Edit course details</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ mt: 0.5 }}>
+            <TextField
+              label="Course title"
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              fullWidth
+            />
+            <Box>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 0.75 }}>
+                <Typography sx={{ fontSize: "0.85rem", fontWeight: 700, color: "text.secondary" }}>
+                  Description <span style={{ fontWeight: 500 }}>· shown in the course header</span>
+                </Typography>
+                <Button
+                  onClick={handleGenerateDescription}
+                  disabled={genDesc}
+                  size="small"
+                  startIcon={genDesc ? <CircularProgress size={14} /> : <Icon icon="mdi:auto-fix" width={16} />}
+                  sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1" }}
+                >
+                  {genDesc ? "Generating…" : "Generate with AI"}
+                </Button>
+              </Stack>
+              <TextField
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                fullWidth
+                multiline
+                minRows={3}
+                placeholder="A short, compelling summary of what this course covers."
+              />
+            </Box>
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setEditOpen(false)} color="inherit">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSaveDetails}
+            variant="contained"
+            disabled={savingDetails}
+            sx={{ textTransform: "none", fontWeight: 700, background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
+          >
+            {savingDetails ? "Saving…" : "Save"}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <Dialog open={dialog !== null} onClose={() => setDialog(null)} fullWidth maxWidth="sm">
         <DialogTitle sx={{ fontWeight: 800 }}>

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -33,6 +33,9 @@ import { MatchedVideoReview } from "@/components/adaptive-video/admin/MatchedVid
 import { CourseStudentsPanel } from "@/components/admin/adaptive-course/CourseStudentsPanel";
 import { CourseCoverArtPanel } from "@/components/admin/adaptive-course/CourseCoverArtPanel";
 import { CalibrationAdminSection } from "@/components/admin/adaptive-course/CalibrationAdminSection";
+import { CalibrationResultsSection } from "@/components/admin/adaptive-course/CalibrationResultsSection";
+import { MockInterviewAdminSection } from "@/components/admin/adaptive-course/MockInterviewAdminSection";
+import { CertificateAdminSection } from "@/components/admin/adaptive-course/CertificateAdminSection";
 import type { CourseImageTarget } from "@/lib/services/admin/admin-adaptive-course.service";
 
 type DialogState =
@@ -69,7 +72,9 @@ export default function AdminAdaptiveCourseDetailPage() {
   const [expandedQuiz, setExpandedQuiz] = useState<number | null>(null);
   const [expandedArticle, setExpandedArticle] = useState<number | null>(null);
   const [expandedCoding, setExpandedCoding] = useState<number | null>(null);
-  const [tab, setTab] = useState<"content" | "students" | "cover">("content");
+  const [tab, setTab] = useState<
+    "content" | "calibration" | "mock" | "certificate" | "students" | "cover"
+  >("content");
   // Edit course title + description (with AI-drafted description).
   const [editOpen, setEditOpen] = useState(false);
   const [editTitle, setEditTitle] = useState("");
@@ -319,9 +324,12 @@ export default function AdminAdaptiveCourseDetailPage() {
                 }
               />
 
-              <Box sx={{ display: "flex", gap: 1, mb: 2.5 }}>
+              <Box sx={{ display: "flex", gap: 1, mb: 2.5, flexWrap: "wrap" }}>
                 {([
                   ["content", "Content", "mdi:book-cog-outline"],
+                  ["calibration", "Calibration", "mdi:shield-half-full"],
+                  ["mock", "Mock interviews", "mdi:account-voice"],
+                  ["certificate", "Certificate", "mdi:certificate"],
                   ["students", "Students", "mdi:account-school-outline"],
                   ["cover", "Cover art", "mdi:image-outline"],
                 ] as const).map(([key, label, icon]) => {
@@ -362,60 +370,16 @@ export default function AdminAdaptiveCourseDetailPage() {
                 <CourseStudentsPanel courseId={course.id} courseTitle={course.title} />
               )}
 
-              {tab === "content" && <CalibrationAdminSection courseId={course.id} />}
-
-              {tab === "content" && (
-                <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 1.5, mb: 2.5 }}>
-                  {([
-                    {
-                      key: "calibration",
-                      title: "Calibration results",
-                      sub: "Submissions + each student's level, strengths & pace",
-                      icon: "mdi:shield-half-full",
-                      accent: "#6366f1",
-                      href: `/admin/adaptive-courses/${course.id}/calibration`,
-                    },
-                    {
-                      key: "mock-interview",
-                      title: "Mock interviews",
-                      sub: "Templates + per-student attempts & feedback",
-                      icon: "mdi:account-voice",
-                      accent: "#a855f7",
-                      href: `/admin/adaptive-courses/${course.id}/mock-interview`,
-                    },
-                    {
-                      key: "certificate",
-                      title: "Certificate",
-                      sub: "Upload the template + set the completion criteria",
-                      icon: "mdi:certificate",
-                      accent: "#f59e0b",
-                      href: `/admin/adaptive-courses/${course.id}/certificate`,
-                    },
-                  ] as const).map((c) => (
-                    <ButtonBase
-                      key={c.key}
-                      onClick={() => router.push(c.href)}
-                      sx={{
-                        textAlign: "left", display: "flex", alignItems: "center", gap: 1.5, p: { xs: 1.75, md: 2 },
-                        borderRadius: 4, width: "100%",
-                        bgcolor: "var(--card-bg, #fff)",
-                        border: "1px solid var(--border-default, #ececf1)",
-                        transition: "transform 120ms ease, border-color 120ms ease",
-                        "&:hover": { transform: "translateY(-1px)", borderColor: `color-mix(in srgb, ${c.accent} 45%, transparent)` },
-                      }}
-                    >
-                      <Box sx={{ width: 42, height: 42, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: `linear-gradient(135deg, ${c.accent} 0%, #a855f7 100%)` }}>
-                        <Icon icon={c.icon} width={22} />
-                      </Box>
-                      <Box sx={{ minWidth: 0, flex: 1 }}>
-                        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>{c.title}</Typography>
-                        <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", mt: 0.1 }}>{c.sub}</Typography>
-                      </Box>
-                      <Icon icon="mdi:arrow-right" width={20} style={{ flexShrink: 0, opacity: 0.5 }} />
-                    </ButtonBase>
-                  ))}
-                </Box>
+              {tab === "calibration" && (
+                <>
+                  <CalibrationAdminSection courseId={course.id} />
+                  <CalibrationResultsSection courseId={course.id} />
+                </>
               )}
+
+              {tab === "mock" && <MockInterviewAdminSection courseId={course.id} />}
+
+              {tab === "certificate" && <CertificateAdminSection courseId={course.id} />}
 
               {tab === "content" && course.skills.length > 0 && (
                 <Box sx={{

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -25,6 +25,7 @@ import {
   Course as ServiceCourse,
 } from "@/lib/services/courses.service";
 import { MainLayout } from "@/components/layout/MainLayout";
+import { CoursesNavTabs } from "@/components/courses/CoursesNavTabs";
 import { CourseCard } from "@/components/course/CourseCard";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
@@ -281,8 +282,8 @@ export default function CoursesPage() {
       await coursesService.enrollInCourse(courseId);
       showToast(t("courses.enrolledSuccess"), "success");
       loadCourses();
-    } catch (err: any) {
-      const data = err?.response?.data;
+    } catch (err: unknown) {
+      const data = (err as { response?: { data?: { error?: unknown; detail?: unknown } } })?.response?.data;
       const message =
         typeof data?.error === "string"
           ? data.error
@@ -323,6 +324,9 @@ export default function CoursesPage() {
             </Typography>
           </Box>
         </Box>
+
+        {/* Section switch: legacy Courses vs. the Adaptive courses page. */}
+        <CoursesNavTabs active="courses" />
 
         <Box
           sx={{

--- a/app/credentials/[credentialId]/CredentialView.tsx
+++ b/app/credentials/[credentialId]/CredentialView.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Button, CircularProgress, Divider, Paper, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type { AdaptiveCredential } from "@/lib/types/adaptive-journey";
+
+function fmtDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+  } catch {
+    return iso;
+  }
+}
+
+export function CredentialView({ credentialId }: { credentialId: string }) {
+  const [cred, setCred] = useState<AdaptiveCredential | null>(null);
+  const [status, setStatus] = useState<"loading" | "ok" | "notfound">("loading");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const c = await adaptiveJourneyService.getPublicCredential(credentialId);
+        if (cancelled) return;
+        if (c?.verified) {
+          setCred(c);
+          setStatus("ok");
+        } else {
+          setStatus("notfound");
+        }
+      } catch {
+        if (!cancelled) setStatus("notfound");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [credentialId]);
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(typeof window !== "undefined" ? window.location.href : "");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch {
+      /* no-op */
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100dvh",
+        display: "grid",
+        placeItems: "center",
+        p: { xs: 2, md: 4 },
+        background: "linear-gradient(135deg, #eef2ff 0%, #faf5ff 50%, #fdf2f8 100%)",
+      }}
+    >
+      {status === "loading" && <CircularProgress sx={{ color: "#6366f1" }} />}
+
+      {status === "notfound" && (
+        <Paper elevation={0} sx={{ p: { xs: 3, md: 5 }, borderRadius: 4, maxWidth: 460, textAlign: "center", border: "1px solid #ececf1" }}>
+          <Icon icon="mdi:alert-circle-outline" width={48} style={{ color: "#f59e0b" }} />
+          <Typography sx={{ fontWeight: 800, fontSize: "1.25rem", mt: 1 }}>Credential not found</Typography>
+          <Typography sx={{ color: "text.secondary", mt: 1 }}>
+            We couldn&apos;t find a credential with the ID <b>{credentialId}</b>. It may have been mistyped.
+          </Typography>
+        </Paper>
+      )}
+
+      {status === "ok" && cred && (
+        <Paper
+          elevation={0}
+          sx={{
+            width: "100%",
+            maxWidth: 680,
+            borderRadius: 5,
+            overflow: "hidden",
+            border: "1px solid #ececf1",
+            boxShadow: "0 30px 60px -30px rgba(15,23,42,0.25)",
+            bgcolor: "#fff",
+          }}
+        >
+          {/* Accent header */}
+          <Box sx={{ height: 8, background: "linear-gradient(90deg, #6366f1 0%, #a855f7 50%, #ec4899 100%)" }} />
+
+          <Box sx={{ p: { xs: 3, md: 5 } }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
+              {cred.issuer_logo_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={cred.issuer_logo_url} alt={cred.issuer_name} style={{ height: 36, objectFit: "contain" }} />
+              ) : (
+                <Typography sx={{ fontWeight: 900, fontSize: "1.1rem", color: "#0f172a" }}>{cred.issuer_name}</Typography>
+              )}
+              <Stack direction="row" spacing={0.5} alignItems="center" sx={{ px: 1.25, py: 0.5, borderRadius: 999, bgcolor: "#dcfce7", color: "#15803d" }}>
+                <Icon icon="mdi:check-decagram" width={18} />
+                <Typography sx={{ fontWeight: 800, fontSize: "0.78rem" }}>Verified Credential</Typography>
+              </Stack>
+            </Stack>
+
+            <Typography sx={{ color: "text.secondary", fontSize: "0.82rem", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+              This certifies that
+            </Typography>
+            <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.7rem", md: "2.2rem" }, lineHeight: 1.15, mt: 0.5, color: "#0f172a" }}>
+              {cred.recipient_name}
+            </Typography>
+            <Typography sx={{ color: "text.secondary", mt: 1.5 }}>has successfully completed</Typography>
+            <Typography sx={{ fontWeight: 800, fontSize: { xs: "1.2rem", md: "1.5rem" }, mt: 0.5, color: "#4f46e5" }}>
+              {cred.course_title}
+            </Typography>
+
+            {cred.template_url && (
+              <Box sx={{ mt: 3, borderRadius: 3, overflow: "hidden", border: "1px solid #ececf1" }}>
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={cred.template_url} alt="Certificate" style={{ width: "100%", height: "auto", display: "block" }} />
+              </Box>
+            )}
+
+            <Stack direction="row" spacing={3} flexWrap="wrap" useFlexGap sx={{ mt: 3 }}>
+              <Meta label="Issued by" value={cred.issuer_name} />
+              <Meta label="Issued on" value={fmtDate(cred.issued_at)} />
+              <Meta label="Completion" value={`${cred.completion_percent}%`} />
+            </Stack>
+
+            <Divider sx={{ my: 3 }} />
+
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5} justifyContent="space-between" alignItems={{ sm: "center" }}>
+              <Box>
+                <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: "0.06em", textTransform: "uppercase", color: "text.secondary" }}>
+                  Credential ID
+                </Typography>
+                <Typography sx={{ fontFamily: "monospace", fontWeight: 700, fontSize: "0.95rem", color: "#0f172a" }}>
+                  {cred.credential_id}
+                </Typography>
+              </Box>
+              <Button
+                onClick={copyLink}
+                variant="outlined"
+                startIcon={<Icon icon={copied ? "mdi:check" : "mdi:link-variant"} width={18} />}
+                sx={{ textTransform: "none", fontWeight: 700, borderColor: "#c7d2fe", color: "#4f46e5", borderRadius: 2 }}
+              >
+                {copied ? "Link copied" : "Copy verify link"}
+              </Button>
+            </Stack>
+          </Box>
+
+          <Box sx={{ px: { xs: 3, md: 5 }, py: 2, bgcolor: "#f8fafc", borderTop: "1px solid #ececf1" }}>
+            <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
+              <Icon icon="mdi:shield-check-outline" width={15} style={{ verticalAlign: "-2px", marginRight: 4 }} />
+              This is a verified credential issued by {cred.issuer_name}. Anyone with this link can confirm its authenticity.
+            </Typography>
+          </Box>
+        </Paper>
+      )}
+    </Box>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: "0.06em", textTransform: "uppercase", color: "text.secondary" }}>
+        {label}
+      </Typography>
+      <Typography sx={{ fontWeight: 700, fontSize: "0.95rem", color: "#0f172a" }}>{value}</Typography>
+    </Box>
+  );
+}

--- a/app/credentials/[credentialId]/CredentialView.tsx
+++ b/app/credentials/[credentialId]/CredentialView.tsx
@@ -18,6 +18,9 @@ export function CredentialView({ credentialId }: { credentialId: string }) {
   const [cred, setCred] = useState<AdaptiveCredential | null>(null);
   const [status, setStatus] = useState<"loading" | "ok" | "notfound">("loading");
   const [copied, setCopied] = useState(false);
+  // The personalized certificate (recipient's name drawn onto the template),
+  // generated the same way the learner's download is. Falls back to the raw template.
+  const [certImageUrl, setCertImageUrl] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -39,6 +42,38 @@ export function CredentialView({ credentialId }: { credentialId: string }) {
       cancelled = true;
     };
   }, [credentialId]);
+
+  // Draw the recipient's name onto the uploaded template (matches the download).
+  useEffect(() => {
+    if (!cred?.template_url) return;
+    let revoked = false;
+    let objectUrl: string | null = null;
+    (async () => {
+      try {
+        const res = await fetch("/api/certificate/generate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            studentName: cred.recipient_name,
+            templateUrl: cred.template_url,
+            courseName: cred.course_title,
+            issuerName: cred.issuer_name,
+            structuredTrainingSubject: cred.course_title,
+          }),
+        });
+        if (!res.ok) return;
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        if (!revoked) setCertImageUrl(objectUrl);
+      } catch {
+        /* fall back to the raw template */
+      }
+    })();
+    return () => {
+      revoked = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [cred?.template_url, cred?.recipient_name, cred?.course_title, cred?.issuer_name]);
 
   const copyLink = async () => {
     try {
@@ -116,7 +151,7 @@ export function CredentialView({ credentialId }: { credentialId: string }) {
             {cred.template_url && (
               <Box sx={{ mt: 3, borderRadius: 3, overflow: "hidden", border: "1px solid #ececf1" }}>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={cred.template_url} alt="Certificate" style={{ width: "100%", height: "auto", display: "block" }} />
+                <img src={certImageUrl ?? cred.template_url} alt="Certificate" style={{ width: "100%", height: "auto", display: "block" }} />
               </Box>
             )}
 

--- a/app/credentials/[credentialId]/credential-data.ts
+++ b/app/credentials/[credentialId]/credential-data.ts
@@ -1,0 +1,24 @@
+import type { AdaptiveCredential } from "@/lib/types/adaptive-journey";
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL || "").replace(/\/$/, "");
+
+/**
+ * Server-side fetch of a public credential (used by generateMetadata + the OG
+ * image route, which run on the server and can't use the browser axios client).
+ * Returns null on any failure so callers render a graceful "not found".
+ */
+export async function fetchCredentialServer(
+  credentialId: string,
+): Promise<AdaptiveCredential | null> {
+  if (!API_BASE) return null;
+  try {
+    const res = await fetch(
+      `${API_BASE}/adaptive-journey/api/credentials/${encodeURIComponent(credentialId)}/`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as AdaptiveCredential;
+  } catch {
+    return null;
+  }
+}

--- a/app/credentials/[credentialId]/opengraph-image.tsx
+++ b/app/credentials/[credentialId]/opengraph-image.tsx
@@ -1,0 +1,66 @@
+import { ImageResponse } from "next/og";
+import { fetchCredentialServer } from "./credential-data";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "Verified credential";
+
+// Rich OG image LinkedIn (and others) show when the credential URL is added as a
+// media link or shared — a clean, branded "Verified Credential" card.
+export default async function Image({ params }: { params: Promise<{ credentialId: string }> }) {
+  const { credentialId } = await params;
+  const cred = await fetchCredentialServer(credentialId);
+  const recipient = cred?.recipient_name || "Learner";
+  const course = cred?.course_title || "Course Completion";
+  const issuer = cred?.issuer_name || "AI Linc";
+  const id = cred?.credential_id || credentialId;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "64px 72px",
+          background: "linear-gradient(135deg, #4f46e5 0%, #7c3aed 55%, #db2777 100%)",
+          color: "white",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div style={{ fontSize: 30, fontWeight: 800, letterSpacing: 2, opacity: 0.95 }}>{issuer}</div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              background: "rgba(255,255,255,0.18)",
+              padding: "10px 22px",
+              borderRadius: 999,
+              fontSize: 26,
+              fontWeight: 700,
+            }}
+          >
+            ✓ Verified Credential
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ fontSize: 28, opacity: 0.85, marginBottom: 12 }}>This certifies that</div>
+          <div style={{ fontSize: 72, fontWeight: 800, lineHeight: 1.05 }}>{recipient}</div>
+          <div style={{ fontSize: 28, opacity: 0.85, margin: "18px 0 6px" }}>has successfully completed</div>
+          <div style={{ fontSize: 46, fontWeight: 700, color: "#fde68a" }}>{course}</div>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", fontSize: 24, opacity: 0.9 }}>
+          <div>Credential ID: {id}</div>
+          <div>Verify at this link</div>
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/credentials/[credentialId]/page.tsx
+++ b/app/credentials/[credentialId]/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { fetchCredentialServer } from "./credential-data";
+import { CredentialView } from "./CredentialView";
+
+interface PageProps {
+  params: Promise<{ credentialId: string }>;
+}
+
+// Server-rendered metadata so LinkedIn / crawlers unfurl the credential with a
+// rich title + description + the certificate OG image (opengraph-image.tsx).
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { credentialId } = await params;
+  const cred = await fetchCredentialServer(credentialId);
+  if (!cred || !cred.verified) {
+    return { title: "Credential not found", robots: { index: false } };
+  }
+  const title = `${cred.course_title} — Verified Credential`;
+  const description = `${cred.recipient_name} has successfully completed ${cred.course_title}, issued by ${cred.issuer_name}. Verify credential ${cred.credential_id}.`;
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "article" },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function CredentialPage({ params }: PageProps) {
+  const { credentialId } = await params;
+  return <CredentialView credentialId={credentialId} />;
+}

--- a/components/adaptive-journey/CertificateCard.tsx
+++ b/components/adaptive-journey/CertificateCard.tsx
@@ -4,6 +4,7 @@ import { Box, ButtonBase, CircularProgress, Stack, Typography } from "@mui/mater
 import { Icon } from "@iconify/react";
 import { useCertificateActions } from "@/components/certificate/useCertificateActions";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import { getPublicAppOrigin } from "@/lib/config";
 import type { JourneyBoard } from "@/lib/types/adaptive-journey";
 
 /** Compact pill button matching the adaptive journey side-panel style. */
@@ -69,6 +70,13 @@ export function CertificateCard({ board }: { board: JourneyBoard }) {
     score: `${completion}%`,
     courseDescription: c.description,
     generatePost: () => adaptiveJourneyService.getCertificateLinkedInPost(c.id),
+    getCredential: async () => {
+      const cred = await adaptiveJourneyService.issueCertificate(c.id);
+      return {
+        credentialId: cred.credential_id,
+        verifyUrl: `${getPublicAppOrigin()}/credentials/${cred.credential_id}`,
+      };
+    },
   });
 
   return (

--- a/components/adaptive-journey/CertificateCard.tsx
+++ b/components/adaptive-journey/CertificateCard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Box, ButtonBase, CircularProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useCertificateActions } from "@/components/certificate/useCertificateActions";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type { JourneyBoard } from "@/lib/types/adaptive-journey";
+
+/** Compact pill button matching the adaptive journey side-panel style. */
+function Pill({
+  icon,
+  label,
+  onClick,
+  disabled,
+  busy,
+  tone,
+}: {
+  icon: string;
+  label: string;
+  onClick: () => void;
+  disabled: boolean;
+  busy?: boolean;
+  tone: "primary" | "linkedin";
+}) {
+  const active = !disabled;
+  const color = active ? (tone === "primary" ? "white" : "#0a66c2") : "#64748b";
+  const bgcolor = active && tone === "primary" ? "#6366f1" : "#f1f5f9";
+  return (
+    <ButtonBase
+      onClick={onClick}
+      disabled={disabled}
+      sx={{
+        flex: 1,
+        py: 0.9,
+        px: 1,
+        borderRadius: 2,
+        fontWeight: 700,
+        fontSize: "0.8rem",
+        gap: 0.5,
+        color,
+        bgcolor,
+        border: "1px solid #eef2f7",
+        transition: "filter 120ms ease",
+        "&:hover": { filter: active ? "brightness(0.96)" : "none" },
+      }}
+    >
+      {busy ? <CircularProgress size={14} sx={{ color }} /> : <Icon icon={icon} width={16} />}
+      {label}
+    </ButtonBase>
+  );
+}
+
+/**
+ * Learner certificate card for the adaptive journey — the compact card with a
+ * download + LinkedIn-share pill (matching the journey side-panel style),
+ * powered by the shared certificate hook. The LinkedIn post is AI-generated
+ * from the course (with a local fallback).
+ */
+export function CertificateCard({ board }: { board: JourneyBoard }) {
+  const c = board.course;
+  const completion = board.progressCard.completionPct ?? 0;
+
+  const cert = useCertificateActions({
+    courseTitle: c.certificateTitle || c.title,
+    certificateAvailable: c.certificateEnabled,
+    uploadedTemplateUrl: c.certificateTemplateUrl,
+    completionPercentage: completion,
+    minCompletion: c.certificateThreshold,
+    score: `${completion}%`,
+    courseDescription: c.description,
+    generatePost: () => adaptiveJourneyService.getCertificateLinkedInPost(c.id),
+  });
+
+  return (
+    <Box sx={{ p: 2, mb: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
+      {cert.portal}
+
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+        <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
+          <Icon icon="mdi:certificate" width={17} />
+        </Box>
+        <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.92rem" }}>Certificate</Typography>
+      </Stack>
+
+      <Typography sx={{ fontSize: "0.82rem", color: "#475569", lineHeight: 1.5 }}>
+        {cert.canClaim ? (
+          <>Your certificate is ready — download it or share it on LinkedIn. 🎓</>
+        ) : (
+          <>
+            Complete <b style={{ color: "#0f172a" }}>{c.certificateThreshold}%</b> of the course to unlock
+            certificate download &amp; LinkedIn sharing.
+          </>
+        )}
+      </Typography>
+
+      <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
+        <Pill
+          icon="mdi:download"
+          label={cert.downloading ? "Preparing…" : "Certificate"}
+          onClick={cert.downloadCertificate}
+          disabled={!cert.canClaim || cert.downloading}
+          busy={cert.downloading}
+          tone="primary"
+        />
+        <Pill
+          icon="mdi:linkedin"
+          label="Share"
+          onClick={cert.shareOnLinkedIn}
+          disabled={!cert.canClaim || cert.sharing}
+          busy={cert.sharing}
+          tone="linkedin"
+        />
+      </Stack>
+
+      <ButtonBase
+        onClick={cert.addToLinkedInProfile}
+        disabled={!cert.canClaim}
+        sx={{
+          mt: 1,
+          gap: 0.5,
+          fontSize: "0.76rem",
+          fontWeight: 700,
+          color: cert.canClaim ? "#0a66c2" : "#94a3b8",
+          "&:hover": { textDecoration: cert.canClaim ? "underline" : "none" },
+        }}
+      >
+        <Icon icon="mdi:linkedin" width={14} /> Add to LinkedIn profile
+      </ButtonBase>
+    </Box>
+  );
+}

--- a/components/adaptive-journey/JourneyBoard.tsx
+++ b/components/adaptive-journey/JourneyBoard.tsx
@@ -205,7 +205,6 @@ function WeekCard({ week, courseId, startStep }: { week: JourneyWeekView; course
   const pct = week.totals.total > 0 ? Math.round((week.totals.earned / week.totals.total) * 100) : 0;
   const dl = daysLeft(week.schedule?.dueAt);
   const locked = week.nodes.every((n) => n.status === "locked");
-  let step = startStep;
 
   return (
     <Box sx={{ border: "1px solid #e9e6f7", borderRadius: 4, overflow: "hidden", bgcolor: "#fff", mb: 2, boxShadow: "0 12px 30px -24px rgba(99,102,241,0.45)" }}>
@@ -255,10 +254,9 @@ function WeekCard({ week, courseId, startStep }: { week: JourneyWeekView; course
       </Box>
 
       <Box sx={{ p: { xs: 1.5, md: 2 } }}>
-        {week.nodes.map((n) => {
-          step += 1;
-          return <NodeRow key={n.id} node={n} courseId={courseId} stepNo={step} dueAt={week.schedule?.dueAt} />;
-        })}
+        {week.nodes.map((n, i) => (
+          <NodeRow key={n.id} node={n} courseId={courseId} stepNo={startStep + i + 1} dueAt={week.schedule?.dueAt} />
+        ))}
       </Box>
     </Box>
   );
@@ -292,8 +290,8 @@ function Hero({ board, courseId }: { board: JourneyBoardData; courseId: number }
 
   return (
     <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 2.5, color: "white", position: "relative", overflow: "hidden", background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -28px rgba(124,58,237,0.6)" }}>
-      <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-        <Box sx={{ minWidth: 0 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2}>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.7)", mb: 1 }}>‹ My Courses / {c.title}</Typography>
           <Stack direction="row" spacing={0.75} sx={{ mb: 1 }}>
             <Chip label={subject} size="small" sx={{ fontWeight: 700, color: "white", bgcolor: "rgba(255,255,255,0.18)" }} />
@@ -301,7 +299,7 @@ function Hero({ board, courseId }: { board: JourneyBoardData; courseId: number }
           </Stack>
           <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.7rem", md: "2.2rem" }, lineHeight: 1.1 }}>{c.title}</Typography>
           {c.description && (
-            <Typography sx={{ fontSize: "0.88rem", color: "rgba(255,255,255,0.82)", mt: 1, maxWidth: 620, lineHeight: 1.5 }}>{c.description}</Typography>
+            <Typography sx={{ fontSize: "0.88rem", color: "rgba(255,255,255,0.82)", mt: 1, maxWidth: { xs: "100%", md: 980 }, lineHeight: 1.5 }}>{c.description}</Typography>
           )}
           <Stack direction="row" flexWrap="wrap" gap={1.5} sx={{ mt: 1.75 }}>
             {meta.map((m) => (

--- a/components/adaptive-journey/JourneySidePanels.tsx
+++ b/components/adaptive-journey/JourneySidePanels.tsx
@@ -1,10 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Avatar, Box, ButtonBase, LinearProgress, Stack, Typography } from "@mui/material";
+import dynamic from "next/dynamic";
+import { Avatar, Box, LinearProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { JourneyBoard, Leaderboard } from "@/lib/types/adaptive-journey";
+
+// Lazy: CertificateButtons drags in jspdf + html-to-image (~500KB gz). Only
+// needed when a course is certifiable, so defer it off the initial bundle.
+const CertificateButtons = dynamic(
+  () =>
+    import("@/components/course/CertificateButtons").then((m) => ({
+      default: m.CertificateButtons,
+    })),
+  { ssr: false },
+);
 
 // Medal colours for the top-3 rank circles.
 const RANK_BG = ["#fde68a", "#e5e7eb", "#e7c4a0"];
@@ -52,7 +63,6 @@ export function JourneySidePanels({ courseId, board }: { courseId: number; board
   const pc = board.progressCard;
   const c = board.course;
   const completion = pc.completionPct ?? 0;
-  const certReady = completion >= c.certificateThreshold;
 
   const current = board.weeks.flatMap((w) => w.nodes).find((n) => n.status === "current");
   const currentWeek = board.weeks.find((w) => w.nodes.some((n) => n.status === "current"));
@@ -64,25 +74,28 @@ export function JourneySidePanels({ courseId, board }: { courseId: number; board
   return (
     <>
       {/* Certificate */}
-      <Card>
-        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
-          <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
-            <Icon icon="mdi:certificate" width={17} />
-          </Box>
-          <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.92rem" }}>Certificate</Typography>
-        </Stack>
-        <Typography sx={{ fontSize: "0.82rem", color: "#475569", lineHeight: 1.5 }}>
-          Complete <b style={{ color: "#0f172a" }}>{c.certificateThreshold}%</b> of the course to unlock certificate download &amp; LinkedIn sharing.
-        </Typography>
-        <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
-          <ButtonBase disabled={!certReady} sx={{ flex: 1, py: 0.9, borderRadius: 2, fontWeight: 700, fontSize: "0.8rem", gap: 0.5, color: certReady ? "white" : "#64748b", bgcolor: certReady ? "#6366f1" : "#f1f5f9", border: "1px solid #eef2f7" }}>
-            <Icon icon="mdi:download" width={16} /> Certificate
-          </ButtonBase>
-          <ButtonBase disabled={!certReady} sx={{ flex: 1, py: 0.9, borderRadius: 2, fontWeight: 700, fontSize: "0.8rem", gap: 0.5, color: certReady ? "#0a66c2" : "#64748b", bgcolor: "#f1f5f9", border: "1px solid #eef2f7" }}>
-            <Icon icon="mdi:linkedin" width={16} /> Share
-          </ButtonBase>
-        </Stack>
-      </Card>
+      {c.certificateEnabled && (
+        <Card>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+            <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
+              <Icon icon="mdi:certificate" width={17} />
+            </Box>
+            <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.92rem" }}>Certificate</Typography>
+          </Stack>
+          <Typography sx={{ fontSize: "0.82rem", color: "#475569", lineHeight: 1.5 }}>
+            Complete <b style={{ color: "#0f172a" }}>{c.certificateThreshold}%</b> of the course to unlock certificate download &amp; LinkedIn sharing.
+          </Typography>
+          <CertificateButtons
+            courseId={c.id}
+            courseTitle={c.certificateTitle || c.title}
+            certificateAvailable
+            uploadedTemplateUrl={c.certificateTemplateUrl}
+            completionPercentage={completion}
+            minCompletion={c.certificateThreshold}
+            score={`${completion}%`}
+          />
+        </Card>
+      )}
 
       {/* Your Progress */}
       <Card>

--- a/components/adaptive-journey/JourneySidePanels.tsx
+++ b/components/adaptive-journey/JourneySidePanels.tsx
@@ -7,12 +7,12 @@ import { Icon } from "@iconify/react";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { JourneyBoard, Leaderboard } from "@/lib/types/adaptive-journey";
 
-// Lazy: CertificateButtons drags in jspdf + html-to-image (~500KB gz). Only
+// Lazy: the certificate card drags in jspdf + html-to-image (~500KB gz). Only
 // needed when a course is certifiable, so defer it off the initial bundle.
-const CertificateButtons = dynamic(
+const CertificateCard = dynamic(
   () =>
-    import("@/components/course/CertificateButtons").then((m) => ({
-      default: m.CertificateButtons,
+    import("@/components/adaptive-journey/CertificateCard").then((m) => ({
+      default: m.CertificateCard,
     })),
   { ssr: false },
 );
@@ -74,28 +74,7 @@ export function JourneySidePanels({ courseId, board }: { courseId: number; board
   return (
     <>
       {/* Certificate */}
-      {c.certificateEnabled && (
-        <Card>
-          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
-            <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
-              <Icon icon="mdi:certificate" width={17} />
-            </Box>
-            <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.92rem" }}>Certificate</Typography>
-          </Stack>
-          <Typography sx={{ fontSize: "0.82rem", color: "#475569", lineHeight: 1.5 }}>
-            Complete <b style={{ color: "#0f172a" }}>{c.certificateThreshold}%</b> of the course to unlock certificate download &amp; LinkedIn sharing.
-          </Typography>
-          <CertificateButtons
-            courseId={c.id}
-            courseTitle={c.certificateTitle || c.title}
-            certificateAvailable
-            uploadedTemplateUrl={c.certificateTemplateUrl}
-            completionPercentage={completion}
-            minCompletion={c.certificateThreshold}
-            score={`${completion}%`}
-          />
-        </Card>
-      )}
+      {c.certificateEnabled && <CertificateCard board={board} />}
 
       {/* Your Progress */}
       <Card>

--- a/components/admin/adaptive-course/CalibrationAdminSection.tsx
+++ b/components/admin/adaptive-course/CalibrationAdminSection.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Box, Button, Chip, CircularProgress, Stack, TextField, Typography } from "@mui/material";
+import { Box, Button, Chip, CircularProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { useToast } from "@/components/common/Toast";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
@@ -20,12 +20,8 @@ export function CalibrationAdminSection({ courseId }: { courseId: number }) {
   const router = useRouter();
   const { showToast } = useToast();
   const [calib, setCalib] = useState<CalibStatus | null>(null);
-  const [startDate, setStartDate] = useState<string>("");
-  const [scheduleSet, setScheduleSet] = useState(false);
-  const [calendarWeeks, setCalendarWeeks] = useState(0);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
-  const [savingDate, setSavingDate] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const stopPolling = () => {
@@ -38,16 +34,10 @@ export function CalibrationAdminSection({ courseId }: { courseId: number }) {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [c, s] = await Promise.allSettled([
-        adaptiveJourneyService.getCalibration(courseId),
-        adaptiveJourneyService.getSchedule(courseId),
-      ]);
-      if (c.status === "fulfilled") setCalib(c.value);
-      if (s.status === "fulfilled") {
-        setScheduleSet(s.value.schedule_set);
-        setCalendarWeeks(s.value.calendar.length);
-        if (s.value.schedule?.start_date) setStartDate(s.value.schedule.start_date);
-      }
+      const c = await adaptiveJourneyService.getCalibration(courseId);
+      setCalib(c);
+    } catch {
+      /* surfaced as not-started */
     } finally {
       setLoading(false);
     }
@@ -101,21 +91,6 @@ export function CalibrationAdminSection({ courseId }: { courseId: number }) {
     }
   };
 
-  const saveStartDate = async () => {
-    if (!startDate) return;
-    setSavingDate(true);
-    try {
-      const res = await adaptiveJourneyService.setSchedule(courseId, { start_date: startDate });
-      setScheduleSet(res.schedule_set);
-      setCalendarWeeks(res.calendar.length);
-      showToast("Cohort start date saved.", "success");
-    } catch {
-      showToast("Couldn't save the start date.", "error");
-    } finally {
-      setSavingDate(false);
-    }
-  };
-
   const card = (children: React.ReactNode) => (
     <Box sx={{ borderRadius: 3, p: { xs: 2, md: 2.5 }, mb: 2.5, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
       {children}
@@ -136,66 +111,37 @@ export function CalibrationAdminSection({ courseId }: { courseId: number }) {
   const chip = STATUS_CHIP[status] ?? STATUS_CHIP.not_started;
 
   return card(
-    <>
-      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
-        <Icon icon="mdi:shield-half-full" width={20} color="#6366f1" />
-        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Calibration & schedule</Typography>
-      </Stack>
-
-      {/* Calibration */}
-      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "center", justifyContent: "space-between", py: 1 }}>
-        <Box sx={{ minWidth: 0 }}>
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Typography sx={{ fontWeight: 700 }}>Calibration assessment</Typography>
-            <Chip label={chip.label} size="small" sx={{ height: 20, fontSize: "0.66rem", fontWeight: 800, color: chip.color, bgcolor: chip.bg }} />
-            {configured && <Typography sx={{ fontSize: "0.8rem", color: "#94a3b8" }}>{calib?.question_count ?? 0} questions</Typography>}
-          </Stack>
-          <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>
-            {generating
-              ? "AI is generating the field-aptitude question set — this card will update when it's ready."
-              : configured
-                ? "Live. Learners take it before personalization unlocks. Edit the questions anytime."
-                : "Proctored, non-adaptive field-aptitude test that seeds each learner's Student Model. New courses get this automatically; generate it here for older courses."}
-          </Typography>
-        </Box>
-        <Stack direction="row" spacing={1}>
-          {configured ? (
-            <Button variant="outlined" onClick={() => router.push(`/admin/assessment/${calib?.assessment_id}/build`)}
-              sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2 }}
-              startIcon={<Icon icon="mdi:playlist-edit" width={18} />}>
-              Edit questions
-            </Button>
-          ) : (
-            <Button variant="contained" disabled={generating} onClick={generate}
-              startIcon={generating ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:auto-fix" width={18} />}
-              sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2, background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}>
-              {generating ? "Generating…" : "Generate calibration (AI)"}
-            </Button>
-          )}
-        </Stack>
-      </Box>
-
-      <Box sx={{ height: "1px", bgcolor: "var(--border-default, #ececf1)", my: 1.5 }} />
-
-      {/* Cohort start date */}
-      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "flex-end", justifyContent: "space-between", py: 1 }}>
-        <Box>
-          <Typography sx={{ fontWeight: 700 }}>Cohort start date</Typography>
-          <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>
-            {scheduleSet
-              ? `Drives weekly windows (9-day stagger, 10-day window) + late penalties — ${calendarWeeks} weeks generated.`
-              : "Not set — week deadlines and late penalties stay inactive until you set a start date."}
-          </Typography>
-        </Box>
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "center", justifyContent: "space-between" }}>
+      <Box sx={{ minWidth: 0 }}>
         <Stack direction="row" spacing={1} alignItems="center">
-          <TextField type="date" size="small" value={startDate} onChange={(e) => setStartDate(e.target.value)}
-            InputLabelProps={{ shrink: true }} sx={{ minWidth: 170 }} />
-          <Button variant="outlined" disabled={!startDate || savingDate} onClick={saveStartDate}
-            sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2 }}>
-            {savingDate ? "Saving…" : "Save"}
-          </Button>
+          <Icon icon="mdi:shield-half-full" width={20} color="#6366f1" />
+          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Calibration assessment</Typography>
+          <Chip label={chip.label} size="small" sx={{ height: 20, fontSize: "0.66rem", fontWeight: 800, color: chip.color, bgcolor: chip.bg }} />
+          {configured && <Typography sx={{ fontSize: "0.8rem", color: "#94a3b8" }}>{calib?.question_count ?? 0} questions</Typography>}
         </Stack>
+        <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.5 }}>
+          {generating
+            ? "AI is generating the field-aptitude question set — this card will update when it's ready."
+            : configured
+              ? "Live. Learners take it before personalization unlocks. Edit the questions anytime."
+              : "Proctored, non-adaptive field-aptitude test that seeds each learner's Student Model. New courses get this automatically; generate it here for older courses."}
+        </Typography>
       </Box>
-    </>,
+      <Stack direction="row" spacing={1}>
+        {configured ? (
+          <Button variant="outlined" onClick={() => router.push(`/admin/assessment/${calib?.assessment_id}/build`)}
+            sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2 }}
+            startIcon={<Icon icon="mdi:playlist-edit" width={18} />}>
+            Edit questions
+          </Button>
+        ) : (
+          <Button variant="contained" disabled={generating} onClick={generate}
+            startIcon={generating ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:auto-fix" width={18} />}
+            sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2, background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}>
+            {generating ? "Generating…" : "Generate calibration (AI)"}
+          </Button>
+        )}
+      </Stack>
+    </Box>,
   );
 }

--- a/components/admin/adaptive-course/CalibrationResultsSection.tsx
+++ b/components/admin/adaptive-course/CalibrationResultsSection.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Avatar, Box, Chip, CircularProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type {
+  CalibrationSubmissionRow,
+  CalibrationSubmissionsResponse,
+} from "@/lib/types/adaptive-journey";
+
+const TIER_COLOR: Record<string, string> = {
+  beginner: "#f59e0b",
+  intermediate: "#3b82f6",
+  advanced: "#16a34a",
+};
+
+/** Per-student calibration submissions + their seeded Student Model (level,
+ *  strengths, pace). Rendered under the Calibration tab + the sub-page. */
+export function CalibrationResultsSection({ courseId }: { courseId: number }) {
+  const [data, setData] = useState<CalibrationSubmissionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!Number.isFinite(courseId)) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const d = await adaptiveJourneyService.getCalibrationSubmissions(courseId);
+        if (!cancelled) setData(d);
+      } catch {
+        /* surfaced as empty state */
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5, mt: 1 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Submissions &amp; student model</Typography>
+        {data && <Chip label={`${data.submission_count} submitted`} size="small" sx={{ fontWeight: 700 }} />}
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: "grid", placeItems: "center", py: 5 }}>
+          <CircularProgress sx={{ color: "#6366f1" }} />
+        </Box>
+      ) : !data || data.submissions.length === 0 ? (
+        <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default, #ececf1)" }}>
+          <Icon icon="mdi:inbox-outline" width={36} style={{ opacity: 0.4 }} />
+          <Typography sx={{ color: "text.secondary", mt: 1 }}>No calibration submissions yet.</Typography>
+        </Box>
+      ) : (
+        <Stack spacing={1.25}>
+          {data.submissions.map((s) => (
+            <SubmissionRow key={s.submission_id} s={s} />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+function SubmissionRow({ s }: { s: CalibrationSubmissionRow }) {
+  return (
+    <Box sx={{ p: 2, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems={{ md: "center" }} justifyContent="space-between">
+        <Stack direction="row" spacing={1.5} alignItems="center" sx={{ minWidth: 0 }}>
+          <Avatar src={s.profile_pic_url || undefined} sx={{ width: 38, height: 38 }}>{s.name?.[0]}</Avatar>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }}>{s.name}</Typography>
+            <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }}>
+              {s.email || "—"}
+              {s.submitted_at ? ` · ${new Date(s.submitted_at).toLocaleDateString()}` : ""}
+            </Typography>
+          </Box>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ gap: 1 }}>
+          {s.level_label && (
+            <Chip label={s.level_label} size="small" sx={{ fontWeight: 800, color: "white", bgcolor: TIER_COLOR[s.field_tier || "intermediate"] }} />
+          )}
+          {s.ability_index != null && <Chip label={`Ability ${Math.round(s.ability_index)}`} size="small" variant="outlined" />}
+          {s.pace && <Chip label={`Pace: ${s.pace}`} size="small" variant="outlined" />}
+        </Stack>
+      </Stack>
+      {s.summary && (
+        <Typography sx={{ mt: 1, fontSize: "0.85rem", color: "text.secondary", lineHeight: 1.5 }}>{s.summary}</Typography>
+      )}
+      {(s.strengths.length > 0 || s.growth_areas.length > 0) && (
+        <Stack direction="row" flexWrap="wrap" sx={{ mt: 1, gap: 0.75 }}>
+          {s.strengths.map((x) => (
+            <Chip key={`s-${x.dimension}`} size="small" label={x.dimension} sx={{ bgcolor: "#dcfce7", color: "#15803d", fontWeight: 700 }} />
+          ))}
+          {s.growth_areas.map((x) => (
+            <Chip key={`g-${x.dimension}`} size="small" label={x.dimension} sx={{ bgcolor: "#fef3c7", color: "#b45309", fontWeight: 700 }} />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/components/admin/adaptive-course/CertificateAdminSection.tsx
+++ b/components/admin/adaptive-course/CertificateAdminSection.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Chip,
+  CircularProgress,
+  FormControlLabel,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { AdminCertificateUploadCard } from "@/components/admin/certificates/AdminCertificateUploadCard";
+import { useToast } from "@/components/common/Toast";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type { AdminCertificateConfig } from "@/lib/types/adaptive-journey";
+
+const AMBER_GRADIENT = "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)";
+const INDIGO_GRADIENT = "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)";
+
+const panelSx = {
+  p: { xs: 2.25, md: 3 },
+  borderRadius: 4,
+  bgcolor: "color-mix(in srgb, var(--card-bg) 92%, transparent)",
+  border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+} as const;
+
+function PanelHeader({
+  icon,
+  gradient,
+  title,
+  sub,
+  right,
+}: {
+  icon: string;
+  gradient: string;
+  title: string;
+  sub: string;
+  right?: React.ReactNode;
+}) {
+  return (
+    <Stack direction="row" alignItems="flex-start" justifyContent="space-between" spacing={1.5} sx={{ mb: 2 }}>
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ minWidth: 0 }}>
+        <Box sx={{ width: 38, height: 38, borderRadius: 2.25, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: gradient }}>
+          <Icon icon={icon} width={20} />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.2 }}>{title}</Typography>
+          <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>{sub}</Typography>
+        </Box>
+      </Stack>
+      {right}
+    </Stack>
+  );
+}
+
+/**
+ * Admin certificate authoring — upload the template + set the unlock criteria
+ * (enabled, min completion %, title). Self-contained section, rendered both as
+ * the Certificate tab on the course detail page and on the standalone sub-page.
+ */
+export function CertificateAdminSection({ courseId }: { courseId: number }) {
+  const { showToast } = useToast();
+
+  const [config, setConfig] = useState<AdminCertificateConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [enabled, setEnabled] = useState(false);
+  const [minCompletion, setMinCompletion] = useState(80);
+  const [title, setTitle] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const hydrate = (c: AdminCertificateConfig) => {
+    setConfig(c);
+    setEnabled(c.enabled);
+    setMinCompletion(c.min_completion_percent);
+    setTitle(c.title);
+  };
+
+  useEffect(() => {
+    if (!Number.isFinite(courseId)) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const c = await adaptiveJourneyService.getCertificateConfig(courseId);
+        if (!cancelled) hydrate(c);
+      } catch {
+        /* surfaced as empty state */
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setUploading(true);
+    try {
+      const c = await adaptiveJourneyService.uploadCertificateTemplate(courseId, file);
+      hydrate(c);
+      setFile(null);
+      showToast("Certificate template uploaded.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Failed to upload template.", "error");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const c = await adaptiveJourneyService.updateCertificateConfig(courseId, {
+        enabled,
+        min_completion_percent: minCompletion,
+        title: title.trim(),
+      });
+      hydrate(c);
+      showToast("Certificate settings saved.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Failed to save settings.", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const dirty =
+    !!config &&
+    (enabled !== config.enabled ||
+      minCompletion !== config.min_completion_percent ||
+      title.trim() !== config.title);
+
+  const clampPct = (v: number) => Math.max(0, Math.min(100, Math.round(v)));
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "grid", placeItems: "center", py: 6 }}>
+        <CircularProgress sx={{ color: "#f59e0b" }} />
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={2.5}>
+      {/* Unlock criteria */}
+      <Box sx={panelSx}>
+        <PanelHeader
+          icon="mdi:flag-checkered"
+          gradient={INDIGO_GRADIENT}
+          title="Unlock criteria"
+          sub="When learners can claim the certificate."
+          right={
+            <Chip
+              size="small"
+              color={config?.configured ? "success" : "warning"}
+              variant="outlined"
+              label={config?.configured ? "Template uploaded" : "No template yet"}
+              sx={{ fontWeight: 700 }}
+            />
+          }
+        />
+
+        <FormControlLabel
+          control={<Switch checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />}
+          label={
+            <Box>
+              <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }}>Certificate enabled</Typography>
+              <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
+                Learners see the certificate card and can claim it once they meet the threshold.
+              </Typography>
+            </Box>
+          }
+          sx={{ alignItems: "flex-start", mb: 2.5, ml: 0 }}
+        />
+
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+          <TextField
+            label="Minimum completion %"
+            type="number"
+            value={minCompletion}
+            onChange={(e) => setMinCompletion(clampPct(Number(e.target.value)))}
+            inputProps={{ min: 0, max: 100 }}
+            helperText="Course completion required to unlock (0–100)."
+            sx={{ width: { xs: "100%", sm: 240 } }}
+          />
+          <TextField
+            label="Certificate title (optional)"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Data Science Professional"
+            helperText="Shown as the credential name on LinkedIn."
+            sx={{ flex: 1 }}
+          />
+        </Stack>
+
+        <Box sx={{ mt: 2.5 }}>
+          <LoadingButton
+            variant="contained"
+            onClick={handleSave}
+            loading={saving}
+            disabled={!dirty}
+            sx={{
+              textTransform: "none", fontWeight: 700, borderRadius: 2, px: 2.5,
+              background: INDIGO_GRADIENT,
+              "&.Mui-disabled": { background: "#e2e8f0", color: "#94a3b8" },
+            }}
+          >
+            Save settings
+          </LoadingButton>
+        </Box>
+      </Box>
+
+      {/* Certificate template */}
+      <Box sx={panelSx}>
+        <PanelHeader
+          icon="mdi:image-outline"
+          gradient={AMBER_GRADIENT}
+          title="Certificate template"
+          sub="The background image the learner's name is drawn onto."
+        />
+        <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", mb: 2 }}>
+          Upload a PNG or JPG. The learner&apos;s name and details are drawn on top when they download or
+          share. Leave empty to use the default branded certificate.
+        </Typography>
+
+        {config?.template_url && (
+          <Box sx={{ mb: 2, borderRadius: 3, overflow: "hidden", border: "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)", maxWidth: 540 }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={config.template_url} alt="Certificate template" style={{ width: "100%", height: "auto", display: "block" }} />
+          </Box>
+        )}
+
+        <AdminCertificateUploadCard
+          selectedFile={file}
+          onSelectFile={setFile}
+          onUpload={handleUpload}
+          uploading={uploading}
+          lastUrl={config?.template_url ?? null}
+        />
+      </Box>
+    </Stack>
+  );
+}

--- a/components/admin/adaptive-course/CohortScheduleSection.tsx
+++ b/components/admin/adaptive-course/CohortScheduleSection.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Button, CircularProgress, Stack, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+
+/**
+ * Cohort start date — drives the weekly windows (stagger + window) and late
+ * penalties for the whole course. Lives under the Content tab.
+ */
+export function CohortScheduleSection({ courseId }: { courseId: number }) {
+  const { showToast } = useToast();
+  const [startDate, setStartDate] = useState("");
+  const [scheduleSet, setScheduleSet] = useState(false);
+  const [calendarWeeks, setCalendarWeeks] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [savingDate, setSavingDate] = useState(false);
+
+  useEffect(() => {
+    if (!Number.isFinite(courseId)) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const s = await adaptiveJourneyService.getSchedule(courseId);
+        if (cancelled) return;
+        setScheduleSet(s.schedule_set);
+        setCalendarWeeks(s.calendar.length);
+        if (s.schedule?.start_date) setStartDate(s.schedule.start_date);
+      } catch {
+        /* leave empty */
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  const saveStartDate = async () => {
+    if (!startDate) return;
+    setSavingDate(true);
+    try {
+      const res = await adaptiveJourneyService.setSchedule(courseId, { start_date: startDate });
+      setScheduleSet(res.schedule_set);
+      setCalendarWeeks(res.calendar.length);
+      showToast("Cohort start date saved.", "success");
+    } catch {
+      showToast("Couldn't save the start date.", "error");
+    } finally {
+      setSavingDate(false);
+    }
+  };
+
+  return (
+    <Box sx={{ borderRadius: 3, p: { xs: 2, md: 2.5 }, mb: 2.5, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+        <Icon icon="mdi:calendar-clock" width={20} color="#6366f1" />
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Cohort start date</Typography>
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: "grid", placeItems: "center", py: 2 }}>
+          <CircularProgress size={22} sx={{ color: "#6366f1" }} />
+        </Box>
+      ) : (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "flex-end", justifyContent: "space-between" }}>
+          <Box>
+            <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>
+              {scheduleSet
+                ? `Drives weekly windows (9-day stagger, 10-day window) + late penalties — ${calendarWeeks} weeks generated.`
+                : "Not set — week deadlines and late penalties stay inactive until you set a start date."}
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <TextField
+              type="date"
+              size="small"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+              sx={{ minWidth: 170 }}
+            />
+            <Button
+              variant="outlined"
+              disabled={!startDate || savingDate}
+              onClick={saveStartDate}
+              sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2 }}
+            >
+              {savingDate ? "Saving…" : "Save"}
+            </Button>
+          </Stack>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/admin/adaptive-course/CohortScheduleSection.tsx
+++ b/components/admin/adaptive-course/CohortScheduleSection.tsx
@@ -70,7 +70,7 @@ export function CohortScheduleSection({ courseId }: { courseId: number }) {
           <Box>
             <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>
               {scheduleSet
-                ? `Drives weekly windows (9-day stagger, 10-day window) + late penalties — ${calendarWeeks} weeks generated.`
+                ? `Weeks open 7 days apart, each with a 10-day points window + late penalties — ${calendarWeeks} weeks generated.`
                 : "Not set — week deadlines and late penalties stay inactive until you set a start date."}
             </Typography>
           </Box>

--- a/components/admin/adaptive-course/MockInterviewAdminSection.tsx
+++ b/components/admin/adaptive-course/MockInterviewAdminSection.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Avatar, Box, Button, Chip, CircularProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type {
+  CalibrationInterviewStatus,
+  CourseInterviewAttempt,
+  CourseInterviewTemplate,
+  CourseInterviewsResponse,
+} from "@/lib/types/adaptive-journey";
+
+const STATUS_CHIP: Record<string, { color: string; bg: string }> = {
+  completed: { color: "#15803d", bg: "#dcfce7" },
+  in_progress: { color: "#4338ca", bg: "#e0e7ff" },
+  scheduled: { color: "#b45309", bg: "#fef3c7" },
+  cancelled: { color: "#64748b", bg: "#f1f5f9" },
+  failed: { color: "#b91c1c", bg: "#fee2e2" },
+};
+
+/**
+ * Admin mock-interview management — the calibration interview, this course's
+ * interview rounds, and every student attempt with AI feedback. Rendered as the
+ * Mock interviews tab + the standalone sub-page.
+ */
+export function MockInterviewAdminSection({ courseId }: { courseId: number }) {
+  const { showToast } = useToast();
+  const [data, setData] = useState<CourseInterviewsResponse | null>(null);
+  const [calib, setCalib] = useState<CalibrationInterviewStatus | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!Number.isFinite(courseId)) return;
+    let cancelled = false;
+    (async () => {
+      const [d, c] = await Promise.allSettled([
+        adaptiveJourneyService.getCourseInterviews(courseId),
+        adaptiveJourneyService.getCalibrationInterview(courseId),
+      ]);
+      if (cancelled) return;
+      if (d.status === "fulfilled") setData(d.value);
+      if (c.status === "fulfilled") setCalib(c.value);
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  const generate = async () => {
+    setGenerating(true);
+    try {
+      const res = await adaptiveJourneyService.createCalibrationInterview(courseId);
+      setCalib(res);
+      const refreshed = await adaptiveJourneyService.getCourseInterviews(courseId);
+      setData(refreshed);
+      showToast("Calibration interview created.", "success");
+    } catch {
+      showToast("Couldn't create the calibration interview.", "error");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "grid", placeItems: "center", py: 6 }}>
+        <CircularProgress sx={{ color: "#6366f1" }} />
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <Box sx={{ p: 2, mb: 2.5, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" flexWrap="wrap" gap={1.5}>
+          <Box sx={{ minWidth: 0 }}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Typography sx={{ fontWeight: 800 }}>Calibration interview</Typography>
+              <Chip
+                label={calib?.exists ? "Ready" : "Not set up"}
+                size="small"
+                sx={{ height: 20, fontWeight: 800, fontSize: "0.66rem", color: calib?.exists ? "#15803d" : "#64748b", bgcolor: calib?.exists ? "#dcfce7" : "#f1f5f9" }}
+              />
+            </Stack>
+            <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>
+              {calib?.exists
+                ? `Live entry level-gauge (~${calib.duration_minutes ?? 10} min) — seeds each student's AI Student Model. New courses get this automatically.`
+                : "AI conversational level-gauge that seeds the Student Model. New courses get this automatically; create it here for older courses."}
+            </Typography>
+          </Box>
+          {!calib?.exists && (
+            <Button
+              variant="contained"
+              disabled={generating}
+              onClick={generate}
+              startIcon={generating ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:auto-fix" width={18} />}
+              sx={{ textTransform: "none", fontWeight: 700, borderRadius: 2, background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
+            >
+              {generating ? "Creating…" : "Generate calibration interview (AI)"}
+            </Button>
+          )}
+        </Stack>
+      </Box>
+
+      <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", mb: 1.25 }}>Interview rounds</Typography>
+      {!data || data.templates.length === 0 ? (
+        <Box sx={{ p: 3, mb: 3, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default, #ececf1)" }}>
+          <Typography sx={{ color: "text.secondary" }}>
+            No interview rounds in this course yet — add an interview node to the journey.
+          </Typography>
+        </Box>
+      ) : (
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 1.25, mb: 3 }}>
+          {data.templates.map((t) => (
+            <TemplateCard key={t.id} t={t} />
+          ))}
+        </Box>
+      )}
+
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.25 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Student attempts &amp; feedback</Typography>
+        {data && <Chip label={`${data.attempt_count} attempts`} size="small" sx={{ fontWeight: 700 }} />}
+      </Stack>
+      {!data || data.attempts.length === 0 ? (
+        <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default, #ececf1)" }}>
+          <Icon icon="mdi:inbox-outline" width={36} style={{ opacity: 0.4 }} />
+          <Typography sx={{ color: "text.secondary", mt: 1 }}>No interview attempts yet.</Typography>
+        </Box>
+      ) : (
+        <Stack spacing={1.25}>
+          {data.attempts.map((a) => (
+            <AttemptRow key={a.interview_id} a={a} />
+          ))}
+        </Stack>
+      )}
+    </>
+  );
+}
+
+function TemplateCard({ t }: { t: CourseInterviewTemplate }) {
+  return (
+    <Box sx={{ p: 2, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>{t.title}</Typography>
+        {t.is_level_gauge && <Chip label="Level gauge" size="small" sx={{ height: 20, fontSize: "0.62rem", fontWeight: 800, color: "#6d28d9", bgcolor: "#ede9fe" }} />}
+      </Stack>
+      <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", mt: 0.25 }}>{t.topic}{t.subtopic ? ` · ${t.subtopic}` : ""}</Typography>
+      <Stack direction="row" spacing={0.75} sx={{ mt: 1, gap: 0.75 }} flexWrap="wrap">
+        <Chip size="small" variant="outlined" label={t.difficulty} />
+        <Chip size="small" variant="outlined" label={`${t.duration_minutes} min`} />
+        <Chip size="small" variant="outlined" label={`Release: ${t.result_release_mode}`} />
+      </Stack>
+    </Box>
+  );
+}
+
+function AttemptRow({ a }: { a: CourseInterviewAttempt }) {
+  const sc = STATUS_CHIP[a.status] ?? STATUS_CHIP.scheduled;
+  return (
+    <Box sx={{ p: 2, borderRadius: 3, bgcolor: "var(--card-bg, #fff)", border: "1px solid var(--border-default, #ececf1)" }}>
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems={{ md: "center" }} justifyContent="space-between">
+        <Stack direction="row" spacing={1.5} alignItems="center" sx={{ minWidth: 0 }}>
+          <Avatar src={a.profile_pic_url || undefined} sx={{ width: 38, height: 38 }}>{a.name?.[0]}</Avatar>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }}>{a.name}</Typography>
+            <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }}>
+              {a.template_title || a.topic}
+              {a.submitted_at ? ` · ${new Date(a.submitted_at).toLocaleDateString()}` : ""}
+            </Typography>
+          </Box>
+        </Stack>
+        <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" sx={{ gap: 1 }}>
+          {a.overall_percentage != null && (
+            <Chip label={`${Math.round(a.overall_percentage)}%`} size="small" sx={{ fontWeight: 800, color: "#0f172a", bgcolor: "#f1f5f9" }} />
+          )}
+          <Chip label={a.status.replace("_", " ")} size="small" sx={{ fontWeight: 700, color: sc.color, bgcolor: sc.bg, textTransform: "capitalize" }} />
+          <Chip
+            size="small"
+            variant="outlined"
+            icon={<Icon icon={a.result_visible_to_student ? "mdi:eye-outline" : "mdi:eye-off-outline"} width={14} />}
+            label={a.result_visible_to_student ? "Result shown" : "Result hidden"}
+          />
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/components/certificate/useCertificateActions.tsx
+++ b/components/certificate/useCertificateActions.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from "@mui/material";
+import { useToast } from "@/components/common/Toast";
+import { useAuth } from "@/lib/auth/auth-context";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import { getUserDisplayName } from "@/lib/utils/user-utils";
+import {
+  getLinkedInPostText,
+  getLinkedInAddToProfileUrl,
+  openLinkedInPopup,
+  blobToBase64,
+  boldHeadline,
+  CERTIFICATE_MIN_COMPLETION,
+} from "@/lib/services/certificate-share.service";
+import { DynamicCertificate } from "@/components/certificate/DynamicCertificate";
+import { buildCourseCompletionCertificate } from "@/lib/certificate/copy";
+import { buildCertificateBranding, finalizeBranding } from "@/lib/certificate/client-branding";
+import { certificateElementToPngBlob } from "@/lib/utils/certificate-export.utils";
+
+export interface UseCertificateActionsOptions {
+  courseTitle: string;
+  certificateAvailable?: boolean;
+  /** Uploaded admin certificate template URL from S3. */
+  uploadedTemplateUrl?: string | null;
+  /** Overall course completion percentage (0–100). */
+  completionPercentage?: number;
+  /** Score to show in the LinkedIn post (e.g. "92%"). */
+  score?: string;
+  /** Minimum completion % required to claim. Defaults to the global 80% constant. */
+  minCompletion?: number;
+  /** Issuing organization name for the LinkedIn "Add to Profile" credential. */
+  organizationName?: string;
+  /** Verified LinkedIn numeric company id, if the tenant maps to a company page. */
+  organizationId?: string | number | null;
+  /** Course description woven into the LinkedIn post so it reflects the real course. */
+  courseDescription?: string;
+  /** Optional async source of an AI-generated post (e.g. the adaptive backend).
+   *  When it resolves to text, it's used instead of the local template; on null/error
+   *  the local template is used. Cached for the component's lifetime. */
+  generatePost?: () => Promise<string | null>;
+}
+
+export interface UseCertificateActions {
+  /** Admin made a certificate available for this course. */
+  available: boolean;
+  /** Certificate content is built (user signed in + a course title is present). */
+  ready: boolean;
+  /** Eligible to download/share (available + ready + completion >= threshold). */
+  canClaim: boolean;
+  /** Effective minimum completion threshold. */
+  minPct: number;
+  downloading: boolean;
+  sharing: boolean;
+  /** Signed-in user (consumers use it for disabled state). */
+  hasUser: boolean;
+  downloadCertificate: () => Promise<void>;
+  shareOnLinkedIn: () => Promise<void>;
+  addToLinkedInProfile: () => void;
+  /** Hidden certificate canvas + share dialog. Render once in the consumer. */
+  portal: ReactNode;
+}
+
+/**
+ * All certificate download + LinkedIn share logic, shared by the legacy
+ * `CertificateButtons` (big buttons) and the adaptive-journey `CertificateCard`
+ * (compact pills) so both stay in sync. Renders the off-screen certificate it
+ * rasterizes and the LinkedIn "copy image + caption" dialog via `portal`.
+ */
+export function useCertificateActions(opts: UseCertificateActionsOptions): UseCertificateActions {
+  const {
+    courseTitle,
+    certificateAvailable,
+    uploadedTemplateUrl,
+    completionPercentage = 0,
+    score = "100%",
+    minCompletion,
+    organizationName,
+    organizationId,
+    courseDescription,
+    generatePost,
+  } = opts;
+
+  const { user } = useAuth();
+  const { showToast } = useToast();
+  const { clientInfo } = useClientInfo();
+  const certRef = useRef<HTMLDivElement>(null);
+  // AI post is fetched once per component lifetime (avoids re-hitting OpenAI on re-share).
+  const aiPostRef = useRef<string | null>(null);
+
+  const [downloading, setDownloading] = useState(false);
+  const [sharing, setSharing] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [sharePostText, setSharePostText] = useState("");
+  const [shareCertificateBlob, setShareCertificateBlob] = useState<Blob | null>(null);
+  const [shareImageObjectUrl, setShareImageObjectUrl] = useState<string | null>(null);
+  const [copyBothStep, setCopyBothStep] = useState<"image" | "message">("image");
+
+  const certificateContent = useMemo(() => {
+    if (!user || !courseTitle?.trim()) return null;
+    const branding = finalizeBranding(buildCertificateBranding(clientInfo));
+    return buildCourseCompletionCertificate({
+      recipientName: getUserDisplayName(user),
+      courseTitle: courseTitle.trim(),
+      branding,
+    });
+  }, [user, courseTitle, clientInfo]);
+
+  const minPct = minCompletion ?? CERTIFICATE_MIN_COMPLETION;
+  const canClaim =
+    certificateAvailable === true && completionPercentage >= minPct && certificateContent != null;
+
+  const safeName = (s: string) => (s || "").replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.-]/g, "");
+
+  const captureBlob = async (): Promise<Blob> => {
+    if (uploadedTemplateUrl && user) {
+      const response = await fetch("/api/certificate/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          studentName: getUserDisplayName(user),
+          templateUrl: uploadedTemplateUrl,
+          courseName: courseTitle,
+          issuerName: clientInfo?.name || "",
+          structuredTrainingSubject: courseTitle,
+        }),
+      });
+      if (!response.ok) {
+        let message = "Failed to generate personalized certificate";
+        try {
+          const data = (await response.json()) as { error?: string };
+          if (data?.error) message = data.error;
+        } catch {
+          // ignore JSON parse failures
+        }
+        throw new Error(message);
+      }
+      return response.blob();
+    }
+
+    const el = certRef.current;
+    if (!el) throw new Error("Certificate is not ready");
+    return certificateElementToPngBlob(el);
+  };
+
+  const downloadCertificate = async () => {
+    if (!user) {
+      showToast("Please login to download certificate", "error");
+      return;
+    }
+    if (!canClaim) {
+      showToast(`Complete ${minPct}% of the course to download the certificate.`, "warning");
+      return;
+    }
+    try {
+      setDownloading(true);
+      const blob = await captureBlob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `certificate-${safeName(getUserDisplayName(user))}-${safeName(courseTitle)}.png`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+      showToast("Certificate downloaded successfully!", "success");
+    } catch (error: unknown) {
+      console.error("Download error:", error);
+      showToast(error instanceof Error ? error.message : "Failed to download certificate", "error");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const shareOnLinkedIn = async () => {
+    if (!user) {
+      showToast("Please login to share certificate", "error");
+      return;
+    }
+    if (!canClaim) {
+      showToast(`Complete ${minPct}% of the course to share your certificate.`, "warning");
+      return;
+    }
+
+    const pageUrl = typeof window !== "undefined" ? window.location.href : "";
+    const fallbackPost = () =>
+      getLinkedInPostText(
+        {
+          name: getUserDisplayName(user),
+          course: courseTitle ?? "",
+          score: score ?? "100%",
+          certificateUrl: pageUrl,
+          courseDescription,
+        },
+        clientInfo,
+      );
+
+    const fetchAiPost = async (): Promise<string | null> => {
+      if (aiPostRef.current) return aiPostRef.current;
+      if (!generatePost) return null;
+      const text = await generatePost().catch(() => null);
+      if (text && text.trim()) aiPostRef.current = text.trim();
+      return aiPostRef.current;
+    };
+
+    setSharing(true);
+    try {
+      // Generate the AI post while the certificate image is being captured.
+      const [blob, aiText] = await Promise.all([captureBlob(), fetchAiPost()]);
+      const postText = aiText ? boldHeadline(aiText) : fallbackPost();
+      setShareCertificateBlob(blob);
+      setShareImageObjectUrl(URL.createObjectURL(blob));
+      try {
+        await navigator.clipboard.writeText(postText);
+        showToast("Message copied! Paste (Ctrl+V or Cmd+V) in LinkedIn.", "success");
+      } catch {
+        showToast('Could not copy. Use "Copy message" below.', "warning");
+      }
+      setSharePostText(postText);
+      setShareDialogOpen(true);
+    } catch (error: unknown) {
+      showToast(error instanceof Error ? error.message : "Failed to prepare share", "error");
+    } finally {
+      setSharing(false);
+    }
+  };
+
+  const addToLinkedInProfile = () => {
+    if (!user) {
+      showToast("Please login to add this certificate to LinkedIn", "error");
+      return;
+    }
+    if (!canClaim) {
+      showToast(
+        `Complete ${minPct}% of the course to add this certificate to your LinkedIn profile.`,
+        "warning",
+      );
+      return;
+    }
+    const now = new Date();
+    openLinkedInPopup(
+      getLinkedInAddToProfileUrl({
+        certificationName: courseTitle || "Course Completion",
+        organizationName: organizationName || clientInfo?.name || "",
+        organizationId: organizationId ?? null,
+        issueYear: now.getFullYear(),
+        issueMonth: now.getMonth() + 1,
+        certUrl: typeof window !== "undefined" ? window.location.href : undefined,
+        certId: certificateContent?.certificateId,
+      }),
+    );
+  };
+
+  const closeShareDialog = () => {
+    if (shareImageObjectUrl) {
+      URL.revokeObjectURL(shareImageObjectUrl);
+      setShareImageObjectUrl(null);
+    }
+    setShareCertificateBlob(null);
+    setCopyBothStep("image");
+    setShareDialogOpen(false);
+  };
+
+  const copyMessage = async () => {
+    try {
+      await navigator.clipboard.writeText(sharePostText);
+      showToast("Message copied! Paste (Ctrl+V or Cmd+V) in LinkedIn.", "success");
+    } catch {
+      showToast("Could not copy. Select the text above and copy manually.", "warning");
+    }
+  };
+
+  const copyImageToClipboard = async (blob: Blob): Promise<boolean> => {
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+      return true;
+    } catch {
+      try {
+        const base64 = await blobToBase64(blob);
+        const html = `<img src="data:image/png;base64,${base64}" alt="Certificate" />`;
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            "image/png": blob,
+            "text/html": new Blob([html], { type: "text/html" }),
+          }),
+        ]);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  };
+
+  const copyImage = async () => {
+    if (!shareCertificateBlob) return;
+    if (await copyImageToClipboard(shareCertificateBlob)) {
+      showToast("Certificate image copied! Paste (Ctrl+V or Cmd+V) in your LinkedIn post.", "success");
+    } else {
+      showToast(
+        "Could not copy image. Please use Download Certificate, then add the file in LinkedIn.",
+        "warning",
+      );
+    }
+  };
+
+  const copyImageAndMessage = async () => {
+    if (!shareCertificateBlob || !sharePostText) return;
+    if (copyBothStep === "image") {
+      if (!(await copyImageToClipboard(shareCertificateBlob))) {
+        showToast('Could not copy image. Use "Copy image" and "Copy message" separately.', "warning");
+        return;
+      }
+      setCopyBothStep("message");
+      showToast("Image copied! Paste in LinkedIn, then click the button again to copy your caption.", "success");
+    } else {
+      try {
+        await navigator.clipboard.writeText(sharePostText);
+        setCopyBothStep("image");
+        showToast("Caption copied! Paste again in your LinkedIn post.", "success");
+      } catch {
+        showToast('Could not copy. Use "Copy message" instead.', "warning");
+      }
+    }
+  };
+
+  const portal = (
+    <>
+      {certificateContent ? (
+        <Box
+          sx={{
+            position: "fixed",
+            left: -14000,
+            top: 0,
+            width: 1200,
+            height: 675,
+            pointerEvents: "none",
+            zIndex: -5,
+            overflow: "visible",
+          }}
+          aria-hidden
+        >
+          <DynamicCertificate ref={certRef} content={certificateContent} />
+        </Box>
+      ) : null}
+
+      <Dialog open={shareDialogOpen} onClose={closeShareDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>Add to your LinkedIn post</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Open LinkedIn and start a new post. Click &quot;Copy image and message&quot; to copy the image,
+            paste (Ctrl+V or Cmd+V) in the post, then click the same button again to copy your caption and
+            paste again.
+          </Typography>
+          {shareImageObjectUrl && (
+            <Box sx={{ mb: 2, borderRadius: 1, overflow: "hidden", border: "1px solid", borderColor: "divider" }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={shareImageObjectUrl} alt="Certificate preview" style={{ width: "100%", height: "auto", display: "block" }} />
+            </Box>
+          )}
+          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+            Message to paste:
+          </Typography>
+          <Box
+            component="pre"
+            sx={{
+              p: 2,
+              bgcolor: "action.hover",
+              borderRadius: 1,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              fontSize: "0.875rem",
+              maxHeight: 220,
+              overflow: "auto",
+            }}
+          >
+            {sharePostText}
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2, flexWrap: "wrap", gap: 1 }}>
+          <Button onClick={closeShareDialog} color="inherit">
+            Cancel
+          </Button>
+          <Button onClick={copyMessage} variant="outlined" size="small">
+            Copy message
+          </Button>
+          {shareCertificateBlob && (
+            <Button onClick={copyImage} variant="outlined" size="small">
+              Copy image
+            </Button>
+          )}
+          {shareCertificateBlob && sharePostText && (
+            <Button onClick={copyImageAndMessage} variant="outlined" size="small">
+              {copyBothStep === "image" ? "Copy image and message" : "Copy caption (paste image first)"}
+            </Button>
+          )}
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+
+  return {
+    available: certificateAvailable === true,
+    ready: certificateContent != null,
+    canClaim,
+    minPct,
+    downloading,
+    sharing,
+    hasUser: !!user,
+    downloadCertificate,
+    shareOnLinkedIn,
+    addToLinkedInProfile,
+    portal,
+  };
+}

--- a/components/certificate/useCertificateActions.tsx
+++ b/components/certificate/useCertificateActions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   Box,
   Button,
@@ -48,6 +48,11 @@ export interface UseCertificateActionsOptions {
    *  When it resolves to text, it's used instead of the local template; on null/error
    *  the local template is used. Cached for the component's lifetime. */
   generatePost?: () => Promise<string | null>;
+  /** Optional async source of a verifiable credential (id + public verify URL).
+   *  Used as the LinkedIn "Add to Profile" credential URL/id (the professional, public
+   *  credential link). Pre-fetched once the learner is eligible so the popup opens
+   *  inside the click gesture. Falls back to the page URL when absent. */
+  getCredential?: () => Promise<{ credentialId: string; verifyUrl: string } | null>;
 }
 
 export interface UseCertificateActions {
@@ -88,6 +93,7 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
     organizationId,
     courseDescription,
     generatePost,
+    getCredential,
   } = opts;
 
   const { user } = useAuth();
@@ -96,6 +102,8 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
   const certRef = useRef<HTMLDivElement>(null);
   // AI post is fetched once per component lifetime (avoids re-hitting OpenAI on re-share).
   const aiPostRef = useRef<string | null>(null);
+  // Verifiable credential (id + public verify URL), pre-issued once eligible.
+  const [credential, setCredential] = useState<{ credentialId: string; verifyUrl: string } | null>(null);
 
   const [downloading, setDownloading] = useState(false);
   const [sharing, setSharing] = useState(false);
@@ -118,6 +126,29 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
   const minPct = minCompletion ?? CERTIFICATE_MIN_COMPLETION;
   const canClaim =
     certificateAvailable === true && completionPercentage >= minPct && certificateContent != null;
+
+  // Pre-issue the credential as soon as the learner is eligible, so the LinkedIn
+  // "Add to Profile" popup (opened synchronously on click) carries the real public
+  // credential URL. Idempotent on the backend; a single request in flight.
+  const issuingRef = useRef(false);
+  useEffect(() => {
+    if (!canClaim || !getCredential || credential || issuingRef.current) return;
+    issuingRef.current = true;
+    let cancelled = false;
+    getCredential()
+      .then((c) => {
+        if (!cancelled && c) setCredential(c);
+      })
+      .catch(() => {
+        /* fall back to the page URL */
+      })
+      .finally(() => {
+        issuingRef.current = false;
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [canClaim, getCredential, credential]);
 
   const safeName = (s: string) => (s || "").replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.-]/g, "");
 
@@ -247,6 +278,10 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
       return;
     }
     const now = new Date();
+    // Prefer the public, verifiable credential URL/id; fall back to the page URL.
+    const certUrl =
+      credential?.verifyUrl || (typeof window !== "undefined" ? window.location.href : undefined);
+    const certId = credential?.credentialId || certificateContent?.certificateId;
     openLinkedInPopup(
       getLinkedInAddToProfileUrl({
         certificationName: courseTitle || "Course Completion",
@@ -254,8 +289,8 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
         organizationId: organizationId ?? null,
         issueYear: now.getFullYear(),
         issueMonth: now.getMonth() + 1,
-        certUrl: typeof window !== "undefined" ? window.location.href : undefined,
-        certId: certificateContent?.certificateId,
+        certUrl,
+        certId,
       }),
     );
   };
@@ -276,6 +311,16 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
       showToast("Message copied! Paste (Ctrl+V or Cmd+V) in LinkedIn.", "success");
     } catch {
       showToast("Could not copy. Select the text above and copy manually.", "warning");
+    }
+  };
+
+  const copyCredentialLink = async () => {
+    if (!credential) return;
+    try {
+      await navigator.clipboard.writeText(credential.verifyUrl);
+      showToast('Credential link copied! Add it via "Add media → Link" in LinkedIn.', "success");
+    } catch {
+      showToast("Could not copy the link.", "warning");
     }
   };
 
@@ -384,6 +429,29 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
           >
             {sharePostText}
           </Box>
+
+          {credential && (
+            <Box sx={{ mt: 2 }}>
+              <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 0.5 }}>
+                Verifiable credential link — LinkedIn can&apos;t auto-fill media, so paste this under
+                &quot;Add media → Link&quot; to attach the certificate, or it appears as &quot;Show
+                credential&quot; on your profile:
+              </Typography>
+              <Box
+                component="pre"
+                sx={{
+                  p: 1.25,
+                  bgcolor: "action.hover",
+                  borderRadius: 1,
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-all",
+                  fontSize: "0.8rem",
+                }}
+              >
+                {credential.verifyUrl}
+              </Box>
+            </Box>
+          )}
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2, flexWrap: "wrap", gap: 1 }}>
           <Button onClick={closeShareDialog} color="inherit">
@@ -392,6 +460,11 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
           <Button onClick={copyMessage} variant="outlined" size="small">
             Copy message
           </Button>
+          {credential && (
+            <Button onClick={copyCredentialLink} variant="outlined" size="small">
+              Copy credential link
+            </Button>
+          )}
           {shareCertificateBlob && (
             <Button onClick={copyImage} variant="outlined" size="small">
               Copy image

--- a/components/certificate/useCertificateActions.tsx
+++ b/components/certificate/useCertificateActions.tsx
@@ -130,14 +130,19 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
   // Pre-issue the credential as soon as the learner is eligible, so the LinkedIn
   // "Add to Profile" popup (opened synchronously on click) carries the real public
   // credential URL. Idempotent on the backend; a single request in flight.
+  // NOTE: getCredential is held in a ref and kept OUT of the effect deps — it's an
+  // inline arrow that changes identity every render, which would otherwise re-run
+  // the effect and cancel the in-flight setCredential before it lands.
   const issuingRef = useRef(false);
+  const getCredentialRef = useRef(getCredential);
+  getCredentialRef.current = getCredential;
   useEffect(() => {
-    if (!canClaim || !getCredential || credential || issuingRef.current) return;
+    const fn = getCredentialRef.current;
+    if (!canClaim || !fn || credential || issuingRef.current) return;
     issuingRef.current = true;
-    let cancelled = false;
-    getCredential()
+    fn()
       .then((c) => {
-        if (!cancelled && c) setCredential(c);
+        if (c) setCredential(c);
       })
       .catch(() => {
         /* fall back to the page URL */
@@ -145,10 +150,7 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
       .finally(() => {
         issuingRef.current = false;
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [canClaim, getCredential, credential]);
+  }, [canClaim, credential]);
 
   const safeName = (s: string) => (s || "").replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.-]/g, "");
 
@@ -277,22 +279,51 @@ export function useCertificateActions(opts: UseCertificateActionsOptions): UseCe
       );
       return;
     }
-    const now = new Date();
-    // Prefer the public, verifiable credential URL/id; fall back to the page URL.
-    const certUrl =
-      credential?.verifyUrl || (typeof window !== "undefined" ? window.location.href : undefined);
-    const certId = credential?.credentialId || certificateContent?.certificateId;
-    openLinkedInPopup(
-      getLinkedInAddToProfileUrl({
+    const buildUrl = (cred: { credentialId: string; verifyUrl: string } | null) => {
+      const now = new Date();
+      // Prefer the public, verifiable credential URL/id; fall back to the page URL.
+      return getLinkedInAddToProfileUrl({
         certificationName: courseTitle || "Course Completion",
         organizationName: organizationName || clientInfo?.name || "",
         organizationId: organizationId ?? null,
         issueYear: now.getFullYear(),
         issueMonth: now.getMonth() + 1,
-        certUrl,
-        certId,
-      }),
-    );
+        certUrl: cred?.verifyUrl || (typeof window !== "undefined" ? window.location.href : undefined),
+        certId: cred?.credentialId || certificateContent?.certificateId,
+      });
+    };
+
+    // Common case: credential already pre-issued — open straight away.
+    if (credential) {
+      openLinkedInPopup(buildUrl(credential));
+      return;
+    }
+
+    // Not issued yet (e.g. a very fast click): open the popup synchronously inside
+    // this click gesture (so it isn't blocked), then point it at the credential URL
+    // once issuance resolves — never the wrong /adaptive-courses URL if we can help it.
+    const fn = getCredentialRef.current;
+    if (!fn || typeof window === "undefined") {
+      openLinkedInPopup(buildUrl(null));
+      return;
+    }
+    const w = 600;
+    const h = 700;
+    const left = Math.max(0, (window.screen.width - w) / 2);
+    const top = Math.max(0, (window.screen.height - h) / 2);
+    const win = window.open("about:blank", "LinkedIn", `width=${w},height=${h},left=${left},top=${top},scrollbars=yes`);
+    fn()
+      .then((c) => {
+        if (c) setCredential(c);
+        const url = buildUrl(c ?? null);
+        if (win) win.location.href = url;
+        else openLinkedInPopup(url);
+      })
+      .catch(() => {
+        const url = buildUrl(null);
+        if (win) win.location.href = url;
+        else openLinkedInPopup(url);
+      });
   };
 
   const closeShareDialog = () => {

--- a/components/course/CertificateButtons.tsx
+++ b/components/course/CertificateButtons.tsx
@@ -18,6 +18,8 @@ import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { getUserDisplayName } from "@/lib/utils/user-utils";
 import {
   getLinkedInPostText,
+  getLinkedInAddToProfileUrl,
+  openLinkedInPopup,
   blobToBase64,
   CERTIFICATE_MIN_COMPLETION,
 } from "@/lib/services/certificate-share.service";
@@ -41,6 +43,13 @@ interface CertificateButtonsProps {
   score?: string;
   /** URL to share (certificate page or course page). Defaults to current window URL. */
   certificateUrl?: string;
+  /** Minimum completion % required to claim. Defaults to the global 80% constant.
+   *  Adaptive courses pass the per-course threshold here so it wins over the default. */
+  minCompletion?: number;
+  /** Issuing organization name for the LinkedIn "Add to Profile" credential. Defaults to the tenant name. */
+  organizationName?: string;
+  /** Verified LinkedIn numeric company id, if the tenant maps to a company page. */
+  organizationId?: string | number | null;
 }
 
 export function CertificateButtons({
@@ -49,6 +58,9 @@ export function CertificateButtons({
   uploadedTemplateUrl,
   completionPercentage = 0,
   score = "100%",
+  minCompletion,
+  organizationName,
+  organizationId,
 }: CertificateButtonsProps) {
   const { user } = useAuth();
   const { showToast } = useToast();
@@ -72,9 +84,11 @@ export function CertificateButtons({
     });
   }, [user, courseTitle, clientInfo]);
 
+  const minPct = minCompletion ?? CERTIFICATE_MIN_COMPLETION;
+
   const canClaimCertificate =
     certificateAvailable === true &&
-    completionPercentage >= CERTIFICATE_MIN_COMPLETION &&
+    completionPercentage >= minPct &&
     certificateContent != null;
 
   if (!certificateAvailable) {
@@ -122,7 +136,7 @@ export function CertificateButtons({
     }
     if (!canClaimCertificate) {
       showToast(
-        `Complete ${CERTIFICATE_MIN_COMPLETION}% of the course to download the certificate.`,
+        `Complete ${minPct}% of the course to download the certificate.`,
         "warning"
       );
       return;
@@ -159,7 +173,7 @@ export function CertificateButtons({
     }
     if (!canClaimCertificate) {
       showToast(
-        `Complete ${CERTIFICATE_MIN_COMPLETION}% of the course to share your certificate.`,
+        `Complete ${minPct}% of the course to share your certificate.`,
         "warning"
       );
       return;
@@ -277,6 +291,31 @@ export function CertificateButtons({
     }
   };
 
+  const handleAddToLinkedInProfile = () => {
+    if (!user) {
+      showToast("Please login to add this certificate to LinkedIn", "error");
+      return;
+    }
+    if (!canClaimCertificate) {
+      showToast(
+        `Complete ${minPct}% of the course to add this certificate to your LinkedIn profile.`,
+        "warning"
+      );
+      return;
+    }
+    const now = new Date();
+    const url = getLinkedInAddToProfileUrl({
+      certificationName: courseTitle || "Course Completion",
+      organizationName: organizationName || clientInfo?.name || "",
+      organizationId: organizationId ?? null,
+      issueYear: now.getFullYear(),
+      issueMonth: now.getMonth() + 1,
+      certUrl: typeof window !== "undefined" ? window.location.href : undefined,
+      certId: certificateContent?.certificateId,
+    });
+    openLinkedInPopup(url);
+  };
+
   return (
     <Box
       sx={{
@@ -311,7 +350,7 @@ export function CertificateButtons({
       )}
       {certificateContent && !canClaimCertificate && (
         <Typography variant="caption" sx={{ color: "text.secondary" }}>
-          Complete {CERTIFICATE_MIN_COMPLETION}% of the course to unlock certificate download and sharing.
+          Complete {minPct}% of the course to unlock certificate download and sharing.
         </Typography>
       )}
       <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
@@ -354,6 +393,23 @@ export function CertificateButtons({
           }}
         >
           Share on LinkedIn
+        </Button>
+
+        <Button
+          variant="outlined"
+          startIcon={<IconWrapper icon="mdi:linkedin" size={20} />}
+          onClick={handleAddToLinkedInProfile}
+          disabled={!user || !canClaimCertificate}
+          sx={{
+            borderColor: "#0077b5",
+            color: "#0077b5",
+            "&:hover": {
+              borderColor: "#005885",
+              backgroundColor: "rgba(0, 119, 181, 0.04)",
+            },
+          }}
+        >
+          Add to LinkedIn profile
         </Button>
       </Box>
 

--- a/components/course/CertificateButtons.tsx
+++ b/components/course/CertificateButtons.tsx
@@ -1,396 +1,78 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
-import {
-  Box,
-  Button,
-  CircularProgress,
-  Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-} from "@mui/material";
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { useToast } from "@/components/common/Toast";
-import { useAuth } from "@/lib/auth/auth-context";
-import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
-import { getUserDisplayName } from "@/lib/utils/user-utils";
 import {
-  getLinkedInPostText,
-  getLinkedInAddToProfileUrl,
-  openLinkedInPopup,
-  blobToBase64,
-  CERTIFICATE_MIN_COMPLETION,
-} from "@/lib/services/certificate-share.service";
-import { DynamicCertificate } from "@/components/certificate/DynamicCertificate";
-import { buildCourseCompletionCertificate } from "@/lib/certificate/copy";
-import {
-  buildCertificateBranding,
-  finalizeBranding,
-} from "@/lib/certificate/client-branding";
-import { certificateElementToPngBlob } from "@/lib/utils/certificate-export.utils";
+  useCertificateActions,
+  type UseCertificateActionsOptions,
+} from "@/components/certificate/useCertificateActions";
 
-interface CertificateButtonsProps {
+interface CertificateButtonsProps extends UseCertificateActionsOptions {
   courseId: number;
-  courseTitle: string;
-  certificateAvailable?: boolean;
-  /** Uploaded admin course certificate template URL from S3. */
-  uploadedTemplateUrl?: string | null;
-  /** Overall course completion percentage (0–100). Buttons are actionable only when > 80%. */
-  completionPercentage?: number;
-  /** Score to show in LinkedIn post (e.g. "92%" or "100%") */
-  score?: string;
   /** URL to share (certificate page or course page). Defaults to current window URL. */
   certificateUrl?: string;
-  /** Minimum completion % required to claim. Defaults to the global 80% constant.
-   *  Adaptive courses pass the per-course threshold here so it wins over the default. */
-  minCompletion?: number;
-  /** Issuing organization name for the LinkedIn "Add to Profile" credential. Defaults to the tenant name. */
-  organizationName?: string;
-  /** Verified LinkedIn numeric company id, if the tenant maps to a company page. */
-  organizationId?: string | number | null;
 }
 
-export function CertificateButtons({
-  courseTitle,
-  certificateAvailable,
-  uploadedTemplateUrl,
-  completionPercentage = 0,
-  score = "100%",
-  minCompletion,
-  organizationName,
-  organizationId,
-}: CertificateButtonsProps) {
-  const { user } = useAuth();
-  const { showToast } = useToast();
-  const [downloading, setDownloading] = useState(false);
-  const [sharing, setSharing] = useState(false);
-  const [shareDialogOpen, setShareDialogOpen] = useState(false);
-  const [sharePostText, setSharePostText] = useState("");
-  const [shareCertificateBlob, setShareCertificateBlob] = useState<Blob | null>(null);
-  const [shareImageObjectUrl, setShareImageObjectUrl] = useState<string | null>(null);
-  const [copyBothStep, setCopyBothStep] = useState<"image" | "message">("image");
-  const { clientInfo } = useClientInfo();
-  const certRef = useRef<HTMLDivElement>(null);
+/**
+ * Learner certificate actions for the legacy LMS course page — Download +
+ * Share on LinkedIn + Add to LinkedIn profile, as full-size buttons. All the
+ * capture/share logic lives in the shared `useCertificateActions` hook.
+ */
+export function CertificateButtons(props: CertificateButtonsProps) {
+  const cert = useCertificateActions(props);
 
-  const certificateContent = useMemo(() => {
-    if (!user || !courseTitle?.trim()) return null;
-    const branding = finalizeBranding(buildCertificateBranding(clientInfo));
-    return buildCourseCompletionCertificate({
-      recipientName: getUserDisplayName(user),
-      courseTitle: courseTitle.trim(),
-      branding,
-    });
-  }, [user, courseTitle, clientInfo]);
+  if (!cert.available) return null;
 
-  const minPct = minCompletion ?? CERTIFICATE_MIN_COMPLETION;
-
-  const canClaimCertificate =
-    certificateAvailable === true &&
-    completionPercentage >= minPct &&
-    certificateContent != null;
-
-  if (!certificateAvailable) {
-    return null;
-  }
-
-  const safeName = (s: string) =>
-    (s || "").replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.-]/g, "");
-
-  const captureBlob = async (): Promise<Blob> => {
-    if (uploadedTemplateUrl && user) {
-      const response = await fetch("/api/certificate/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          studentName: getUserDisplayName(user),
-          templateUrl: uploadedTemplateUrl,
-          courseName: courseTitle,
-          issuerName: clientInfo?.name || "",
-          structuredTrainingSubject: courseTitle,
-        }),
-      });
-      if (!response.ok) {
-        let message = "Failed to generate personalized certificate";
-        try {
-          const data = (await response.json()) as { error?: string };
-          if (data?.error) message = data.error;
-        } catch {
-          // ignore JSON parse failures
-        }
-        throw new Error(message);
-      }
-      return response.blob();
-    }
-
-    const el = certRef.current;
-    if (!el) throw new Error("Certificate is not ready");
-    return certificateElementToPngBlob(el);
-  };
-
-  const handleDownloadCertificate = async () => {
-    if (!user) {
-      showToast("Please login to download certificate", "error");
-      return;
-    }
-    if (!canClaimCertificate) {
-      showToast(
-        `Complete ${minPct}% of the course to download the certificate.`,
-        "warning"
-      );
-      return;
-    }
-
-    try {
-      setDownloading(true);
-      const blob = await captureBlob();
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      const studentName = getUserDisplayName(user);
-      a.download = `certificate-${safeName(studentName)}-${safeName(courseTitle)}.png`;
-      document.body.appendChild(a);
-      a.click();
-      window.URL.revokeObjectURL(url);
-      document.body.removeChild(a);
-      showToast("Certificate downloaded successfully!", "success");
-    } catch (error: unknown) {
-      console.error("Download error:", error);
-      showToast(
-        error instanceof Error ? error.message : "Failed to download certificate",
-        "error"
-      );
-    } finally {
-      setDownloading(false);
-    }
-  };
-
-  const handleShareOnLinkedIn = async () => {
-    if (!user) {
-      showToast("Please login to share certificate", "error");
-      return;
-    }
-    if (!canClaimCertificate) {
-      showToast(
-        `Complete ${minPct}% of the course to share your certificate.`,
-        "warning"
-      );
-      return;
-    }
-
-    const pageUrl = typeof window !== "undefined" ? window.location.href : "";
-    const postText = getLinkedInPostText(
-      {
-        name: getUserDisplayName(user),
-        course: courseTitle ?? "",
-        score: score ?? "100%",
-        certificateUrl: pageUrl,
-      },
-      clientInfo
-    );
-
-    setSharing(true);
-    try {
-      const blob = await captureBlob();
-      setShareCertificateBlob(blob);
-      const objectUrl = URL.createObjectURL(blob);
-      setShareImageObjectUrl(objectUrl);
-
-      try {
-        await navigator.clipboard.writeText(postText);
-        showToast("Message copied! Paste (Ctrl+V or Cmd+V) in LinkedIn.", "success");
-      } catch {
-        showToast('Could not copy. Use "Copy message" below.', "warning");
-      }
-
-      setSharePostText(postText);
-      setShareDialogOpen(true);
-    } catch (error: unknown) {
-      showToast(
-        error instanceof Error ? error.message : "Failed to prepare share",
-        "error"
-      );
-    } finally {
-      setSharing(false);
-    }
-  };
-
-  const handleCloseShareDialog = () => {
-    if (shareImageObjectUrl) {
-      URL.revokeObjectURL(shareImageObjectUrl);
-      setShareImageObjectUrl(null);
-    }
-    setShareCertificateBlob(null);
-    setCopyBothStep("image");
-    setShareDialogOpen(false);
-  };
-
-  const handleCopyMessage = async () => {
-    try {
-      await navigator.clipboard.writeText(sharePostText);
-      showToast("Message copied! Paste (Ctrl+V or Cmd+V) in LinkedIn.", "success");
-    } catch {
-      showToast("Could not copy. Select the text above and copy manually.", "warning");
-    }
-  };
-
-  const copyImageToClipboard = async (blob: Blob): Promise<boolean> => {
-    try {
-      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-      return true;
-    } catch {
-      try {
-        const base64 = await blobToBase64(blob);
-        const dataUrl = `data:image/png;base64,${base64}`;
-        const html = `<img src="${dataUrl}" alt="Certificate" />`;
-        await navigator.clipboard.write([
-          new ClipboardItem({
-            "image/png": blob,
-            "text/html": new Blob([html], { type: "text/html" }),
-          }),
-        ]);
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  };
-
-  const handleCopyImage = async () => {
-    if (!shareCertificateBlob) return;
-    const ok = await copyImageToClipboard(shareCertificateBlob);
-    if (ok) {
-      showToast("Certificate image copied! Paste (Ctrl+V or Cmd+V) in your LinkedIn post.", "success");
-    } else {
-      showToast(
-        'Could not copy image. Please use Download Certificate, then add the file in LinkedIn.',
-        "warning"
-      );
-    }
-  };
-
-  const handleCopyImageAndMessage = async () => {
-    if (!shareCertificateBlob || !sharePostText) return;
-    if (copyBothStep === "image") {
-      const imageOk = await copyImageToClipboard(shareCertificateBlob);
-      if (!imageOk) {
-        showToast('Could not copy image. Use "Copy image" and "Copy message" separately.', "warning");
-        return;
-      }
-      setCopyBothStep("message");
-      showToast("Image copied! Paste in LinkedIn, then click the button again to copy your caption.", "success");
-    } else {
-      try {
-        await navigator.clipboard.writeText(sharePostText);
-        setCopyBothStep("image");
-        showToast("Caption copied! Paste again in your LinkedIn post.", "success");
-      } catch {
-        showToast('Could not copy. Use "Copy message" instead.', "warning");
-      }
-    }
-  };
-
-  const handleAddToLinkedInProfile = () => {
-    if (!user) {
-      showToast("Please login to add this certificate to LinkedIn", "error");
-      return;
-    }
-    if (!canClaimCertificate) {
-      showToast(
-        `Complete ${minPct}% of the course to add this certificate to your LinkedIn profile.`,
-        "warning"
-      );
-      return;
-    }
-    const now = new Date();
-    const url = getLinkedInAddToProfileUrl({
-      certificationName: courseTitle || "Course Completion",
-      organizationName: organizationName || clientInfo?.name || "",
-      organizationId: organizationId ?? null,
-      issueYear: now.getFullYear(),
-      issueMonth: now.getMonth() + 1,
-      certUrl: typeof window !== "undefined" ? window.location.href : undefined,
-      certId: certificateContent?.certificateId,
-    });
-    openLinkedInPopup(url);
-  };
+  const linkedInSx = {
+    borderColor: "#0077b5",
+    color: "#0077b5",
+    "&:hover": { borderColor: "#005885", backgroundColor: "rgba(0, 119, 181, 0.04)" },
+  } as const;
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 1.5,
-        mt: 2,
-      }}
-    >
-      {certificateContent ? (
-        <Box
-          sx={{
-            position: "fixed",
-            left: -14000,
-            top: 0,
-            width: 1200,
-            height: 675,
-            pointerEvents: "none",
-            zIndex: -5,
-            overflow: "visible",
-          }}
-          aria-hidden
-        >
-          <DynamicCertificate ref={certRef} content={certificateContent} />
-        </Box>
-      ) : null}
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mt: 2 }}>
+      {cert.portal}
 
-      {!certificateContent && (
+      {!cert.ready && (
         <Typography variant="caption" sx={{ color: "text.secondary" }}>
           Sign in to generate your certificate.
         </Typography>
       )}
-      {certificateContent && !canClaimCertificate && (
+      {cert.ready && !cert.canClaim && (
         <Typography variant="caption" sx={{ color: "text.secondary" }}>
-          Complete {minPct}% of the course to unlock certificate download and sharing.
+          Complete {cert.minPct}% of the course to unlock certificate download and sharing.
         </Typography>
       )}
+
       <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
         <Button
           variant="contained"
           startIcon={
-            downloading ? (
+            cert.downloading ? (
               <CircularProgress size={16} color="inherit" />
             ) : (
               <IconWrapper icon="mdi:download" size={20} />
             )
           }
-          onClick={handleDownloadCertificate}
-          disabled={downloading || !user || !canClaimCertificate}
+          onClick={cert.downloadCertificate}
+          disabled={cert.downloading || !cert.hasUser || !cert.canClaim}
           sx={{
             backgroundColor: "var(--primary-600)",
             color: "var(--font-light)",
-            "&:hover": {
-              backgroundColor: "var(--primary-700)",
-            },
+            "&:hover": { backgroundColor: "var(--primary-700)" },
           }}
         >
-          {downloading ? "Downloading..." : "Download Certificate"}
+          {cert.downloading ? "Downloading..." : "Download Certificate"}
         </Button>
 
         <Button
           variant="outlined"
           startIcon={
-            sharing ? <CircularProgress size={20} /> : <IconWrapper icon="mdi:linkedin" size={20} />
+            cert.sharing ? <CircularProgress size={20} /> : <IconWrapper icon="mdi:linkedin" size={20} />
           }
-          onClick={handleShareOnLinkedIn}
-          disabled={!user || sharing || !canClaimCertificate}
-          sx={{
-            borderColor: "#0077b5",
-            color: "#0077b5",
-            "&:hover": {
-              borderColor: "#005885",
-              backgroundColor: "rgba(0, 119, 181, 0.04)",
-            },
-          }}
+          onClick={cert.shareOnLinkedIn}
+          disabled={!cert.hasUser || cert.sharing || !cert.canClaim}
+          sx={linkedInSx}
         >
           Share on LinkedIn
         </Button>
@@ -398,77 +80,13 @@ export function CertificateButtons({
         <Button
           variant="outlined"
           startIcon={<IconWrapper icon="mdi:linkedin" size={20} />}
-          onClick={handleAddToLinkedInProfile}
-          disabled={!user || !canClaimCertificate}
-          sx={{
-            borderColor: "#0077b5",
-            color: "#0077b5",
-            "&:hover": {
-              borderColor: "#005885",
-              backgroundColor: "rgba(0, 119, 181, 0.04)",
-            },
-          }}
+          onClick={cert.addToLinkedInProfile}
+          disabled={!cert.hasUser || !cert.canClaim}
+          sx={linkedInSx}
         >
           Add to LinkedIn profile
         </Button>
       </Box>
-
-      <Dialog open={shareDialogOpen} onClose={handleCloseShareDialog} maxWidth="sm" fullWidth>
-        <DialogTitle>Add to your LinkedIn post</DialogTitle>
-        <DialogContent>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            Open LinkedIn and start a new post. Click &quot;Copy image and message&quot; to copy the image,
-            paste (Ctrl+V or Cmd+V) in the post, then click the same button again to copy your caption and
-            paste again.
-          </Typography>
-          {shareImageObjectUrl && (
-            <Box sx={{ mb: 2, borderRadius: 1, overflow: "hidden", border: "1px solid", borderColor: "divider" }}>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={shareImageObjectUrl}
-                alt="Certificate preview"
-                style={{ width: "100%", height: "auto", display: "block" }}
-              />
-            </Box>
-          )}
-          <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
-            Message to paste:
-          </Typography>
-          <Box
-            component="pre"
-            sx={{
-              p: 2,
-              bgcolor: "action.hover",
-              borderRadius: 1,
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-              fontSize: "0.875rem",
-              maxHeight: 220,
-              overflow: "auto",
-            }}
-          >
-            {sharePostText}
-          </Box>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2, flexWrap: "wrap", gap: 1 }}>
-          <Button onClick={handleCloseShareDialog} color="inherit">
-            Cancel
-          </Button>
-          <Button onClick={handleCopyMessage} variant="outlined" size="small">
-            Copy message
-          </Button>
-          {shareCertificateBlob && (
-            <Button onClick={handleCopyImage} variant="outlined" size="small">
-              Copy image
-            </Button>
-          )}
-          {shareCertificateBlob && sharePostText && (
-            <Button onClick={handleCopyImageAndMessage} variant="outlined" size="small">
-              {copyBothStep === "image" ? "Copy image and message" : "Copy caption (paste image first)"}
-            </Button>
-          )}
-        </DialogActions>
-      </Dialog>
     </Box>
   );
 }

--- a/components/courses/AdaptiveCourseCard.tsx
+++ b/components/courses/AdaptiveCourseCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Box, ButtonBase, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { AdaptiveCourseListItem } from "@/lib/services/adaptive-course.service";
+
+/** A single adaptive-course card. Shared by the standalone library page and the
+ *  "Adaptive courses" section embedded under /courses. */
+export function AdaptiveCourseCard({
+  course,
+  onOpen,
+}: {
+  course: AdaptiveCourseListItem;
+  onOpen: () => void;
+}) {
+  return (
+    <ButtonBase
+      onClick={onOpen}
+      sx={{
+        width: "100%",
+        height: "100%",
+        textAlign: "left",
+        display: "block",
+        borderRadius: 3,
+        p: 2.5,
+        bgcolor: "var(--card-bg, #fff)",
+        border: "1px solid var(--border-default, #ececf1)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.04), 0 10px 26px -22px rgba(16,24,40,0.18)",
+        transition: "transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease",
+        "&:hover": {
+          transform: "translateY(-3px)",
+          borderColor: "color-mix(in srgb, #6366f1 40%, transparent)",
+          boxShadow: "0 20px 40px -26px rgba(99, 102, 241, 0.45)",
+        },
+      }}
+    >
+      {course.card_image_url && (
+        <Box sx={{ width: "100%", aspectRatio: "16 / 9", borderRadius: 2.5, overflow: "hidden", mb: 1.5, bgcolor: "color-mix(in srgb, #6366f1 8%, transparent)" }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={course.card_image_url} alt={course.title} loading="lazy" style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} />
+        </Box>
+      )}
+
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.5 }}>
+        <Box sx={{ width: 44, height: 44, borderRadius: 3, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)", boxShadow: "0 14px 26px -14px rgba(168, 85, 247, 0.6)" }}>
+          <Icon icon="mdi:book-education-outline" width={22} />
+        </Box>
+        <Box component="span" sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.65rem", fontWeight: 800, letterSpacing: 0.4, textTransform: "uppercase", color: "#a855f7", bgcolor: "color-mix(in srgb, #a855f7 14%, transparent)" }}>
+          Adaptive
+        </Box>
+      </Box>
+
+      <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3 }}>{course.title}</Typography>
+      {course.description && (
+        <Typography sx={{ color: "text.secondary", mt: 0.75, fontSize: "0.86rem", lineHeight: 1.5, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+          {course.description}
+        </Typography>
+      )}
+
+      <Box sx={{ display: "flex", gap: 2, mt: 2, flexWrap: "wrap" }}>
+        <Metric icon="mdi:view-module-outline" label="modules" value={course.module_count} />
+        <Metric icon="mdi:file-tree-outline" label="submodules" value={course.submodule_count} />
+        <Metric icon="mdi:book-open-variant" label="articles" value={course.article_count} />
+        <Metric icon="mdi:tune-vertical" label="quizzes" value={course.quiz_count} />
+        {(course.coding_count ?? 0) > 0 && <Metric icon="mdi:robot-happy-outline" label="coding" value={course.coding_count ?? 0} />}
+        {(course.video_count ?? 0) > 0 && <Metric icon="mdi:play-circle-outline" label="videos" value={course.video_count ?? 0} />}
+      </Box>
+    </ButtonBase>
+  );
+}
+
+function Metric({ icon, label, value }: { icon: string; label: string; value: number }) {
+  return (
+    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6 }}>
+      <Icon icon={icon} width={16} style={{ color: "#6366f1" }} />
+      <Typography component="span" sx={{ fontWeight: 800, fontSize: "0.85rem" }}>{value}</Typography>
+      <Typography component="span" sx={{ color: "text.secondary", fontSize: "0.78rem" }}>{label}</Typography>
+    </Box>
+  );
+}

--- a/components/courses/CoursesNavTabs.tsx
+++ b/components/courses/CoursesNavTabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * Section switch shown at the top of the Courses area: "Courses" (legacy) and
+ * "Adaptive courses" (the adaptive library page). Each tab is its own page/route
+ * — adaptive courses are a section *within* Courses, not a separate sidebar item.
+ * The Adaptive tab only appears when the tenant has the adaptive feature.
+ */
+export function CoursesNavTabs({ active }: { active: "courses" | "adaptive" }) {
+  const router = useRouter();
+  const adaptiveOn = useIsAdaptiveQuizEnabled();
+
+  const tabs: { key: "courses" | "adaptive"; label: string; icon: string; href: string }[] = [
+    { key: "courses", label: "Courses", icon: "mdi:book-open-page-variant-outline", href: "/courses" },
+  ];
+  if (adaptiveOn) {
+    tabs.push({ key: "adaptive", label: "Adaptive courses", icon: "mdi:book-education-outline", href: "/adaptive-courses" });
+  }
+
+  // With only one tab there's nothing to switch between.
+  if (tabs.length < 2) return null;
+
+  return (
+    <Box sx={{ display: "flex", gap: 1, mb: 3, flexWrap: "wrap" }}>
+      {tabs.map((t) => {
+        const isActive = t.key === active;
+        return (
+          <ButtonBase
+            key={t.key}
+            onClick={() => !isActive && router.push(t.href)}
+            sx={{
+              px: 2.25, py: 0.9, borderRadius: 999, fontWeight: 800, fontSize: "0.9rem", gap: 0.6,
+              display: "inline-flex", alignItems: "center",
+              color: isActive ? "white" : "text.primary",
+              background: isActive
+                ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
+                : "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+              border: isActive ? "1px solid transparent" : "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+            }}
+          >
+            <Icon icon={t.icon} width={17} />
+            {t.label}
+          </ButtonBase>
+        );
+      })}
+    </Box>
+  );
+}

--- a/components/courses/CoursesNavTabs.tsx
+++ b/components/courses/CoursesNavTabs.tsx
@@ -1,32 +1,66 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Box, ButtonBase } from "@mui/material";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
 
+interface TabDef {
+  key: "courses" | "adaptive";
+  label: string;
+  sub: string;
+  icon: string;
+  href: string;
+}
+
 /**
- * Section switch shown at the top of the Courses area: "Courses" (legacy) and
- * "Adaptive courses" (the adaptive library page). Each tab is its own page/route
- * — adaptive courses are a section *within* Courses, not a separate sidebar item.
- * The Adaptive tab only appears when the tenant has the adaptive feature.
+ * Prominent section switcher for the Courses area: "Courses" (legacy) and
+ * "Adaptive courses" (the adaptive library page). Rendered as a clear segmented
+ * control so the section is obvious — each tab is its own route. The Adaptive
+ * tab only appears when the tenant has the adaptive feature.
  */
 export function CoursesNavTabs({ active }: { active: "courses" | "adaptive" }) {
   const router = useRouter();
   const adaptiveOn = useIsAdaptiveQuizEnabled();
 
-  const tabs: { key: "courses" | "adaptive"; label: string; icon: string; href: string }[] = [
-    { key: "courses", label: "Courses", icon: "mdi:book-open-page-variant-outline", href: "/courses" },
+  const tabs: TabDef[] = [
+    {
+      key: "courses",
+      label: "Courses",
+      sub: "Structured & self-paced",
+      icon: "mdi:book-open-page-variant-outline",
+      href: "/courses",
+    },
   ];
   if (adaptiveOn) {
-    tabs.push({ key: "adaptive", label: "Adaptive courses", icon: "mdi:book-education-outline", href: "/adaptive-courses" });
+    tabs.push({
+      key: "adaptive",
+      label: "Adaptive courses",
+      sub: "AI-personalised in real time",
+      icon: "mdi:book-education-outline",
+      href: "/adaptive-courses",
+    });
   }
 
-  // With only one tab there's nothing to switch between.
+  // Nothing to switch between with a single section.
   if (tabs.length < 2) return null;
 
   return (
-    <Box sx={{ display: "flex", gap: 1, mb: 3, flexWrap: "wrap" }}>
+    <Box
+      sx={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 1,
+        p: 0.75,
+        mb: 3,
+        borderRadius: 4,
+        width: "fit-content",
+        maxWidth: "100%",
+        bgcolor: "color-mix(in srgb, var(--card-bg) 70%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.04)",
+      }}
+    >
       {tabs.map((t) => {
         const isActive = t.key === active;
         return (
@@ -34,17 +68,43 @@ export function CoursesNavTabs({ active }: { active: "courses" | "adaptive" }) {
             key={t.key}
             onClick={() => !isActive && router.push(t.href)}
             sx={{
-              px: 2.25, py: 0.9, borderRadius: 999, fontWeight: 800, fontSize: "0.9rem", gap: 0.6,
-              display: "inline-flex", alignItems: "center",
+              flex: { xs: 1, sm: "0 0 auto" },
+              minWidth: 0,
+              px: { xs: 2, sm: 2.75 },
+              py: 1.1,
+              borderRadius: 3,
+              textAlign: "left",
               color: isActive ? "white" : "text.primary",
               background: isActive
                 ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
-                : "color-mix(in srgb, var(--card-bg) 60%, transparent)",
-              border: isActive ? "1px solid transparent" : "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+                : "transparent",
+              boxShadow: isActive ? "0 14px 28px -14px rgba(124,58,237,0.6)" : "none",
+              transition: "background 140ms ease, box-shadow 140ms ease",
+              "&:hover": { background: isActive ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" : "color-mix(in srgb, #6366f1 8%, transparent)" },
             }}
           >
-            <Icon icon={t.icon} width={17} />
-            {t.label}
+            <Stack direction="row" spacing={1.25} alignItems="center">
+              <Box
+                sx={{
+                  width: 34,
+                  height: 34,
+                  borderRadius: 2,
+                  flexShrink: 0,
+                  display: "grid",
+                  placeItems: "center",
+                  color: isActive ? "white" : "#6366f1",
+                  bgcolor: isActive ? "rgba(255,255,255,0.18)" : "color-mix(in srgb, #6366f1 12%, transparent)",
+                }}
+              >
+                <Icon icon={t.icon} width={20} />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{ fontWeight: 800, fontSize: "0.98rem", lineHeight: 1.15 }}>{t.label}</Typography>
+                <Typography sx={{ fontSize: "0.72rem", lineHeight: 1.2, color: isActive ? "rgba(255,255,255,0.82)" : "text.secondary" }}>
+                  {t.sub}
+                </Typography>
+              </Box>
+            </Stack>
           </ButtonBase>
         );
       })}

--- a/components/layout/BottomNavigation.tsx
+++ b/components/layout/BottomNavigation.tsx
@@ -43,12 +43,7 @@ const regularNavigationItems: NavigationItem[] = [
     icon: "mdi:file-document-edit",
     featureName: "assessment",
   },
-  {
-    label: "Adaptive",
-    path: "/adaptive-quizzes",
-    icon: "mdi:tune-vertical",
-    featureName: "adaptive_quiz",
-  },
+  // Adaptive courses now live under the main Courses page — no separate nav entry.
   {
     label: "Jobs",
     path: "/jobs-v2",

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -213,13 +213,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
       icon: "mdi:file-document-edit",
       featureName: "assessment",
     },
-    {
-      label: "Adaptive Course",
-      labelKey: "nav.adaptiveQuizzes",
-      path: "/adaptive-courses",
-      icon: "mdi:book-education-outline",
-      featureName: "adaptive_quiz",
-    },
+    // Adaptive courses now live under the main Courses page (AdaptiveCoursesSection),
+    // so no separate sidebar entry — see app/courses + components/courses.
     {
       label: "Mock Interview",
       labelKey: "nav.mockInterview",

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -58,6 +58,15 @@ export const adaptiveJourneyService = {
     return data;
   },
 
+  /** AI-written LinkedIn post celebrating completion of this course (built from the
+   *  course title + description). Returns "" if the AI call failed — caller falls back. */
+  async getCertificateLinkedInPost(courseId: number): Promise<string> {
+    const { data } = await apiClient.get<{ post: string }>(
+      `${BASE}/courses/${courseId}/certificate/linkedin-post/`,
+    );
+    return data?.post ?? "";
+  },
+
   // ---- Admin course-builder ----
   async getSchedule(courseId: number): Promise<CohortScheduleResponse> {
     const { data } = await apiClient.get<CohortScheduleResponse>(`${ADMIN}/courses/${courseId}/schedule/`);

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -1,5 +1,6 @@
 import apiClient from "./api";
 import type {
+  AdaptiveCredential,
   AdminCertificateConfig,
   AdminJourneyNode,
   AdminNodeWritePayload,
@@ -65,6 +66,23 @@ export const adaptiveJourneyService = {
       `${BASE}/courses/${courseId}/certificate/linkedin-post/`,
     );
     return data?.post ?? "";
+  },
+
+  /** Issue (idempotently) the learner's verifiable credential. Eligibility-gated;
+   *  rejects with 409 if the certificate isn't enabled or completion < threshold. */
+  async issueCertificate(courseId: number): Promise<AdaptiveCredential> {
+    const { data } = await apiClient.post<AdaptiveCredential>(
+      `${BASE}/courses/${courseId}/certificate/issue/`,
+    );
+    return data;
+  },
+
+  /** PUBLIC credential verification (no auth required) — powers /credentials/<id>. */
+  async getPublicCredential(credentialId: string): Promise<AdaptiveCredential> {
+    const { data } = await apiClient.get<AdaptiveCredential>(
+      `${BASE}/credentials/${encodeURIComponent(credentialId)}/`,
+    );
+    return data;
   },
 
   // ---- Admin course-builder ----

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -1,5 +1,6 @@
 import apiClient from "./api";
 import type {
+  AdminCertificateConfig,
   AdminJourneyNode,
   AdminNodeWritePayload,
   CalibrationInterviewStatus,
@@ -184,6 +185,39 @@ export const adaptiveJourneyService = {
     courseId: number,
   ): Promise<CalibrationInterviewStatus & { template_id: number; node_id: number }> {
     const { data } = await apiClient.post(`${ADMIN}/courses/${courseId}/interview/`, {});
+    return data;
+  },
+
+  // ---- Admin certificate ----
+  /** Read the course's certificate settings (enabled, completion threshold, title, template). */
+  async getCertificateConfig(courseId: number): Promise<AdminCertificateConfig> {
+    const { data } = await apiClient.get<AdminCertificateConfig>(
+      `${ADMIN}/courses/${courseId}/certificate/`,
+    );
+    return data;
+  },
+
+  /** Update the certificate criteria (any subset of enabled / threshold / title). */
+  async updateCertificateConfig(
+    courseId: number,
+    payload: { enabled?: boolean; min_completion_percent?: number; title?: string },
+  ): Promise<AdminCertificateConfig> {
+    const { data } = await apiClient.patch<AdminCertificateConfig>(
+      `${ADMIN}/courses/${courseId}/certificate/`,
+      payload,
+    );
+    return data;
+  },
+
+  /** Upload the certificate template image (multipart). Returns the refreshed config. */
+  async uploadCertificateTemplate(courseId: number, file: File): Promise<AdminCertificateConfig> {
+    const form = new FormData();
+    form.append("file", file);
+    // Don't set Content-Type — the browser adds the multipart boundary; forcing it breaks DRF.
+    const { data } = await apiClient.post<AdminCertificateConfig>(
+      `${ADMIN}/courses/${courseId}/certificate/upload/`,
+      form,
+    );
     return data;
   },
 };

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -401,6 +401,28 @@ export const adminAdaptiveCourseService = {
     return data;
   },
 
+  /** Edit the course title and/or description. Returns the updated course detail. */
+  async updateCourse(
+    courseId: number,
+    payload: { title?: string; description?: string },
+  ): Promise<AdminAdaptiveCourseDetail> {
+    const { data } = await apiClient.patch<AdminAdaptiveCourseDetail>(
+      `${BASE}/courses/${courseId}/`,
+      payload,
+    );
+    return data;
+  },
+
+  /** AI-draft a course description (from the title + modules). Returns the text only —
+   *  the admin reviews/edits it, then saves with updateCourse. */
+  async generateCourseDescription(courseId: number): Promise<string> {
+    const { data } = await apiClient.post<{ description: string }>(
+      `${BASE}/courses/${courseId}/generate-description/`,
+      {},
+    );
+    return data?.description ?? "";
+  },
+
   async getCourseArticle(
     courseId: number,
     articleId: number,

--- a/lib/services/certificate-share.service.ts
+++ b/lib/services/certificate-share.service.ts
@@ -85,6 +85,59 @@ export function getLinkedInShareUrl(_pageUrl: string): string {
   return "https://www.linkedin.com/sharing/share-offsite/";
 }
 
+/** Params for the LinkedIn "Add to Profile" certifications deep link. */
+export interface AddToProfileParams {
+  /** Credential name (e.g. course title) — becomes the certification name on LinkedIn. */
+  certificationName: string;
+  /** Issuing organization name (tenant/client). Used when no numeric org id is available. */
+  organizationName: string;
+  /** Verified LinkedIn numeric company id, if the tenant maps to a real company page. */
+  organizationId?: string | number | null;
+  /** Issue year/month (1–12). */
+  issueYear: number;
+  issueMonth: number;
+  /** Public URL for the credential (course/journey page). */
+  certUrl?: string;
+  /** Stable credential id, if any. */
+  certId?: string;
+}
+
+/**
+ * Build the LinkedIn "Add to Profile" deep link. This pre-fills the member's
+ * Certifications form (no OAuth / app review needed) — the same mechanism Coursera,
+ * Udemy and Duolingo use. When a numeric organizationId is available it links the
+ * credential to the company page; otherwise it falls back to organizationName text.
+ */
+export function getLinkedInAddToProfileUrl(p: AddToProfileParams): string {
+  const params = new URLSearchParams();
+  params.set("startTask", "CERTIFICATION_NAME");
+  params.set("name", p.certificationName || "Course Completion");
+  if (p.organizationId) {
+    params.set("organizationId", String(p.organizationId));
+  } else if (p.organizationName) {
+    params.set("organizationName", p.organizationName);
+  }
+  params.set("issueYear", String(p.issueYear));
+  params.set("issueMonth", String(p.issueMonth));
+  if (p.certUrl) params.set("certUrl", p.certUrl);
+  if (p.certId) params.set("certId", p.certId);
+  return `https://www.linkedin.com/profile/add?${params.toString()}`;
+}
+
+/** Open a centered LinkedIn popup window (share-offsite / add-to-profile). */
+export function openLinkedInPopup(url: string): void {
+  if (typeof window === "undefined") return;
+  const w = 600;
+  const h = 700;
+  const left = Math.max(0, (window.screen.width - w) / 2);
+  const top = Math.max(0, (window.screen.height - h) / 2);
+  window.open(
+    url,
+    "LinkedIn",
+    `width=${w},height=${h},left=${left},top=${top},noopener,noreferrer,scrollbars=yes`,
+  );
+}
+
 /** Minimum course completion percentage required to claim certificate (download/share). */
 export const CERTIFICATE_MIN_COMPLETION = 80;
 
@@ -125,6 +178,8 @@ export const certificateShareService = {
   getLinkedInPostText,
   blobToBase64,
   getLinkedInShareUrl,
+  getLinkedInAddToProfileUrl,
+  openLinkedInPopup,
   CERTIFICATE_MIN_COMPLETION,
   normalizeCourseNameToPath,
   checkCertificateImageInPublicImages,

--- a/lib/services/certificate-share.service.ts
+++ b/lib/services/certificate-share.service.ts
@@ -4,6 +4,9 @@ export interface CertificatePostData {
   course: string;
   score: string;
   certificateUrl: string;
+  /** Optional course description / details, woven into the post body so it
+   *  reflects the actual course instead of a generic template. */
+  courseDescription?: string;
 }
 
 const CERTIFICATE_IMAGE_EXTENSIONS = [".jpeg", ".jpg", ".png"] as const;
@@ -26,6 +29,14 @@ export function getHashtags(courseTitle: string, clientName: string): string {
   return [...new Set(tags)].join(" ");
 }
 
+/** Bold only the first line of a post (LinkedIn has no rich text; unicode-bold makes the
+ *  headline stand out). Used for AI-generated posts that arrive as plain text. */
+export function boldHeadline(text: string): string {
+  const nl = text.indexOf("\n");
+  if (nl === -1) return toBoldUnicode(text);
+  return toBoldUnicode(text.slice(0, nl)) + text.slice(nl);
+}
+
 /** Convert string to Unicode mathematical bold so it appears bold when pasted as plain text. */
 export function toBoldUnicode(str: string): string {
   return str
@@ -40,28 +51,34 @@ export function toBoldUnicode(str: string): string {
     .join("");
 }
 
-/** Build the post text that will be copied to clipboard (LinkedIn does not pre-fill from URL). */
+/** Build the post text that will be copied to clipboard (LinkedIn does not pre-fill from URL).
+ *  The body is derived from the ACTUAL course title + description so the post matches the
+ *  course the learner completed (not a hardcoded template). */
 export function getLinkedInPostText(
   data: CertificatePostData,
   clientInfo: { name?: string } | null
 ): string {
   const clientName = clientInfo?.name ?? "";
-  const hashtags = getHashtags(data.course || "", clientName);
-  const firstLine =
-    "I'm happy to share that I have successfully completed a 4-month training program with " +
-    clientName +
-    " 🎓";
-  return [
-    toBoldUnicode(firstLine),
-    "",
-    "The program was designed to strengthen Quantitative Aptitude while also focusing on Professional Skills such as communication, confidence, and workplace etiquette. With trainers aligned throughout the journey, the sessions were structured, interactive, and practice-oriented, helping me steadily improve my skills and mindset.",
-    "",
-    "Thankful to the " +
-      clientName +
-      " team and trainers for their guidance, consistency, and encouragement. This experience has been a valuable step in my professional development, and I look forward to applying these learnings in the future 🚀",
-    "",
-    hashtags,
-  ]
+  const course = (data.course || "").trim();
+  const courseLabel = course || "a new course";
+  const hashtags = getHashtags(course, clientName);
+  const withClient = clientName ? ` with ${clientName}` : "";
+
+  const headline = `I'm excited to share that I've completed ${courseLabel}${withClient}! 🎓`;
+
+  // Prefer the real course description; otherwise a course-aware fallback sentence.
+  const desc = (data.courseDescription || "").trim();
+  const body = desc
+    ? desc.length > 320
+      ? desc.slice(0, 317).trimEnd() + "…"
+      : desc
+    : `This program took me through hands-on lessons, quizzes, and projects in ${courseLabel} — strengthening both my skills and my confidence to apply them in real work.`;
+
+  const closing = clientName
+    ? `Grateful to the ${clientName} team for the structured, practice-oriented learning experience. Excited to put these learnings to work! 🚀`
+    : "Excited to put these learnings to work! 🚀";
+
+  return [toBoldUnicode(headline), "", body, "", closing, "", hashtags]
     .join("\n")
     .trim();
 }

--- a/lib/types/adaptive-journey.ts
+++ b/lib/types/adaptive-journey.ts
@@ -52,6 +52,19 @@ export interface JourneyWeekView {
   nodes: JourneyNodeView[];
 }
 
+/** Admin-facing certificate settings for an adaptive course (snake_case, like other admin responses). */
+export interface AdminCertificateConfig {
+  enabled: boolean;
+  min_completion_percent: number;
+  title: string;
+  /** Stored template blob ({name, alt}); empty object when none uploaded. */
+  template: { name?: string; alt?: string };
+  /** Re-signed URL of the uploaded template image, or null. */
+  template_url: string | null;
+  /** True once a template image has been uploaded. */
+  configured: boolean;
+}
+
 export interface JourneyBoard {
   course: {
     id: number;
@@ -61,6 +74,12 @@ export interface JourneyBoard {
     abilityIndex: number | null;
     enrolledCount: number;
     certificateThreshold: number;
+    /** Admin enabled the certificate for this course. */
+    certificateEnabled: boolean;
+    /** Re-signed URL of the admin-uploaded certificate template image, or null. */
+    certificateTemplateUrl: string | null;
+    /** Optional admin label for the certificate (e.g. "Data Science Professional"). */
+    certificateTitle: string;
     estHours: number | null;
     sections: number;
     items: number;

--- a/lib/types/adaptive-journey.ts
+++ b/lib/types/adaptive-journey.ts
@@ -52,6 +52,19 @@ export interface JourneyWeekView {
   nodes: JourneyNodeView[];
 }
 
+/** A verifiable, publicly-shareable course-completion credential. */
+export interface AdaptiveCredential {
+  credential_id: string;
+  recipient_name: string;
+  course_title: string;
+  issuer_name: string;
+  issuer_logo_url: string;
+  completion_percent: number;
+  issued_at: string;
+  template_url: string | null;
+  verified: boolean;
+}
+
 /** Admin-facing certificate settings for an adaptive course (snake_case, like other admin responses). */
 export interface AdminCertificateConfig {
   enabled: boolean;

--- a/proxy.ts
+++ b/proxy.ts
@@ -22,6 +22,8 @@ export function proxy(request: NextRequest) {
     "/forgot-password",
     "/reset-password",
     "/auth/handoff",
+    // Public credential verification pages — anyone (incl. LinkedIn's crawler) can open these.
+    "/credentials",
   ];
   const isPublicRoute = publicRoutes.some((route) =>
     pathname.startsWith(route)
@@ -49,7 +51,9 @@ export function proxy(request: NextRequest) {
     isPublicRoute &&
     token &&
     pathname !== "/verify-email" &&
-    !pathname.startsWith("/auth/")
+    !pathname.startsWith("/auth/") &&
+    // Credential pages must render for signed-in users too (don't bounce to /dashboard).
+    !pathname.startsWith("/credentials")
   ) {
     return NextResponse.redirect(new URL("/dashboard", request.url));
   }


### PR DESCRIPTION
Adds the adaptive-course certificate experience end to end on the frontend.

Admin:
- New /admin/adaptive-courses/[courseId]/certificate page to upload the certificate template and set criteria (enabled + min completion % + title), reusing AdminCertificateUploadCard. Launcher card added to the course hub.
- adaptiveJourneyService gains getCertificateConfig / updateCertificateConfig / uploadCertificateTemplate.

Learner:
- JourneySidePanels certificate card is wired to the real download + LinkedIn flow (was disabled placeholders); shown only when the admin enables it and gated on the per-course threshold from the board.
- CertificateButtons takes an optional minCompletion override and a new "Add to LinkedIn profile" button (LinkedIn Add-to-Profile deep link).
- certificate-share.service: getLinkedInAddToProfileUrl + openLinkedInPopup.