### PR TITLE
feat(adaptive-journey): Additional Practice section on the submodule …

### DIFF
--- a/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
@@ -10,6 +10,7 @@ import mockInterviewService, {
 } from "@/lib/services/mock-interview.service";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { InterviewResult } from "@/lib/types/adaptive-journey";
+import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { useSpeechToText } from "@/lib/hooks/useSpeechToText";
 import { readSttEngine } from "@/lib/utils/stt-engine";
 import { AIAvatar } from "@/components/mock-interview/AIAvatar";
@@ -276,6 +277,7 @@ function CourseInterviewInner() {
           const r = await adaptiveJourneyService.getInterviewResult(courseId);
           if (r.done && r.insight) {
             setResult(r);
+            notifyContentCompleted(); // eval done + scored → counts toward the streak
             break;
           }
         } catch {

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
@@ -6,6 +6,7 @@ import { Box, ButtonBase, CircularProgress, Popover, Typography } from "@mui/mat
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
+import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
 import { AIBeacon } from "@/components/adaptive-quiz/shared/AIBeacon";
@@ -74,8 +75,12 @@ export default function AdaptiveArticleReaderPage() {
         setHtml(data.content_html);
         setReadingTime(data.reading_time_minutes);
         // Reading an article counts as course activity: awards points + keeps the
-        // daily streak alive (idempotent server-side per student+article).
-        void adaptiveCourseService.completeArticle(articleId).catch(() => {});
+        // daily streak alive (idempotent server-side per student+article). Notify the
+        // streak celebration once the server records it.
+        void adaptiveCourseService
+          .completeArticle(articleId)
+          .then(() => notifyContentCompleted())
+          .catch(() => {});
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load article.");
       } finally {

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
@@ -60,6 +60,10 @@ export default function AdaptiveArticleReaderPage() {
   const [activeHeading, setActiveHeading] = useState<string>("");
   const [progress, setProgress] = useState(0);
   const bodyWrapRef = useRef<HTMLDivElement | null>(null);
+  // Reading marks the article complete on the server (on load), but we defer the streak
+  // celebration until the learner LEAVES the article — so it pops on the page they go to,
+  // not the moment they open it.
+  const completedRef = useRef(false);
   // Professional onyx narration (replaces robotic browser speechSynthesis).
   const narration = useArticleNarration(html);
 
@@ -75,11 +79,11 @@ export default function AdaptiveArticleReaderPage() {
         setHtml(data.content_html);
         setReadingTime(data.reading_time_minutes);
         // Reading an article counts as course activity: awards points + keeps the
-        // daily streak alive (idempotent server-side per student+article). Notify the
-        // streak celebration once the server records it.
+        // daily streak alive (idempotent server-side per student+article). The streak
+        // celebration is fired on unmount (see below) so it shows after the learner reads.
         void adaptiveCourseService
           .completeArticle(articleId)
-          .then(() => notifyContentCompleted())
+          .then(() => { completedRef.current = true; })
           .catch(() => {});
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load article.");
@@ -89,6 +93,14 @@ export default function AdaptiveArticleReaderPage() {
     })();
     return () => { cancelled = true; };
   }, [articleId]);
+
+  // Fire the streak celebration when the learner leaves the article (navigates back or
+  // anywhere else) — not the instant it opens.
+  useEffect(() => {
+    return () => {
+      if (completedRef.current) notifyContentCompleted();
+    };
+  }, []);
 
   // Scroll-spy: highlight the table-of-contents entry nearest the top.
   useEffect(() => {

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -9,6 +9,7 @@ import {
   type AdaptiveCourseSubModule,
 } from "@/lib/services/adaptive-course.service";
 import { MainLayout } from "@/components/layout/MainLayout";
+import { AdditionalPractice } from "@/components/adaptive-journey/AdditionalPractice";
 
 type FlowKind = "video" | "article" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
@@ -236,6 +237,9 @@ export default function AdaptiveCourseSubmodulePage() {
                 </Box>
               </>
             )}
+
+            {/* Additional Practice — learner-generated extra content (no points) */}
+            <AdditionalPractice courseId={courseId} submoduleId={submoduleId} />
           </>
         )}
       </Box>

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -219,34 +219,39 @@ export default function AdaptiveCourseSubmodulePage() {
                 <Typography sx={{ color: "text.secondary", mt: 1 }}>No content in this topic yet.</Typography>
               </Box>
             ) : (
-              <>
-                {/* Section header with gradient badge */}
-                <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 1.75 }}>
-                  <Box sx={{ width: 34, height: 34, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)", boxShadow: "0 8px 18px -10px rgba(124,58,237,0.6)" }}>
-                    <Icon icon="mdi:map-marker-path" width={19} />
-                  </Box>
+              // Two-column like the course page: learning path (main) + points (sidebar).
+              <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 1fr) 390px" }, gap: 2.5, alignItems: "start" }}>
+                <Box sx={{ minWidth: 0 }}>
+                  {/* Section header with gradient badge */}
+                  <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 1.75 }}>
+                    <Box sx={{ width: 34, height: 34, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)", boxShadow: "0 8px 18px -10px rgba(124,58,237,0.6)" }}>
+                      <Icon icon="mdi:map-marker-path" width={19} />
+                    </Box>
+                    <Box>
+                      <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#0f172a" }}>Your learning path</Typography>
+                      <Typography sx={{ fontSize: "0.8rem", color: "#64748b" }}>{pathSubtitle}</Typography>
+                    </Box>
+                  </Stack>
+
                   <Box>
-                    <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#0f172a" }}>Your learning path</Typography>
-                    <Typography sx={{ fontSize: "0.8rem", color: "#64748b" }}>{pathSubtitle}</Typography>
+                    {items.map((it, idx) => (
+                      <PathRow
+                        key={it.key}
+                        item={it}
+                        step={idx + 1}
+                        last={idx === items.length - 1}
+                        status={it.completed ? "done" : idx === firstIncomplete ? "current" : "upcoming"}
+                      />
+                    ))}
                   </Box>
-                </Stack>
-
-                <Box>
-                  {items.map((it, idx) => (
-                    <PathRow
-                      key={it.key}
-                      item={it}
-                      step={idx + 1}
-                      last={idx === items.length - 1}
-                      status={it.completed ? "done" : idx === firstIncomplete ? "current" : "upcoming"}
-                    />
-                  ))}
                 </Box>
-              </>
-            )}
 
-            {/* Points breakdown — where this topic's points come from */}
-            <PointsBreakdown courseId={courseId} submoduleId={submoduleId} />
+                {/* Sidebar — points breakdown, mirrors the course page side panels */}
+                <Box>
+                  <PointsBreakdown courseId={courseId} submoduleId={submoduleId} />
+                </Box>
+              </Box>
+            )}
 
             {/* Additional Practice — learner-generated extra content (no points) */}
             <AdditionalPractice courseId={courseId} submoduleId={submoduleId} />

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -22,6 +22,8 @@ interface FlowItem {
   chips: { icon: string; text: string }[];
   onClick: () => void;
   completed: boolean;
+  /** Where "Review" goes once completed (e.g. past quiz results); falls back to onClick. */
+  onReview?: () => void;
 }
 
 const VERB: Record<FlowKind, string> = { video: "watch", article: "read", quiz: "quiz", coding: "practice" };
@@ -71,6 +73,10 @@ function buildItems(
         ...q.target_skills.slice(0, 2).map((s) => ({ icon: "mdi:tag-outline", text: s })),
       ],
       onClick: () => router.push(`/adaptive-quizzes/start?configId=${q.config_id}`),
+      // Completed → open the last attempt's results instead of restarting.
+      onReview: q.last_session_id
+        ? () => router.push(`/adaptive-quizzes/session/${q.last_session_id}/results`)
+        : undefined,
     }),
   );
   (sm.coding_sets ?? []).forEach((set) =>
@@ -255,6 +261,10 @@ function PathRow({ item, step, last, status }: { item: FlowItem; step: number; l
   const m = FLOW_META[item.kind];
   const done = status === "done";
   const current = status === "current";
+  // When done, "Review" (and tapping the card) opens past results where available,
+  // instead of restarting the activity.
+  const reviewAction = item.onReview ?? item.onClick;
+  const cardAction = done ? reviewAction : item.onClick;
 
   // Status marker — mirrors the course timeline: green check (done), indigo ring
   // (current), light numbered (upcoming).
@@ -283,7 +293,7 @@ function PathRow({ item, step, last, status }: { item: FlowItem; step: number; l
       </Box>
 
       <Box
-        onClick={item.onClick}
+        onClick={cardAction}
         sx={{
           flex: 1, mb: 1.5, p: 2, borderRadius: 3, border: "1px solid",
           borderLeft: "4px solid", borderLeftColor: m.color,
@@ -329,10 +339,10 @@ function PathRow({ item, step, last, status }: { item: FlowItem; step: number; l
           </Box>
           {done ? (
             <ButtonBase
-              onClick={(e) => { e.stopPropagation(); item.onClick(); }}
+              onClick={(e) => { e.stopPropagation(); reviewAction(); }}
               sx={{ flexShrink: 0, px: 2, py: 0.9, borderRadius: 999, fontWeight: 800, color: "#475569", fontSize: "0.82rem", gap: 0.5, border: "1px solid #cbd5e1", bgcolor: "transparent" }}
             >
-              <Icon icon="mdi:refresh" width={15} />
+              <Icon icon={item.onReview ? "mdi:eye-outline" : "mdi:refresh"} width={15} />
               Review
             </ButtonBase>
           ) : (

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/services/adaptive-course.service";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { AdditionalPractice } from "@/components/adaptive-journey/AdditionalPractice";
+import { PointsBreakdown } from "@/components/adaptive-journey/PointsBreakdown";
 
 type FlowKind = "video" | "article" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
@@ -237,6 +238,9 @@ export default function AdaptiveCourseSubmodulePage() {
                 </Box>
               </>
             )}
+
+            {/* Points breakdown — where this topic's points come from */}
+            <PointsBreakdown courseId={courseId} submoduleId={submoduleId} />
 
             {/* Additional Practice — learner-generated extra content (no points) */}
             <AdditionalPractice courseId={courseId} submoduleId={submoduleId} />

--- a/app/assessments/[slug]/calibration/page.tsx
+++ b/app/assessments/[slug]/calibration/page.tsx
@@ -6,6 +6,7 @@ import { Box, Button, Chip, CircularProgress, Stack, Typography } from "@mui/mat
 import { Icon } from "@iconify/react";
 import { assessmentService } from "@/lib/services/assessment.service";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import type { CalibrationResult } from "@/lib/types/adaptive-journey";
 
 interface CalibMcq {
@@ -215,6 +216,8 @@ function CalibrationTakeInner() {
         streamRef.current?.getTracks().forEach((t) => t.stop());
         if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
         setSubmitted(true);
+        notifyContentCompleted(); // counts toward the daily streak
+
         // Fetch the "what we learned about you" profile (evaluation runs on submit).
         if (courseId) {
           setResultLoading(true);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,21 +2,13 @@
 
 import { Box } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { DashboardContent } from "@/components/dashboard/DashboardContent";
-import { useDashboardData } from "@/hooks/useDashboardData";
+import { DashboardV2 } from "@/components/dashboard/v2/DashboardV2";
 
 export default function DashboardPage() {
-  const { loading, courses, selectedCourseId } = useDashboardData();
-
   return (
     <MainLayout>
-      <Box sx={{ p: 3 }}>
-        <DashboardContent
-          courses={courses}
-          loading={loading}
-          streakDays={[23, 25, 27]}
-          currentStreak={3}
-        />
+      <Box sx={{ p: { xs: 2, md: 3 } }}>
+        <DashboardV2 />
       </Box>
     </MainLayout>
   );

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,8 +6,8 @@ import { DashboardV2 } from "@/components/dashboard/v2/DashboardV2";
 
 export default function DashboardPage() {
   return (
-    <MainLayout>
-      <Box sx={{ p: { xs: 2, md: 3 } }}>
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1600, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 } }}>
         <DashboardV2 />
       </Box>
     </MainLayout>

--- a/app/leaderboard-streaks/page.tsx
+++ b/app/leaderboard-streaks/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Box, ButtonBase } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useRouter } from "next/navigation";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { LeaderboardStreaksContent } from "@/components/leaderboard-streaks/LeaderboardStreaksContent";
+
+export default function LeaderboardStreaksPage() {
+  const router = useRouter();
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1600, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 } }}>
+        <ButtonBase onClick={() => router.back()} sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.85rem" }}>
+          <Icon icon="mdi:arrow-left" width={18} /> Back
+        </ButtonBase>
+        <LeaderboardStreaksContent />
+      </Box>
+    </MainLayout>
+  );
+}
+
+export const dynamic = "force-dynamic";

--- a/app/points-system/page.tsx
+++ b/app/points-system/page.tsx
@@ -10,7 +10,7 @@ export default function PointsSystemPage() {
   const router = useRouter();
   return (
     <MainLayout fullWidthContent>
-      <Box sx={{ maxWidth: 1280, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 } }}>
+      <Box sx={{ maxWidth: 1600, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 } }}>
         <ButtonBase onClick={() => router.back()} sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.85rem" }}>
           <Icon icon="mdi:arrow-left" width={18} /> Back
         </ButtonBase>

--- a/app/points-system/page.tsx
+++ b/app/points-system/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Box, ButtonBase } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useRouter } from "next/navigation";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { PointsSystemContent } from "@/components/points-system/PointsSystemContent";
+
+export default function PointsSystemPage() {
+  const router = useRouter();
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1280, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 } }}>
+        <ButtonBase onClick={() => router.back()} sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.85rem" }}>
+          <Icon icon="mdi:arrow-left" width={18} /> Back
+        </ButtonBase>
+        <PointsSystemContent />
+      </Box>
+    </MainLayout>
+  );
+}
+
+export const dynamic = "force-dynamic";

--- a/components/adaptive-journey/AdditionalPractice.tsx
+++ b/components/adaptive-journey/AdditionalPractice.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, CircularProgress, Stack, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import {
+  adaptiveCourseService,
+  type PracticeDifficulty,
+  type PracticeItem,
+  type PracticeKind,
+  type PracticeState,
+} from "@/lib/services/adaptive-course.service";
+
+const KIND_CARDS: { kind: PracticeKind; icon: string; title: string; sub: string }[] = [
+  { kind: "article", icon: "mdi:file-document-outline", title: "Article", sub: "Explainer at your level" },
+  { kind: "quiz", icon: "mdi:help-circle-outline", title: "Quiz", sub: "Adaptive MCQs" },
+  { kind: "coding", icon: "mdi:laptop", title: "Coding", sub: "Hands-on problems" },
+];
+
+const DIFFS: { value: PracticeDifficulty; label: string; color: string }[] = [
+  { value: "Easy", label: "Easy", color: "#16a34a" },
+  { value: "Medium", label: "Medium", color: "#d97706" },
+  { value: "Hard", label: "Hard", color: "#dc2626" },
+  { value: "match", label: "✦ Match me", color: "#7c3aed" },
+];
+
+const COUNTS = [3, 5, 10];
+
+const KIND_META: Record<PracticeKind, { icon: string; color: string; bg: string; unit: string }> = {
+  article: { icon: "mdi:file-document-outline", color: "#a855f7", bg: "#f5f3ff", unit: "explainer" },
+  quiz: { icon: "mdi:help-circle", color: "#6366f1", bg: "#eef2ff", unit: "questions" },
+  coding: { icon: "mdi:laptop", color: "#ec4899", bg: "#fdf2f8", unit: "problems" },
+};
+
+export function AdditionalPractice({ courseId, submoduleId }: { courseId: number; submoduleId: number }) {
+  const router = useRouter();
+  const [state, setState] = useState<PracticeState | null>(null);
+  const [open, setOpen] = useState(true);
+  const [kind, setKind] = useState<PracticeKind>("quiz");
+  const [difficulty, setDifficulty] = useState<PracticeDifficulty>("match");
+  const [count, setCount] = useState(5);
+  const [custom, setCustom] = useState(false);
+  const [focus, setFocus] = useState("");
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    adaptiveCourseService
+      .getSubmodulePractice(courseId, submoduleId)
+      .then((s) => { if (!cancelled) setState(s); })
+      .catch(() => { if (!cancelled) setState({ usage: { used: 0, limit: 20, left: 20, by_kind: { quiz: 0, coding: 0, article: 0 } }, items: [] }); });
+    return () => { cancelled = true; };
+  }, [courseId, submoduleId]);
+
+  const usage = state?.usage;
+  const used = usage?.used ?? 0;
+  const limit = usage?.limit ?? 20;
+  const left = usage?.left ?? 0;
+  const pct = limit ? Math.min(100, (used / limit) * 100) : 0;
+  const items = state?.items ?? [];
+
+  const need = kind === "article" ? 1 : count;
+  const canGenerate = !generating && left > 0 && need <= left;
+  const btnUnit = kind === "article" ? "explainer" : `${count} ${KIND_META[kind].unit}`;
+
+  const openItem = (it: PracticeItem) => {
+    if (it.kind === "quiz" && it.config_id) router.push(`/adaptive-quizzes/start?configId=${it.config_id}`);
+    else if (it.kind === "coding" && it.problem_id) router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}/coding/${it.problem_id}?configId=${it.config_id}`);
+    else if (it.kind === "article" && it.article_id) router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}/article/${it.article_id}`);
+  };
+
+  const generate = async () => {
+    if (!canGenerate) return;
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await adaptiveCourseService.generatePractice(courseId, submoduleId, {
+        kind, difficulty, count, focus: focus.trim(),
+      });
+      setState({ usage: res.usage, items: res.items });
+      setFocus("");
+    } catch (e: unknown) {
+      const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || "Couldn't generate practice right now. Please try again.");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const exhausted = left <= 0;
+
+  return (
+    <Box sx={{ mt: 3, borderRadius: 4, border: "1.5px solid #ddd6fe", overflow: "hidden", bgcolor: "#fff" }}>
+      {/* Header band */}
+      <Box sx={{ p: { xs: 2, md: 2.5 }, background: "linear-gradient(180deg, #faf5ff 0%, #f5f3ff 100%)", borderBottom: open ? "1px solid #ede9fe" : "none" }}>
+        <Stack direction="row" alignItems="flex-start" spacing={1.5}>
+          <Box sx={{ width: 44, height: 44, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #7c3aed 0%, #ec4899 100%)", boxShadow: "0 8px 20px -8px rgba(124,58,237,0.6)" }}>
+            <Icon icon="mdi:auto-fix" width={24} />
+          </Box>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Stack direction="row" alignItems="center" spacing={1} flexWrap="wrap">
+              <Typography sx={{ fontWeight: 800, fontSize: "1.15rem", color: "#1e1b4b" }}>Additional Practice</Typography>
+              <Stack direction="row" spacing={0.3} alignItems="center" sx={{ px: 1, py: 0.3, borderRadius: 999, color: "white", background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 100%)" }}>
+                <Icon icon="mdi:plus" width={12} />
+                <Typography sx={{ fontSize: "0.66rem", fontWeight: 800 }}>Generate</Typography>
+              </Stack>
+            </Stack>
+            <Typography sx={{ fontSize: "0.84rem", color: "#475569", mt: 0.25 }}>
+              Want more reps on this topic? Generate extra content tuned to your level.{" "}
+              <Box component="span" sx={{ fontWeight: 800, color: "#1e293b" }}>Practice only — these don&apos;t earn points.</Box>
+            </Typography>
+          </Box>
+          {/* Quota meter */}
+          <Box sx={{ minWidth: 150, textAlign: "right", flexShrink: 0, display: { xs: "none", sm: "block" } }}>
+            <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#1e1b4b" }}>
+              <Box component="span" sx={{ color: "#7c3aed", fontWeight: 900 }}>{used}</Box> / {limit} generated
+            </Typography>
+            <Box sx={{ height: 6, borderRadius: 999, bgcolor: "#ede9fe", mt: 0.5, overflow: "hidden" }}>
+              <Box sx={{ height: "100%", width: `${pct}%`, borderRadius: 999, background: "linear-gradient(90deg, #7c3aed 0%, #ec4899 100%)", transition: "width .3s" }} />
+            </Box>
+            <Typography sx={{ fontSize: "0.7rem", color: "#94a3b8", mt: 0.4 }}>{left} left for this topic</Typography>
+          </Box>
+          <ButtonBase onClick={() => setOpen((o) => !o)} sx={{ width: 30, height: 30, borderRadius: 2, border: "1px solid #ddd6fe", color: "#7c3aed", flexShrink: 0 }}>
+            <Icon icon={open ? "mdi:chevron-up" : "mdi:chevron-down"} width={20} />
+          </ButtonBase>
+        </Stack>
+      </Box>
+
+      {open && (
+        <Box sx={{ p: { xs: 2, md: 2.5 } }}>
+          {/* Step 1 — what to generate */}
+          <StepLabel n={1} text="WHAT DO YOU WANT TO GENERATE?" />
+          <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" }, gap: 1.5, mb: 2.5 }}>
+            {KIND_CARDS.map((c) => {
+              const active = kind === c.kind;
+              const m = KIND_META[c.kind];
+              return (
+                <ButtonBase key={c.kind} onClick={() => setKind(c.kind)} sx={{
+                  p: 2, borderRadius: 3, border: "1.5px solid", textAlign: "center", flexDirection: "column", gap: 0.5,
+                  borderColor: active ? m.color : "#e5e7eb", bgcolor: active ? m.bg : "#fff",
+                  transition: "border-color .15s, background .15s", position: "relative",
+                }}>
+                  {active && <Icon icon="mdi:check" width={16} color={m.color} style={{ position: "absolute", top: 8, right: 8 }} />}
+                  <Box sx={{ color: active ? m.color : "#94a3b8" }}><Icon icon={c.icon} width={28} /></Box>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: active ? m.color : "#334155" }}>{c.title}</Typography>
+                  <Typography sx={{ fontSize: "0.74rem", color: "#94a3b8" }}>{c.sub}</Typography>
+                </ButtonBase>
+              );
+            })}
+          </Box>
+
+          <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" }, gap: { xs: 2, md: 3 }, mb: 2 }}>
+            {/* Step 2 — difficulty */}
+            <Box>
+              <StepLabel n={2} text="DIFFICULTY" />
+              <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                {DIFFS.map((d) => {
+                  const active = difficulty === d.value;
+                  return (
+                    <ButtonBase key={d.value} onClick={() => setDifficulty(d.value)} sx={{
+                      px: 1.75, py: 0.85, borderRadius: 999, fontWeight: 700, fontSize: "0.84rem", border: "1.5px solid",
+                      borderColor: active ? d.color : "#e5e7eb",
+                      bgcolor: active ? d.color : "#fff", color: active ? "#fff" : "#475569",
+                      transition: "all .15s",
+                    }}>
+                      {d.label}
+                    </ButtonBase>
+                  );
+                })}
+              </Stack>
+            </Box>
+
+            {/* Step 3 — how many (hidden for article) */}
+            {kind !== "article" && (
+              <Box>
+                <StepLabel n={3} text={`HOW MANY`} hint={`MAX ${left} LEFT`} />
+                <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap alignItems="center">
+                  {COUNTS.map((c) => {
+                    const active = !custom && count === c;
+                    const disabled = c > left;
+                    return (
+                      <ButtonBase key={c} disabled={disabled} onClick={() => { setCustom(false); setCount(c); }} sx={{
+                        minWidth: 48, px: 1.5, py: 0.85, borderRadius: 2, fontWeight: 800, fontSize: "0.9rem", border: "1.5px solid",
+                        borderColor: active ? "#7c3aed" : "#e5e7eb", color: active ? "#7c3aed" : disabled ? "#cbd5e1" : "#475569",
+                        bgcolor: active ? "#f5f3ff" : "#fff", opacity: disabled ? 0.5 : 1,
+                      }}>
+                        {c}
+                      </ButtonBase>
+                    );
+                  })}
+                  <ButtonBase onClick={() => setCustom(true)} sx={{
+                    px: 1.5, py: 0.85, borderRadius: 2, fontWeight: 700, fontSize: "0.84rem", border: "1.5px solid",
+                    borderColor: custom ? "#7c3aed" : "#e5e7eb", color: custom ? "#7c3aed" : "#475569", bgcolor: custom ? "#f5f3ff" : "#fff",
+                  }}>
+                    Custom…
+                  </ButtonBase>
+                  {custom && (
+                    <TextField
+                      type="number" size="small" value={count}
+                      onChange={(e) => setCount(Math.max(1, Math.min(Number(e.target.value) || 1, Math.min(10, left || 10))))}
+                      inputProps={{ min: 1, max: Math.min(10, left || 10), style: { width: 56, padding: "8px" } }}
+                    />
+                  )}
+                </Stack>
+              </Box>
+            )}
+          </Box>
+
+          {/* Focus + generate */}
+          <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems={{ md: "stretch" }} sx={{ mb: 1.5 }}>
+            <TextField
+              fullWidth size="small" value={focus} onChange={(e) => setFocus(e.target.value)}
+              placeholder={'Optional: focus on… e.g. "string slicing & f-strings"'}
+              InputProps={{ startAdornment: <Icon icon="mdi:target" width={16} style={{ marginRight: 8, color: "#a855f7", flexShrink: 0 }} /> }}
+            />
+            <ButtonBase onClick={generate} disabled={!canGenerate} sx={{
+              flexShrink: 0, px: 3, py: 1.2, borderRadius: 2, fontWeight: 800, fontSize: "0.9rem", color: "white", gap: 0.75, whiteSpace: "nowrap",
+              background: canGenerate ? "linear-gradient(135deg, #7c3aed 0%, #ec4899 100%)" : "#cbd5e1",
+              boxShadow: canGenerate ? "0 12px 28px -14px rgba(124,58,237,0.7)" : "none",
+            }}>
+              {generating ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:auto-fix" width={18} />}
+              {generating ? "Generating…" : exhausted ? "Topic limit reached" : `Generate ${btnUnit}`}
+            </ButtonBase>
+          </Stack>
+
+          {error && <Typography sx={{ fontSize: "0.8rem", color: "#dc2626", mb: 1, fontWeight: 600 }}>{error}</Typography>}
+
+          <Stack direction="row" spacing={0.6} alignItems="flex-start">
+            <Icon icon="mdi:information-outline" width={14} style={{ color: "#94a3b8", marginTop: 2, flexShrink: 0 }} />
+            <Typography sx={{ fontSize: "0.74rem", color: "#94a3b8", lineHeight: 1.5 }}>
+              Generated practice is unlimited to retry but capped at{" "}
+              <Box component="span" sx={{ fontWeight: 800, color: "#475569" }}>{limit} new items per topic</Box>{" "}
+              to keep your path focused. Resets if the topic is re-published.
+            </Typography>
+          </Stack>
+
+          {/* Your generated practice */}
+          {items.length > 0 && (
+            <Box sx={{ mt: 2.5, pt: 2.5, borderTop: "1px solid #f1f5f9" }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.25 }}>
+                <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: 0.6, color: "#64748b" }}>
+                  YOUR GENERATED PRACTICE ({items.length})
+                </Typography>
+                <Stack direction="row" spacing={0.75} alignItems="center">
+                  <Box sx={{ px: 1, py: 0.3, borderRadius: 999, bgcolor: "#f1f5f9", fontSize: "0.66rem", fontWeight: 800, color: "#475569" }}>Practice · no points</Box>
+                  <Typography sx={{ fontSize: "0.7rem", color: "#94a3b8", display: { xs: "none", sm: "block" } }}>doesn&apos;t affect score or rank</Typography>
+                </Stack>
+              </Stack>
+              <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" }, gap: 1.25 }}>
+                {items.map((it) => {
+                  const m = KIND_META[it.kind];
+                  return (
+                    <Stack key={it.id} direction="row" alignItems="center" spacing={1.25} sx={{ p: 1.5, borderRadius: 2.5, border: "1px solid #eef2f7" }}>
+                      <Box sx={{ width: 36, height: 36, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: m.color, bgcolor: m.bg }}>
+                        <Icon icon={m.icon} width={19} />
+                      </Box>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
+                        <Typography sx={{ fontWeight: 700, fontSize: "0.88rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{it.title}</Typography>
+                        <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8", textTransform: "capitalize" }}>
+                          {it.kind} · {it.item_count} {it.kind === "article" ? "explainer" : it.kind === "coding" ? "problem" + (it.item_count > 1 ? "s" : "") : "MCQ" + (it.item_count > 1 ? "s" : "")}
+                        </Typography>
+                      </Box>
+                      <ButtonBase onClick={() => openItem(it)} sx={{ flexShrink: 0, px: 1.75, py: 0.7, borderRadius: 999, fontWeight: 800, fontSize: "0.8rem", color: m.color, border: `1px solid ${m.color}`, gap: 0.4 }}>
+                        Open <Icon icon="mdi:arrow-right" width={14} />
+                      </ButtonBase>
+                    </Stack>
+                  );
+                })}
+              </Box>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function StepLabel({ n, text, hint }: { n: number; text: string; hint?: string }) {
+  return (
+    <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: 0.6, color: "#64748b", mb: 1 }}>
+      {n} · {text}{hint ? <Box component="span" sx={{ color: "#cbd5e1", ml: 0.75 }}>({hint})</Box> : null}
+    </Typography>
+  );
+}

--- a/components/adaptive-journey/JourneySidePanels.tsx
+++ b/components/adaptive-journey/JourneySidePanels.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { Avatar, Box, LinearProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
+import { PointsInfo } from "@/components/common/PointsInfo";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { JourneyBoard, Leaderboard } from "@/lib/types/adaptive-journey";
 
@@ -98,7 +99,10 @@ export function JourneySidePanels({ courseId, board }: { courseId: number; board
 
         <Stack direction="row" spacing={1} sx={{ mt: 1.25 }}>
           <Box sx={{ flex: 1, p: 1, borderRadius: 2.5, bgcolor: "#f5f3ff", border: "1px solid #ede9fe" }}>
-            <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "#7c3aed" }}>POINTS EARNED</Typography>
+            <Stack direction="row" spacing={0.25} alignItems="center">
+              <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "#7c3aed" }}>POINTS EARNED</Typography>
+              <PointsInfo size={12} color="#a78bfa" />
+            </Stack>
             <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.95rem" }}>
               {pc.pointsEarned}<span style={{ color: "#64748b", fontSize: "0.75rem", fontWeight: 600 }}> / {pc.pointsTotal}</span>
             </Typography>

--- a/components/adaptive-journey/PointsBreakdown.tsx
+++ b/components/adaptive-journey/PointsBreakdown.tsx
@@ -9,6 +9,7 @@ import {
   type PointsKind,
   type SubmodulePointsBreakdown,
 } from "@/lib/services/adaptive-course.service";
+import { PointsInfo } from "@/components/common/PointsInfo";
 
 const KIND: Record<PointsKind, { icon: string; color: string; bg: string; label: string }> = {
   quiz: { icon: "mdi:tune-vertical", color: "#6366f1", bg: "#eef2ff", label: "Quiz" },
@@ -58,10 +59,11 @@ export function PointsBreakdown({ courseId, submoduleId }: { courseId: number; s
         <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
           <Icon icon="mdi:trophy" width={17} />
         </Box>
-        <Box sx={{ minWidth: 0 }}>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
           <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.92rem" }}>Points breakdown</Typography>
           <Typography sx={{ fontSize: "0.72rem", color: "#64748b" }}>Where this topic&apos;s points come from</Typography>
         </Box>
+        <PointsInfo />
       </Stack>
 
       {/* Total — mirrors the "Overall completion" highlight, in points gold */}

--- a/components/adaptive-journey/PointsBreakdown.tsx
+++ b/components/adaptive-journey/PointsBreakdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, CircularProgress, LinearProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
   adaptiveCourseService,
@@ -15,6 +15,14 @@ const KIND: Record<PointsKind, { icon: string; color: string; bg: string; label:
   coding: { icon: "mdi:code-tags", color: "#ec4899", bg: "#fdf2f8", label: "Coding" },
   article: { icon: "mdi:book-open-page-variant", color: "#a855f7", bg: "#f5f3ff", label: "Article" },
   video: { icon: "mdi:play-circle", color: "#0ea5e9", bg: "#e0f2fe", label: "Video" },
+};
+
+// The "accuracy"-style factor only means something for graded/timed content. Articles
+// are flat (read = full credit), so we never show a "% correct" for them.
+const CORRECTNESS_LABEL: Partial<Record<PointsKind, string>> = {
+  quiz: "correct",
+  coding: "tests passed",
+  video: "watched",
 };
 
 export function PointsBreakdown({ courseId, submoduleId }: { courseId: number; submoduleId: number }) {
@@ -33,7 +41,7 @@ export function PointsBreakdown({ courseId, submoduleId }: { courseId: number; s
 
   if (loading) {
     return (
-      <Box sx={{ mt: 3, p: 3, display: "grid", placeItems: "center" }}>
+      <Box sx={{ p: 3, display: "grid", placeItems: "center", borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
         <CircularProgress size={20} sx={{ color: "#f59e0b" }} />
       </Box>
     );
@@ -41,46 +49,43 @@ export function PointsBreakdown({ courseId, submoduleId }: { courseId: number; s
   if (!data || data.items.length === 0) return null;
 
   const { earned, on_offer } = data.topic;
-  const pct = on_offer ? Math.min(100, (earned / on_offer) * 100) : 0;
+  const pct = on_offer ? Math.min(100, Math.round((earned / on_offer) * 100)) : 0;
 
   return (
-    <Box sx={{ mt: 3, borderRadius: 4, border: "1px solid #fde68a", overflow: "hidden", bgcolor: "#fff" }}>
-      {/* Header + topic total */}
-      <Box sx={{ p: { xs: 2, md: 2.5 }, background: "linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%)", borderBottom: "1px solid #fde68a" }}>
-        <Stack direction="row" alignItems="center" spacing={1.5} flexWrap="wrap" useFlexGap>
-          <Box sx={{ width: 44, height: 44, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)", boxShadow: "0 8px 20px -8px rgba(245,158,11,0.6)" }}>
-            <Icon icon="mdi:trophy-variant" width={24} />
-          </Box>
-          <Box sx={{ flex: 1, minWidth: 180 }}>
-            <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#78350f" }}>Points breakdown</Typography>
-            <Typography sx={{ fontSize: "0.8rem", color: "#92755b" }}>
-              Where this topic&apos;s points come from — completed content earns, the rest is on offer.
-            </Typography>
-          </Box>
-          <Box sx={{ minWidth: 170, flexShrink: 0 }}>
-            <Typography sx={{ fontWeight: 900, fontSize: "1.3rem", color: "#78350f", textAlign: { sm: "right" } }}>
-              {earned}<Box component="span" sx={{ color: "#b08968", fontWeight: 700, fontSize: "0.95rem" }}> / {on_offer} pts</Box>
-            </Typography>
-            <Box sx={{ height: 7, borderRadius: 999, bgcolor: "#fde68a", mt: 0.5, overflow: "hidden" }}>
-              <Box sx={{ height: "100%", width: `${pct}%`, borderRadius: 999, background: "linear-gradient(90deg, #f59e0b 0%, #f97316 100%)", transition: "width .3s" }} />
-            </Box>
-          </Box>
+    <Box sx={{ p: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
+      {/* Header — matches the course side-panel section headers */}
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 1.5 }}>
+        <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
+          <Icon icon="mdi:trophy" width={17} />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.92rem" }}>Points breakdown</Typography>
+          <Typography sx={{ fontSize: "0.72rem", color: "#64748b" }}>Where this topic&apos;s points come from</Typography>
+        </Box>
+      </Stack>
+
+      {/* Total — mirrors the "Overall completion" highlight, in points gold */}
+      <Box sx={{ p: 1.5, borderRadius: 3, color: "white", background: "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)" }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="baseline">
+          <Typography sx={{ fontSize: "0.78rem", fontWeight: 600, color: "rgba(255,255,255,0.9)" }}>Points earned</Typography>
+          <Typography sx={{ fontWeight: 900, fontSize: "1.5rem", lineHeight: 1 }}>
+            {earned}<Box component="span" sx={{ fontSize: "0.85rem", fontWeight: 700, color: "rgba(255,255,255,0.85)" }}> / {on_offer}</Box>
+          </Typography>
         </Stack>
+        <LinearProgress variant="determinate" value={pct} sx={{ mt: 0.75, height: 7, borderRadius: 4, bgcolor: "rgba(255,255,255,0.25)", "& .MuiLinearProgress-bar": { bgcolor: "white" } }} />
       </Box>
 
       {/* Per-content rows */}
-      <Box sx={{ p: { xs: 1.5, md: 2 } }}>
-        <Stack spacing={1}>
-          {data.items.map((it) => <Row key={it.content_key} item={it} />)}
-        </Stack>
-        <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.5 }}>
-          <Icon icon="mdi:information-outline" width={14} style={{ color: "#cbd5e1", marginTop: 2, flexShrink: 0 }} />
-          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8", lineHeight: 1.5 }}>
-            Quiz &amp; coding points start high and ease down the longer you take; articles &amp; videos are flat.
-            Late submissions keep less. Additional Practice doesn&apos;t earn points.
-          </Typography>
-        </Stack>
-      </Box>
+      <Stack spacing={1} sx={{ mt: 1.5 }}>
+        {data.items.map((it) => <Row key={it.content_key} item={it} />)}
+      </Stack>
+
+      <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.25, p: 1, borderRadius: 2, bgcolor: "#fffbeb" }}>
+        <Icon icon="mdi:star-four-points" width={13} color="#b45309" style={{ flexShrink: 0, marginTop: 3 }} />
+        <Typography sx={{ fontSize: "0.72rem", color: "#92400e", fontWeight: 600, lineHeight: 1.45 }}>
+          Quiz &amp; coding ease down the longer you take; articles &amp; videos are flat. Practice earns no points.
+        </Typography>
+      </Stack>
     </Box>
   );
 }
@@ -93,7 +98,7 @@ function Factor({ text, tone = "muted" }: { text: string; tone?: "muted" | "warn
       ? { color: "#b45309", bgcolor: "#fef3c7" }
       : { color: "#475569", bgcolor: "#f1f5f9" };
   return (
-    <Box component="span" sx={{ px: 0.85, py: 0.25, borderRadius: 999, fontSize: "0.68rem", fontWeight: 700, ...styles }}>
+    <Box component="span" sx={{ px: 0.75, py: 0.2, borderRadius: 999, fontSize: "0.64rem", fontWeight: 700, ...styles }}>
       {text}
     </Box>
   );
@@ -107,45 +112,46 @@ function Row({ item }: { item: PointsBreakdownItem }) {
   const factors: { text: string; tone?: "muted" | "warn" | "good" }[] = [];
   if (b) {
     factors.push({ text: `${b.base} base` });
-    if (b.after_decay < b.base) factors.push({ text: `${b.after_decay} after time`, tone: "warn" });
-    factors.push({ text: `${Math.round(b.correctness_factor * 100)}% correct` });
+    if (b.after_decay < b.base) factors.push({ text: `time −${b.base - b.after_decay}`, tone: "warn" });
+    const accLabel = CORRECTNESS_LABEL[item.kind];
+    if (accLabel) factors.push({ text: `${Math.round(b.correctness_factor * 100)}% ${accLabel}` });
     if (b.late_penalty_mult < 1) factors.push({ text: `late −${Math.round((1 - b.late_penalty_mult) * 100)}%`, tone: "warn" });
     if (b.weight > 1) factors.push({ text: `×${b.weight} weight` });
   }
 
   return (
-    <Box sx={{ p: 1.5, borderRadius: 2.5, border: "1px solid #f1f5f9", bgcolor: done ? "#fefce8" : "#fff" }}>
-      <Stack direction="row" alignItems="center" spacing={1.25}>
-        <Box sx={{ width: 36, height: 36, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: k.color, bgcolor: k.bg }}>
-          <Icon icon={k.icon} width={19} />
+    <Box sx={{ p: 1.25, borderRadius: 2.5, border: "1px solid #eef2f7", borderLeft: "3px solid", borderLeftColor: k.color, bgcolor: done ? "#fffdf5" : "#fff" }}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Box sx={{ width: 32, height: 32, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: k.color, bgcolor: k.bg }}>
+          <Icon icon={k.icon} width={17} />
         </Box>
         <Box sx={{ minWidth: 0, flex: 1 }}>
-          <Typography sx={{ fontWeight: 700, fontSize: "0.9rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{item.title}</Typography>
-          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8" }}>{k.label} · {item.detail}</Typography>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.84rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{item.title}</Typography>
+          <Typography sx={{ fontSize: "0.68rem", color: "#94a3b8" }}>{k.label} · {item.detail}</Typography>
         </Box>
         <Box sx={{ textAlign: "right", flexShrink: 0 }}>
           {done ? (
             <>
-              <Typography sx={{ fontWeight: 900, fontSize: "1rem", color: "#15803d" }}>+{item.earned}</Typography>
-              <Typography sx={{ fontSize: "0.62rem", color: "#94a3b8", fontWeight: 700 }}>of {item.on_offer} pts</Typography>
+              <Typography sx={{ fontWeight: 900, fontSize: "0.95rem", color: "#15803d", lineHeight: 1 }}>+{item.earned}</Typography>
+              <Typography sx={{ fontSize: "0.58rem", color: "#94a3b8", fontWeight: 700 }}>of {item.on_offer}</Typography>
             </>
           ) : (
             <>
-              <Typography sx={{ fontWeight: 800, fontSize: "1rem", color: "#475569" }}>{item.on_offer}</Typography>
-              <Typography sx={{ fontSize: "0.62rem", color: "#94a3b8", fontWeight: 700 }}>on offer</Typography>
+              <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#475569", lineHeight: 1 }}>{item.on_offer}</Typography>
+              <Typography sx={{ fontSize: "0.58rem", color: "#94a3b8", fontWeight: 700 }}>on offer</Typography>
             </>
           )}
         </Box>
       </Stack>
       {done && factors.length > 0 && (
-        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap alignItems="center" sx={{ mt: 1, pl: { sm: 6 } }}>
+        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap alignItems="center" sx={{ mt: 0.85, pl: 5 }}>
           {factors.map((f, i) => (
-            <Box key={i} component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}>
-              {i > 0 && <Icon icon="mdi:chevron-right" width={12} color="#cbd5e1" />}
+            <Box key={i} component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.4 }}>
+              {i > 0 && <Icon icon="mdi:chevron-right" width={11} color="#cbd5e1" />}
               <Factor text={f.text} tone={f.tone} />
             </Box>
           ))}
-          <Icon icon="mdi:equal" width={12} color="#cbd5e1" style={{ marginLeft: 2 }} />
+          <Icon icon="mdi:equal" width={11} color="#cbd5e1" style={{ marginLeft: 1 }} />
           <Factor text={`${item.earned} pts`} tone="good" />
         </Stack>
       )}

--- a/components/adaptive-journey/PointsBreakdown.tsx
+++ b/components/adaptive-journey/PointsBreakdown.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import {
+  adaptiveCourseService,
+  type PointsBreakdownItem,
+  type PointsKind,
+  type SubmodulePointsBreakdown,
+} from "@/lib/services/adaptive-course.service";
+
+const KIND: Record<PointsKind, { icon: string; color: string; bg: string; label: string }> = {
+  quiz: { icon: "mdi:tune-vertical", color: "#6366f1", bg: "#eef2ff", label: "Quiz" },
+  coding: { icon: "mdi:code-tags", color: "#ec4899", bg: "#fdf2f8", label: "Coding" },
+  article: { icon: "mdi:book-open-page-variant", color: "#a855f7", bg: "#f5f3ff", label: "Article" },
+  video: { icon: "mdi:play-circle", color: "#0ea5e9", bg: "#e0f2fe", label: "Video" },
+};
+
+export function PointsBreakdown({ courseId, submoduleId }: { courseId: number; submoduleId: number }) {
+  const [data, setData] = useState<SubmodulePointsBreakdown | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    adaptiveCourseService
+      .getSubmodulePoints(courseId, submoduleId)
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [courseId, submoduleId]);
+
+  if (loading) {
+    return (
+      <Box sx={{ mt: 3, p: 3, display: "grid", placeItems: "center" }}>
+        <CircularProgress size={20} sx={{ color: "#f59e0b" }} />
+      </Box>
+    );
+  }
+  if (!data || data.items.length === 0) return null;
+
+  const { earned, on_offer } = data.topic;
+  const pct = on_offer ? Math.min(100, (earned / on_offer) * 100) : 0;
+
+  return (
+    <Box sx={{ mt: 3, borderRadius: 4, border: "1px solid #fde68a", overflow: "hidden", bgcolor: "#fff" }}>
+      {/* Header + topic total */}
+      <Box sx={{ p: { xs: 2, md: 2.5 }, background: "linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%)", borderBottom: "1px solid #fde68a" }}>
+        <Stack direction="row" alignItems="center" spacing={1.5} flexWrap="wrap" useFlexGap>
+          <Box sx={{ width: 44, height: 44, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)", boxShadow: "0 8px 20px -8px rgba(245,158,11,0.6)" }}>
+            <Icon icon="mdi:trophy-variant" width={24} />
+          </Box>
+          <Box sx={{ flex: 1, minWidth: 180 }}>
+            <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#78350f" }}>Points breakdown</Typography>
+            <Typography sx={{ fontSize: "0.8rem", color: "#92755b" }}>
+              Where this topic&apos;s points come from — completed content earns, the rest is on offer.
+            </Typography>
+          </Box>
+          <Box sx={{ minWidth: 170, flexShrink: 0 }}>
+            <Typography sx={{ fontWeight: 900, fontSize: "1.3rem", color: "#78350f", textAlign: { sm: "right" } }}>
+              {earned}<Box component="span" sx={{ color: "#b08968", fontWeight: 700, fontSize: "0.95rem" }}> / {on_offer} pts</Box>
+            </Typography>
+            <Box sx={{ height: 7, borderRadius: 999, bgcolor: "#fde68a", mt: 0.5, overflow: "hidden" }}>
+              <Box sx={{ height: "100%", width: `${pct}%`, borderRadius: 999, background: "linear-gradient(90deg, #f59e0b 0%, #f97316 100%)", transition: "width .3s" }} />
+            </Box>
+          </Box>
+        </Stack>
+      </Box>
+
+      {/* Per-content rows */}
+      <Box sx={{ p: { xs: 1.5, md: 2 } }}>
+        <Stack spacing={1}>
+          {data.items.map((it) => <Row key={it.content_key} item={it} />)}
+        </Stack>
+        <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.5 }}>
+          <Icon icon="mdi:information-outline" width={14} style={{ color: "#cbd5e1", marginTop: 2, flexShrink: 0 }} />
+          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8", lineHeight: 1.5 }}>
+            Quiz &amp; coding points start high and ease down the longer you take; articles &amp; videos are flat.
+            Late submissions keep less. Additional Practice doesn&apos;t earn points.
+          </Typography>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+function Factor({ text, tone = "muted" }: { text: string; tone?: "muted" | "warn" | "good" }) {
+  const styles =
+    tone === "good"
+      ? { color: "#15803d", bgcolor: "#dcfce7" }
+      : tone === "warn"
+      ? { color: "#b45309", bgcolor: "#fef3c7" }
+      : { color: "#475569", bgcolor: "#f1f5f9" };
+  return (
+    <Box component="span" sx={{ px: 0.85, py: 0.25, borderRadius: 999, fontSize: "0.68rem", fontWeight: 700, ...styles }}>
+      {text}
+    </Box>
+  );
+}
+
+function Row({ item }: { item: PointsBreakdownItem }) {
+  const k = KIND[item.kind];
+  const done = item.status === "earned";
+  const b = item.breakdown;
+
+  const factors: { text: string; tone?: "muted" | "warn" | "good" }[] = [];
+  if (b) {
+    factors.push({ text: `${b.base} base` });
+    if (b.after_decay < b.base) factors.push({ text: `${b.after_decay} after time`, tone: "warn" });
+    factors.push({ text: `${Math.round(b.correctness_factor * 100)}% correct` });
+    if (b.late_penalty_mult < 1) factors.push({ text: `late −${Math.round((1 - b.late_penalty_mult) * 100)}%`, tone: "warn" });
+    if (b.weight > 1) factors.push({ text: `×${b.weight} weight` });
+  }
+
+  return (
+    <Box sx={{ p: 1.5, borderRadius: 2.5, border: "1px solid #f1f5f9", bgcolor: done ? "#fefce8" : "#fff" }}>
+      <Stack direction="row" alignItems="center" spacing={1.25}>
+        <Box sx={{ width: 36, height: 36, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: k.color, bgcolor: k.bg }}>
+          <Icon icon={k.icon} width={19} />
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.9rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{item.title}</Typography>
+          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8" }}>{k.label} · {item.detail}</Typography>
+        </Box>
+        <Box sx={{ textAlign: "right", flexShrink: 0 }}>
+          {done ? (
+            <>
+              <Typography sx={{ fontWeight: 900, fontSize: "1rem", color: "#15803d" }}>+{item.earned}</Typography>
+              <Typography sx={{ fontSize: "0.62rem", color: "#94a3b8", fontWeight: 700 }}>of {item.on_offer} pts</Typography>
+            </>
+          ) : (
+            <>
+              <Typography sx={{ fontWeight: 800, fontSize: "1rem", color: "#475569" }}>{item.on_offer}</Typography>
+              <Typography sx={{ fontSize: "0.62rem", color: "#94a3b8", fontWeight: 700 }}>on offer</Typography>
+            </>
+          )}
+        </Box>
+      </Stack>
+      {done && factors.length > 0 && (
+        <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap alignItems="center" sx={{ mt: 1, pl: { sm: 6 } }}>
+          {factors.map((f, i) => (
+            <Box key={i} component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}>
+              {i > 0 && <Icon icon="mdi:chevron-right" width={12} color="#cbd5e1" />}
+              <Factor text={f.text} tone={f.tone} />
+            </Box>
+          ))}
+          <Icon icon="mdi:equal" width={12} color="#cbd5e1" style={{ marginLeft: 2 }} />
+          <Factor text={`${item.earned} pts`} tone="good" />
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -11,6 +11,7 @@ import {
   type WatchMode,
 } from "@/lib/services/adaptive-video.service";
 import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { useVimeoController } from "./useVimeoController";
 import { AutoPauseCheckIn } from "./AutoPauseCheckIn";
 import { ReExplainPanel } from "./ReExplainPanel";
@@ -102,9 +103,15 @@ export function VideoCompanion({ configId }: { configId: number }) {
   }, [sessionId, currentTime, completeness, watchMode, ctl.playbackRate, ctl.rewinds]);
 
   // End the session when the surface unmounts (finalizes comprehension → quiz seed).
+  // The server scores the watch on end → notify the streak celebration once it's recorded.
   useEffect(() => {
     return () => {
-      if (sessionId) adaptiveVideoService.endSession(sessionId).catch(() => {});
+      if (sessionId) {
+        adaptiveVideoService
+          .endSession(sessionId)
+          .then(() => notifyContentCompleted())
+          .catch(() => {});
+      }
     };
   }, [sessionId]);
 

--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -8,6 +8,7 @@ import { CodeEditor } from "@/components/editor/MonacoEditor";
 import { AdaptiveCodingProblemPanel } from "@/components/coding/AdaptiveCodingProblemPanel";
 import { AdaptiveCodingSubmissions } from "@/components/coding/AdaptiveCodingSubmissions";
 import { useToast } from "@/components/common/Toast";
+import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import {
   getAvailableLanguages,
   getLanguageId,
@@ -189,6 +190,8 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
       } else {
         showToast(`${res.grade.passed}/${res.grade.total} passed — read the mentor's diagnosis.`, "warning");
       }
+      // A graded submit counts as a completion (server scores it) — fire the streak celebration.
+      if (!res.detail) notifyContentCompleted();
     } catch (e) {
       showToast(e instanceof Error ? e.message : "Submit failed.", "error");
     } finally {

--- a/components/common/MomentumInfo.tsx
+++ b/components/common/MomentumInfo.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, type MouseEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, IconButton, Popover, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { MomentumInfo as MomentumInfoData } from "@/lib/types/momentum";
+
+/**
+ * "i" affordance beside a momentum score. Opens a popover that explains — from live data —
+ * exactly how the number was calculated for this learner, with a link to their streak.
+ */
+export function MomentumInfo({ info, size = 15, color = "#94a3b8" }: { info: MomentumInfoData; size?: number; color?: string }) {
+  const router = useRouter();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  const open = (e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setAnchor(e.currentTarget);
+  };
+  const close = () => setAnchor(null);
+
+  const { current, perDay, cap, value, daysToMax, atMax, formula } = info;
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={open}
+        aria-label="How momentum is calculated"
+        sx={{ p: 0.2, color, "&:hover": { color: "#f59e0b", bgcolor: "transparent" } }}
+      >
+        <Icon icon="mdi:information-outline" width={size} />
+      </IconButton>
+      <Popover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={close}
+        onClick={(e) => e.stopPropagation()}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{ paper: { sx: { mt: 0.5, borderRadius: 3, border: "1px solid #eef2f7", boxShadow: "0 18px 44px -18px rgba(16,24,40,0.32)", maxWidth: 320 } } }}
+      >
+        <Box sx={{ p: 2 }}>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.75 }}>
+            <Box sx={{ width: 26, height: 26, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
+              <Icon icon="mdi:chart-line-variant" width={15} />
+            </Box>
+            <Typography sx={{ fontWeight: 800, fontSize: "0.88rem", color: "#0f172a" }}>How momentum is calculated</Typography>
+          </Stack>
+
+          <Typography sx={{ fontSize: "0.78rem", color: "#64748b", lineHeight: 1.55 }}>
+            Momentum is driven by your <b>daily streak</b> — each active day adds {perDay}, up to {cap}.
+          </Typography>
+
+          {/* The formula, then your numbers plugged in. */}
+          <Box sx={{ mt: 1.25, p: 1.25, borderRadius: 2, bgcolor: "#fff7ed", border: "1px solid #fed7aa" }}>
+            <Typography sx={{ fontFamily: "monospace", fontSize: "0.74rem", color: "#9a3412" }}>{formula}</Typography>
+            <Typography sx={{ fontSize: "0.8rem", color: "#0f172a", fontWeight: 700, mt: 0.5 }}>
+              {atMax
+                ? `Your ${current}-day streak maxes it at ${cap}. 🔥`
+                : `Your ${current}-day streak × ${perDay} = ${value}.`}
+            </Typography>
+            {!atMax && daysToMax > 0 && (
+              <Typography sx={{ fontSize: "0.74rem", color: "#b45309", fontWeight: 600, mt: 0.25 }}>
+                {daysToMax} more active day{daysToMax === 1 ? "" : "s"} → {cap}.
+              </Typography>
+            )}
+          </Box>
+
+          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8", mt: 1, lineHeight: 1.5 }}>
+            Miss a day and your streak resets — so momentum drops too.
+          </Typography>
+
+          <ButtonBase
+            onClick={() => { close(); router.push("/leaderboard-streaks"); }}
+            sx={{ mt: 1.25, fontWeight: 800, fontSize: "0.8rem", color: "#f97316", gap: 0.4 }}
+          >
+            View your streak <Icon icon="mdi:arrow-right" width={15} />
+          </ButtonBase>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/components/common/PointsInfo.tsx
+++ b/components/common/PointsInfo.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, type MouseEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, IconButton, Popover, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+
+/**
+ * Small "i" affordance shown beside any points figure. Opens a short explainer popover
+ * with a link to the full /points-system page.
+ */
+export function PointsInfo({ size = 15, color = "#94a3b8" }: { size?: number; color?: string }) {
+  const router = useRouter();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  const open = (e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setAnchor(e.currentTarget);
+  };
+  const close = () => setAnchor(null);
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={open}
+        aria-label="How points work"
+        sx={{ p: 0.2, color, "&:hover": { color: "#7c3aed", bgcolor: "transparent" } }}
+      >
+        <Icon icon="mdi:information-outline" width={size} />
+      </IconButton>
+      <Popover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={close}
+        onClick={(e) => e.stopPropagation()}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        slotProps={{ paper: { sx: { mt: 0.5, borderRadius: 3, border: "1px solid #eef2f7", boxShadow: "0 18px 44px -18px rgba(16,24,40,0.32)", maxWidth: 300 } } }}
+      >
+        <Box sx={{ p: 2 }}>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.75 }}>
+            <Box sx={{ width: 26, height: 26, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7)" }}>
+              <Icon icon="mdi:star-four-points" width={15} />
+            </Box>
+            <Typography sx={{ fontWeight: 800, fontSize: "0.88rem", color: "#0f172a" }}>How points work</Typography>
+          </Stack>
+          <Typography sx={{ fontSize: "0.78rem", color: "#64748b", lineHeight: 1.55 }}>
+            Every activity awards points — harder + faster earns more, and late submissions are
+            penalised. It all rolls up to the leaderboard.
+          </Typography>
+          <ButtonBase
+            onClick={() => { close(); router.push("/points-system"); }}
+            sx={{ mt: 1.25, fontWeight: 800, fontSize: "0.8rem", color: "#7c3aed", gap: 0.4 }}
+          >
+            Know more about the point system <Icon icon="mdi:arrow-right" width={15} />
+          </ButtonBase>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/components/common/StreakCelebrationOverlay.tsx
+++ b/components/common/StreakCelebrationOverlay.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Box, Typography } from "@mui/material";
+import {
+  commitNavBump,
+  dismissCelebration,
+  useStreakCelebration,
+} from "@/lib/streak/streakCelebration";
+
+const COLORS = ["#f59e0b", "#f97316", "#ef4444", "#fbbf24", "#fb7185", "#a855f7", "#34d399"];
+const BURST_MS = 2100;
+
+type Phase = "idle" | "burst" | "fly";
+
+export function StreakCelebrationOverlay() {
+  const { celebrating, celebrateCount } = useStreakCelebration();
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [flyTo, setFlyTo] = useState<{ x: number; y: number } | null>(null);
+
+  // Confetti pieces — regenerated each celebration.
+  const confetti = useMemo(
+    () =>
+      Array.from({ length: 40 }, (_, i) => {
+        const angle = (Math.PI * 2 * i) / 40 + Math.random() * 0.4;
+        const dist = 160 + Math.random() * 260;
+        return {
+          id: i,
+          dx: Math.cos(angle) * dist,
+          dy: Math.sin(angle) * dist - 60,
+          color: COLORS[i % COLORS.length],
+          size: 7 + Math.random() * 9,
+          rotate: Math.random() * 720 - 360,
+          delay: Math.random() * 0.15,
+          rounded: Math.random() > 0.5,
+        };
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [celebrating, celebrateCount],
+  );
+
+  useEffect(() => {
+    if (!celebrating) { setPhase("idle"); setFlyTo(null); return; }
+    setPhase("burst");
+    const t = setTimeout(() => {
+      const el = typeof document !== "undefined" ? document.getElementById("nav-streak-flame") : null;
+      if (el) {
+        const r = el.getBoundingClientRect();
+        setFlyTo({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
+        setPhase("fly");
+      } else {
+        // No nav target (e.g. hidden on small screens) — just commit + close.
+        commitNavBump();
+        dismissCelebration();
+      }
+    }, BURST_MS);
+    return () => clearTimeout(t);
+  }, [celebrating]);
+
+  if (!celebrating) return null;
+
+  const cx = typeof window !== "undefined" ? window.innerWidth / 2 : 0;
+  const cy = typeof window !== "undefined" ? window.innerHeight / 2 : 0;
+
+  const onFlyComplete = () => {
+    commitNavBump();
+    setTimeout(() => dismissCelebration(), 200);
+  };
+
+  return (
+    <Box sx={{ position: "fixed", inset: 0, zIndex: 2200, pointerEvents: "none", overflow: "hidden" }}>
+      {/* Backdrop */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: phase === "fly" ? 0 : 1 }}
+        transition={{ duration: phase === "fly" ? 0.5 : 0.35 }}
+        style={{
+          position: "absolute", inset: 0,
+          background: "radial-gradient(circle at 50% 42%, rgba(120,53,15,0.55) 0%, rgba(15,23,42,0.82) 70%)",
+          backdropFilter: "blur(2px)",
+        }}
+      />
+
+      {/* Center burst: confetti + flame + count */}
+      <AnimatePresence>
+        {phase === "burst" && (
+          <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}>
+            {/* Confetti */}
+            {confetti.map((c) => (
+              <motion.div
+                key={c.id}
+                initial={{ x: 0, y: 0, opacity: 1, rotate: 0, scale: 1 }}
+                animate={{ x: c.dx, y: c.dy, opacity: 0, rotate: c.rotate, scale: 0.6 }}
+                transition={{ duration: 1.5, delay: c.delay, ease: "easeOut" }}
+                style={{
+                  position: "absolute",
+                  width: c.size, height: c.size,
+                  background: c.color,
+                  borderRadius: c.rounded ? "50%" : 2,
+                }}
+              />
+            ))}
+
+            <motion.div
+              initial={{ scale: 0, opacity: 0, y: 10 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.6 }}
+              transition={{ type: "spring", stiffness: 220, damping: 16 }}
+              style={{ textAlign: "center", position: "relative", zIndex: 2 }}
+            >
+              {/* Glowing flame disc */}
+              <motion.div
+                animate={{ boxShadow: [
+                  "0 0 40px 8px rgba(245,158,11,0.5)",
+                  "0 0 70px 18px rgba(249,115,22,0.7)",
+                  "0 0 40px 8px rgba(245,158,11,0.5)",
+                ] }}
+                transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
+                style={{
+                  width: 132, height: 132, borderRadius: "50%", margin: "0 auto 20px",
+                  display: "grid", placeItems: "center",
+                  background: "radial-gradient(circle at 50% 35%, #fde68a 0%, #f59e0b 45%, #ea580c 100%)",
+                  border: "4px solid rgba(255,255,255,0.9)",
+                }}
+              >
+                <motion.span
+                  animate={{ rotate: [0, 10, -10, 8, 0], scale: [1, 1.15, 1.05, 1.12, 1] }}
+                  transition={{ duration: 1.4, repeat: Infinity }}
+                  style={{ fontSize: 64, lineHeight: 1 }}
+                >
+                  🔥
+                </motion.span>
+              </motion.div>
+
+              <motion.div
+                initial={{ scale: 0.5, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ delay: 0.15, type: "spring", stiffness: 260, damping: 14 }}
+              >
+                <Typography sx={{ fontWeight: 900, fontSize: { xs: "3rem", sm: "4rem" }, color: "#fff", lineHeight: 1, textShadow: "0 4px 24px rgba(0,0,0,0.35)" }}>
+                  {celebrateCount}
+                </Typography>
+              </motion.div>
+              <Typography sx={{ fontWeight: 800, fontSize: { xs: "1.1rem", sm: "1.35rem" }, color: "#fde68a", mt: 0.5 }}>
+                day streak{celebrateCount === 1 ? " started!" : "!"}
+              </Typography>
+              <Typography sx={{ fontSize: "0.95rem", color: "rgba(255,255,255,0.82)", mt: 0.75 }}>
+                You&apos;re on fire — keep it going 🚀
+              </Typography>
+            </motion.div>
+          </Box>
+        )}
+      </AnimatePresence>
+
+      {/* Flame flies to the nav streak chip, then the nav ticks +1 */}
+      {phase === "fly" && flyTo && (
+        <motion.div
+          initial={{ x: cx, y: cy, scale: 2.2, opacity: 1 }}
+          animate={{ x: flyTo.x, y: flyTo.y, scale: 0.45, opacity: 0.95 }}
+          transition={{ duration: 0.8, ease: [0.4, 0, 0.2, 1] }}
+          onAnimationComplete={onFlyComplete}
+          style={{ position: "fixed", top: 0, left: 0, marginLeft: -28, marginTop: -28, fontSize: 56, zIndex: 3, filter: "drop-shadow(0 6px 16px rgba(249,115,22,0.6))" }}
+        >
+          🔥
+        </motion.div>
+      )}
+    </Box>
+  );
+}

--- a/components/common/StreakCelebrationOverlay.tsx
+++ b/components/common/StreakCelebrationOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Box, Typography } from "@mui/material";
 import {
@@ -10,7 +10,7 @@ import {
 } from "@/lib/streak/streakCelebration";
 
 const COLORS = ["#f59e0b", "#f97316", "#ef4444", "#fbbf24", "#fb7185", "#a855f7", "#34d399"];
-const BURST_MS = 2100;
+const BURST_MS = 4200; // long enough to read the count + message; tap to skip early
 
 type Phase = "idle" | "burst" | "fly";
 
@@ -18,6 +18,8 @@ export function StreakCelebrationOverlay() {
   const { celebrating, celebrateCount } = useStreakCelebration();
   const [phase, setPhase] = useState<Phase>("idle");
   const [flyTo, setFlyTo] = useState<{ x: number; y: number } | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flyingRef = useRef(false);
 
   // Confetti pieces — regenerated each celebration.
   const confetti = useMemo(
@@ -40,23 +42,30 @@ export function StreakCelebrationOverlay() {
     [celebrating, celebrateCount],
   );
 
+  // Start the flame's flight to the nav (idempotent — also used by tap-to-skip).
+  const startFly = useCallback(() => {
+    if (flyingRef.current) return;
+    flyingRef.current = true;
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    const el = typeof document !== "undefined" ? document.getElementById("nav-streak-flame") : null;
+    if (el) {
+      const r = el.getBoundingClientRect();
+      setFlyTo({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
+      setPhase("fly");
+    } else {
+      // No nav target (e.g. hidden on small screens) — just commit + close.
+      commitNavBump();
+      dismissCelebration();
+    }
+  }, []);
+
   useEffect(() => {
-    if (!celebrating) { setPhase("idle"); setFlyTo(null); return; }
+    if (!celebrating) { setPhase("idle"); setFlyTo(null); flyingRef.current = false; return; }
+    flyingRef.current = false;
     setPhase("burst");
-    const t = setTimeout(() => {
-      const el = typeof document !== "undefined" ? document.getElementById("nav-streak-flame") : null;
-      if (el) {
-        const r = el.getBoundingClientRect();
-        setFlyTo({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
-        setPhase("fly");
-      } else {
-        // No nav target (e.g. hidden on small screens) — just commit + close.
-        commitNavBump();
-        dismissCelebration();
-      }
-    }, BURST_MS);
-    return () => clearTimeout(t);
-  }, [celebrating]);
+    timerRef.current = setTimeout(startFly, BURST_MS);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [celebrating, startFly]);
 
   if (!celebrating) return null;
 
@@ -69,7 +78,10 @@ export function StreakCelebrationOverlay() {
   };
 
   return (
-    <Box sx={{ position: "fixed", inset: 0, zIndex: 2200, pointerEvents: "none", overflow: "hidden" }}>
+    <Box
+      onClick={phase === "burst" ? startFly : undefined}
+      sx={{ position: "fixed", inset: 0, zIndex: 2200, pointerEvents: phase === "burst" ? "auto" : "none", cursor: phase === "burst" ? "pointer" : "default", overflow: "hidden" }}
+    >
       {/* Backdrop */}
       <motion.div
         initial={{ opacity: 0 }}
@@ -152,6 +164,20 @@ export function StreakCelebrationOverlay() {
           </Box>
         )}
       </AnimatePresence>
+
+      {/* Tap-to-continue hint (the burst lingers ~4s; let the impatient skip ahead) */}
+      {phase === "burst" && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1.3 }}
+          style={{ position: "absolute", bottom: 44, left: 0, right: 0, textAlign: "center" }}
+        >
+          <Typography sx={{ fontSize: "0.78rem", fontWeight: 600, color: "rgba(255,255,255,0.6)" }}>
+            Tap anywhere to continue
+          </Typography>
+        </motion.div>
+      )}
 
       {/* Flame flies to the nav streak chip, then the nav ticks +1 */}
       {phase === "fly" && flyTo && (

--- a/components/common/StreakInfo.tsx
+++ b/components/common/StreakInfo.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState, type MouseEvent } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, IconButton, Popover, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+
+/**
+ * Small "i" affordance shown beside a streak figure. Opens a short explainer popover with
+ * a link to the full /leaderboard-streaks page (streak history + cohort leaderboard).
+ */
+export function StreakInfo({ size = 15, color = "#94a3b8" }: { size?: number; color?: string }) {
+  const router = useRouter();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  const open = (e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    setAnchor(e.currentTarget);
+  };
+  const close = () => setAnchor(null);
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={open}
+        aria-label="How streaks work"
+        sx={{ p: 0.2, color, "&:hover": { color: "#f97316", bgcolor: "transparent" } }}
+      >
+        <Icon icon="mdi:information-outline" width={size} />
+      </IconButton>
+      <Popover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={close}
+        onClick={(e) => e.stopPropagation()}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        transformOrigin={{ vertical: "top", horizontal: "left" }}
+        slotProps={{ paper: { sx: { mt: 0.5, borderRadius: 3, border: "1px solid #eef2f7", boxShadow: "0 18px 44px -18px rgba(16,24,40,0.32)", maxWidth: 300 } } }}
+      >
+        <Box sx={{ p: 2 }}>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.75 }}>
+            <Box sx={{ width: 26, height: 26, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
+              <Icon icon="mdi:fire" width={15} />
+            </Box>
+            <Typography sx={{ fontWeight: 800, fontSize: "0.88rem", color: "#0f172a" }}>How streaks work</Typography>
+          </Stack>
+          <Typography sx={{ fontSize: "0.78rem", color: "#64748b", lineHeight: 1.55 }}>
+            Do at least one activity a day to grow your streak. Longer streaks build momentum
+            and help you climb the cohort leaderboard.
+          </Typography>
+          <ButtonBase
+            onClick={() => { close(); router.push("/leaderboard-streaks"); }}
+            sx={{ mt: 1.25, fontWeight: 800, fontSize: "0.8rem", color: "#f97316", gap: 0.4 }}
+          >
+            View leaderboard &amp; streaks <Icon icon="mdi:arrow-right" width={15} />
+          </ButtonBase>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/components/dashboard/v2/AiBriefingHero.tsx
+++ b/components/dashboard/v2/AiBriefingHero.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { Reveal } from "@/components/scorecard/shared";
+import type { AiBriefing, LearnerDashboard } from "@/lib/types/dashboard";
+
+const ACTION_ICON: Record<string, string> = {
+  topic: "mdi:book-open-page-variant",
+  checkpoint: "mdi:shield-check",
+  week_final: "mdi:flag-checkered",
+  interview: "mdi:account-voice",
+  resume: "mdi:play",
+  explore: "mdi:compass-outline",
+};
+
+function ActionCard({
+  eyebrow, title, sub, icon, onClick,
+}: { eyebrow: string; title: string; sub?: string; icon: string; onClick?: () => void }) {
+  return (
+    <ButtonBase
+      onClick={onClick}
+      sx={{
+        flex: 1, textAlign: "left", justifyContent: "flex-start", p: 1.75, borderRadius: 3, gap: 1.5,
+        bgcolor: "rgba(0,0,0,0.18)", border: "1px solid rgba(255,255,255,0.15)",
+        transition: "border-color .15s, background .15s",
+        "&:hover": { borderColor: "rgba(255,255,255,0.35)", bgcolor: "rgba(0,0,0,0.26)" },
+      }}
+    >
+      <Box sx={{ width: 38, height: 38, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #a855f7, #ec4899)" }}>
+        <Icon icon={icon} width={20} />
+      </Box>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.6, color: "rgba(255,255,255,0.6)" }}>{eyebrow}</Typography>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#fff", lineHeight: 1.2 }}>{title}</Typography>
+        {sub && <Typography sx={{ fontSize: "0.74rem", color: "rgba(255,255,255,0.7)", mt: 0.25 }}>{sub}</Typography>}
+      </Box>
+    </ButtonBase>
+  );
+}
+
+export function AiBriefingHero({
+  briefing, profile,
+}: { briefing: AiBriefing; profile: LearnerDashboard["profile"] }) {
+  const router = useRouter();
+  const go = (route?: string) => route && router.push(route);
+  const action0 = briefing.actions[0];
+
+  return (
+    <Reveal>
+      <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 2.5, color: "white", position: "relative", overflow: "hidden", background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -28px rgba(124,58,237,0.6)" }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2} sx={{ mb: 1 }}>
+          <Stack direction="row" spacing={0.75} alignItems="center">
+            <Box sx={{ px: 1, py: 0.4, borderRadius: 999, fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.5, color: "white", bgcolor: "rgba(255,255,255,0.18)", display: "inline-flex", alignItems: "center", gap: 0.4 }}>
+              <Icon icon="mdi:star-four-points" width={12} /> YOUR AI BRIEFING
+            </Box>
+          </Stack>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ flexShrink: 0 }}>
+            {profile.weekNo != null && (
+              <Box sx={{ px: 1, py: 0.5, borderRadius: 2, bgcolor: "rgba(255,255,255,0.14)", fontSize: "0.72rem", fontWeight: 700, display: "inline-flex", alignItems: "center", gap: 0.5 }}>
+                <Icon icon="mdi:calendar" width={14} /> Week {profile.weekNo}
+              </Box>
+            )}
+            <Box sx={{ px: 1, py: 0.5, borderRadius: 2, bgcolor: "rgba(255,255,255,0.14)", fontSize: "0.78rem", fontWeight: 800, display: "inline-flex", alignItems: "center", gap: 0.4 }}>
+              <Icon icon="mdi:fire" width={15} color="#fb923c" /> {profile.streakDays}
+            </Box>
+          </Stack>
+        </Stack>
+
+        <Typography sx={{ fontSize: "0.72rem", fontWeight: 800, letterSpacing: 1.2, color: "rgba(255,255,255,0.7)", mb: 1 }}>
+          WELCOME BACK, {profile.name.toUpperCase()}
+        </Typography>
+
+        {briefing.lastWeek && (
+          <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.25, py: 0.5, borderRadius: 999, bgcolor: "rgba(255,255,255,0.14)", mb: 1.5 }}>
+            <Typography sx={{ fontSize: "0.78rem", fontWeight: 600, color: "rgba(255,255,255,0.92)" }}>🎉 {briefing.lastWeek}</Typography>
+          </Box>
+        )}
+
+        <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.6rem", md: "2.1rem" }, lineHeight: 1.15, maxWidth: 820 }}>
+          {briefing.headline}
+        </Typography>
+
+        {briefing.weakestSkill && (
+          <Typography sx={{ fontSize: "0.88rem", color: "rgba(255,255,255,0.82)", mt: 1.25, maxWidth: 760, lineHeight: 1.5 }}>
+            Your weakest skill right now is{" "}
+            <Box component="span" sx={{ fontWeight: 800, color: "#fff" }}>{briefing.weakestSkill.skill}</Box>{" "}
+            in <Box component="span" sx={{ fontWeight: 800, color: "#fff" }}>{briefing.weakestSkill.course}</Box>.{" "}
+            {briefing.weakestSkill.fixSuggestion}{" "}
+            <Box component="span" onClick={() => go(briefing.weakestSkill?.route)} sx={{ fontWeight: 800, color: "#fde68a", cursor: "pointer", whiteSpace: "nowrap" }}>
+              Fix it →
+            </Box>
+          </Typography>
+        )}
+
+        <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} sx={{ mt: 2.5 }}>
+          <ActionCard
+            eyebrow="DO THIS WEEK"
+            title={briefing.thisWeek.focus}
+            sub={briefing.thisWeek.course}
+            icon="mdi:pin"
+            onClick={() => go(briefing.focusRoute)}
+          />
+          <ActionCard
+            eyebrow="DO TODAY"
+            title={briefing.today}
+            sub={action0?.course}
+            icon={ACTION_ICON[action0?.kind || "topic"] || "mdi:lightning-bolt"}
+            onClick={() => go(action0?.route || briefing.focusRoute)}
+          />
+        </Stack>
+
+        <ButtonBase
+          onClick={() => go(briefing.focusRoute)}
+          sx={{ mt: 2.5, px: 3, py: 1.25, borderRadius: 999, fontWeight: 800, fontSize: "0.95rem", color: "#7c3aed", bgcolor: "white", gap: 0.75, boxShadow: "0 12px 30px -12px rgba(0,0,0,0.4)", "&:hover": { bgcolor: "#f5f3ff" } }}
+        >
+          <Icon icon="mdi:timer-outline" width={18} /> Start this week&apos;s focus →
+        </ButtonBase>
+      </Box>
+    </Reveal>
+  );
+}

--- a/components/dashboard/v2/AiBriefingHero.tsx
+++ b/components/dashboard/v2/AiBriefingHero.tsx
@@ -12,7 +12,6 @@ const ACTION_ICON: Record<string, string> = {
   checkpoint: "mdi:shield-check",
   week_final: "mdi:flag-checkered",
   interview: "mdi:account-voice",
-  resume: "mdi:play",
   explore: "mdi:compass-outline",
 };
 

--- a/components/dashboard/v2/AiBriefingHero.tsx
+++ b/components/dashboard/v2/AiBriefingHero.tsx
@@ -5,6 +5,7 @@ import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { Reveal } from "@/components/scorecard/shared";
 import type { AiBriefing, LearnerDashboard } from "@/lib/types/dashboard";
+import { fmtDate } from "./parts";
 
 const ACTION_ICON: Record<string, string> = {
   topic: "mdi:book-open-page-variant",
@@ -58,11 +59,20 @@ export function AiBriefingHero({
           </Stack>
           <Stack direction="row" spacing={1} alignItems="center" sx={{ flexShrink: 0 }}>
             {profile.weekNo != null && (
-              <Box sx={{ px: 1, py: 0.5, borderRadius: 2, bgcolor: "rgba(255,255,255,0.14)", fontSize: "0.72rem", fontWeight: 700, display: "inline-flex", alignItems: "center", gap: 0.5 }}>
-                <Icon icon="mdi:calendar" width={14} /> Week {profile.weekNo}
-              </Box>
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ px: 1.25, py: 0.6, borderRadius: 2.5, bgcolor: "rgba(255,255,255,0.1)", border: "1px solid rgba(255,255,255,0.12)" }}>
+                <Stack direction="row" spacing={0.4} alignItems="center">
+                  <Icon icon="mdi:calendar" width={14} />
+                  <Typography sx={{ fontSize: "0.78rem", fontWeight: 800 }}>Week {profile.weekNo}</Typography>
+                </Stack>
+                {profile.weekDueAt && (
+                  <Typography sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.65)" }}>due {fmtDate(profile.weekDueAt)}</Typography>
+                )}
+                <Box sx={{ width: 72, height: 6, borderRadius: 999, bgcolor: "rgba(255,255,255,0.18)", overflow: "hidden" }}>
+                  <Box sx={{ width: `${Math.min(100, profile.weekProgressPct)}%`, height: "100%", borderRadius: 999, background: "linear-gradient(90deg, #a855f7, #ec4899)" }} />
+                </Box>
+              </Stack>
             )}
-            <Box sx={{ px: 1, py: 0.5, borderRadius: 2, bgcolor: "rgba(255,255,255,0.14)", fontSize: "0.78rem", fontWeight: 800, display: "inline-flex", alignItems: "center", gap: 0.4 }}>
+            <Box sx={{ px: 1, py: 0.5, borderRadius: 2.5, bgcolor: "rgba(255,255,255,0.1)", border: "1px solid rgba(255,255,255,0.12)", fontSize: "0.82rem", fontWeight: 800, display: "inline-flex", alignItems: "center", gap: 0.4 }}>
               <Icon icon="mdi:fire" width={15} color="#fb923c" /> {profile.streakDays}
             </Box>
           </Stack>

--- a/components/dashboard/v2/AiBriefingHero.tsx
+++ b/components/dashboard/v2/AiBriefingHero.tsx
@@ -49,7 +49,7 @@ export function AiBriefingHero({
 
   return (
     <Reveal>
-      <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 2.5, color: "white", position: "relative", overflow: "hidden", background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -28px rgba(124,58,237,0.6)" }}>
+      <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 2.5, color: "white", position: "relative", overflow: "hidden", background: "radial-gradient(110% 130% at 12% 112%, rgba(192,38,211,0.45) 0%, rgba(124,58,237,0.30) 30%, rgba(15,10,40,0) 60%), linear-gradient(150deg, #271a5c 0%, #181040 55%, #100a2c 100%)", boxShadow: "0 24px 60px -30px rgba(76,29,149,0.7)" }}>
         <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={2} sx={{ mb: 1 }}>
           <Stack direction="row" spacing={0.75} alignItems="center">
             <Box sx={{ px: 1, py: 0.4, borderRadius: 999, fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.5, color: "white", bgcolor: "rgba(255,255,255,0.18)", display: "inline-flex", alignItems: "center", gap: 0.4 }}>
@@ -83,7 +83,7 @@ export function AiBriefingHero({
         </Typography>
 
         {briefing.weakestSkill && (
-          <Typography sx={{ fontSize: "0.88rem", color: "rgba(255,255,255,0.82)", mt: 1.25, maxWidth: 760, lineHeight: 1.5 }}>
+          <Typography sx={{ fontSize: "0.9rem", color: "rgba(255,255,255,0.9)", mt: 1.25, maxWidth: 760, lineHeight: 1.55 }}>
             Your weakest skill right now is{" "}
             <Box component="span" sx={{ fontWeight: 800, color: "#fff" }}>{briefing.weakestSkill.skill}</Box>{" "}
             in <Box component="span" sx={{ fontWeight: 800, color: "#fff" }}>{briefing.weakestSkill.course}</Box>.{" "}
@@ -113,7 +113,7 @@ export function AiBriefingHero({
 
         <ButtonBase
           onClick={() => go(briefing.focusRoute)}
-          sx={{ mt: 2.5, px: 3, py: 1.25, borderRadius: 999, fontWeight: 800, fontSize: "0.95rem", color: "#7c3aed", bgcolor: "white", gap: 0.75, boxShadow: "0 12px 30px -12px rgba(0,0,0,0.4)", "&:hover": { bgcolor: "#f5f3ff" } }}
+          sx={{ mt: 2.5, px: 3, py: 1.25, borderRadius: 999, fontWeight: 800, fontSize: "0.95rem", color: "white", background: "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)", gap: 0.75, boxShadow: "0 14px 34px -12px rgba(192,38,211,0.7)", "&:hover": { filter: "brightness(1.06)" } }}
         >
           <Icon icon="mdi:timer-outline" width={18} /> Start this week&apos;s focus →
         </ButtonBase>

--- a/components/dashboard/v2/CertificatePanel.tsx
+++ b/components/dashboard/v2/CertificatePanel.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, LinearProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { DashboardCourse } from "@/lib/types/dashboard";
+import { PanelCard } from "./parts";
+
+export function CertificatePanel({ course }: { course: DashboardCourse }) {
+  const router = useRouter();
+  const { pct, threshold } = course.certificate;
+  const ready = pct >= threshold;
+
+  return (
+    <PanelCard>
+      <Box sx={{ textAlign: "center", py: 0.5 }}>
+        <Box sx={{ width: 56, height: 56, mx: "auto", mb: 1, borderRadius: 3, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7)", boxShadow: "0 12px 26px -12px rgba(124,58,237,0.6)" }}>
+          <Icon icon="mdi:certificate" width={28} />
+        </Box>
+        <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.6, color: "#7c3aed", textTransform: "uppercase" }}>
+          Certificate · {course.title}
+        </Typography>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a", mt: 0.5 }}>
+          {ready ? "Your certificate is ready 🎓" : `You're ${pct}% toward your certificate`}
+        </Typography>
+        <Typography sx={{ fontSize: "0.8rem", color: "#64748b", mt: 0.5 }}>
+          {ready ? "Open the course to download & share it." : `Complete ${threshold}% of the track to unlock your shareable certificate.`}
+        </Typography>
+      </Box>
+
+      <Box sx={{ mt: 1.5 }}>
+        <LinearProgress variant="determinate" value={Math.min(100, pct)} sx={{ height: 8, borderRadius: 4, bgcolor: "#eef2f7", "& .MuiLinearProgress-bar": { borderRadius: 4, background: "linear-gradient(90deg, #7c3aed, #ec4899)" } }} />
+        <Stack direction="row" justifyContent="space-between" sx={{ mt: 0.5 }}>
+          <Typography sx={{ fontSize: "0.68rem", color: "#94a3b8", fontWeight: 700 }}>{pct}% done</Typography>
+          <Typography sx={{ fontSize: "0.68rem", color: "#94a3b8", fontWeight: 700 }}>{threshold}% to unlock</Typography>
+        </Stack>
+      </Box>
+
+      <ButtonBase
+        onClick={() => router.push(`/adaptive-courses/${course.id}`)}
+        sx={{ mt: 1.5, width: "100%", py: 1.1, borderRadius: 2.5, fontWeight: 800, fontSize: "0.88rem", color: "white", gap: 0.5, background: "linear-gradient(135deg, #7c3aed, #ec4899)" }}
+      >
+        {ready ? "View certificate" : "Keep going"} <Icon icon="mdi:arrow-right" width={16} />
+      </ButtonBase>
+    </PanelCard>
+  );
+}

--- a/components/dashboard/v2/ContinueCoursesRow.tsx
+++ b/components/dashboard/v2/ContinueCoursesRow.tsx
@@ -34,7 +34,15 @@ export function ContinueCoursesRow({ courses }: { courses: DashboardCourse[] }) 
           return (
             <Reveal key={c.id} delay={i * 0.05}>
               <Box sx={{ borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff", overflow: "hidden", boxShadow: "0 1px 2px rgba(16,24,40,0.04)", display: "flex", flexDirection: "column", height: "100%" }}>
-                <Box sx={{ height: 4, background: accent.bar }} />
+                {c.cardImageUrl ? (
+                  <Box sx={{ position: "relative", height: 116, overflow: "hidden" }}>
+                    <Box component="img" src={c.cardImageUrl} alt="" loading="lazy" sx={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} />
+                    <Box sx={{ position: "absolute", inset: 0, background: "linear-gradient(180deg, rgba(15,10,40,0) 45%, rgba(15,10,40,0.35) 100%)" }} />
+                    <Box sx={{ position: "absolute", top: 0, left: 0, right: 0, height: 4, background: accent.bar }} />
+                  </Box>
+                ) : (
+                  <Box sx={{ height: 4, background: accent.bar }} />
+                )}
                 <Box sx={{ p: 2, display: "flex", flexDirection: "column", flex: 1 }}>
                   <Typography sx={{ fontWeight: 800, fontSize: "1rem", color: "#0f172a", lineHeight: 1.25 }}>{c.title}</Typography>
 

--- a/components/dashboard/v2/ContinueCoursesRow.tsx
+++ b/components/dashboard/v2/ContinueCoursesRow.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, LinearProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { Reveal } from "@/components/scorecard/shared";
+import type { DashboardCourse } from "@/lib/types/dashboard";
+import { SectionHeader, daysLeft, fmtDate } from "./parts";
+
+const ACCENTS = [
+  { bar: "linear-gradient(90deg,#7c3aed,#a855f7)", btn: "linear-gradient(135deg,#7c3aed,#a855f7)" },
+  { bar: "linear-gradient(90deg,#6366f1,#3b82f6)", btn: "linear-gradient(135deg,#6366f1,#3b82f6)" },
+  { bar: "linear-gradient(90deg,#10b981,#22c55e)", btn: "linear-gradient(135deg,#10b981,#22c55e)" },
+  { bar: "linear-gradient(90deg,#f59e0b,#f97316)", btn: "linear-gradient(135deg,#f59e0b,#f97316)" },
+];
+
+export function ContinueCoursesRow({ courses }: { courses: DashboardCourse[] }) {
+  const router = useRouter();
+  if (!courses.length) return null;
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <SectionHeader icon="mdi:play-box-multiple" title="Continue your courses" subtitle="Pick up where you left off" />
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2,1fr)", lg: "repeat(3,1fr)" }, gap: 2 }}>
+        {courses.map((c, i) => {
+          const accent = ACCENTS[i % ACCENTS.length];
+          const left = c.upNext?.title || "Get started";
+          const dl = daysLeft(c.due?.dueAt);
+          const overdue = dl != null && dl < 0;
+          const soon = dl != null && dl >= 0 && dl <= 2;
+          const resume = c.resumeSubmoduleId
+            ? `/adaptive-courses/${c.id}/submodule/${c.resumeSubmoduleId}`
+            : `/adaptive-courses/${c.id}`;
+          return (
+            <Reveal key={c.id} delay={i * 0.05}>
+              <Box sx={{ borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff", overflow: "hidden", boxShadow: "0 1px 2px rgba(16,24,40,0.04)", display: "flex", flexDirection: "column", height: "100%" }}>
+                <Box sx={{ height: 4, background: accent.bar }} />
+                <Box sx={{ p: 2, display: "flex", flexDirection: "column", flex: 1 }}>
+                  <Typography sx={{ fontWeight: 800, fontSize: "1rem", color: "#0f172a", lineHeight: 1.25 }}>{c.title}</Typography>
+
+                  <Box sx={{ mt: 1.25, p: 1.25, borderRadius: 2.5, bgcolor: "#f8fafc", border: "1px solid #eef2f7" }}>
+                    <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.5, color: "#94a3b8", textTransform: "uppercase" }}>You left at</Typography>
+                    <Typography sx={{ fontWeight: 700, fontSize: "0.88rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{left}</Typography>
+                  </Box>
+
+                  <Stack direction="row" justifyContent="space-between" sx={{ mt: 1.5, mb: 0.5 }}>
+                    <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#64748b" }}>Progress</Typography>
+                    <Typography sx={{ fontSize: "0.78rem", fontWeight: 800, color: "#0f172a" }}>{c.completionPct}%</Typography>
+                  </Stack>
+                  <LinearProgress variant="determinate" value={c.completionPct} sx={{ height: 7, borderRadius: 4, bgcolor: "#eef2f7", "& .MuiLinearProgress-bar": { borderRadius: 4, background: accent.bar } }} />
+
+                  {c.due?.dueAt && (
+                    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 1.25 }}>
+                      <Icon icon={overdue ? "mdi:alarm" : "mdi:calendar-clock"} width={14} color={overdue ? "#dc2626" : soon ? "#b45309" : "#15803d"} />
+                      <Typography sx={{ fontSize: "0.76rem", fontWeight: 700, color: overdue ? "#dc2626" : soon ? "#b45309" : "#15803d" }}>
+                        Due {fmtDate(c.due.dueAt)}{dl != null && dl >= 0 ? ` · ${dl} day${dl === 1 ? "" : "s"} left` : overdue ? " · overdue" : ""}
+                      </Typography>
+                    </Stack>
+                  )}
+                  {c.due?.penaltyNote && (
+                    <Stack direction="row" spacing={0.5} alignItems="flex-start" sx={{ mt: 0.5 }}>
+                      <Icon icon="mdi:alert" width={13} color={overdue || soon ? "#dc2626" : "#94a3b8"} style={{ flexShrink: 0, marginTop: 2 }} />
+                      <Typography sx={{ fontSize: "0.72rem", color: overdue || soon ? "#dc2626" : "#94a3b8", lineHeight: 1.4 }}>{c.due.penaltyNote}</Typography>
+                    </Stack>
+                  )}
+
+                  <Box sx={{ flex: 1 }} />
+                  <ButtonBase
+                    onClick={() => router.push(resume)}
+                    sx={{ mt: 1.75, py: 1.1, borderRadius: 2.5, fontWeight: 800, fontSize: "0.88rem", color: "white", gap: 0.5, background: accent.btn }}
+                  >
+                    Continue <Icon icon="mdi:arrow-right" width={16} />
+                  </ButtonBase>
+                </Box>
+              </Box>
+            </Reveal>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/components/dashboard/v2/CourseReadinessCard.tsx
+++ b/components/dashboard/v2/CourseReadinessCard.tsx
@@ -66,17 +66,18 @@ export function CourseReadinessCard({
 
       {/* Ring + signals */}
       <Stack direction={{ xs: "column", md: "row" }} spacing={3} alignItems="center">
-        <Box sx={{ position: "relative", flexShrink: 0, display: "grid", placeItems: "center" }}>
-          <AnimatedRing value={overall.percent ?? 0} size={150} strokeWidth={12} color="#a855f7" colorEnd="#6366f1" trackColor="rgba(255,255,255,0.12)" showValue={false} />
-          <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", textAlign: "center" }}>
-            <Box>
+        <Box sx={{ flexShrink: 0, textAlign: "center" }}>
+          {/* Overlay confined to the ring box (150x150) so the % sits at the ring's centre */}
+          <Box sx={{ position: "relative", width: 150, height: 150, mx: "auto" }}>
+            <AnimatedRing value={overall.percent ?? 0} size={150} strokeWidth={12} color="#a855f7" colorEnd="#6366f1" trackColor="rgba(255,255,255,0.12)" showValue={false} />
+            <Box sx={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
               <Typography sx={{ fontWeight: 900, fontSize: "2rem", color: "#fff", lineHeight: 1 }}>
                 {overall.percent ?? "—"}<Box component="span" sx={{ fontSize: "1rem" }}>%</Box>
               </Typography>
-              <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 1, color: "rgba(255,255,255,0.6)" }}>READY</Typography>
+              <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 1, color: "rgba(255,255,255,0.6)", mt: 0.4 }}>READY</Typography>
             </Box>
           </Box>
-          <Typography sx={{ mt: 1, fontSize: "0.78rem", fontWeight: 700, color: "rgba(255,255,255,0.7)", textAlign: "center" }}>{active.title}</Typography>
+          <Typography sx={{ mt: 1, fontSize: "0.78rem", fontWeight: 700, color: "rgba(255,255,255,0.7)" }}>{active.title}</Typography>
         </Box>
 
         <Box sx={{ flex: 1, width: "100%" }}>

--- a/components/dashboard/v2/CourseReadinessCard.tsx
+++ b/components/dashboard/v2/CourseReadinessCard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { AnimatedRing } from "@/components/scorecard/shared";
+import type { DashboardCourse } from "@/lib/types/dashboard";
+import { BAND_STYLE, SignalBar } from "./parts";
+
+const SIGNALS: { key: "coverage" | "precision" | "craft" | "clutch"; icon: string; label: string; sub: string }[] = [
+  { key: "coverage", icon: "mdi:book-open-variant", label: "Curriculum Coverage", sub: "topics & skills completed" },
+  { key: "precision", icon: "mdi:target", label: "Practice Precision", sub: "accuracy in quizzes & drills" },
+  { key: "craft", icon: "mdi:code-tags", label: "Applied Craft", sub: "hands-on coding expertise" },
+  { key: "clutch", icon: "mdi:trophy-variant", label: "Clutch Performance", sub: "assessments & interviews" },
+];
+
+export function CourseReadinessCard({
+  courses, activeCourseId, onSelect,
+}: { courses: DashboardCourse[]; activeCourseId: number | null; onSelect: (id: number) => void }) {
+  const router = useRouter();
+  const active = courses.find((c) => c.id === activeCourseId) ?? courses[0];
+  if (!active) return null;
+
+  const overall = active.readiness.overall;
+  const ringColor = BAND_STYLE[overall.band].bar;
+  const skills = active.skillProfile.skills;
+  const strongest = skills.length ? skills[0] : null;
+  const weakest = skills.length ? skills[skills.length - 1] : null;
+  const fixRoute = active.resumeSubmoduleId
+    ? `/adaptive-courses/${active.id}/submodule/${active.resumeSubmoduleId}`
+    : `/adaptive-courses/${active.id}`;
+
+  return (
+    <Box sx={{ borderRadius: 4, p: { xs: 2, md: 2.5 }, mb: 2.5, color: "#fff", backgroundColor: "#0f172a", backgroundImage: "linear-gradient(135deg, #0f172a 0%, #1e293b 100%)", boxShadow: "0 18px 40px -22px rgba(15,23,42,0.7)" }}>
+      {/* Header */}
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 1.75 }}>
+        <Stack direction="row" spacing={1.25} alignItems="center">
+          <Box sx={{ width: 32, height: 32, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1, #a855f7)" }}>
+            <Icon icon="mdi:target-variant" width={18} />
+          </Box>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.15rem" }}>Course readiness</Typography>
+        </Stack>
+        <Typography sx={{ fontSize: "0.76rem", color: "rgba(255,255,255,0.55)", display: { xs: "none", sm: "block" }, maxWidth: 240, textAlign: "right" }}>
+          Four signals of how prepared you are in each course
+        </Typography>
+      </Stack>
+
+      {/* Tabs */}
+      {courses.length > 1 && (
+        <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
+          {courses.map((c) => {
+            const on = c.id === active.id;
+            return (
+              <ButtonBase
+                key={c.id}
+                onClick={() => onSelect(c.id)}
+                sx={{ px: 1.5, py: 0.75, borderRadius: 999, gap: 0.6, fontSize: "0.82rem", fontWeight: 700, color: on ? "#fff" : "rgba(255,255,255,0.6)", bgcolor: on ? "rgba(255,255,255,0.14)" : "transparent", border: "1px solid", borderColor: on ? "rgba(255,255,255,0.2)" : "transparent" }}
+              >
+                <Box sx={{ width: 7, height: 7, borderRadius: "50%", bgcolor: BAND_STYLE[c.readiness.overall.band].bar }} />
+                {c.title}
+                <Box component="span" sx={{ color: "rgba(255,255,255,0.5)", fontWeight: 800 }}>{c.readiness.overall.percent ?? "—"}%</Box>
+              </ButtonBase>
+            );
+          })}
+        </Stack>
+      )}
+
+      {/* Ring + signals */}
+      <Stack direction={{ xs: "column", md: "row" }} spacing={3} alignItems="center">
+        <Box sx={{ position: "relative", flexShrink: 0, display: "grid", placeItems: "center" }}>
+          <AnimatedRing value={overall.percent ?? 0} size={150} strokeWidth={12} color={ringColor} colorEnd="#a855f7" trackColor="rgba(255,255,255,0.12)" showValue={false} />
+          <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", textAlign: "center" }}>
+            <Box>
+              <Typography sx={{ fontWeight: 900, fontSize: "2rem", color: "#fff", lineHeight: 1 }}>
+                {overall.percent ?? "—"}<Box component="span" sx={{ fontSize: "1rem" }}>%</Box>
+              </Typography>
+              <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 1, color: "rgba(255,255,255,0.6)" }}>READY</Typography>
+            </Box>
+          </Box>
+          <Typography sx={{ mt: 1, fontSize: "0.78rem", fontWeight: 700, color: "rgba(255,255,255,0.7)", textAlign: "center" }}>{active.title}</Typography>
+        </Box>
+
+        <Box sx={{ flex: 1, width: "100%" }}>
+          {SIGNALS.map((s) => {
+            const cell = active.readiness[s.key];
+            return <SignalBar key={s.key} icon={s.icon} label={s.label} sub={s.sub} percent={cell.percent} band={cell.band} dark />;
+          })}
+        </Box>
+      </Stack>
+
+      {/* AI insight strip */}
+      {(strongest || weakest) && (
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5} alignItems={{ sm: "center" }} justifyContent="space-between" sx={{ mt: 1.5, p: 1.75, borderRadius: 3, bgcolor: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.1)" }}>
+          <Stack direction="row" spacing={0.75} alignItems="flex-start" sx={{ minWidth: 0 }}>
+            <Icon icon="mdi:star-four-points" width={16} color="#fde68a" style={{ flexShrink: 0, marginTop: 2 }} />
+            <Typography sx={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.85)", lineHeight: 1.5 }}>
+              In <b style={{ color: "#fff" }}>{active.title}</b> you&apos;re strongest at{" "}
+              {strongest && <Box component="span" sx={{ color: "#86efac", fontWeight: 700 }}>{strongest.skill} ({strongest.percent}%)</Box>}
+              {strongest && weakest && " and weakest at "}
+              {weakest && <Box component="span" sx={{ color: "#f0abfc", fontWeight: 700 }}>{weakest.skill} ({weakest.percent}%)</Box>}. {active.skillProfile.aiTip}
+            </Typography>
+          </Stack>
+          <ButtonBase onClick={() => router.push(fixRoute)} sx={{ flexShrink: 0, px: 2.25, py: 1, borderRadius: 999, fontWeight: 800, fontSize: "0.85rem", color: "white", gap: 0.5, background: "linear-gradient(135deg, #a855f7, #ec4899)" }}>
+            Fix it <Icon icon="mdi:arrow-right" width={16} />
+          </ButtonBase>
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/components/dashboard/v2/CourseReadinessCard.tsx
+++ b/components/dashboard/v2/CourseReadinessCard.tsx
@@ -22,7 +22,6 @@ export function CourseReadinessCard({
   if (!active) return null;
 
   const overall = active.readiness.overall;
-  const ringColor = BAND_STYLE[overall.band].bar;
   const skills = active.skillProfile.skills;
   const strongest = skills.length ? skills[0] : null;
   const weakest = skills.length ? skills[skills.length - 1] : null;
@@ -31,7 +30,7 @@ export function CourseReadinessCard({
     : `/adaptive-courses/${active.id}`;
 
   return (
-    <Box sx={{ borderRadius: 4, p: { xs: 2, md: 2.5 }, mb: 2.5, color: "#fff", backgroundColor: "#0f172a", backgroundImage: "linear-gradient(135deg, #0f172a 0%, #1e293b 100%)", boxShadow: "0 18px 40px -22px rgba(15,23,42,0.7)" }}>
+    <Box sx={{ borderRadius: 4, p: { xs: 2, md: 2.5 }, mb: 2.5, color: "#fff", backgroundColor: "#110b2e", backgroundImage: "linear-gradient(160deg, #1a1442 0%, #110b2e 100%)", boxShadow: "0 18px 40px -24px rgba(76,29,149,0.6)" }}>
       {/* Header */}
       <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 1.75 }}>
         <Stack direction="row" spacing={1.25} alignItems="center">
@@ -68,7 +67,7 @@ export function CourseReadinessCard({
       {/* Ring + signals */}
       <Stack direction={{ xs: "column", md: "row" }} spacing={3} alignItems="center">
         <Box sx={{ position: "relative", flexShrink: 0, display: "grid", placeItems: "center" }}>
-          <AnimatedRing value={overall.percent ?? 0} size={150} strokeWidth={12} color={ringColor} colorEnd="#a855f7" trackColor="rgba(255,255,255,0.12)" showValue={false} />
+          <AnimatedRing value={overall.percent ?? 0} size={150} strokeWidth={12} color="#a855f7" colorEnd="#6366f1" trackColor="rgba(255,255,255,0.12)" showValue={false} />
           <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", textAlign: "center" }}>
             <Box>
               <Typography sx={{ fontWeight: 900, fontSize: "2rem", color: "#fff", lineHeight: 1 }}>

--- a/components/dashboard/v2/DashboardSkeleton.tsx
+++ b/components/dashboard/v2/DashboardSkeleton.tsx
@@ -9,15 +9,13 @@ const sweep = keyframes`
   100% { background-position: -200% 0; }
 `;
 
-function Shimmer({ h, dark = false, sx }: { h: number | string; dark?: boolean; sx?: object }) {
+function Shimmer({ h, sx }: { h: number | string; sx?: object }) {
   return (
     <Box
       sx={{
         height: h,
         borderRadius: 3,
-        background: dark
-          ? "linear-gradient(90deg, #181040 25%, #2a2060 50%, #181040 75%)"
-          : "linear-gradient(90deg, #eef2f7 25%, #f8fafc 50%, #eef2f7 75%)",
+        background: "linear-gradient(90deg, #eef2f7 25%, #f8fafc 50%, #eef2f7 75%)",
         backgroundSize: "200% 100%",
         animation: `${sweep} 1.5s ease-in-out infinite`,
         ...sx,
@@ -36,11 +34,11 @@ export function DashboardSkeleton({ hideLeaderboard }: { hideLeaderboard: boolea
     >
       {/* Left column: hero → stat cards → readiness → continue */}
       <Box sx={{ minWidth: 0 }}>
-        <Shimmer h={262} dark sx={{ borderRadius: 5, mb: 2.5 }} />
+        <Shimmer h={262} sx={{ borderRadius: 5, mb: 2.5 }} />
         <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2,1fr)", sm: "repeat(3,1fr)", lg: `repeat(${stat},1fr)` }, gap: 1.5, mb: 2.5 }}>
           {Array.from({ length: stat }).map((_, i) => <Shimmer key={i} h={92} />)}
         </Box>
-        <Shimmer h={430} dark sx={{ borderRadius: 4, mb: 2.5 }} />
+        <Shimmer h={430} sx={{ borderRadius: 4, mb: 2.5 }} />
         <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2,1fr)", lg: "repeat(3,1fr)" }, gap: 2 }}>
           {Array.from({ length: 3 }).map((_, i) => <Shimmer key={i} h={240} sx={{ borderRadius: 4 }} />)}
         </Box>

--- a/components/dashboard/v2/DashboardSkeleton.tsx
+++ b/components/dashboard/v2/DashboardSkeleton.tsx
@@ -1,23 +1,58 @@
 "use client";
 
-import { Box, Skeleton, Stack } from "@mui/material";
+import { Box, Stack } from "@mui/material";
+import { keyframes } from "@mui/system";
+
+// Modern gradient-sweep shimmer (replaces the dated MUI pulse skeleton).
+const sweep = keyframes`
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+`;
+
+function Shimmer({ h, dark = false, sx }: { h: number | string; dark?: boolean; sx?: object }) {
+  return (
+    <Box
+      sx={{
+        height: h,
+        borderRadius: 3,
+        background: dark
+          ? "linear-gradient(90deg, #181040 25%, #2a2060 50%, #181040 75%)"
+          : "linear-gradient(90deg, #eef2f7 25%, #f8fafc 50%, #eef2f7 75%)",
+        backgroundSize: "200% 100%",
+        animation: `${sweep} 1.5s ease-in-out infinite`,
+        ...sx,
+      }}
+    />
+  );
+}
 
 export function DashboardSkeleton({ hideLeaderboard }: { hideLeaderboard: boolean }) {
+  const stat = hideLeaderboard ? 4 : 5;
   return (
-    <Box>
-      <Skeleton variant="rounded" height={260} sx={{ borderRadius: 5, mb: 2.5 }} />
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2,1fr)", lg: hideLeaderboard ? "repeat(4,1fr)" : "repeat(5,1fr)" }, gap: 1.5, mb: 2.5 }}>
-        {Array.from({ length: hideLeaderboard ? 4 : 5 }).map((_, i) => (
-          <Skeleton key={i} variant="rounded" height={92} sx={{ borderRadius: 3 }} />
-        ))}
+    <Box
+      role="status"
+      aria-busy="true"
+      sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5, alignItems: "start" }}
+    >
+      {/* Left column: hero → stat cards → readiness → continue */}
+      <Box sx={{ minWidth: 0 }}>
+        <Shimmer h={262} dark sx={{ borderRadius: 5, mb: 2.5 }} />
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2,1fr)", sm: "repeat(3,1fr)", lg: `repeat(${stat},1fr)` }, gap: 1.5, mb: 2.5 }}>
+          {Array.from({ length: stat }).map((_, i) => <Shimmer key={i} h={92} />)}
+        </Box>
+        <Shimmer h={430} dark sx={{ borderRadius: 4, mb: 2.5 }} />
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2,1fr)", lg: "repeat(3,1fr)" }, gap: 2 }}>
+          {Array.from({ length: 3 }).map((_, i) => <Shimmer key={i} h={240} sx={{ borderRadius: 4 }} />)}
+        </Box>
       </Box>
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5 }}>
-        <Skeleton variant="rounded" height={420} sx={{ borderRadius: 4 }} />
-        <Stack spacing={2}>
-          <Skeleton variant="rounded" height={300} sx={{ borderRadius: 4 }} />
-          <Skeleton variant="rounded" height={180} sx={{ borderRadius: 4 }} />
-        </Stack>
-      </Box>
+
+      {/* Sidebar: skill profile → certificate → up next → leaderboard */}
+      <Stack spacing={2}>
+        <Shimmer h={320} sx={{ borderRadius: 4 }} />
+        <Shimmer h={200} sx={{ borderRadius: 4 }} />
+        <Shimmer h={180} sx={{ borderRadius: 4 }} />
+        {!hideLeaderboard && <Shimmer h={220} sx={{ borderRadius: 4 }} />}
+      </Stack>
     </Box>
   );
 }

--- a/components/dashboard/v2/DashboardSkeleton.tsx
+++ b/components/dashboard/v2/DashboardSkeleton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Box, Skeleton, Stack } from "@mui/material";
+
+export function DashboardSkeleton({ hideLeaderboard }: { hideLeaderboard: boolean }) {
+  return (
+    <Box>
+      <Skeleton variant="rounded" height={260} sx={{ borderRadius: 5, mb: 2.5 }} />
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2,1fr)", lg: hideLeaderboard ? "repeat(4,1fr)" : "repeat(5,1fr)" }, gap: 1.5, mb: 2.5 }}>
+        {Array.from({ length: hideLeaderboard ? 4 : 5 }).map((_, i) => (
+          <Skeleton key={i} variant="rounded" height={92} sx={{ borderRadius: 3 }} />
+        ))}
+      </Box>
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5 }}>
+        <Skeleton variant="rounded" height={420} sx={{ borderRadius: 4 }} />
+        <Stack spacing={2}>
+          <Skeleton variant="rounded" height={300} sx={{ borderRadius: 4 }} />
+          <Skeleton variant="rounded" height={180} sx={{ borderRadius: 4 }} />
+        </Stack>
+      </Box>
+    </Box>
+  );
+}

--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import {
+  useHideLeaderboardView,
+  useIsCourseEnabled,
+  useIsScorecardEnabled,
+} from "@/lib/contexts/ClientInfoContext";
+import { DashboardContent } from "@/components/dashboard/DashboardContent";
+import { useDashboardData } from "@/hooks/useDashboardData";
+import type { LearnerDashboard } from "@/lib/types/dashboard";
+import { AiBriefingHero } from "./AiBriefingHero";
+import { StatCards } from "./StatCards";
+import { CourseReadinessCard } from "./CourseReadinessCard";
+import { SkillProfilePanel } from "./SkillProfilePanel";
+import { CertificatePanel } from "./CertificatePanel";
+import { UpNextPanel } from "./UpNextPanel";
+import { LeaderboardPanel } from "./LeaderboardPanel";
+import { ContinueCoursesRow } from "./ContinueCoursesRow";
+import { DashboardSkeleton } from "./DashboardSkeleton";
+
+/** Degraded view for learners with no adaptive courses — the existing dashboard
+ *  (regular-course grid + streak + leaderboard). Mounts useDashboardData only here. */
+function DegradedDashboard() {
+  const { loading, courses } = useDashboardData();
+  return <DashboardContent courses={courses} loading={loading} streakDays={[23, 25, 27]} currentStreak={3} />;
+}
+
+export function DashboardV2() {
+  const hideLeaderboard = useHideLeaderboardView();
+  const scorecardEnabled = useIsScorecardEnabled();
+  const courseEnabled = useIsCourseEnabled();
+
+  const [data, setData] = useState<LearnerDashboard | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeCourseId, setActiveCourseId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    adaptiveJourneyService
+      .getLearnerDashboard()
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load your dashboard."); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) return <DashboardSkeleton hideLeaderboard={hideLeaderboard} />;
+  if (error) return <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center", fontWeight: 600 }}>{error}</Typography>;
+  if (!data || data.courses.length === 0) return <DegradedDashboard />;
+
+  const activeCourse = data.courses.find((c) => c.id === activeCourseId) ?? data.courses[0];
+  const showSidebar =
+    (scorecardEnabled) || activeCourse?.certificate.enabled || courseEnabled || !hideLeaderboard;
+
+  return (
+    <Box>
+      {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
+      <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
+
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: showSidebar ? "minmax(0,1fr) 390px" : "1fr" }, gap: 2.5, alignItems: "start" }}>
+        <Box sx={{ minWidth: 0 }}>
+          {scorecardEnabled && (
+            <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
+          )}
+          {/* When the analytics surfaces are gated off, promote the continue row into the main column. */}
+          {!scorecardEnabled && courseEnabled && <ContinueCoursesRow courses={data.courses} />}
+        </Box>
+
+        {showSidebar && (
+          <Stack spacing={2}>
+            {scorecardEnabled && (
+              <SkillProfilePanel
+                courses={data.courses}
+                activeCourseId={activeCourse?.id ?? null}
+                onSelect={setActiveCourseId}
+                crossCourseMastery={data.aggregate.overallMasteryAvg}
+              />
+            )}
+            {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
+            {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
+            {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
+          </Stack>
+        )}
+      </Box>
+
+      {scorecardEnabled && courseEnabled && <ContinueCoursesRow courses={data.courses} />}
+    </Box>
+  );
+}

--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -25,7 +25,9 @@ import { DashboardSkeleton } from "./DashboardSkeleton";
  *  (regular-course grid + streak + leaderboard). Mounts useDashboardData only here. */
 function DegradedDashboard() {
   const { loading, courses } = useDashboardData();
-  return <DashboardContent courses={courses} loading={loading} streakDays={[23, 25, 27]} currentStreak={3} />;
+  // streak props are deprecated on DashboardContent (StreakTable fetches the real streak
+  // from the API); don't pass placeholder values.
+  return <DashboardContent courses={courses} loading={loading} />;
 }
 
 export function DashboardV2() {

--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -38,6 +38,7 @@ export function DashboardV2() {
   const [data, setData] = useState<LearnerDashboard | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [degraded, setDegraded] = useState(false);
   const [activeCourseId, setActiveCourseId] = useState<number | null>(null);
 
   useEffect(() => {
@@ -45,14 +46,21 @@ export function DashboardV2() {
     adaptiveJourneyService
       .getLearnerDashboard()
       .then((d) => { if (!cancelled) setData(d); })
-      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load your dashboard."); })
+      .catch((e) => {
+        if (cancelled) return;
+        // Tenants without the adaptive feature 403 here — that's not an error, just fall
+        // back to the regular-course dashboard. Reserve the error banner for real failures.
+        const status = (e as { response?: { status?: number } })?.response?.status;
+        if (status === 403 || status === 404) setDegraded(true);
+        else setError(e instanceof Error ? e.message : "Failed to load your dashboard.");
+      })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, []);
 
   if (loading) return <DashboardSkeleton hideLeaderboard={hideLeaderboard} />;
   if (error) return <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center", fontWeight: 600 }}>{error}</Typography>;
-  if (!data || data.courses.length === 0) return <DegradedDashboard />;
+  if (degraded || !data || data.courses.length === 0) return <DegradedDashboard />;
 
   const activeCourse = data.courses.find((c) => c.id === activeCourseId) ?? data.courses[0];
   const showSidebar =

--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -57,37 +57,33 @@ export function DashboardV2() {
     (scorecardEnabled) || activeCourse?.certificate.enabled || courseEnabled || !hideLeaderboard;
 
   return (
-    <Box>
-      {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
-      <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
-
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: showSidebar ? "minmax(0,1fr) 390px" : "1fr" }, gap: 2.5, alignItems: "start" }}>
-        <Box sx={{ minWidth: 0 }}>
-          {scorecardEnabled && (
-            <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
-          )}
-          {/* When the analytics surfaces are gated off, promote the continue row into the main column. */}
-          {!scorecardEnabled && courseEnabled && <ContinueCoursesRow courses={data.courses} />}
-        </Box>
-
-        {showSidebar && (
-          <Stack spacing={2}>
-            {scorecardEnabled && (
-              <SkillProfilePanel
-                courses={data.courses}
-                activeCourseId={activeCourse?.id ?? null}
-                onSelect={setActiveCourseId}
-                crossCourseMastery={data.aggregate.overallMasteryAvg}
-              />
-            )}
-            {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
-            {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
-            {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
-          </Stack>
+    // Two columns like the mockup: AI briefing + stats + readiness + continue on the
+    // left; skill profile + certificate + up-next + leaderboard on the right.
+    <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: showSidebar ? "minmax(0,1fr) 390px" : "1fr" }, gap: 2.5, alignItems: "start" }}>
+      <Box sx={{ minWidth: 0 }}>
+        {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
+        <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
+        {scorecardEnabled && (
+          <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
         )}
+        {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
       </Box>
 
-      {scorecardEnabled && courseEnabled && <ContinueCoursesRow courses={data.courses} />}
+      {showSidebar && (
+        <Stack spacing={2}>
+          {scorecardEnabled && (
+            <SkillProfilePanel
+              courses={data.courses}
+              activeCourseId={activeCourse?.id ?? null}
+              onSelect={setActiveCourseId}
+              crossCourseMastery={data.aggregate.overallMasteryAvg}
+            />
+          )}
+          {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
+          {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
+          {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
+        </Stack>
+      )}
     </Box>
   );
 }

--- a/components/dashboard/v2/LeaderboardPanel.tsx
+++ b/components/dashboard/v2/LeaderboardPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Stack, Typography } from "@mui/material";
+import { Avatar, Box, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import type { DashboardLeaderboard } from "@/lib/types/dashboard";
 import { PanelCard, RANK_BG, RANK_FG, avatarColor } from "./parts";
@@ -38,7 +38,7 @@ export function LeaderboardPanel({ leaderboard }: { leaderboard: DashboardLeader
               sx={{ p: 0.85, borderRadius: 2.5, bgcolor: r.is_current_user ? "#f5f3ff" : "transparent", border: r.is_current_user ? "1px solid #ede9fe" : "1px solid transparent" }}
             >
               <Box sx={{ width: 22, height: 22, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", fontSize: "0.66rem", fontWeight: 800, color: RANK_FG[r.rank] || "#64748b", bgcolor: RANK_BG[r.rank] || "#f1f5f9" }}>{r.rank}</Box>
-              <Box sx={{ width: 28, height: 28, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", fontSize: "0.78rem", fontWeight: 800, bgcolor: avatarColor(r.name || "?") }}>{initial}</Box>
+              <Avatar src={r.profile_pic_url ?? undefined} sx={{ width: 28, height: 28, flexShrink: 0, fontSize: "0.78rem", fontWeight: 800, color: "white", bgcolor: avatarColor(r.name || "?") }}>{initial}</Avatar>
               <Typography sx={{ flex: 1, minWidth: 0, fontWeight: r.is_current_user ? 800 : 600, fontSize: "0.85rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 {r.is_current_user ? "You" : r.name}
               </Typography>

--- a/components/dashboard/v2/LeaderboardPanel.tsx
+++ b/components/dashboard/v2/LeaderboardPanel.tsx
@@ -40,7 +40,7 @@ export function LeaderboardPanel({ leaderboard }: { leaderboard: DashboardLeader
               <Box sx={{ width: 22, height: 22, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", fontSize: "0.66rem", fontWeight: 800, color: RANK_FG[r.rank] || "#64748b", bgcolor: RANK_BG[r.rank] || "#f1f5f9" }}>{r.rank}</Box>
               <Avatar src={r.profile_pic_url ?? undefined} sx={{ width: 28, height: 28, flexShrink: 0, fontSize: "0.78rem", fontWeight: 800, color: "white", bgcolor: avatarColor(r.name || "?") }}>{initial}</Avatar>
               <Typography sx={{ flex: 1, minWidth: 0, fontWeight: r.is_current_user ? 800 : 600, fontSize: "0.85rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {r.is_current_user ? "You" : r.name}
+                {r.name}{r.is_current_user && <Box component="span" sx={{ color: "#7c3aed", fontWeight: 700 }}> (you)</Box>}
               </Typography>
               <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", color: "#475569", flexShrink: 0 }}>{r.score.toLocaleString()}</Typography>
             </Stack>

--- a/components/dashboard/v2/LeaderboardPanel.tsx
+++ b/components/dashboard/v2/LeaderboardPanel.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Box, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { DashboardLeaderboard } from "@/lib/types/dashboard";
+import { PanelCard, RANK_BG, RANK_FG, avatarColor } from "./parts";
+
+export function LeaderboardPanel({ leaderboard }: { leaderboard: DashboardLeaderboard }) {
+  const me = leaderboard.me;
+  if (!me || !leaderboard.rows.length) return null;
+  const delta = me.rankDelta || 0;
+
+  return (
+    <PanelCard>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.25 }}>
+        <Stack direction="row" spacing={1.25} alignItems="center">
+          <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
+            <Icon icon="mdi:trophy" width={17} />
+          </Box>
+          <Box>
+            <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.95rem", lineHeight: 1.1 }}>
+              You&apos;re #{me.rank}
+              {delta > 0 && <Box component="span" sx={{ color: "#15803d", fontWeight: 800, ml: 0.5, fontSize: "0.8rem" }}>▲ +{delta}</Box>}
+              {delta < 0 && <Box component="span" sx={{ color: "#b91c1c", fontWeight: 800, ml: 0.5, fontSize: "0.8rem" }}>▼ {delta}</Box>}
+            </Typography>
+            <Typography sx={{ fontSize: "0.72rem", color: "#64748b" }}>this week · top {me.percentile}%</Typography>
+          </Box>
+        </Stack>
+      </Stack>
+
+      <Stack spacing={0.75}>
+        {leaderboard.rows.map((r) => {
+          const initial = (r.name || "?").charAt(0).toUpperCase();
+          return (
+            <Stack
+              key={r.rank}
+              direction="row" alignItems="center" spacing={1}
+              sx={{ p: 0.85, borderRadius: 2.5, bgcolor: r.is_current_user ? "#f5f3ff" : "transparent", border: r.is_current_user ? "1px solid #ede9fe" : "1px solid transparent" }}
+            >
+              <Box sx={{ width: 22, height: 22, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", fontSize: "0.66rem", fontWeight: 800, color: RANK_FG[r.rank] || "#64748b", bgcolor: RANK_BG[r.rank] || "#f1f5f9" }}>{r.rank}</Box>
+              <Box sx={{ width: 28, height: 28, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", fontSize: "0.78rem", fontWeight: 800, bgcolor: avatarColor(r.name || "?") }}>{initial}</Box>
+              <Typography sx={{ flex: 1, minWidth: 0, fontWeight: r.is_current_user ? 800 : 600, fontSize: "0.85rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {r.is_current_user ? "You" : r.name}
+              </Typography>
+              <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", color: "#475569", flexShrink: 0 }}>{r.score.toLocaleString()}</Typography>
+            </Stack>
+          );
+        })}
+      </Stack>
+
+      {leaderboard.aiTip && (
+        <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.25, p: 1, borderRadius: 2, background: "linear-gradient(135deg, #f5f3ff, #fdf2f8)" }}>
+          <Icon icon="mdi:star-four-points" width={13} color="#6d28d9" style={{ flexShrink: 0, marginTop: 2 }} />
+          <Typography sx={{ fontSize: "0.74rem", color: "#6d28d9", fontWeight: 600, lineHeight: 1.45 }}>{leaderboard.aiTip}</Typography>
+        </Stack>
+      )}
+    </PanelCard>
+  );
+}

--- a/components/dashboard/v2/SkillProfilePanel.tsx
+++ b/components/dashboard/v2/SkillProfilePanel.tsx
@@ -50,10 +50,44 @@ export function SkillProfilePanel({
           value={active.id}
           onChange={(e) => onSelect(Number(e.target.value))}
           fullWidth
-          sx={{ mb: 1.5, fontSize: "0.82rem", fontWeight: 700, "& .MuiSelect-select": { py: 0.75 } }}
+          MenuProps={{
+            elevation: 0,
+            PaperProps: { sx: { mt: 0.75, borderRadius: 3, border: "1px solid #eef2f7", boxShadow: "0 18px 44px -18px rgba(16,24,40,0.32)", overflow: "hidden" } },
+            MenuListProps: { sx: { py: 0.5 } },
+          }}
+          renderValue={(val) => {
+            const c = courses.find((x) => x.id === val);
+            return (
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ minWidth: 0 }}>
+                <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "#a855f7", flexShrink: 0 }} />
+                <Box component="span" sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c?.title}</Box>
+              </Stack>
+            );
+          }}
+          sx={{
+            mb: 1.5, borderRadius: 2.5, bgcolor: "#fff", fontSize: "0.86rem", fontWeight: 700, color: "#0f172a",
+            "& .MuiOutlinedInput-notchedOutline": { borderColor: "#e5e7eb" },
+            "&:hover .MuiOutlinedInput-notchedOutline": { borderColor: "#c4b5fd" },
+            "&.Mui-focused .MuiOutlinedInput-notchedOutline": { borderColor: "#7c3aed", borderWidth: 2 },
+            "& .MuiSelect-select": { py: 1, pl: 1.5, display: "flex", alignItems: "center" },
+            "& .MuiSelect-icon": { color: "#94a3b8", right: 10 },
+          }}
         >
           {courses.map((c) => (
-            <MenuItem key={c.id} value={c.id} sx={{ fontSize: "0.82rem" }}>{c.title}</MenuItem>
+            <MenuItem
+              key={c.id}
+              value={c.id}
+              sx={{
+                fontSize: "0.86rem", fontWeight: 600, py: 1, px: 1.5, gap: 1, mx: 0.5, borderRadius: 2,
+                "&:hover": { bgcolor: "#f8fafc" },
+                "&.Mui-selected": { bgcolor: "#f5f3ff" },
+                "&.Mui-selected:hover": { bgcolor: "#ede9fe" },
+              }}
+            >
+              <Box sx={{ width: 8, height: 8, borderRadius: "50%", flexShrink: 0, bgcolor: c.id === active.id ? "#a855f7" : "#cbd5e1" }} />
+              <Box component="span" sx={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{c.title}</Box>
+              {c.id === active.id && <Icon icon="mdi:check" width={16} color="#7c3aed" />}
+            </MenuItem>
           ))}
         </Select>
       )}

--- a/components/dashboard/v2/SkillProfilePanel.tsx
+++ b/components/dashboard/v2/SkillProfilePanel.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Box, LinearProgress, MenuItem, Select, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { DashboardCourse } from "@/lib/types/dashboard";
+import { PanelCard } from "./parts";
+
+const SKILL_STYLE = {
+  strong: { color: "#15803d", bg: "#dcfce7", bar: "#22c55e", label: "Strong" },
+  emerging: { color: "#b45309", bg: "#fef3c7", bar: "#f59e0b", label: "Emerging" },
+};
+
+export function SkillProfilePanel({
+  courses, activeCourseId, onSelect, crossCourseMastery,
+}: {
+  courses: DashboardCourse[];
+  activeCourseId: number | null;
+  onSelect: (id: number) => void;
+  crossCourseMastery: number | null;
+}) {
+  const active = courses.find((c) => c.id === activeCourseId) ?? courses[0];
+  if (!active) return null;
+  const sp = active.skillProfile;
+  const tier = sp.fieldTier ? sp.fieldTier.toUpperCase() : null;
+
+  return (
+    <PanelCard>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start" sx={{ mb: 1.25 }}>
+        <Stack direction="row" spacing={1.25} alignItems="center">
+          <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1, #a855f7)" }}>
+            <Icon icon="mdi:brain" width={17} />
+          </Box>
+          <Box>
+            <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.6, color: "#7c3aed" }}>
+              ADAPTIVE{tier ? ` · ${tier}` : ""}
+            </Typography>
+            <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.95rem", lineHeight: 1.1 }}>Your Skill Profile</Typography>
+          </Box>
+        </Stack>
+      </Stack>
+
+      {courses.length > 1 && (
+        <Select
+          size="small"
+          value={active.id}
+          onChange={(e) => onSelect(Number(e.target.value))}
+          fullWidth
+          sx={{ mb: 1.5, fontSize: "0.82rem", fontWeight: 700, "& .MuiSelect-select": { py: 0.75 } }}
+        >
+          {courses.map((c) => (
+            <MenuItem key={c.id} value={c.id} sx={{ fontSize: "0.82rem" }}>{c.title}</MenuItem>
+          ))}
+        </Select>
+      )}
+
+      <Box sx={{ p: 1.5, borderRadius: 3, color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)", mb: 1.5 }}>
+        <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "rgba(255,255,255,0.85)" }}>MASTERY · THIS COURSE</Typography>
+        <Stack direction="row" alignItems="baseline" justifyContent="space-between">
+          <Typography sx={{ fontWeight: 900, fontSize: "2rem", lineHeight: 1 }}>{sp.mastery ?? "—"}%</Typography>
+          <Typography sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.85)" }}>{sp.skillsTracked} skills tracked</Typography>
+        </Stack>
+        {crossCourseMastery != null && (
+          <Typography sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.8)", mt: 0.5 }}>Across all courses: {crossCourseMastery}%</Typography>
+        )}
+      </Box>
+
+      {sp.skills.length > 0 ? (
+        <Stack spacing={1.1}>
+          {sp.skills.slice(0, 6).map((sk) => {
+            const s = SKILL_STYLE[sk.band];
+            return (
+              <Box key={sk.skill}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 0.4 }}>
+                  <Typography sx={{ fontSize: "0.82rem", fontWeight: 700, color: "#0f172a" }}>{sk.skill}</Typography>
+                  <Stack direction="row" spacing={0.75} alignItems="center">
+                    <Box component="span" sx={{ px: 0.75, py: 0.15, borderRadius: 999, fontSize: "0.6rem", fontWeight: 800, color: s.color, bgcolor: s.bg }}>{s.label}</Box>
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", color: s.color, minWidth: 36, textAlign: "right" }}>{sk.percent}%</Typography>
+                  </Stack>
+                </Stack>
+                <LinearProgress variant="determinate" value={sk.percent} sx={{ height: 6, borderRadius: 4, bgcolor: "#eef2f7", "& .MuiLinearProgress-bar": { bgcolor: s.bar, borderRadius: 4 } }} />
+              </Box>
+            );
+          })}
+        </Stack>
+      ) : (
+        <Typography sx={{ fontSize: "0.8rem", color: "#94a3b8", py: 1 }}>Take the calibration to map your skills here.</Typography>
+      )}
+
+      <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f5f3ff" }}>
+        <Icon icon="mdi:star-four-points" width={13} color="#6d28d9" style={{ flexShrink: 0, marginTop: 2 }} />
+        <Typography sx={{ fontSize: "0.74rem", color: "#6d28d9", fontWeight: 600, lineHeight: 1.45 }}>{sp.aiTip}</Typography>
+      </Stack>
+    </PanelCard>
+  );
+}

--- a/components/dashboard/v2/SkillProfilePanel.tsx
+++ b/components/dashboard/v2/SkillProfilePanel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { Box, LinearProgress, MenuItem, Select, Stack, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, LinearProgress, MenuItem, Select, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import type { DashboardCourse } from "@/lib/types/dashboard";
 import { PanelCard } from "./parts";
 
 const SKILL_STYLE = {
   strong: { color: "#15803d", bg: "#dcfce7", bar: "#22c55e", label: "Strong" },
-  emerging: { color: "#b45309", bg: "#fef3c7", bar: "#f59e0b", label: "Emerging" },
+  emerging: { color: "#7c3aed", bg: "#f3e8ff", bar: "#a855f7", label: "Emerging" },
 };
 
 export function SkillProfilePanel({
@@ -18,6 +19,7 @@ export function SkillProfilePanel({
   onSelect: (id: number) => void;
   crossCourseMastery: number | null;
 }) {
+  const router = useRouter();
   const active = courses.find((c) => c.id === activeCourseId) ?? courses[0];
   if (!active) return null;
   const sp = active.skillProfile;
@@ -37,6 +39,9 @@ export function SkillProfilePanel({
             <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.95rem", lineHeight: 1.1 }}>Your Skill Profile</Typography>
           </Box>
         </Stack>
+        <ButtonBase onClick={() => router.push(`/adaptive-courses/${active.id}`)} sx={{ fontSize: "0.74rem", fontWeight: 700, color: "#7c3aed", flexShrink: 0, gap: 0.25 }}>
+          Full report →
+        </ButtonBase>
       </Stack>
 
       {courses.length > 1 && (
@@ -53,14 +58,14 @@ export function SkillProfilePanel({
         </Select>
       )}
 
-      <Box sx={{ p: 1.5, borderRadius: 3, color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)", mb: 1.5 }}>
-        <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "rgba(255,255,255,0.85)" }}>MASTERY · THIS COURSE</Typography>
+      <Box sx={{ p: 1.5, borderRadius: 3, bgcolor: "#f5f3ff", border: "1px solid #ede9fe", mb: 1.5 }}>
+        <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "#94a3b8" }}>MASTERY · THIS COURSE</Typography>
         <Stack direction="row" alignItems="baseline" justifyContent="space-between">
-          <Typography sx={{ fontWeight: 900, fontSize: "2rem", lineHeight: 1 }}>{sp.mastery ?? "—"}%</Typography>
-          <Typography sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.85)" }}>{sp.skillsTracked} skills tracked</Typography>
+          <Typography sx={{ fontWeight: 900, fontSize: "2.2rem", lineHeight: 1, color: "#6366f1" }}>{sp.mastery ?? "—"}%</Typography>
+          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8" }}>{sp.skillsTracked} skills tracked</Typography>
         </Stack>
         {crossCourseMastery != null && (
-          <Typography sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.8)", mt: 0.5 }}>Across all courses: {crossCourseMastery}%</Typography>
+          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8", mt: 0.5 }}>Across all courses: <b style={{ color: "#475569" }}>{crossCourseMastery}%</b></Typography>
         )}
       </Box>
 

--- a/components/dashboard/v2/StatCards.tsx
+++ b/components/dashboard/v2/StatCards.tsx
@@ -16,7 +16,7 @@ export function StatCards({
       label="Total points"
       value={<CountUp value={a.totalPoints} />}
       sub={a.pointsThisWeek ? `+${a.pointsThisWeek} this week` : "Start earning"}
-      subColor={a.pointsThisWeek ? "#15803d" : "#94a3b8"}
+      subColor={a.pointsThisWeek ? "#7c3aed" : "#94a3b8"}
       icon="mdi:star-four-points"
       accent="#7c3aed"
     />,
@@ -25,9 +25,9 @@ export function StatCards({
       label="Day streak"
       value={<CountUp value={a.streak.current} />}
       sub={`best ${a.streak.best}`}
-      subColor="#b45309"
+      subColor="#94a3b8"
       icon="mdi:fire"
-      accent="#f97316"
+      accent="#ef4444"
     />,
   ];
 
@@ -40,7 +40,7 @@ export function StatCards({
         sub={rankDelta > 0 ? `▲ +${rankDelta} this week` : rankDelta < 0 ? `▼ ${rankDelta} this week` : "holding steady"}
         subColor={rankDelta > 0 ? "#15803d" : rankDelta < 0 ? "#b91c1c" : "#94a3b8"}
         icon="mdi:trophy"
-        accent="#6366f1"
+        accent="#3b82f6"
       />,
     );
   }
@@ -52,7 +52,7 @@ export function StatCards({
       value={<CountUp value={a.momentum} />}
       sub="of 100"
       icon="mdi:chart-line-variant"
-      accent="#0ea5e9"
+      accent="#f59e0b"
     />,
     <StatBox
       key="ontime"

--- a/components/dashboard/v2/StatCards.tsx
+++ b/components/dashboard/v2/StatCards.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Box } from "@mui/material";
+import { CountUp, Reveal } from "@/components/scorecard/shared";
+import type { DashboardAggregate } from "@/lib/types/dashboard";
+import { StatBox } from "./parts";
+
+export function StatCards({
+  aggregate, hideLeaderboard,
+}: { aggregate: DashboardAggregate; hideLeaderboard: boolean }) {
+  const a = aggregate;
+  const rankDelta = a.cohortRank.rankDelta || 0;
+  const cards: React.ReactNode[] = [
+    <StatBox
+      key="points"
+      label="Total points"
+      value={<CountUp value={a.totalPoints} />}
+      sub={a.pointsThisWeek ? `+${a.pointsThisWeek} this week` : "Start earning"}
+      subColor={a.pointsThisWeek ? "#15803d" : "#94a3b8"}
+      icon="mdi:star-four-points"
+      accent="#7c3aed"
+    />,
+    <StatBox
+      key="streak"
+      label="Day streak"
+      value={<CountUp value={a.streak.current} />}
+      sub={`best ${a.streak.best}`}
+      subColor="#b45309"
+      icon="mdi:fire"
+      accent="#f97316"
+    />,
+  ];
+
+  if (!hideLeaderboard && a.cohortRank.bestRank) {
+    cards.push(
+      <StatBox
+        key="rank"
+        label="Cohort rank"
+        value={`#${a.cohortRank.bestRank}`}
+        sub={rankDelta > 0 ? `▲ +${rankDelta} this week` : rankDelta < 0 ? `▼ ${rankDelta} this week` : "holding steady"}
+        subColor={rankDelta > 0 ? "#15803d" : rankDelta < 0 ? "#b91c1c" : "#94a3b8"}
+        icon="mdi:trophy"
+        accent="#6366f1"
+      />,
+    );
+  }
+
+  cards.push(
+    <StatBox
+      key="momentum"
+      label="Momentum"
+      value={<CountUp value={a.momentum} />}
+      sub="of 100"
+      icon="mdi:chart-line-variant"
+      accent="#0ea5e9"
+    />,
+    <StatBox
+      key="ontime"
+      label="On-time rate"
+      value={a.onTimeRate == null ? "—" : `${Math.round(a.onTimeRate * 100)}%`}
+      sub={a.onTimeRate === 1 ? "no penalties" : a.onTimeRate == null ? "no data yet" : "keep it up"}
+      subColor={a.onTimeRate === 1 ? "#15803d" : "#94a3b8"}
+      icon="mdi:check-circle-outline"
+      accent="#22c55e"
+    />,
+  );
+
+  const cols = cards.length;
+  return (
+    <Reveal>
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2,1fr)", sm: "repeat(3,1fr)", lg: `repeat(${cols},1fr)` }, gap: 1.5, mb: 2.5 }}>
+        {cards}
+      </Box>
+    </Reveal>
+  );
+}

--- a/components/dashboard/v2/StatCards.tsx
+++ b/components/dashboard/v2/StatCards.tsx
@@ -2,6 +2,7 @@
 
 import { Box } from "@mui/material";
 import { CountUp, Reveal } from "@/components/scorecard/shared";
+import { PointsInfo } from "@/components/common/PointsInfo";
 import type { DashboardAggregate } from "@/lib/types/dashboard";
 import { StatBox } from "./parts";
 
@@ -19,6 +20,7 @@ export function StatCards({
       subColor={a.pointsThisWeek ? "#7c3aed" : "#94a3b8"}
       icon="mdi:star-four-points"
       accent="#7c3aed"
+      info={<PointsInfo size={13} />}
     />,
     <StatBox
       key="streak"

--- a/components/dashboard/v2/StatCards.tsx
+++ b/components/dashboard/v2/StatCards.tsx
@@ -4,6 +4,7 @@ import { Box } from "@mui/material";
 import { CountUp, Reveal } from "@/components/scorecard/shared";
 import { PointsInfo } from "@/components/common/PointsInfo";
 import { StreakInfo } from "@/components/common/StreakInfo";
+import { MomentumInfo } from "@/components/common/MomentumInfo";
 import type { DashboardAggregate } from "@/lib/types/dashboard";
 import { StatBox } from "./parts";
 
@@ -57,6 +58,7 @@ export function StatCards({
       sub="of 100"
       icon="mdi:chart-line-variant"
       accent="#f59e0b"
+      info={<MomentumInfo info={a.momentumInfo} size={13} />}
     />,
     <StatBox
       key="ontime"

--- a/components/dashboard/v2/StatCards.tsx
+++ b/components/dashboard/v2/StatCards.tsx
@@ -3,6 +3,7 @@
 import { Box } from "@mui/material";
 import { CountUp, Reveal } from "@/components/scorecard/shared";
 import { PointsInfo } from "@/components/common/PointsInfo";
+import { StreakInfo } from "@/components/common/StreakInfo";
 import type { DashboardAggregate } from "@/lib/types/dashboard";
 import { StatBox } from "./parts";
 
@@ -30,6 +31,7 @@ export function StatCards({
       subColor="#94a3b8"
       icon="mdi:fire"
       accent="#ef4444"
+      info={<StreakInfo size={13} />}
     />,
   ];
 

--- a/components/dashboard/v2/UpNextPanel.tsx
+++ b/components/dashboard/v2/UpNextPanel.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { CrossCourseUpNext } from "@/lib/types/dashboard";
+import { PanelCard, SectionHeader } from "./parts";
+
+const KIND: Record<string, { icon: string; color: string; bg: string }> = {
+  topic: { icon: "mdi:book-open-page-variant", color: "#6366f1", bg: "#eef2ff" },
+  quiz: { icon: "mdi:help-circle", color: "#6366f1", bg: "#eef2ff" },
+  checkpoint: { icon: "mdi:shield-check", color: "#a855f7", bg: "#f5f3ff" },
+  week_final: { icon: "mdi:flag-checkered", color: "#f59e0b", bg: "#fff7ed" },
+  interview: { icon: "mdi:account-voice", color: "#ec4899", bg: "#fdf2f8" },
+};
+
+export function UpNextPanel({ items }: { items: CrossCourseUpNext[] }) {
+  const router = useRouter();
+  if (!items.length) return null;
+
+  const go = (it: CrossCourseUpNext) => {
+    if (it.resumeSubmoduleId) router.push(`/adaptive-courses/${it.courseId}/submodule/${it.resumeSubmoduleId}`);
+    else router.push(`/adaptive-courses/${it.courseId}`);
+  };
+
+  return (
+    <PanelCard>
+      <SectionHeader
+        icon="mdi:arrow-right-bold-box"
+        title="Up Next"
+        subtitle="Across your courses"
+      />
+      <Stack spacing={1}>
+        {items.map((it) => {
+          const k = KIND[it.type] || KIND.topic;
+          return (
+            <ButtonBase
+              key={`${it.courseId}-${it.nodeId}`}
+              onClick={() => go(it)}
+              sx={{ width: "100%", textAlign: "left", justifyContent: "flex-start", p: 1.25, borderRadius: 2.5, border: "1px solid #eef2f7", gap: 1.25, "&:hover": { borderColor: "#cbd5e1" } }}
+            >
+              <Box sx={{ width: 34, height: 34, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: k.color, bgcolor: k.bg }}>
+                <Icon icon={k.icon} width={18} />
+              </Box>
+              <Box sx={{ minWidth: 0, flex: 1 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: "0.86rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{it.title}</Typography>
+                <Box component="span" sx={{ display: "inline-block", mt: 0.25, px: 0.75, py: 0.1, borderRadius: 999, fontSize: "0.64rem", fontWeight: 700, color: "#475569", bgcolor: "#f1f5f9" }}>{it.courseTitle}</Box>
+              </Box>
+              {it.points ? <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", color: "#7c3aed", flexShrink: 0 }}>+{it.points}</Typography> : null}
+            </ButtonBase>
+          );
+        })}
+      </Stack>
+    </PanelCard>
+  );
+}

--- a/components/dashboard/v2/UpNextPanel.tsx
+++ b/components/dashboard/v2/UpNextPanel.tsx
@@ -8,7 +8,6 @@ import { PanelCard, SectionHeader } from "./parts";
 
 const KIND: Record<string, { icon: string; color: string; bg: string }> = {
   topic: { icon: "mdi:book-open-page-variant", color: "#6366f1", bg: "#eef2ff" },
-  quiz: { icon: "mdi:help-circle", color: "#6366f1", bg: "#eef2ff" },
   checkpoint: { icon: "mdi:shield-check", color: "#a855f7", bg: "#f5f3ff" },
   week_final: { icon: "mdi:flag-checkered", color: "#f59e0b", bg: "#fff7ed" },
   interview: { icon: "mdi:account-voice", color: "#ec4899", bg: "#fdf2f8" },

--- a/components/dashboard/v2/parts.tsx
+++ b/components/dashboard/v2/parts.tsx
@@ -68,9 +68,9 @@ export function SectionHeader({
 }
 
 export function StatBox({
-  label, value, sub, subColor = "#94a3b8", icon, accent = "#7c3aed",
+  label, value, sub, subColor = "#94a3b8", icon, accent = "#7c3aed", info,
 }: {
-  label: string; value: ReactNode; sub?: ReactNode; subColor?: string; icon?: string; accent?: string;
+  label: string; value: ReactNode; sub?: ReactNode; subColor?: string; icon?: string; accent?: string; info?: ReactNode;
 }) {
   return (
     <Box sx={{ p: 1.75, borderRadius: 3, border: "1px solid #eef2f7", bgcolor: "#fff", boxShadow: "0 1px 2px rgba(16,24,40,0.04)", position: "relative", overflow: "hidden" }}>
@@ -78,7 +78,10 @@ export function StatBox({
       <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
         <Box sx={{ minWidth: 0 }}>
           <Typography sx={{ fontWeight: 900, fontSize: "1.5rem", color: "#0f172a", lineHeight: 1 }}>{value}</Typography>
-          <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.5, textTransform: "uppercase", color: "#64748b", mt: 0.5 }}>{label}</Typography>
+          <Stack direction="row" spacing={0.25} alignItems="center" sx={{ mt: 0.5 }}>
+            <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.5, textTransform: "uppercase", color: "#64748b" }}>{label}</Typography>
+            {info}
+          </Stack>
           {sub != null && <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: subColor, mt: 0.25 }}>{sub}</Typography>}
         </Box>
         {icon && <Icon icon={icon} width={20} color={accent} style={{ flexShrink: 0, opacity: 0.85 }} />}

--- a/components/dashboard/v2/parts.tsx
+++ b/components/dashboard/v2/parts.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Box, LinearProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { ReadinessBand } from "@/lib/types/dashboard";
+
+// --- band → color (single source) ---
+export const BAND_STYLE: Record<ReadinessBand, { color: string; bg: string; label: string; bar: string }> = {
+  "not-started": { color: "#94a3b8", bg: "#f1f5f9", label: "Not started", bar: "#cbd5e1" },
+  "needs-work": { color: "#b91c1c", bg: "#fef2f2", label: "Needs work", bar: "#ef4444" },
+  building: { color: "#b45309", bg: "#fffbeb", label: "Building", bar: "#f59e0b" },
+  strong: { color: "#15803d", bg: "#f0fdf4", label: "Strong", bar: "#22c55e" },
+};
+
+export function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  } catch {
+    return "";
+  }
+}
+
+export function daysLeft(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime() - Date.now();
+  if (Number.isNaN(ms)) return null;
+  return Math.ceil(ms / 86_400_000);
+}
+
+// --- leaderboard helpers (mirror JourneySidePanels) ---
+export const RANK_BG: Record<number, string> = { 1: "#fef3c7", 2: "#f1f5f9", 3: "#fde7d3" };
+export const RANK_FG: Record<number, string> = { 1: "#b45309", 2: "#475569", 3: "#9a3412" };
+const AV_COLORS = ["#6366f1", "#a855f7", "#ec4899", "#0ea5e9", "#14b8a6", "#f59e0b"];
+export function avatarColor(name: string): string {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+  return AV_COLORS[h % AV_COLORS.length];
+}
+
+// --- atoms ---
+export function PanelCard({ children, sx }: { children: ReactNode; sx?: object }) {
+  return (
+    <Box sx={{ p: 2, mb: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff", ...sx }}>
+      {children}
+    </Box>
+  );
+}
+
+export function SectionHeader({
+  icon, title, subtitle, gradient = "linear-gradient(135deg, #6366f1, #a855f7)", action,
+}: {
+  icon: string; title: string; subtitle?: string; gradient?: string; action?: ReactNode;
+}) {
+  return (
+    <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 1.5 }}>
+      <Box sx={{ width: 30, height: 30, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: gradient }}>
+        <Icon icon={icon} width={17} />
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontWeight: 800, color: "#0f172a", fontSize: "0.95rem", lineHeight: 1.2 }}>{title}</Typography>
+        {subtitle && <Typography sx={{ fontSize: "0.72rem", color: "#64748b" }}>{subtitle}</Typography>}
+      </Box>
+      {action}
+    </Stack>
+  );
+}
+
+export function StatBox({
+  label, value, sub, subColor = "#94a3b8", icon, accent = "#7c3aed",
+}: {
+  label: string; value: ReactNode; sub?: ReactNode; subColor?: string; icon?: string; accent?: string;
+}) {
+  return (
+    <Box sx={{ p: 1.75, borderRadius: 3, border: "1px solid #eef2f7", bgcolor: "#fff", boxShadow: "0 1px 2px rgba(16,24,40,0.04)", position: "relative", overflow: "hidden" }}>
+      <Box sx={{ position: "absolute", top: 0, left: 0, right: 0, height: 3, background: `linear-gradient(90deg, ${accent}, #a855f7)` }} />
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 900, fontSize: "1.5rem", color: "#0f172a", lineHeight: 1 }}>{value}</Typography>
+          <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.5, textTransform: "uppercase", color: "#64748b", mt: 0.5 }}>{label}</Typography>
+          {sub != null && <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: subColor, mt: 0.25 }}>{sub}</Typography>}
+        </Box>
+        {icon && <Icon icon={icon} width={20} color={accent} style={{ flexShrink: 0, opacity: 0.85 }} />}
+      </Stack>
+    </Box>
+  );
+}
+
+export function BandPill({ band }: { band: ReadinessBand }) {
+  const s = BAND_STYLE[band];
+  return (
+    <Box component="span" sx={{ px: 0.85, py: 0.2, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: s.color, bgcolor: s.bg }}>
+      {s.label}
+    </Box>
+  );
+}
+
+export function SignalBar({
+  icon, label, sub, percent, band, dark = false,
+}: {
+  icon: string; label: string; sub?: string; percent: number | null; band: ReadinessBand; dark?: boolean;
+}) {
+  const s = BAND_STYLE[band];
+  const textColor = dark ? "#fff" : "#0f172a";
+  const subColor = dark ? "rgba(255,255,255,0.55)" : "#94a3b8";
+  const track = dark ? "rgba(255,255,255,0.12)" : "#eef2f7";
+  return (
+    <Box sx={{ mb: 1.25 }}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Box sx={{ width: 30, height: 30, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: s.bar, bgcolor: dark ? "rgba(255,255,255,0.08)" : s.bg }}>
+          <Icon icon={icon} width={16} />
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.85rem", color: textColor, lineHeight: 1.2 }}>{label}</Typography>
+          {sub && <Typography sx={{ fontSize: "0.66rem", color: subColor }}>{sub}</Typography>}
+        </Box>
+        <BandPill band={band} />
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: textColor, minWidth: 42, textAlign: "right" }}>
+          {percent == null ? "—" : `${percent}%`}
+        </Typography>
+      </Stack>
+      <LinearProgress
+        variant="determinate"
+        value={percent ?? 0}
+        sx={{ mt: 0.75, ml: "38px", height: 7, borderRadius: 4, bgcolor: track, "& .MuiLinearProgress-bar": { bgcolor: s.bar, borderRadius: 4 } }}
+      />
+    </Box>
+  );
+}

--- a/components/dashboard/v2/parts.tsx
+++ b/components/dashboard/v2/parts.tsx
@@ -74,7 +74,7 @@ export function StatBox({
 }) {
   return (
     <Box sx={{ p: 1.75, borderRadius: 3, border: "1px solid #eef2f7", bgcolor: "#fff", boxShadow: "0 1px 2px rgba(16,24,40,0.04)", position: "relative", overflow: "hidden" }}>
-      <Box sx={{ position: "absolute", top: 0, left: 0, right: 0, height: 3, background: `linear-gradient(90deg, ${accent}, #a855f7)` }} />
+      <Box sx={{ position: "absolute", top: 0, left: 0, right: 0, height: 3, bgcolor: accent }} />
       <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
         <Box sx={{ minWidth: 0 }}>
           <Typography sx={{ fontWeight: 900, fontSize: "1.5rem", color: "#0f172a", lineHeight: 1 }}>{value}</Typography>
@@ -87,10 +87,17 @@ export function StatBox({
   );
 }
 
-export function BandPill({ band }: { band: ReadinessBand }) {
+export function BandPill({ band, dark = false }: { band: ReadinessBand; dark?: boolean }) {
   const s = BAND_STYLE[band];
   return (
-    <Box component="span" sx={{ px: 0.85, py: 0.2, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: s.color, bgcolor: s.bg }}>
+    <Box
+      component="span"
+      sx={{
+        px: 0.85, py: 0.2, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800,
+        color: dark ? s.bar : s.color,
+        bgcolor: dark ? "rgba(255,255,255,0.1)" : s.bg,
+      }}
+    >
       {s.label}
     </Box>
   );
@@ -115,7 +122,7 @@ export function SignalBar({
           <Typography sx={{ fontWeight: 700, fontSize: "0.85rem", color: textColor, lineHeight: 1.2 }}>{label}</Typography>
           {sub && <Typography sx={{ fontSize: "0.66rem", color: subColor }}>{sub}</Typography>}
         </Box>
-        <BandPill band={band} />
+        <BandPill band={band} dark={dark} />
         <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: textColor, minWidth: 42, textAlign: "right" }}>
           {percent == null ? "—" : `${percent}%`}
         </Typography>

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -31,8 +31,9 @@ import {
 import { useClientInfo, useHideLeaderboardView } from "@/lib/contexts/ClientInfoContext";
 import { useAdminMode } from "@/lib/contexts/AdminModeContext";
 import Image from "next/image";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { useLeaderboardAndStreak } from "@/lib/hooks/useLeaderboardAndStreak";
+import { useStreakCelebration, primeNavStreak } from "@/lib/streak/streakCelebration";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { Settings } from "lucide-react";
 import { LanguageSelect } from "@/components/common/LanguageSelect";
@@ -75,6 +76,14 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
     leaderboardError,
     refreshStreak,
   } = useLeaderboardAndStreak();
+
+  // Nav streak number is driven by the shared celebration store so it ticks +1 exactly
+  // when the celebration animation lands. Seed it from the server value on load.
+  const streakCel = useStreakCelebration();
+  useEffect(() => {
+    if (!isStreakLoading && streak) primeNavStreak(streak.current_streak ?? 0);
+  }, [isStreakLoading, streak]);
+  const navStreak = streakCel.primed ? streakCel.navCount : streak?.current_streak ?? 0;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [leaderboardAnchorEl, setLeaderboardAnchorEl] =
@@ -857,11 +866,27 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
                   repeatDelay: 3,
                 }}
               >
-                {isStreakLoading ? "..." : streak?.current_streak || 0}
+                {isStreakLoading && !streakCel.primed ? (
+                  "..."
+                ) : (
+                  <AnimatePresence mode="popLayout" initial={false}>
+                    <motion.span
+                      key={navStreak}
+                      initial={{ y: -16, opacity: 0, scale: 1.7 }}
+                      animate={{ y: 0, opacity: 1, scale: 1 }}
+                      exit={{ y: 16, opacity: 0, position: "absolute" }}
+                      transition={{ type: "spring", stiffness: 500, damping: 22 }}
+                      style={{ display: "inline-block" }}
+                    >
+                      {navStreak}
+                    </motion.span>
+                  </AnimatePresence>
+                )}
               </motion.span>
 
               {/* Fire emoji */}
               <motion.span
+                id="nav-streak-flame"
                 style={{
                   position: "relative",
                   zIndex: 10,

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -9,9 +9,8 @@ import { Sidebar, DRAWER_WIDTH } from "./Sidebar";
 import { BottomNavigation } from "./BottomNavigation";
 import { ReactNode } from "react";
 import { useTimeTracking } from "@/hooks/useTimeTracking";
-import { useLeaderboardAndStreak } from "@/lib/hooks/useLeaderboardAndStreak";
-import { useStreakCongratulations } from "@/lib/hooks/useStreakCongratulations";
-import { StreakCongratulationsModal } from "@/components/common/StreakCongratulationsModal";
+import { reportContentCompleted } from "@/lib/streak/streakCelebration";
+import { StreakCelebrationOverlay } from "@/components/common/StreakCelebrationOverlay";
 import { ReportIssueFAB } from "@/components/common/ReportIssueFAB";
 import { useHideLeaderboardView } from "@/lib/contexts/ClientInfoContext";
 
@@ -35,28 +34,21 @@ export const MainLayout: React.FC<MainLayoutProps> = memo(({
   // Global app time tracking
   useTimeTracking();
 
-  // Streak congratulations modal (hidden when no_leaderboard_view)
+  // Streak celebration (hidden when no_leaderboard_view)
   const hideLeaderboardView = useHideLeaderboardView();
-  const { streak, isStreakLoading, refreshStreak } = useLeaderboardAndStreak();
-  const { showModal, streakCount, handleClose, triggerCheck } =
-    useStreakCongratulations(streak, isStreakLoading, refreshStreak);
 
-  // Listen for submodule completion events
+  // Any content completion (legacy or adaptive) dispatches "submodule-complete";
+  // refetch the streak and celebrate if it went up.
   useEffect(() => {
+    if (hideLeaderboardView || typeof window === "undefined") return;
     const handleSubmoduleComplete = () => {
-      triggerCheck();
+      reportContentCompleted();
     };
-
-    if (typeof window !== "undefined") {
-      window.addEventListener("submodule-complete", handleSubmoduleComplete);
-      return () => {
-        window.removeEventListener(
-          "submodule-complete",
-          handleSubmoduleComplete
-        );
-      };
-    }
-  }, [triggerCheck]);
+    window.addEventListener("submodule-complete", handleSubmoduleComplete);
+    return () => {
+      window.removeEventListener("submodule-complete", handleSubmoduleComplete);
+    };
+  }, [hideLeaderboardView]);
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
@@ -145,14 +137,8 @@ export const MainLayout: React.FC<MainLayoutProps> = memo(({
       {/* Bottom Navigation for Mobile - Hidden on full page views like submodule pages */}
       {!fullPage && <BottomNavigation />}
 
-      {/* Streak Congratulations Modal - hidden when no_leaderboard_view */}
-      {!hideLeaderboardView && (
-        <StreakCongratulationsModal
-          open={showModal}
-          onClose={handleClose}
-          streakCount={streakCount}
-        />
-      )}
+      {/* Streak celebration overlay (store-driven; hidden when no_leaderboard_view) */}
+      {!hideLeaderboardView && <StreakCelebrationOverlay />}
 
       {/* Report Issue FAB - Shows on all pages except excluded routes, only when authenticated */}
       <ReportIssueFAB />

--- a/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
+++ b/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
@@ -30,16 +30,16 @@ function HeroChip({ icon, text }: { icon: string; text: string }) {
 }
 
 function RankDeltaPill({ delta }: { delta: number }) {
-  if (delta > 0) return <Pill icon="mdi:triangle" text={`${delta}`} color="#15803d" bg="#f0fdf4" />;
-  if (delta < 0) return <Pill icon="mdi:triangle-down" text={`${Math.abs(delta)}`} color="#b91c1c" bg="#fef2f2" />;
-  return <Pill icon="mdi:minus" text="0" color="#94a3b8" bg="#f1f5f9" />;
+  if (delta > 0) return <Pill icon="mdi:triangle" text={`${delta}`} color="#15803d" bg="#f0fdf4" title={`Up ${delta} this week`} />;
+  if (delta < 0) return <Pill icon="mdi:triangle-down" text={`${Math.abs(delta)}`} color="#b91c1c" bg="#fef2f2" title={`Down ${Math.abs(delta)} this week`} />;
+  return <Pill icon="mdi:minus" color="#94a3b8" bg="#f1f5f9" title="No change this week" />;
 }
 
-function Pill({ icon, text, color, bg }: { icon: string; text: string; color: string; bg: string }) {
+function Pill({ icon, text, color, bg, title }: { icon: string; text?: string; color: string; bg: string; title?: string }) {
   return (
-    <Stack direction="row" spacing={0.3} alignItems="center" sx={{ px: 0.75, py: 0.25, borderRadius: 999, bgcolor: bg }}>
+    <Stack direction="row" spacing={0.3} alignItems="center" title={title} sx={{ px: 0.75, py: 0.25, borderRadius: 999, bgcolor: bg }}>
       <Icon icon={icon} width={9} color={color} />
-      <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, color }}>{text}</Typography>
+      {text ? <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, color }}>{text}</Typography> : null}
     </Stack>
   );
 }
@@ -63,7 +63,7 @@ function LeaderRow({ r, scoreLabel }: { r: LbRow; scoreLabel: string }) {
       </Avatar>
       <Box sx={{ minWidth: 0, flex: 1 }}>
         <Typography sx={{ fontWeight: 800, fontSize: "0.92rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-          {me ? "You" : r.name}{me && <Box component="span" sx={{ color: "#7c3aed", fontWeight: 700, ml: 0.5 }}>(you)</Box>}
+          {r.name}{me && <Box component="span" sx={{ color: "#7c3aed", fontWeight: 700, ml: 0.5 }}>(you)</Box>}
         </Typography>
         <Typography sx={{ fontSize: "0.74rem", color: "#94a3b8" }}>{scoreLabel}: {r.score.toLocaleString()}</Typography>
       </Box>

--- a/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
+++ b/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Avatar, Box, CircularProgress, Menu, MenuItem, Stack, Typography } from "@mui/material";
-import { ButtonBase } from "@mui/material";
+import { Avatar, Box, ButtonBase, CircularProgress, Menu, MenuItem, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { Reveal } from "@/components/scorecard/shared";
+import { MomentumInfo } from "@/components/common/MomentumInfo";
 import { avatarColor, RANK_BG, RANK_FG } from "@/components/dashboard/v2/parts";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { LbRow, LeaderboardPeriod, LeaderboardStreaks } from "@/lib/types/leaderboard-streaks";
@@ -12,6 +12,22 @@ import type { LbRow, LeaderboardPeriod, LeaderboardStreaks } from "@/lib/types/l
 const CARD = { borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff", boxShadow: "0 1px 2px rgba(16,24,40,0.04)" };
 const WEEKDAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
 const PERIOD_LABEL: Record<LeaderboardPeriod, string> = { week: "This week", all: "All time" };
+
+function SectionBadge({ icon, gradient }: { icon: string; gradient: string }) {
+  return (
+    <Box sx={{ width: 34, height: 34, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: gradient, boxShadow: "0 8px 18px -10px rgba(124,58,237,0.6)" }}>
+      <Icon icon={icon} width={19} />
+    </Box>
+  );
+}
+
+function HeroChip({ icon, text }: { icon: string; text: string }) {
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ px: 1.1, py: 0.5, borderRadius: 999, bgcolor: "rgba(255,255,255,0.16)", fontSize: "0.76rem", fontWeight: 700 }}>
+      <Icon icon={icon} width={14} /> {text}
+    </Stack>
+  );
+}
 
 function RankDeltaPill({ delta }: { delta: number }) {
   if (delta > 0) return <Pill icon="mdi:triangle" text={`${delta}`} color="#15803d" bg="#f0fdf4" />;
@@ -33,7 +49,11 @@ function LeaderRow({ r }: { r: LbRow }) {
   return (
     <Stack
       direction="row" alignItems="center" spacing={1.5}
-      sx={{ p: 1.25, borderRadius: 3, border: "1px solid", borderColor: me ? "#ddd6fe" : "#eef2f7", bgcolor: me ? "#f5f3ff" : "#fff" }}
+      sx={{
+        p: 1.25, borderRadius: 3, border: "1px solid", borderColor: me ? "#ddd6fe" : "#eef2f7",
+        bgcolor: me ? "#f5f3ff" : "#fff", transition: "transform .12s, box-shadow .12s, border-color .12s",
+        "&:hover": { transform: "translateX(2px)", borderColor: me ? "#c4b5fd" : "#e2e8f0", boxShadow: "0 10px 24px -18px rgba(16,24,40,0.3)" },
+      }}
     >
       <Box sx={{ width: 26, height: 26, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", fontSize: "0.78rem", fontWeight: 800, color: RANK_FG[r.rank] ?? "#64748b", bgcolor: RANK_BG[r.rank] ?? "#f1f5f9" }}>
         {r.rank}
@@ -61,7 +81,13 @@ function Calendar({ cal, bestDay }: { cal: LeaderboardStreaks["calendar"]; bestD
   return (
     <Box sx={{ ...CARD, p: 2.25 }}>
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.75 }}>
-        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a" }}>{cal.label}</Typography>
+        <Stack direction="row" spacing={1.25} alignItems="center">
+          <SectionBadge icon="mdi:calendar-month" gradient="linear-gradient(135deg, #f59e0b, #f97316)" />
+          <Box>
+            <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a", lineHeight: 1.15 }}>{cal.label}</Typography>
+            <Typography sx={{ fontSize: "0.74rem", color: "#64748b" }}>Days you showed up</Typography>
+          </Box>
+        </Stack>
         {bestDay && (
           <Stack direction="row" spacing={0.4} alignItems="center" sx={{ px: 1, py: 0.4, borderRadius: 999, bgcolor: "#f5f3ff" }}>
             <Icon icon="mdi:star-four-points" width={12} color="#7c3aed" />
@@ -102,18 +128,22 @@ function Calendar({ cal, bestDay }: { cal: LeaderboardStreaks["calendar"]; bestD
 function StreakCard({ s }: { s: LeaderboardStreaks["streak"] }) {
   return (
     <Box sx={{ borderRadius: 4, overflow: "hidden", boxShadow: "0 18px 44px -26px rgba(249,115,22,0.7)" }}>
-      <Box sx={{ p: 2.5, color: "white", background: "linear-gradient(120deg, #f59e0b 0%, #f97316 60%, #ea580c 100%)" }}>
+      <Box sx={{ p: 2.5, color: "white", position: "relative", overflow: "hidden", background: "radial-gradient(120% 120% at 100% 0%, rgba(251,191,36,0.5) 0%, rgba(249,115,22,0) 55%), linear-gradient(120deg, #f97316 0%, #ea580c 60%, #c2410c 100%)" }}>
         <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
           <Box>
-            <Typography sx={{ fontSize: "0.78rem", fontWeight: 700, color: "rgba(255,255,255,0.85)" }}>Current streak</Typography>
+            <Typography sx={{ fontSize: "0.78rem", fontWeight: 700, color: "rgba(255,255,255,0.92)" }}>Current streak</Typography>
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
               <Typography sx={{ fontSize: "2.4rem" }}>🔥</Typography>
               <Typography sx={{ fontWeight: 900, fontSize: "2.4rem", lineHeight: 1 }}>{s.current} <Box component="span" sx={{ fontSize: "1.2rem", fontWeight: 700 }}>days</Box></Typography>
             </Stack>
+            <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "rgba(255,255,255,0.85)", mt: 0.75 }}>Personal best: {s.longest} days</Typography>
           </Box>
           <Box sx={{ textAlign: "right" }}>
-            <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "rgba(255,255,255,0.85)" }}>AI momentum score</Typography>
-            <Typography sx={{ fontWeight: 900, fontSize: "1.8rem", lineHeight: 1.1 }}>{s.momentum}<Box component="span" sx={{ fontSize: "0.95rem", fontWeight: 700, color: "rgba(255,255,255,0.8)" }}>/100</Box></Typography>
+            <Stack direction="row" spacing={0.25} alignItems="center" justifyContent="flex-end">
+              <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#fff" }}>AI momentum score</Typography>
+              <MomentumInfo info={s.momentumInfo} size={14} color="#ffffff" />
+            </Stack>
+            <Typography sx={{ fontWeight: 900, fontSize: "1.8rem", lineHeight: 1.1 }}>{s.momentum}<Box component="span" sx={{ fontSize: "0.95rem", fontWeight: 700, color: "rgba(255,255,255,0.85)" }}>/100</Box></Typography>
           </Box>
         </Stack>
       </Box>
@@ -154,20 +184,37 @@ export function LeaderboardStreaksContent() {
     return () => { cancelled = true; };
   }, [period]);
 
+  const me = data?.leaderboard.me;
+
   return (
     <Box>
-      {/* Header */}
-      <Stack direction="row" spacing={1.75} alignItems="flex-start" sx={{ mb: 3 }}>
-        <Box sx={{ width: 48, height: 48, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7, #c026d3)", boxShadow: "0 12px 26px -12px rgba(124,58,237,0.6)" }}>
-          <Icon icon="mdi:star-four-points" width={24} />
+      {/* Hero */}
+      <Reveal>
+        <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 3, color: "white", position: "relative", overflow: "hidden", background: "radial-gradient(110% 130% at 90% -10%, rgba(236,72,153,0.45) 0%, rgba(124,58,237,0) 55%), linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -30px rgba(124,58,237,0.7)" }}>
+          <Stack direction="row" spacing={1.75} alignItems="flex-start">
+            <Box sx={{ width: 52, height: 52, borderRadius: 3, flexShrink: 0, display: "grid", placeItems: "center", bgcolor: "rgba(255,255,255,0.16)", border: "1px solid rgba(255,255,255,0.25)" }}>
+              <Icon icon="mdi:trophy-variant" width={28} />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.6rem", md: "2.1rem" }, lineHeight: 1.1 }}>Leaderboard &amp; Streaks</Typography>
+                <Box sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: "#7c3aed", bgcolor: "white" }}>AI INSIGHT</Box>
+              </Stack>
+              <Typography sx={{ fontSize: "0.92rem", color: "rgba(255,255,255,0.88)", mt: 1, maxWidth: 720, lineHeight: 1.55 }}>
+                Not just rankings — how to climb, and how to keep your momentum.
+              </Typography>
+              {data && (
+                <Stack direction="row" gap={1} flexWrap="wrap" sx={{ mt: 1.75 }}>
+                  {me && <HeroChip icon="mdi:trophy" text={`Rank #${me.rank} · Top ${me.percentile}%`} />}
+                  <HeroChip icon="mdi:fire" text={`${data.streak.current}-day streak`} />
+                  <HeroChip icon="mdi:chart-line-variant" text={`Momentum ${data.streak.momentum}/100`} />
+                  <HeroChip icon="mdi:account-group" text={`${data.leaderboard.total} in cohort`} />
+                </Stack>
+              )}
+            </Box>
+          </Stack>
         </Box>
-        <Box>
-          <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.5rem", md: "1.9rem" }, color: "#0f172a", lineHeight: 1.1 }}>Leaderboard &amp; Streaks</Typography>
-          <Typography sx={{ fontSize: "0.9rem", color: "#64748b", mt: 0.5, maxWidth: 720, lineHeight: 1.5 }}>
-            Now with AI insight — not just rankings, but how to climb and how to keep your momentum.
-          </Typography>
-        </Box>
-      </Stack>
+      </Reveal>
 
       {loading && !data ? (
         <Box sx={{ display: "grid", placeItems: "center", py: 12 }}><CircularProgress sx={{ color: "#7c3aed" }} /></Box>
@@ -180,12 +227,13 @@ export function LeaderboardStreaksContent() {
             <Box sx={{ ...CARD, p: 2.5, opacity: loading ? 0.6 : 1, transition: "opacity .2s" }}>
               <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.75 }}>
                 <Stack direction="row" spacing={1.25} alignItems="center">
-                  <Box sx={{ width: 34, height: 34, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
-                    <Icon icon="mdi:trophy" width={19} />
+                  <SectionBadge icon="mdi:trophy" gradient="linear-gradient(135deg, #f59e0b, #f97316)" />
+                  <Box>
+                    <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#0f172a", lineHeight: 1.15 }}>Leaderboard</Typography>
+                    <Typography sx={{ fontSize: "0.74rem", color: "#64748b" }}>Where you stand in your cohort</Typography>
                   </Box>
-                  <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#0f172a" }}>Leaderboard</Typography>
                 </Stack>
-                <ButtonBase onClick={(e) => setMenuEl(e.currentTarget)} sx={{ px: 1.25, py: 0.6, borderRadius: 999, border: "1px solid #e2e8f0", fontSize: "0.8rem", fontWeight: 700, color: "#475569", gap: 0.4 }}>
+                <ButtonBase onClick={(e) => setMenuEl(e.currentTarget)} sx={{ px: 1.25, py: 0.6, borderRadius: 999, border: "1px solid #e2e8f0", fontSize: "0.8rem", fontWeight: 700, color: "#475569", gap: 0.4, "&:hover": { borderColor: "#c4b5fd", color: "#6d28d9" } }}>
                   {PERIOD_LABEL[data.period]} <Icon icon="mdi:chevron-down" width={16} />
                 </ButtonBase>
                 <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={() => setMenuEl(null)}>
@@ -198,7 +246,7 @@ export function LeaderboardStreaksContent() {
               </Stack>
 
               {data.leaderboard.climbText && (
-                <Stack direction="row" spacing={0.75} alignItems="flex-start" sx={{ mb: 1.75, p: 1.5, borderRadius: 3, background: "linear-gradient(120deg, #f5f3ff, #fdf2f8)" }}>
+                <Stack direction="row" spacing={0.75} alignItems="flex-start" sx={{ mb: 1.75, p: 1.5, borderRadius: 3, background: "linear-gradient(120deg, #f5f3ff, #fdf2f8)", border: "1px solid #f1ebff" }}>
                   <Icon icon="mdi:star-four-points" width={15} color="#7c3aed" style={{ flexShrink: 0, marginTop: 2 }} />
                   <Typography sx={{ fontSize: "0.82rem", color: "#475569", lineHeight: 1.5 }}>
                     <Box component="span" sx={{ fontWeight: 800, color: "#6d28d9" }}>AI climb plan: </Box>{data.leaderboard.climbText}

--- a/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
+++ b/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
@@ -44,7 +44,7 @@ function Pill({ icon, text, color, bg }: { icon: string; text: string; color: st
   );
 }
 
-function LeaderRow({ r }: { r: LbRow }) {
+function LeaderRow({ r, scoreLabel }: { r: LbRow; scoreLabel: string }) {
   const me = r.is_current_user;
   return (
     <Stack
@@ -65,7 +65,7 @@ function LeaderRow({ r }: { r: LbRow }) {
         <Typography sx={{ fontWeight: 800, fontSize: "0.92rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {me ? "You" : r.name}{me && <Box component="span" sx={{ color: "#7c3aed", fontWeight: 700, ml: 0.5 }}>(you)</Box>}
         </Typography>
-        <Typography sx={{ fontSize: "0.74rem", color: "#94a3b8" }}>Score: {r.score.toLocaleString()}</Typography>
+        <Typography sx={{ fontSize: "0.74rem", color: "#94a3b8" }}>{scoreLabel}: {r.score.toLocaleString()}</Typography>
       </Box>
       <RankDeltaPill delta={r.rankDelta} />
       <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#7c3aed", minWidth: 34, textAlign: "right" }}>#{r.rank}</Typography>
@@ -170,7 +170,10 @@ function StreakCard({ s }: { s: LeaderboardStreaks["streak"] }) {
 export function LeaderboardStreaksContent() {
   const [data, setData] = useState<LeaderboardStreaks | null>(null);
   const [loading, setLoading] = useState(true);
-  const [period, setPeriod] = useState<LeaderboardPeriod>("week");
+  // Default to all-time so the headline score matches the dashboard's total. "This week"
+  // is an explicit lens that shows this-week points (labelled, so a small/0 value reads
+  // as "0 this week", not a bug).
+  const [period, setPeriod] = useState<LeaderboardPeriod>("all");
   const [menuEl, setMenuEl] = useState<HTMLElement | null>(null);
 
   // State is only set in the async callbacks (never synchronously in the effect body);
@@ -258,7 +261,9 @@ export function LeaderboardStreaksContent() {
                 <Typography sx={{ color: "#94a3b8", textAlign: "center", py: 4, fontSize: "0.85rem" }}>No leaderboard activity yet — earn some points to appear here.</Typography>
               ) : (
                 <Stack spacing={1}>
-                  {data.leaderboard.rows.map((r) => <LeaderRow key={r.rank + r.name} r={r} />)}
+                  {data.leaderboard.rows.map((r) => (
+                    <LeaderRow key={r.rank + r.name} r={r} scoreLabel={data.period === "week" ? "This week" : "Score"} />
+                  ))}
                 </Stack>
               )}
             </Box>

--- a/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
+++ b/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Avatar, Box, CircularProgress, Menu, MenuItem, Stack, Typography } from "@mui/material";
+import { ButtonBase } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { Reveal } from "@/components/scorecard/shared";
+import { avatarColor, RANK_BG, RANK_FG } from "@/components/dashboard/v2/parts";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type { LbRow, LeaderboardPeriod, LeaderboardStreaks } from "@/lib/types/leaderboard-streaks";
+
+const CARD = { borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff", boxShadow: "0 1px 2px rgba(16,24,40,0.04)" };
+const WEEKDAYS = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"];
+const PERIOD_LABEL: Record<LeaderboardPeriod, string> = { week: "This week", all: "All time" };
+
+function RankDeltaPill({ delta }: { delta: number }) {
+  if (delta > 0) return <Pill icon="mdi:triangle" text={`${delta}`} color="#15803d" bg="#f0fdf4" />;
+  if (delta < 0) return <Pill icon="mdi:triangle-down" text={`${Math.abs(delta)}`} color="#b91c1c" bg="#fef2f2" />;
+  return <Pill icon="mdi:minus" text="0" color="#94a3b8" bg="#f1f5f9" />;
+}
+
+function Pill({ icon, text, color, bg }: { icon: string; text: string; color: string; bg: string }) {
+  return (
+    <Stack direction="row" spacing={0.3} alignItems="center" sx={{ px: 0.75, py: 0.25, borderRadius: 999, bgcolor: bg }}>
+      <Icon icon={icon} width={9} color={color} />
+      <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, color }}>{text}</Typography>
+    </Stack>
+  );
+}
+
+function LeaderRow({ r }: { r: LbRow }) {
+  const me = r.is_current_user;
+  return (
+    <Stack
+      direction="row" alignItems="center" spacing={1.5}
+      sx={{ p: 1.25, borderRadius: 3, border: "1px solid", borderColor: me ? "#ddd6fe" : "#eef2f7", bgcolor: me ? "#f5f3ff" : "#fff" }}
+    >
+      <Box sx={{ width: 26, height: 26, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", fontSize: "0.78rem", fontWeight: 800, color: RANK_FG[r.rank] ?? "#64748b", bgcolor: RANK_BG[r.rank] ?? "#f1f5f9" }}>
+        {r.rank}
+      </Box>
+      <Avatar src={r.profile_pic_url ?? undefined} sx={{ width: 38, height: 38, fontSize: "0.95rem", fontWeight: 800, bgcolor: avatarColor(r.name) }}>
+        {r.name.charAt(0).toUpperCase()}
+      </Avatar>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.92rem", color: "#0f172a", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {me ? "You" : r.name}{me && <Box component="span" sx={{ color: "#7c3aed", fontWeight: 700, ml: 0.5 }}>(you)</Box>}
+        </Typography>
+        <Typography sx={{ fontSize: "0.74rem", color: "#94a3b8" }}>Score: {r.score.toLocaleString()}</Typography>
+      </Box>
+      <RankDeltaPill delta={r.rankDelta} />
+      <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#7c3aed", minWidth: 34, textAlign: "right" }}>#{r.rank}</Typography>
+    </Stack>
+  );
+}
+
+function Calendar({ cal, bestDay }: { cal: LeaderboardStreaks["calendar"]; bestDay: string | null }) {
+  const cells: ({ day: number; active: boolean } | null)[] = [
+    ...Array.from({ length: cal.firstWeekday }, () => null),
+    ...cal.days,
+  ];
+  return (
+    <Box sx={{ ...CARD, p: 2.25 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.75 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a" }}>{cal.label}</Typography>
+        {bestDay && (
+          <Stack direction="row" spacing={0.4} alignItems="center" sx={{ px: 1, py: 0.4, borderRadius: 999, bgcolor: "#f5f3ff" }}>
+            <Icon icon="mdi:star-four-points" width={12} color="#7c3aed" />
+            <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "#6d28d9" }}>Best day: {bestDay}</Typography>
+          </Stack>
+        )}
+      </Stack>
+      <Box sx={{ display: "grid", gridTemplateColumns: "repeat(7,1fr)", gap: 0.75 }}>
+        {WEEKDAYS.map((d) => (
+          <Typography key={d} sx={{ textAlign: "center", fontSize: "0.72rem", fontWeight: 700, color: "#94a3b8", mb: 0.5 }}>{d}</Typography>
+        ))}
+        {cells.map((c, i) => {
+          if (!c) return <Box key={`e${i}`} />;
+          const today = c.day === cal.todayDay;
+          return (
+            <Box
+              key={c.day}
+              sx={{
+                aspectRatio: "1", borderRadius: 2.5, display: "grid", placeItems: "center",
+                fontSize: "0.85rem", fontWeight: c.active ? 800 : 600,
+                color: c.active ? "white" : "#94a3b8",
+                background: c.active ? "linear-gradient(155deg, #fbbf24, #f97316)" : "transparent",
+                boxShadow: c.active ? "0 6px 14px -8px rgba(249,115,22,0.7)" : "none",
+                border: today && !c.active ? "2px solid #f97316" : "none",
+                outline: today && c.active ? "2px solid #c2410c" : "none",
+                outlineOffset: today && c.active ? "1px" : 0,
+              }}
+            >
+              {c.day}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+function StreakCard({ s }: { s: LeaderboardStreaks["streak"] }) {
+  return (
+    <Box sx={{ borderRadius: 4, overflow: "hidden", boxShadow: "0 18px 44px -26px rgba(249,115,22,0.7)" }}>
+      <Box sx={{ p: 2.5, color: "white", background: "linear-gradient(120deg, #f59e0b 0%, #f97316 60%, #ea580c 100%)" }}>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+          <Box>
+            <Typography sx={{ fontSize: "0.78rem", fontWeight: 700, color: "rgba(255,255,255,0.85)" }}>Current streak</Typography>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.5 }}>
+              <Typography sx={{ fontSize: "2.4rem" }}>🔥</Typography>
+              <Typography sx={{ fontWeight: 900, fontSize: "2.4rem", lineHeight: 1 }}>{s.current} <Box component="span" sx={{ fontSize: "1.2rem", fontWeight: 700 }}>days</Box></Typography>
+            </Stack>
+          </Box>
+          <Box sx={{ textAlign: "right" }}>
+            <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color: "rgba(255,255,255,0.85)" }}>AI momentum score</Typography>
+            <Typography sx={{ fontWeight: 900, fontSize: "1.8rem", lineHeight: 1.1 }}>{s.momentum}<Box component="span" sx={{ fontSize: "0.95rem", fontWeight: 700, color: "rgba(255,255,255,0.8)" }}>/100</Box></Typography>
+          </Box>
+        </Stack>
+      </Box>
+      <Box sx={{ p: 2, bgcolor: "#fff", border: "1px solid #eef2f7", borderTop: "none", borderRadius: "0 0 16px 16px" }}>
+        <Stack direction="row" spacing={0.75} alignItems="flex-start">
+          <Icon icon="mdi:star-four-points" width={15} color="#7c3aed" style={{ flexShrink: 0, marginTop: 2 }} />
+          <Typography sx={{ fontSize: "0.82rem", color: "#475569", lineHeight: 1.5 }}>
+            <Box component="span" sx={{ fontWeight: 800, color: "#6d28d9" }}>AI forecast: </Box>{s.forecast}
+          </Typography>
+        </Stack>
+        {s.atRisk && (
+          <Stack direction="row" spacing={0.75} alignItems="flex-start" sx={{ mt: 1.25, p: 1.25, borderRadius: 2.5, bgcolor: "#fffbeb", border: "1px solid #fde68a" }}>
+            <Icon icon="mdi:alarm" width={16} color="#b45309" style={{ flexShrink: 0, marginTop: 1 }} />
+            <Typography sx={{ fontSize: "0.8rem", color: "#92400e", lineHeight: 1.5 }}>
+              <Box component="span" sx={{ fontWeight: 800 }}>Streak at risk. </Box>{s.atRiskTip}
+            </Typography>
+          </Stack>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export function LeaderboardStreaksContent() {
+  const [data, setData] = useState<LeaderboardStreaks | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState<LeaderboardPeriod>("week");
+  const [menuEl, setMenuEl] = useState<HTMLElement | null>(null);
+
+  // State is only set in the async callbacks (never synchronously in the effect body);
+  // the period-change spinner is armed in the menu handler instead.
+  useEffect(() => {
+    let cancelled = false;
+    adaptiveJourneyService.getLeaderboardStreaks(period)
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch(() => { if (!cancelled) setData(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [period]);
+
+  return (
+    <Box>
+      {/* Header */}
+      <Stack direction="row" spacing={1.75} alignItems="flex-start" sx={{ mb: 3 }}>
+        <Box sx={{ width: 48, height: 48, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7, #c026d3)", boxShadow: "0 12px 26px -12px rgba(124,58,237,0.6)" }}>
+          <Icon icon="mdi:star-four-points" width={24} />
+        </Box>
+        <Box>
+          <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.5rem", md: "1.9rem" }, color: "#0f172a", lineHeight: 1.1 }}>Leaderboard &amp; Streaks</Typography>
+          <Typography sx={{ fontSize: "0.9rem", color: "#64748b", mt: 0.5, maxWidth: 720, lineHeight: 1.5 }}>
+            Now with AI insight — not just rankings, but how to climb and how to keep your momentum.
+          </Typography>
+        </Box>
+      </Stack>
+
+      {loading && !data ? (
+        <Box sx={{ display: "grid", placeItems: "center", py: 12 }}><CircularProgress sx={{ color: "#7c3aed" }} /></Box>
+      ) : !data ? (
+        <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center", fontWeight: 600 }}>Couldn&apos;t load leaderboard &amp; streaks.</Typography>
+      ) : (
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 1fr" }, gap: 2.5, alignItems: "start" }}>
+          {/* Leaderboard */}
+          <Reveal>
+            <Box sx={{ ...CARD, p: 2.5, opacity: loading ? 0.6 : 1, transition: "opacity .2s" }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.75 }}>
+                <Stack direction="row" spacing={1.25} alignItems="center">
+                  <Box sx={{ width: 34, height: 34, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #f59e0b, #f97316)" }}>
+                    <Icon icon="mdi:trophy" width={19} />
+                  </Box>
+                  <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#0f172a" }}>Leaderboard</Typography>
+                </Stack>
+                <ButtonBase onClick={(e) => setMenuEl(e.currentTarget)} sx={{ px: 1.25, py: 0.6, borderRadius: 999, border: "1px solid #e2e8f0", fontSize: "0.8rem", fontWeight: 700, color: "#475569", gap: 0.4 }}>
+                  {PERIOD_LABEL[data.period]} <Icon icon="mdi:chevron-down" width={16} />
+                </ButtonBase>
+                <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={() => setMenuEl(null)}>
+                  {(["week", "all"] as LeaderboardPeriod[]).map((p) => (
+                    <MenuItem key={p} selected={p === period} onClick={() => { if (p !== period) setLoading(true); setPeriod(p); setMenuEl(null); }} sx={{ fontSize: "0.85rem" }}>
+                      {PERIOD_LABEL[p]}
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </Stack>
+
+              {data.leaderboard.climbText && (
+                <Stack direction="row" spacing={0.75} alignItems="flex-start" sx={{ mb: 1.75, p: 1.5, borderRadius: 3, background: "linear-gradient(120deg, #f5f3ff, #fdf2f8)" }}>
+                  <Icon icon="mdi:star-four-points" width={15} color="#7c3aed" style={{ flexShrink: 0, marginTop: 2 }} />
+                  <Typography sx={{ fontSize: "0.82rem", color: "#475569", lineHeight: 1.5 }}>
+                    <Box component="span" sx={{ fontWeight: 800, color: "#6d28d9" }}>AI climb plan: </Box>{data.leaderboard.climbText}
+                  </Typography>
+                </Stack>
+              )}
+
+              {data.leaderboard.rows.length === 0 ? (
+                <Typography sx={{ color: "#94a3b8", textAlign: "center", py: 4, fontSize: "0.85rem" }}>No leaderboard activity yet — earn some points to appear here.</Typography>
+              ) : (
+                <Stack spacing={1}>
+                  {data.leaderboard.rows.map((r) => <LeaderRow key={r.rank + r.name} r={r} />)}
+                </Stack>
+              )}
+            </Box>
+          </Reveal>
+
+          {/* Streak + calendar */}
+          <Stack spacing={2.5}>
+            <Reveal><StreakCard s={data.streak} /></Reveal>
+            <Reveal><Calendar cal={data.calendar} bestDay={data.streak.bestDay} /></Reveal>
+          </Stack>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
+++ b/components/leaderboard-streaks/LeaderboardStreaksContent.tsx
@@ -67,7 +67,9 @@ function LeaderRow({ r, scoreLabel }: { r: LbRow; scoreLabel: string }) {
         </Typography>
         <Typography sx={{ fontSize: "0.74rem", color: "#94a3b8" }}>{scoreLabel}: {r.score.toLocaleString()}</Typography>
       </Box>
-      <RankDeltaPill delta={r.rankDelta} />
+      <Box sx={{ minWidth: 58, display: "flex", justifyContent: "flex-end" }}>
+        <RankDeltaPill delta={r.rankDelta} />
+      </Box>
       <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#7c3aed", minWidth: 34, textAlign: "right" }}>#{r.rank}</Typography>
     </Stack>
   );
@@ -260,11 +262,23 @@ export function LeaderboardStreaksContent() {
               {data.leaderboard.rows.length === 0 ? (
                 <Typography sx={{ color: "#94a3b8", textAlign: "center", py: 4, fontSize: "0.85rem" }}>No leaderboard activity yet — earn some points to appear here.</Typography>
               ) : (
-                <Stack spacing={1}>
-                  {data.leaderboard.rows.map((r) => (
-                    <LeaderRow key={r.rank + r.name} r={r} scoreLabel={data.period === "week" ? "This week" : "Score"} />
-                  ))}
-                </Stack>
+                <>
+                  {/* Column labels so the ▲/▼ pill reads as "rank change this week", not points. */}
+                  <Stack direction="row" alignItems="center" spacing={1.5} sx={{ px: 1.25, mb: 0.75 }}>
+                    <Box sx={{ flex: 1 }} />
+                    <Typography sx={{ minWidth: 58, textAlign: "right", whiteSpace: "nowrap", fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.4, textTransform: "uppercase", color: "#94a3b8" }}>This wk</Typography>
+                    <Typography sx={{ minWidth: 34, textAlign: "right", fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.4, textTransform: "uppercase", color: "#94a3b8" }}>Rank</Typography>
+                  </Stack>
+                  <Stack spacing={1}>
+                    {data.leaderboard.rows.map((r) => (
+                      <LeaderRow key={r.rank + r.name} r={r} scoreLabel={data.period === "week" ? "This week" : "Score"} />
+                    ))}
+                  </Stack>
+                  <Typography sx={{ mt: 1.25, fontSize: "0.72rem", color: "#94a3b8", lineHeight: 1.5 }}>
+                    <Box component="span" sx={{ fontWeight: 800, color: "#15803d" }}>▲</Box> /{" "}
+                    <Box component="span" sx={{ fontWeight: 800, color: "#b91c1c" }}>▼</Box> show places moved this week; <b>–</b> means no change. Score is your total points.
+                  </Typography>
+                </>
               )}
             </Box>
           </Reveal>

--- a/components/points-system/PointsSystemContent.tsx
+++ b/components/points-system/PointsSystemContent.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import type { DecaySpec, PointsSystem } from "@/lib/types/points-system";
+
+const fmtSecs = (s: number) => (s < 120 ? `${s}s` : `${Math.round(s / 60)} min`);
+const fmtTick = (s: number) => (s < 60 ? `${s}s` : `${Math.round(s / 60)}m`);
+
+function SectionLabel({ n, text }: { n: number; text: string }) {
+  return (
+    <Typography sx={{ fontSize: "0.72rem", fontWeight: 800, letterSpacing: 0.8, color: "#94a3b8", textTransform: "uppercase", mb: 1.5 }}>
+      {n} · {text}
+    </Typography>
+  );
+}
+
+function DecayChart({ spec }: { spec: DecaySpec }) {
+  const W = 480, H = 150, padL = 30, padB = 22, padT = 10, padR = 10;
+  const innerW = W - padL - padR, innerH = H - padT - padB;
+  const x = (t: number) => padL + (t / spec.tMax) * innerW;
+  const y = (p: number) => padT + (1 - p / spec.base) * innerH;
+  const line = spec.curve.map((c, i) => `${i === 0 ? "M" : "L"} ${x(c.t).toFixed(1)} ${y(c.pts).toFixed(1)}`).join(" ");
+  const area = `${line} L ${x(spec.tMax).toFixed(1)} ${y(0).toFixed(1)} L ${x(0).toFixed(1)} ${y(0).toFixed(1)} Z`;
+  const ticks = [0, Math.round(spec.tMax / 2), spec.tMax];
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" style={{ display: "block" }}>
+      <defs>
+        <linearGradient id={`fill-${spec.title}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#a855f7" stopOpacity={0.28} />
+          <stop offset="100%" stopColor="#a855f7" stopOpacity={0.02} />
+        </linearGradient>
+      </defs>
+      {/* grace (full-credit) band */}
+      <rect x={padL} y={padT} width={x(spec.grace) - padL} height={innerH} fill="#22c55e" opacity={0.1} />
+      <text x={x(spec.grace / 2)} y={padT + 14} textAnchor="middle" fontSize="9" fontWeight="700" fill="#16a34a">full</text>
+      {/* y labels */}
+      {[spec.base, Math.round(spec.base / 2), 0].map((p) => (
+        <text key={p} x={padL - 6} y={y(p) + 3} textAnchor="end" fontSize="9" fill="#94a3b8">{p}</text>
+      ))}
+      {/* x labels */}
+      {ticks.map((t) => (
+        <text key={t} x={x(t)} y={H - 6} textAnchor="middle" fontSize="9" fill="#94a3b8">{fmtTick(t)}</text>
+      ))}
+      <path d={area} fill={`url(#fill-${spec.title})`} />
+      <path d={line} fill="none" stroke="#7c3aed" strokeWidth={2.5} strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ChartCard({ spec }: { spec: DecaySpec }) {
+  return (
+    <Box sx={{ p: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="baseline" sx={{ mb: 1 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#0f172a" }}>{spec.title} · {spec.base} pts</Typography>
+        <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8" }}>grace {fmtSecs(spec.grace)}, then −{spec.dec} / {spec.iv}s</Typography>
+      </Stack>
+      <DecayChart spec={spec} />
+      <Typography sx={{ fontSize: "0.76rem", color: "#64748b", mt: 1, lineHeight: 1.5 }}>
+        Full <b>{spec.base}</b> for the first {fmtSecs(spec.grace)}; then −{spec.dec} every {spec.iv}s, down to a <b>{spec.floor}</b> floor.
+      </Typography>
+    </Box>
+  );
+}
+
+const DIFF_STYLE: Record<string, { color: string; bg: string }> = {
+  Easy: { color: "#15803d", bg: "#f0fdf4" },
+  Medium: { color: "#b45309", bg: "#fffbeb" },
+  Hard: { color: "#b91c1c", bg: "#fef2f2" },
+};
+const LATE_STYLE = [
+  { color: "#15803d", bg: "#f0fdf4", border: "#bbf7d0" },
+  { color: "#b45309", bg: "#fffbeb", border: "#fde68a" },
+  { color: "#b91c1c", bg: "#fef2f2", border: "#fecaca" },
+];
+
+export function PointsSystemContent() {
+  const [data, setData] = useState<PointsSystem | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    adaptiveJourneyService.getPointsSystem()
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) return <Box sx={{ display: "grid", placeItems: "center", py: 12 }}><CircularProgress sx={{ color: "#7c3aed" }} /></Box>;
+  if (!data) return <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center", fontWeight: 600 }}>Couldn&apos;t load the points system.</Typography>;
+
+  const wkExampleDay = (n: number) => (n - 1) * data.late.staggerDays + 1;
+
+  return (
+    <Box>
+      {/* Header */}
+      <Stack direction="row" spacing={1.5} alignItems="flex-start" sx={{ mb: 3 }}>
+        <Box sx={{ width: 48, height: 48, borderRadius: 3, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7)", boxShadow: "0 12px 26px -12px rgba(124,58,237,0.6)" }}>
+          <Icon icon="mdi:star-four-points" width={26} />
+        </Box>
+        <Box>
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+            <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.5rem", md: "1.9rem" }, color: "#0f172a", lineHeight: 1.1 }}>{data.title}</Typography>
+            <Box sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7)" }}>UNIFIED</Box>
+          </Stack>
+          <Typography sx={{ fontSize: "0.9rem", color: "#64748b", mt: 0.5, maxWidth: 760, lineHeight: 1.5 }}>{data.subtitle}</Typography>
+        </Box>
+      </Stack>
+
+      {/* 1 · Points by activity */}
+      <SectionLabel n={1} text="Points by activity" />
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2,1fr)", lg: "repeat(4,1fr)" }, gap: 1.5, mb: 4 }}>
+        {data.activities.map((a) => (
+          <Stack key={a.key} direction="row" alignItems="center" spacing={1.25} sx={{ p: 1.75, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
+            <Box sx={{ width: 38, height: 38, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center", color: a.accent, bgcolor: `${a.accent}1a` }}>
+              <Icon icon={a.icon} width={20} />
+            </Box>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography sx={{ fontWeight: 800, fontSize: "0.86rem", color: "#0f172a", lineHeight: 1.2 }}>{a.label}</Typography>
+              <Typography sx={{ fontSize: "0.7rem", color: "#94a3b8" }}>{a.sub}</Typography>
+            </Box>
+            <Box sx={{ textAlign: "right", flexShrink: 0 }}>
+              <Typography component="span" sx={{ fontWeight: 900, fontSize: "1.05rem", color: a.accent }}>{a.points}</Typography>
+              <Typography component="span" sx={{ fontSize: "0.66rem", color: "#94a3b8", ml: 0.3 }}>{a.unit}</Typography>
+            </Box>
+          </Stack>
+        ))}
+      </Box>
+
+      {/* 2 · Time-decay */}
+      <SectionLabel n={2} text="Time-decay — answer well & quickly to keep more" />
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr 340px" }, gap: 1.5, mb: 4 }}>
+        <ChartCard spec={data.decay.quizEasy} />
+        <ChartCard spec={data.decay.codingHard} />
+        <Box sx={{ p: 2.25, borderRadius: 4, color: "#fff", backgroundColor: "#0f0a28", backgroundImage: "linear-gradient(160deg, #1a1442, #0f0a28)" }}>
+          <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "rgba(255,255,255,0.6)", mb: 1 }}>THE FORMULA</Typography>
+          <Box sx={{ p: 1.5, borderRadius: 2, bgcolor: "rgba(0,0,0,0.35)", fontFamily: "monospace", fontSize: "0.8rem", color: "#c4b5fd", lineHeight: 1.6, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+            {data.formula}
+          </Box>
+          <Typography sx={{ fontSize: "0.74rem", color: "rgba(255,255,255,0.65)", mt: 1.5, lineHeight: 1.55 }}>{data.formulaNote}</Typography>
+        </Box>
+      </Box>
+
+      {/* 3 + 4 side by side */}
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" }, gap: 2, mb: 4 }}>
+        {/* 3 · Difficulty multiplier */}
+        <Box sx={{ p: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
+          <SectionLabel n={3} text="Difficulty multiplier" />
+          <Stack spacing={1}>
+            {data.difficulty.map((d) => {
+              const s = DIFF_STYLE[d.label] ?? DIFF_STYLE.Medium;
+              return (
+                <Stack key={d.label} direction="row" alignItems="center" spacing={2} sx={{ p: 1.25, borderRadius: 2.5, bgcolor: s.bg }}>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.86rem", color: s.color, minWidth: 64 }}>{d.label}</Typography>
+                  <Typography sx={{ fontWeight: 900, fontSize: "0.95rem", color: s.color, minWidth: 48 }}>×{d.mult.toFixed(1)}</Typography>
+                  <Typography sx={{ fontSize: "0.8rem", color: "#475569" }}>Quiz <b>{d.quiz}</b> · Coding <b>{d.coding}</b></Typography>
+                </Stack>
+              );
+            })}
+          </Stack>
+          <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f5f3ff" }}>
+            <Icon icon="mdi:star-four-points" width={13} color="#6d28d9" style={{ flexShrink: 0, marginTop: 2 }} />
+            <Typography sx={{ fontSize: "0.74rem", color: "#6d28d9", fontWeight: 600, lineHeight: 1.45 }}>
+              The AI serves difficulty matched to your level — so the points you earn reflect real stretch, not farming easy items.
+            </Typography>
+          </Stack>
+        </Box>
+
+        {/* 4 · Weekly late penalty */}
+        <Box sx={{ p: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
+          <SectionLabel n={4} text="Weekly late penalty" />
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+            {data.late.bands.map((b, i) => {
+              const s = LATE_STYLE[i] ?? LATE_STYLE[0];
+              return (
+                <Box key={b.label} sx={{ flex: 1, p: 1.5, borderRadius: 2.5, bgcolor: s.bg, border: `1px solid ${s.border}` }}>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", color: "#0f172a" }}>{b.label}</Typography>
+                  <Typography sx={{ fontSize: "0.66rem", color: "#94a3b8" }}>{b.note}</Typography>
+                  <Typography sx={{ fontWeight: 900, fontSize: "1.4rem", color: s.color, mt: 0.5 }}>×{b.mult.toFixed(1)}</Typography>
+                  <Typography sx={{ fontSize: "0.7rem", color: s.color, fontWeight: 700 }}>{b.caption}</Typography>
+                </Box>
+              );
+            })}
+          </Stack>
+          <Box sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f8fafc" }}>
+            <Typography sx={{ fontSize: "0.74rem", color: "#475569", lineHeight: 1.5 }}>
+              <b>Per-week windows.</b> Admin sets a course start date; week N opens on day{" "}
+              <b>(N−1)×{data.late.staggerDays} + 1</b> with a {data.late.windowDays}-day window. e.g. Week 4 →
+              days {wkExampleDay(4)}–{wkExampleDay(4) + data.late.windowDays - 1}. The multiplier hits the points you earn that week.
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Worked example */}
+      <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, color: "white", background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -30px rgba(124,58,237,0.6)" }}>
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "300px 1fr" }, gap: { xs: 2.5, md: 4 }, alignItems: "center" }}>
+          <Box>
+            <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "rgba(255,255,255,0.7)" }}>WORKED EXAMPLE · ONE WEEK</Typography>
+            <Typography sx={{ fontSize: "0.92rem", color: "rgba(255,255,255,0.92)", mt: 1, lineHeight: 1.55 }}>{data.workedExample.summary}</Typography>
+          </Box>
+          <Box>
+            <Stack spacing={0.5}>
+              {data.workedExample.rows.map((r) => (
+                <Stack key={r.label} direction="row" alignItems="center" spacing={1.5} sx={{ py: 0.85, borderBottom: "1px solid rgba(255,255,255,0.12)" }}>
+                  <Typography sx={{ flex: 1, minWidth: 0, fontSize: "0.84rem", color: "rgba(255,255,255,0.9)" }}>{r.label}</Typography>
+                  {r.late ? (
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>
+                      <Box component="span" sx={{ color: "rgba(255,255,255,0.5)", textDecoration: "line-through", mr: 0.75 }}>{r.raw}</Box>
+                      {r.final}
+                    </Typography>
+                  ) : (
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>{r.final}</Typography>
+                  )}
+                  <Box sx={{ px: 0.85, py: 0.2, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: "white", bgcolor: r.late ? "rgba(239,68,68,0.35)" : "rgba(255,255,255,0.18)", minWidth: 64, textAlign: "center" }}>
+                    {r.late ? `−${data.workedExample.latePct}% late` : "on time"}
+                  </Box>
+                </Stack>
+              ))}
+            </Stack>
+            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 1.5 }}>
+              <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>Week total</Typography>
+              <Typography sx={{ fontWeight: 900, fontSize: "1.6rem" }}>{data.workedExample.total} <Box component="span" sx={{ fontSize: "0.9rem", fontWeight: 700 }}>pts</Box></Typography>
+            </Stack>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/components/points-system/PointsSystemContent.tsx
+++ b/components/points-system/PointsSystemContent.tsx
@@ -3,17 +3,34 @@
 import { useEffect, useState } from "react";
 import { Box, CircularProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
+import { Reveal } from "@/components/scorecard/shared";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { DecaySpec, PointsSystem } from "@/lib/types/points-system";
 
 const fmtSecs = (s: number) => (s < 120 ? `${s}s` : `${Math.round(s / 60)} min`);
 const fmtTick = (s: number) => (s < 60 ? `${s}s` : `${Math.round(s / 60)}m`);
 
-function SectionLabel({ n, text }: { n: number; text: string }) {
+// Shared card style + hover lift, matching the dashboard / course panels.
+const CARD = {
+  borderRadius: 4,
+  border: "1px solid #eef2f7",
+  bgcolor: "#fff",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.04)",
+  transition: "transform .15s, box-shadow .15s",
+  "&:hover": { transform: "translateY(-2px)", boxShadow: "0 16px 34px -22px rgba(16,24,40,0.25)" },
+};
+
+function SectionHeader({ icon, title, subtitle, gradient = "linear-gradient(135deg, #6366f1, #a855f7)" }: { icon: string; title: string; subtitle: string; gradient?: string }) {
   return (
-    <Typography sx={{ fontSize: "0.72rem", fontWeight: 800, letterSpacing: 0.8, color: "#94a3b8", textTransform: "uppercase", mb: 1.5 }}>
-      {n} · {text}
-    </Typography>
+    <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 1.75 }}>
+      <Box sx={{ width: 34, height: 34, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: gradient, boxShadow: "0 8px 18px -10px rgba(124,58,237,0.6)" }}>
+        <Icon icon={icon} width={19} />
+      </Box>
+      <Box>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#0f172a", lineHeight: 1.15 }}>{title}</Typography>
+        <Typography sx={{ fontSize: "0.8rem", color: "#64748b" }}>{subtitle}</Typography>
+      </Box>
+    </Stack>
   );
 }
 
@@ -25,35 +42,38 @@ function DecayChart({ spec }: { spec: DecaySpec }) {
   const line = spec.curve.map((c, i) => `${i === 0 ? "M" : "L"} ${x(c.t).toFixed(1)} ${y(c.pts).toFixed(1)}`).join(" ");
   const area = `${line} L ${x(spec.tMax).toFixed(1)} ${y(0).toFixed(1)} L ${x(0).toFixed(1)} ${y(0).toFixed(1)} Z`;
   const ticks = [0, Math.round(spec.tMax / 2), spec.tMax];
+  const gid = spec.title.replace(/\s+/g, "");
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} width="100%" style={{ display: "block" }}>
       <defs>
-        <linearGradient id={`fill-${spec.title}`} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#a855f7" stopOpacity={0.28} />
+        <linearGradient id={`fill-${gid}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#a855f7" stopOpacity={0.3} />
           <stop offset="100%" stopColor="#a855f7" stopOpacity={0.02} />
         </linearGradient>
+        <linearGradient id={`line-${gid}`} x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stopColor="#6366f1" />
+          <stop offset="100%" stopColor="#c026d3" />
+        </linearGradient>
       </defs>
-      {/* grace (full-credit) band */}
-      <rect x={padL} y={padT} width={x(spec.grace) - padL} height={innerH} fill="#22c55e" opacity={0.1} />
+      <rect x={padL} y={padT} width={x(spec.grace) - padL} height={innerH} fill="#22c55e" opacity={0.1} rx={3} />
       <text x={x(spec.grace / 2)} y={padT + 14} textAnchor="middle" fontSize="9" fontWeight="700" fill="#16a34a">full</text>
-      {/* y labels */}
       {[spec.base, Math.round(spec.base / 2), 0].map((p) => (
         <text key={p} x={padL - 6} y={y(p) + 3} textAnchor="end" fontSize="9" fill="#94a3b8">{p}</text>
       ))}
-      {/* x labels */}
       {ticks.map((t) => (
         <text key={t} x={x(t)} y={H - 6} textAnchor="middle" fontSize="9" fill="#94a3b8">{fmtTick(t)}</text>
       ))}
-      <path d={area} fill={`url(#fill-${spec.title})`} />
-      <path d={line} fill="none" stroke="#7c3aed" strokeWidth={2.5} strokeLinejoin="round" />
+      <path d={area} fill={`url(#fill-${gid})`} />
+      <path d={line} fill="none" stroke={`url(#line-${gid})`} strokeWidth={2.5} strokeLinejoin="round" />
+      <circle cx={x(0)} cy={y(spec.base)} r={3.5} fill="#6366f1" />
     </svg>
   );
 }
 
 function ChartCard({ spec }: { spec: DecaySpec }) {
   return (
-    <Box sx={{ p: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
+    <Box sx={{ ...CARD, p: 2 }}>
       <Stack direction="row" justifyContent="space-between" alignItems="baseline" sx={{ mb: 1 }}>
         <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#0f172a" }}>{spec.title} · {spec.base} pts</Typography>
         <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8" }}>grace {fmtSecs(spec.grace)}, then −{spec.dec} / {spec.iv}s</Typography>
@@ -77,6 +97,14 @@ const LATE_STYLE = [
   { color: "#b91c1c", bg: "#fef2f2", border: "#fecaca" },
 ];
 
+function HeroChip({ icon, text }: { icon: string; text: string }) {
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center" sx={{ px: 1.1, py: 0.5, borderRadius: 999, bgcolor: "rgba(255,255,255,0.16)", fontSize: "0.76rem", fontWeight: 700 }}>
+      <Icon icon={icon} width={14} /> {text}
+    </Stack>
+  );
+}
+
 export function PointsSystemContent() {
   const [data, setData] = useState<PointsSystem | null>(null);
   const [loading, setLoading] = useState(true);
@@ -93,142 +121,168 @@ export function PointsSystemContent() {
   if (loading) return <Box sx={{ display: "grid", placeItems: "center", py: 12 }}><CircularProgress sx={{ color: "#7c3aed" }} /></Box>;
   if (!data) return <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center", fontWeight: 600 }}>Couldn&apos;t load the points system.</Typography>;
 
-  const wkExampleDay = (n: number) => (n - 1) * data.late.staggerDays + 1;
+  const wkDay = (n: number) => (n - 1) * data.late.staggerDays + 1;
 
   return (
     <Box>
-      {/* Header */}
-      <Stack direction="row" spacing={1.5} alignItems="flex-start" sx={{ mb: 3 }}>
-        <Box sx={{ width: 48, height: 48, borderRadius: 3, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7)", boxShadow: "0 12px 26px -12px rgba(124,58,237,0.6)" }}>
-          <Icon icon="mdi:star-four-points" width={26} />
-        </Box>
-        <Box>
-          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-            <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.5rem", md: "1.9rem" }, color: "#0f172a", lineHeight: 1.1 }}>{data.title}</Typography>
-            <Box sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: "white", background: "linear-gradient(135deg, #7c3aed, #a855f7)" }}>UNIFIED</Box>
+      {/* Hero */}
+      <Reveal>
+        <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 3, color: "white", position: "relative", overflow: "hidden", background: "radial-gradient(110% 130% at 90% -10%, rgba(236,72,153,0.45) 0%, rgba(124,58,237,0.0) 55%), linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -30px rgba(124,58,237,0.7)" }}>
+          <Stack direction="row" spacing={1.75} alignItems="flex-start">
+            <Box sx={{ width: 52, height: 52, borderRadius: 3, flexShrink: 0, display: "grid", placeItems: "center", bgcolor: "rgba(255,255,255,0.16)", border: "1px solid rgba(255,255,255,0.25)" }}>
+              <Icon icon="mdi:star-four-points" width={28} />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.6rem", md: "2.1rem" }, lineHeight: 1.1 }}>{data.title}</Typography>
+                <Box sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: "#7c3aed", bgcolor: "white" }}>UNIFIED</Box>
+              </Stack>
+              <Typography sx={{ fontSize: "0.92rem", color: "rgba(255,255,255,0.88)", mt: 1, maxWidth: 720, lineHeight: 1.55 }}>{data.subtitle}</Typography>
+              <Stack direction="row" gap={1} flexWrap="wrap" sx={{ mt: 1.75 }}>
+                <HeroChip icon="mdi:medal-outline" text={`${data.activities.length} ways to earn`} />
+                <HeroChip icon="mdi:timer-sand" text="Time-decay" />
+                <HeroChip icon="mdi:speedometer" text="Difficulty ×" />
+                <HeroChip icon="mdi:calendar-clock" text="Weekly windows" />
+              </Stack>
+            </Box>
           </Stack>
-          <Typography sx={{ fontSize: "0.9rem", color: "#64748b", mt: 0.5, maxWidth: 760, lineHeight: 1.5 }}>{data.subtitle}</Typography>
         </Box>
-      </Stack>
+      </Reveal>
 
       {/* 1 · Points by activity */}
-      <SectionLabel n={1} text="Points by activity" />
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2,1fr)", lg: "repeat(4,1fr)" }, gap: 1.5, mb: 4 }}>
-        {data.activities.map((a) => (
-          <Stack key={a.key} direction="row" alignItems="center" spacing={1.25} sx={{ p: 1.75, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
-            <Box sx={{ width: 38, height: 38, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center", color: a.accent, bgcolor: `${a.accent}1a` }}>
-              <Icon icon={a.icon} width={20} />
-            </Box>
-            <Box sx={{ minWidth: 0, flex: 1 }}>
-              <Typography sx={{ fontWeight: 800, fontSize: "0.86rem", color: "#0f172a", lineHeight: 1.2 }}>{a.label}</Typography>
-              <Typography sx={{ fontSize: "0.7rem", color: "#94a3b8" }}>{a.sub}</Typography>
-            </Box>
-            <Box sx={{ textAlign: "right", flexShrink: 0 }}>
-              <Typography component="span" sx={{ fontWeight: 900, fontSize: "1.05rem", color: a.accent }}>{a.points}</Typography>
-              <Typography component="span" sx={{ fontSize: "0.66rem", color: "#94a3b8", ml: 0.3 }}>{a.unit}</Typography>
-            </Box>
-          </Stack>
-        ))}
-      </Box>
+      <Reveal>
+        <Box sx={{ mb: 4 }}>
+          <SectionHeader icon="mdi:medal" title="Points by activity" subtitle="Every activity awards points — harder + faster earns more." gradient="linear-gradient(135deg, #6366f1, #a855f7)" />
+          <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2,1fr)", lg: "repeat(4,1fr)" }, gap: 1.5 }}>
+            {data.activities.map((a) => (
+              <Stack key={a.key} direction="row" alignItems="center" spacing={1.25} sx={{ ...CARD, p: 1.75, borderLeft: "3px solid", borderLeftColor: a.accent }}>
+                <Box sx={{ width: 38, height: 38, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center", color: a.accent, bgcolor: `${a.accent}1a` }}>
+                  <Icon icon={a.icon} width={20} />
+                </Box>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.86rem", color: "#0f172a", lineHeight: 1.2 }}>{a.label}</Typography>
+                  <Typography sx={{ fontSize: "0.7rem", color: "#94a3b8" }}>{a.sub}</Typography>
+                </Box>
+                <Box sx={{ textAlign: "right", flexShrink: 0 }}>
+                  <Typography component="span" sx={{ fontWeight: 900, fontSize: "1.05rem", color: a.accent }}>{a.points}</Typography>
+                  <Typography component="span" sx={{ fontSize: "0.66rem", color: "#94a3b8", ml: 0.3 }}>{a.unit}</Typography>
+                </Box>
+              </Stack>
+            ))}
+          </Box>
+        </Box>
+      </Reveal>
 
       {/* 2 · Time-decay */}
-      <SectionLabel n={2} text="Time-decay — answer well & quickly to keep more" />
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr 340px" }, gap: 1.5, mb: 4 }}>
-        <ChartCard spec={data.decay.quizEasy} />
-        <ChartCard spec={data.decay.codingHard} />
-        <Box sx={{ p: 2.25, borderRadius: 4, color: "#fff", backgroundColor: "#0f0a28", backgroundImage: "linear-gradient(160deg, #1a1442, #0f0a28)" }}>
-          <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "rgba(255,255,255,0.6)", mb: 1 }}>THE FORMULA</Typography>
-          <Box sx={{ p: 1.5, borderRadius: 2, bgcolor: "rgba(0,0,0,0.35)", fontFamily: "monospace", fontSize: "0.8rem", color: "#c4b5fd", lineHeight: 1.6, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
-            {data.formula}
-          </Box>
-          <Typography sx={{ fontSize: "0.74rem", color: "rgba(255,255,255,0.65)", mt: 1.5, lineHeight: 1.55 }}>{data.formulaNote}</Typography>
-        </Box>
-      </Box>
-
-      {/* 3 + 4 side by side */}
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" }, gap: 2, mb: 4 }}>
-        {/* 3 · Difficulty multiplier */}
-        <Box sx={{ p: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
-          <SectionLabel n={3} text="Difficulty multiplier" />
-          <Stack spacing={1}>
-            {data.difficulty.map((d) => {
-              const s = DIFF_STYLE[d.label] ?? DIFF_STYLE.Medium;
-              return (
-                <Stack key={d.label} direction="row" alignItems="center" spacing={2} sx={{ p: 1.25, borderRadius: 2.5, bgcolor: s.bg }}>
-                  <Typography sx={{ fontWeight: 800, fontSize: "0.86rem", color: s.color, minWidth: 64 }}>{d.label}</Typography>
-                  <Typography sx={{ fontWeight: 900, fontSize: "0.95rem", color: s.color, minWidth: 48 }}>×{d.mult.toFixed(1)}</Typography>
-                  <Typography sx={{ fontSize: "0.8rem", color: "#475569" }}>Quiz <b>{d.quiz}</b> · Coding <b>{d.coding}</b></Typography>
-                </Stack>
-              );
-            })}
-          </Stack>
-          <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f5f3ff" }}>
-            <Icon icon="mdi:star-four-points" width={13} color="#6d28d9" style={{ flexShrink: 0, marginTop: 2 }} />
-            <Typography sx={{ fontSize: "0.74rem", color: "#6d28d9", fontWeight: 600, lineHeight: 1.45 }}>
-              The AI serves difficulty matched to your level — so the points you earn reflect real stretch, not farming easy items.
-            </Typography>
-          </Stack>
-        </Box>
-
-        {/* 4 · Weekly late penalty */}
-        <Box sx={{ p: 2, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#fff" }}>
-          <SectionLabel n={4} text="Weekly late penalty" />
-          <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
-            {data.late.bands.map((b, i) => {
-              const s = LATE_STYLE[i] ?? LATE_STYLE[0];
-              return (
-                <Box key={b.label} sx={{ flex: 1, p: 1.5, borderRadius: 2.5, bgcolor: s.bg, border: `1px solid ${s.border}` }}>
-                  <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", color: "#0f172a" }}>{b.label}</Typography>
-                  <Typography sx={{ fontSize: "0.66rem", color: "#94a3b8" }}>{b.note}</Typography>
-                  <Typography sx={{ fontWeight: 900, fontSize: "1.4rem", color: s.color, mt: 0.5 }}>×{b.mult.toFixed(1)}</Typography>
-                  <Typography sx={{ fontSize: "0.7rem", color: s.color, fontWeight: 700 }}>{b.caption}</Typography>
-                </Box>
-              );
-            })}
-          </Stack>
-          <Box sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f8fafc" }}>
-            <Typography sx={{ fontSize: "0.74rem", color: "#475569", lineHeight: 1.5 }}>
-              <b>Per-week windows.</b> Admin sets a course start date; week N opens on day{" "}
-              <b>(N−1)×{data.late.staggerDays} + 1</b> with a {data.late.windowDays}-day window. e.g. Week 4 →
-              days {wkExampleDay(4)}–{wkExampleDay(4) + data.late.windowDays - 1}. The multiplier hits the points you earn that week.
-            </Typography>
+      <Reveal>
+        <Box sx={{ mb: 4 }}>
+          <SectionHeader icon="mdi:timer-sand" title="Time-decay" subtitle="Answer well & quickly to keep more." gradient="linear-gradient(135deg, #8b5cf6, #ec4899)" />
+          <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr 340px" }, gap: 1.5 }}>
+            <ChartCard spec={data.decay.quizEasy} />
+            <ChartCard spec={data.decay.codingHard} />
+            <Box sx={{ p: 2.25, borderRadius: 4, color: "#fff", backgroundColor: "#0f0a28", backgroundImage: "linear-gradient(160deg, #1a1442, #0f0a28)", boxShadow: "0 18px 40px -24px rgba(76,29,149,0.6)" }}>
+              <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 1 }}>
+                <Icon icon="mdi:function-variant" width={16} color="#c4b5fd" />
+                <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "rgba(255,255,255,0.6)" }}>THE FORMULA</Typography>
+              </Stack>
+              <Box sx={{ p: 1.5, borderRadius: 2, bgcolor: "rgba(0,0,0,0.35)", fontFamily: "monospace", fontSize: "0.8rem", color: "#c4b5fd", lineHeight: 1.6, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                {data.formula}
+              </Box>
+              <Typography sx={{ fontSize: "0.74rem", color: "rgba(255,255,255,0.65)", mt: 1.5, lineHeight: 1.55 }}>{data.formulaNote}</Typography>
+            </Box>
           </Box>
         </Box>
-      </Box>
+      </Reveal>
+
+      {/* 3 + 4 */}
+      <Reveal>
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" }, gap: 2, mb: 4 }}>
+          <Box sx={{ ...CARD, p: 2.25, "&:hover": undefined }}>
+            <SectionHeader icon="mdi:speedometer" title="Difficulty multiplier" subtitle="Harder items are worth more." gradient="linear-gradient(135deg, #f59e0b, #ef4444)" />
+            <Stack spacing={1}>
+              {data.difficulty.map((d) => {
+                const s = DIFF_STYLE[d.label] ?? DIFF_STYLE.Medium;
+                return (
+                  <Stack key={d.label} direction="row" alignItems="center" spacing={2} sx={{ p: 1.25, borderRadius: 2.5, bgcolor: s.bg }}>
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.86rem", color: s.color, minWidth: 64 }}>{d.label}</Typography>
+                    <Typography sx={{ fontWeight: 900, fontSize: "0.95rem", color: s.color, minWidth: 48 }}>×{d.mult.toFixed(1)}</Typography>
+                    <Typography sx={{ fontSize: "0.8rem", color: "#475569" }}>Quiz <b>{d.quiz}</b> · Coding <b>{d.coding}</b></Typography>
+                  </Stack>
+                );
+              })}
+            </Stack>
+            <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f5f3ff" }}>
+              <Icon icon="mdi:star-four-points" width={13} color="#6d28d9" style={{ flexShrink: 0, marginTop: 2 }} />
+              <Typography sx={{ fontSize: "0.74rem", color: "#6d28d9", fontWeight: 600, lineHeight: 1.45 }}>
+                The AI serves difficulty matched to your level — so the points you earn reflect real stretch, not farming easy items.
+              </Typography>
+            </Stack>
+          </Box>
+
+          <Box sx={{ ...CARD, p: 2.25, "&:hover": undefined }}>
+            <SectionHeader icon="mdi:calendar-clock" title="Weekly late penalty" subtitle="Beat the deadline to keep full credit." gradient="linear-gradient(135deg, #ef4444, #f59e0b)" />
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+              {data.late.bands.map((b, i) => {
+                const s = LATE_STYLE[i] ?? LATE_STYLE[0];
+                return (
+                  <Box key={b.label} sx={{ flex: 1, p: 1.5, borderRadius: 2.5, bgcolor: s.bg, border: `1px solid ${s.border}` }}>
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", color: "#0f172a" }}>{b.label}</Typography>
+                    <Typography sx={{ fontSize: "0.66rem", color: "#94a3b8" }}>{b.note}</Typography>
+                    <Typography sx={{ fontWeight: 900, fontSize: "1.4rem", color: s.color, mt: 0.5 }}>×{b.mult.toFixed(1)}</Typography>
+                    <Typography sx={{ fontSize: "0.7rem", color: s.color, fontWeight: 700 }}>{b.caption}</Typography>
+                  </Box>
+                );
+              })}
+            </Stack>
+            <Box sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f8fafc" }}>
+              <Typography sx={{ fontSize: "0.74rem", color: "#475569", lineHeight: 1.5 }}>
+                <b>Per-week windows.</b> Admin sets a course start date; week N opens on day{" "}
+                <b>(N−1)×{data.late.staggerDays} + 1</b> with a {data.late.windowDays}-day window. e.g. Week 4 →
+                days {wkDay(4)}–{wkDay(4) + data.late.windowDays - 1}.
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      </Reveal>
 
       {/* Worked example */}
-      <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, color: "white", background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -30px rgba(124,58,237,0.6)" }}>
-        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "300px 1fr" }, gap: { xs: 2.5, md: 4 }, alignItems: "center" }}>
-          <Box>
-            <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "rgba(255,255,255,0.7)" }}>WORKED EXAMPLE · ONE WEEK</Typography>
-            <Typography sx={{ fontSize: "0.92rem", color: "rgba(255,255,255,0.92)", mt: 1, lineHeight: 1.55 }}>{data.workedExample.summary}</Typography>
-          </Box>
-          <Box>
-            <Stack spacing={0.5}>
-              {data.workedExample.rows.map((r) => (
-                <Stack key={r.label} direction="row" alignItems="center" spacing={1.5} sx={{ py: 0.85, borderBottom: "1px solid rgba(255,255,255,0.12)" }}>
-                  <Typography sx={{ flex: 1, minWidth: 0, fontSize: "0.84rem", color: "rgba(255,255,255,0.9)" }}>{r.label}</Typography>
-                  {r.late ? (
-                    <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>
-                      <Box component="span" sx={{ color: "rgba(255,255,255,0.5)", textDecoration: "line-through", mr: 0.75 }}>{r.raw}</Box>
-                      {r.final}
-                    </Typography>
-                  ) : (
-                    <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>{r.final}</Typography>
-                  )}
-                  <Box sx={{ px: 0.85, py: 0.2, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: "white", bgcolor: r.late ? "rgba(239,68,68,0.35)" : "rgba(255,255,255,0.18)", minWidth: 64, textAlign: "center" }}>
-                    {r.late ? `−${data.workedExample.latePct}% late` : "on time"}
-                  </Box>
-                </Stack>
-              ))}
-            </Stack>
-            <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 1.5 }}>
-              <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>Week total</Typography>
-              <Typography sx={{ fontWeight: 900, fontSize: "1.6rem" }}>{data.workedExample.total} <Box component="span" sx={{ fontSize: "0.9rem", fontWeight: 700 }}>pts</Box></Typography>
-            </Stack>
+      <Reveal>
+        <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, color: "white", position: "relative", overflow: "hidden", background: "radial-gradient(110% 130% at 10% 110%, rgba(236,72,153,0.4) 0%, rgba(124,58,237,0) 55%), linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -30px rgba(124,58,237,0.7)" }}>
+          <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "300px 1fr" }, gap: { xs: 2.5, md: 4 }, alignItems: "center" }}>
+            <Box>
+              <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 1 }}>
+                <Icon icon="mdi:lightbulb-on" width={16} />
+                <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "rgba(255,255,255,0.75)" }}>WORKED EXAMPLE · ONE WEEK</Typography>
+              </Stack>
+              <Typography sx={{ fontSize: "0.92rem", color: "rgba(255,255,255,0.92)", lineHeight: 1.55 }}>{data.workedExample.summary}</Typography>
+            </Box>
+            <Box>
+              <Stack spacing={0.5}>
+                {data.workedExample.rows.map((r) => (
+                  <Stack key={r.label} direction="row" alignItems="center" spacing={1.5} sx={{ py: 0.85, borderBottom: "1px solid rgba(255,255,255,0.12)" }}>
+                    <Typography sx={{ flex: 1, minWidth: 0, fontSize: "0.84rem", color: "rgba(255,255,255,0.9)" }}>{r.label}</Typography>
+                    {r.late ? (
+                      <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>
+                        <Box component="span" sx={{ color: "rgba(255,255,255,0.5)", textDecoration: "line-through", mr: 0.75 }}>{r.raw}</Box>
+                        {r.final}
+                      </Typography>
+                    ) : (
+                      <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>{r.final}</Typography>
+                    )}
+                    <Box sx={{ px: 0.85, py: 0.2, borderRadius: 999, fontSize: "0.62rem", fontWeight: 800, color: "white", bgcolor: r.late ? "rgba(239,68,68,0.4)" : "rgba(255,255,255,0.18)", minWidth: 64, textAlign: "center" }}>
+                      {r.late ? `−${data.workedExample.latePct}% late` : "on time"}
+                    </Box>
+                  </Stack>
+                ))}
+              </Stack>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 1.5 }}>
+                <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>Week total</Typography>
+                <Typography sx={{ fontWeight: 900, fontSize: "1.6rem" }}>{data.workedExample.total} <Box component="span" sx={{ fontSize: "0.9rem", fontWeight: 700 }}>pts</Box></Typography>
+              </Stack>
+            </Box>
           </Box>
         </Box>
-      </Box>
+      </Reveal>
     </Box>
   );
 }

--- a/hooks/useAdaptiveSession.ts
+++ b/hooks/useAdaptiveSession.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { adaptiveQuizService } from "@/lib/services/adaptive-quiz.service";
+import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import type {
   AdaptiveQuestion,
   AdaptiveSessionDetail,
@@ -146,6 +147,8 @@ export function useAdaptiveSession({
         };
       });
       resetForNextQuestion();
+      // Finishing the quiz counts as a completion — trigger the streak celebration.
+      if (result.session_complete) notifyContentCompleted();
       return result;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to submit answer");

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -174,6 +174,32 @@ export interface GeneratePracticeResult extends PracticeState {
   item: PracticeItem;
 }
 
+// --- Points breakdown (per-content on-offer + earned) ---
+export type PointsKind = "quiz" | "coding" | "article" | "video";
+
+export interface PointsBreakdownItem {
+  kind: PointsKind;
+  title: string;
+  detail: string;
+  content_key: string;
+  on_offer: number;
+  earned: number;
+  status: "earned" | "available";
+  breakdown?: {
+    base: number;
+    after_decay: number;
+    correctness_factor: number;
+    late_penalty_mult: number;
+    weight: number;
+    earned_at: string | null;
+  };
+}
+
+export interface SubmodulePointsBreakdown {
+  topic: { earned: number; on_offer: number };
+  items: PointsBreakdownItem[];
+}
+
 export const adaptiveCourseService = {
   async listCourses(): Promise<AdaptiveCourseListItem[]> {
     const { data } = await apiClient.get<AdaptiveCourseListItem[]>(`${BASE}/courses/`);
@@ -210,6 +236,13 @@ export const adaptiveCourseService = {
     const { data } = await apiClient.post<GeneratePracticeResult>(
       `${BASE}/courses/${courseId}/submodules/${submoduleId}/practice/generate/`,
       body,
+    );
+    return data;
+  },
+
+  async getSubmodulePoints(courseId: number, submoduleId: number): Promise<SubmodulePointsBreakdown> {
+    const { data } = await apiClient.get<SubmodulePointsBreakdown>(
+      `${BASE}/courses/${courseId}/submodules/${submoduleId}/points/`,
     );
     return data;
   },

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -12,6 +12,8 @@ export interface AdaptiveCourseQuizSummary {
   hint_tokens: number;
   confidence_prompt_enabled: boolean;
   completed?: boolean;
+  /** Latest completed session id — used to "Review" past results instead of restarting. */
+  last_session_id?: string | null;
 }
 
 export type ReadingTier = "Beginner" | "Intermediate" | "Advanced" | "Expert";

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -136,6 +136,44 @@ export interface AdaptiveCourseDetail extends AdaptiveCourseListItem {
   modules: AdaptiveCourseModule[];
 }
 
+// --- Additional Practice (learner-generated, no points) ---
+export type PracticeKind = "quiz" | "coding" | "article";
+export type PracticeDifficulty = "Easy" | "Medium" | "Hard" | "match";
+
+export interface PracticeUsage {
+  used: number;
+  limit: number;
+  left: number;
+  by_kind: { quiz: number; coding: number; article: number };
+}
+
+export interface PracticeItem {
+  id: string;
+  kind: PracticeKind;
+  title: string;
+  item_count: number;
+  created_at: string;
+  config_id?: number;
+  problem_id?: number | null;
+  article_id?: number;
+}
+
+export interface PracticeState {
+  usage: PracticeUsage;
+  items: PracticeItem[];
+}
+
+export interface GeneratePracticeBody {
+  kind: PracticeKind;
+  difficulty: PracticeDifficulty;
+  count?: number;
+  focus?: string;
+}
+
+export interface GeneratePracticeResult extends PracticeState {
+  item: PracticeItem;
+}
+
 export const adaptiveCourseService = {
   async listCourses(): Promise<AdaptiveCourseListItem[]> {
     const { data } = await apiClient.get<AdaptiveCourseListItem[]>(`${BASE}/courses/`);
@@ -153,6 +191,25 @@ export const adaptiveCourseService = {
   ): Promise<AdaptiveCourseSubModule> {
     const { data } = await apiClient.get<AdaptiveCourseSubModule>(
       `${BASE}/courses/${courseId}/submodules/${submoduleId}/`,
+    );
+    return data;
+  },
+
+  async getSubmodulePractice(courseId: number, submoduleId: number): Promise<PracticeState> {
+    const { data } = await apiClient.get<PracticeState>(
+      `${BASE}/courses/${courseId}/submodules/${submoduleId}/practice/`,
+    );
+    return data;
+  },
+
+  async generatePractice(
+    courseId: number,
+    submoduleId: number,
+    body: GeneratePracticeBody,
+  ): Promise<GeneratePracticeResult> {
+    const { data } = await apiClient.post<GeneratePracticeResult>(
+      `${BASE}/courses/${courseId}/submodules/${submoduleId}/practice/generate/`,
+      body,
     );
     return data;
   },

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -16,6 +16,7 @@ import type {
   StreakSummary,
 } from "@/lib/types/adaptive-journey";
 import type { LearnerDashboard } from "@/lib/types/dashboard";
+import type { PointsSystem } from "@/lib/types/points-system";
 
 const BASE = "/adaptive-journey/api";
 const ADMIN = "/adaptive-journey/api/admin";
@@ -24,6 +25,11 @@ export const adaptiveJourneyService = {
   // ---- Learner surfaces ----
   async getLearnerDashboard(): Promise<LearnerDashboard> {
     const { data } = await apiClient.get<LearnerDashboard>(`${BASE}/learner/dashboard/`);
+    return data;
+  },
+
+  async getPointsSystem(): Promise<PointsSystem> {
+    const { data } = await apiClient.get<PointsSystem>(`${BASE}/points-system/`);
     return data;
   },
 

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -15,12 +15,18 @@ import type {
   PointsWallet,
   StreakSummary,
 } from "@/lib/types/adaptive-journey";
+import type { LearnerDashboard } from "@/lib/types/dashboard";
 
 const BASE = "/adaptive-journey/api";
 const ADMIN = "/adaptive-journey/api/admin";
 
 export const adaptiveJourneyService = {
   // ---- Learner surfaces ----
+  async getLearnerDashboard(): Promise<LearnerDashboard> {
+    const { data } = await apiClient.get<LearnerDashboard>(`${BASE}/learner/dashboard/`);
+    return data;
+  },
+
   async getJourney(courseId: number): Promise<JourneyBoard> {
     const { data } = await apiClient.get<JourneyBoard>(`${BASE}/courses/${courseId}/journey/`);
     return data;

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -17,6 +17,7 @@ import type {
 } from "@/lib/types/adaptive-journey";
 import type { LearnerDashboard } from "@/lib/types/dashboard";
 import type { PointsSystem } from "@/lib/types/points-system";
+import type { LeaderboardPeriod, LeaderboardStreaks } from "@/lib/types/leaderboard-streaks";
 
 const BASE = "/adaptive-journey/api";
 const ADMIN = "/adaptive-journey/api/admin";
@@ -30,6 +31,13 @@ export const adaptiveJourneyService = {
 
   async getPointsSystem(): Promise<PointsSystem> {
     const { data } = await apiClient.get<PointsSystem>(`${BASE}/points-system/`);
+    return data;
+  },
+
+  async getLeaderboardStreaks(period: LeaderboardPeriod = "all"): Promise<LeaderboardStreaks> {
+    const { data } = await apiClient.get<LeaderboardStreaks>(
+      `${BASE}/learner/leaderboard-streaks/`, { params: { period } },
+    );
     return data;
   },
 

--- a/lib/streak/streakCelebration.ts
+++ b/lib/streak/streakCelebration.ts
@@ -56,8 +56,10 @@ export async function reportContentCompleted(): Promise<void> {
     const s = await profileService.getMonthlyStreak();
     const next = s.current_streak ?? 0;
     if (next > state.navCount) {
-      // Defer the nav bump to the overlay's flame-landing for a satisfying +1.
-      set({ celebrating: true, celebrateCount: next, primed: true });
+      // Defer the nav bump to the overlay's flame-landing for a satisfying +1. Seed
+      // navCount to next-1 so the tick is a clean +1 even when the nav was never primed
+      // (e.g. the completion happened on an immersive page with no nav).
+      set({ celebrating: true, celebrateCount: next, navCount: Math.max(state.navCount, next - 1), primed: true });
     } else {
       set({ navCount: next, primed: true });
     }
@@ -78,11 +80,19 @@ export function dismissCelebration() {
 }
 
 /**
- * Fire-and-forget signal that the learner just completed a piece of content. Reuses the
- * existing "submodule-complete" channel so both the celebration (MainLayout) and the
- * nav popover refresh (AppBar) react. Call after the completion is confirmed server-side.
+ * Fire-and-forget signal that the learner just completed a piece of content. Call after
+ * the completion is confirmed server-side.
+ *
+ * Updates the store DIRECTLY (not only via the "submodule-complete" listener) so it also
+ * works on immersive pages that aren't wrapped in MainLayout — e.g. the calibration take
+ * page and the interview page have no MainLayout (so no listener, no overlay, no nav).
+ * The celebration then plays on the next MainLayout page the learner lands on (where the
+ * nav exists), and the chip ticks +1. `reportContentCompleted` is in-flight-guarded, so
+ * the extra "submodule-complete" ping (for the nav popover refresh + legacy flows) is
+ * de-duped rather than double-fetching.
  */
 export function notifyContentCompleted() {
+  void reportContentCompleted();
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent("submodule-complete"));
   }

--- a/lib/streak/streakCelebration.ts
+++ b/lib/streak/streakCelebration.ts
@@ -1,0 +1,93 @@
+"use client";
+
+/**
+ * Streak celebration store — a tiny module-level store (no provider needed) so any
+ * content-completion flow can deterministically trigger the celebration, and the nav
+ * streak chip + the celebration overlay both read from one source of truth.
+ *
+ * Flow: a completion calls `reportContentCompleted()`, which refetches the streak and,
+ * if it went up, fires the celebration (without bumping the nav yet). The overlay plays,
+ * then calls `commitNavBump()` as its flame lands on the nav — so the nav number ticks
+ * +1 exactly when the animation arrives. No increase => the nav number just syncs.
+ */
+
+import { useSyncExternalStore } from "react";
+import { profileService } from "@/lib/services/profile.service";
+import { invalidateStreakCache } from "@/lib/hooks/useLeaderboardAndStreak";
+
+export interface StreakCelebrationState {
+  celebrating: boolean;
+  celebrateCount: number; // the new streak being celebrated
+  navCount: number;       // the value the nav chip should show right now
+  primed: boolean;        // nav has reported its real value at least once
+}
+
+let state: StreakCelebrationState = { celebrating: false, celebrateCount: 0, navCount: 0, primed: false };
+const listeners = new Set<() => void>();
+
+function set(next: Partial<StreakCelebrationState>) {
+  state = { ...state, ...next };
+  listeners.forEach((l) => l());
+}
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+function getSnapshot() { return state; }
+
+/**
+ * The nav reports the server streak once on load to seed navCount. Only the FIRST prime
+ * takes effect — after that navCount is owned by the store (moved by `commitNavBump` when
+ * the celebration lands, or synced by `reportContentCompleted`). This avoids a race where
+ * the nav's own streak refetch would bump the number before the celebration arrives.
+ */
+export function primeNavStreak(n: number) {
+  if (typeof n !== "number" || n < 0) return;
+  if (!state.primed) set({ navCount: n, primed: true });
+}
+
+let inFlight = false;
+/** Call right after any content completion is confirmed by the server. */
+export async function reportContentCompleted(): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    invalidateStreakCache();
+    const s = await profileService.getMonthlyStreak();
+    const next = s.current_streak ?? 0;
+    if (next > state.navCount) {
+      // Defer the nav bump to the overlay's flame-landing for a satisfying +1.
+      set({ celebrating: true, celebrateCount: next, primed: true });
+    } else {
+      set({ navCount: next, primed: true });
+    }
+  } catch {
+    /* streak is non-critical; never surface an error here */
+  } finally {
+    inFlight = false;
+  }
+}
+
+/** Overlay calls this when its flame reaches the nav — nav number ticks to the new value. */
+export function commitNavBump() {
+  if (state.celebrateCount > state.navCount) set({ navCount: state.celebrateCount });
+}
+
+export function dismissCelebration() {
+  set({ celebrating: false });
+}
+
+/**
+ * Fire-and-forget signal that the learner just completed a piece of content. Reuses the
+ * existing "submodule-complete" channel so both the celebration (MainLayout) and the
+ * nav popover refresh (AppBar) react. Call after the completion is confirmed server-side.
+ */
+export function notifyContentCompleted() {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("submodule-complete"));
+  }
+}
+
+export function useStreakCelebration(): StreakCelebrationState {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/lib/types/adaptive-journey.ts
+++ b/lib/types/adaptive-journey.ts
@@ -3,6 +3,8 @@
 // `adaptive_journey` app. Board endpoints use camelCase; wallet/leaderboard/
 // streak/admin endpoints use snake_case — preserved here verbatim.
 
+import type { MomentumInfo } from "./momentum";
+
 export type NodeType = "topic" | "checkpoint" | "interview" | "week_final";
 export type NodeStatus = "locked" | "current" | "done";
 export type UnlockRule = "sequential" | "week_open" | "prev_passed" | "always";
@@ -244,6 +246,7 @@ export interface StreakSummary {
   longest_len: number;
   last_active_date: string | null;
   momentum_score: number;
+  momentum_info: MomentumInfo; // snake_case here (streak endpoint convention)
   forecast_days: number;
   at_risk: boolean;
   weekly_goal: { target: number; text: string };

--- a/lib/types/dashboard.ts
+++ b/lib/types/dashboard.ts
@@ -65,6 +65,7 @@ export interface CourseDue {
 export interface DashboardCourse {
   id: number;
   title: string;
+  cardImageUrl: string | null;
   completionPct: number;
   readiness: CourseReadiness;
   skillProfile: CourseSkillProfile;

--- a/lib/types/dashboard.ts
+++ b/lib/types/dashboard.ts
@@ -111,7 +111,14 @@ export interface AiBriefing {
 }
 
 export interface LearnerDashboard {
-  profile: { name: string; weekNo: number | null; streakDays: number; bestStreak: number };
+  profile: {
+    name: string;
+    weekNo: number | null;
+    weekDueAt: string | null;
+    weekProgressPct: number;
+    streakDays: number;
+    bestStreak: number;
+  };
   aggregate: DashboardAggregate;
   courses: DashboardCourse[];
   crossCourseUpNext: CrossCourseUpNext[];

--- a/lib/types/dashboard.ts
+++ b/lib/types/dashboard.ts
@@ -1,4 +1,5 @@
 import type { FieldTier, LeaderboardRow } from "./adaptive-journey";
+import type { MomentumInfo } from "./momentum";
 
 // Payload for GET /adaptive-journey/api/learner/dashboard/
 
@@ -81,6 +82,7 @@ export interface DashboardAggregate {
   pointsThisWeek: number;
   streak: { current: number; best: number; atRisk: boolean };
   momentum: number;
+  momentumInfo: MomentumInfo;
   onTimeRate: number | null;
   overallMasteryAvg: number | null;
   cohortRank: { bestRank: number | null; rankDelta: number; perCourse: Record<string, number | null> };

--- a/lib/types/dashboard.ts
+++ b/lib/types/dashboard.ts
@@ -1,4 +1,4 @@
-import type { FieldTier, LeaderboardRow, TrendDirection } from "./adaptive-journey";
+import type { FieldTier, LeaderboardRow } from "./adaptive-journey";
 
 // Payload for GET /adaptive-journey/api/learner/dashboard/
 
@@ -87,7 +87,9 @@ export interface DashboardAggregate {
 }
 
 export interface DashboardLeaderboard {
-  me: { rank: number; score: number; trend: TrendDirection; percentile: number; rankDelta: number } | null;
+  // score + trend are also sent by the API but surfaced via the rows (current-user row)
+  // and the rankDelta arrow, so the panel only consumes rank / percentile / rankDelta.
+  me: { rank: number; percentile: number; rankDelta: number } | null;
   rows: LeaderboardRow[];
   aiTip: string | null;
 }

--- a/lib/types/dashboard.ts
+++ b/lib/types/dashboard.ts
@@ -1,0 +1,121 @@
+import type { FieldTier, LeaderboardRow, TrendDirection } from "./adaptive-journey";
+
+// Payload for GET /adaptive-journey/api/learner/dashboard/
+
+export type ReadinessBand = "not-started" | "needs-work" | "building" | "strong";
+
+export interface ReadinessCell {
+  percent: number | null;
+  band: ReadinessBand;
+}
+
+export interface CourseReadiness {
+  coverage: ReadinessCell;
+  precision: ReadinessCell;
+  craft: ReadinessCell;
+  clutch: ReadinessCell;
+  overall: ReadinessCell;
+}
+
+export interface DashboardSkill {
+  skill: string;
+  percent: number;
+  band: "strong" | "emerging";
+}
+
+export interface CourseSkillProfile {
+  abilityIndex: number | null;
+  fieldTier: FieldTier | null;
+  mastery: number | null;
+  skillsTracked: number;
+  skills: DashboardSkill[];
+  aiTip: string;
+}
+
+export interface NodeRef {
+  submoduleId?: number;
+  assessmentId?: number;
+  interviewTemplateId?: number;
+}
+
+export interface UpNextNode {
+  nodeId: number;
+  title: string;
+  type: string;
+  points: number;
+  weekNo: number | null;
+  ref: NodeRef;
+  dueAt: string | null;
+  lockReason: string | null;
+  why: string;
+}
+
+export interface CrossCourseUpNext extends UpNextNode {
+  courseId: number;
+  courseTitle: string;
+  resumeSubmoduleId: number | null;
+}
+
+export interface CourseDue {
+  dueAt: string | null;
+  zeroAfter: string | null;
+  penaltyNote: string | null;
+}
+
+export interface DashboardCourse {
+  id: number;
+  title: string;
+  completionPct: number;
+  readiness: CourseReadiness;
+  skillProfile: CourseSkillProfile;
+  upNext: UpNextNode | null;
+  resumeSubmoduleId: number | null;
+  due: CourseDue | null;
+  leaderboardRank: number | null;
+  certificate: { enabled: boolean; pct: number; threshold: number };
+}
+
+export interface DashboardAggregate {
+  totalPoints: number;
+  pointsThisWeek: number;
+  streak: { current: number; best: number; atRisk: boolean };
+  momentum: number;
+  onTimeRate: number | null;
+  overallMasteryAvg: number | null;
+  cohortRank: { bestRank: number | null; rankDelta: number; perCourse: Record<string, number | null> };
+}
+
+export interface DashboardLeaderboard {
+  me: { rank: number; score: number; trend: TrendDirection; percentile: number; rankDelta: number } | null;
+  rows: LeaderboardRow[];
+  aiTip: string | null;
+}
+
+export interface BriefingAction {
+  label: string;
+  course: string;
+  route: string;
+  points: number;
+  kind: string;
+}
+
+export interface AiBriefing {
+  headline: string;
+  lastWeek: string;
+  thisWeek: { focus: string; course: string };
+  today: string;
+  weakestSkill: { skill: string; course: string; percent: number; fixSuggestion: string; route: string } | null;
+  actions: BriefingAction[];
+  focusRoute: string;
+  source: string;
+}
+
+export interface LearnerDashboard {
+  profile: { name: string; weekNo: number | null; streakDays: number; bestStreak: number };
+  aggregate: DashboardAggregate;
+  courses: DashboardCourse[];
+  crossCourseUpNext: CrossCourseUpNext[];
+  leaderboard: DashboardLeaderboard;
+  briefing: AiBriefing | null;
+  generatedAt: string;
+}

--- a/lib/types/leaderboard-streaks.ts
+++ b/lib/types/leaderboard-streaks.ts
@@ -1,5 +1,7 @@
 // Payload for GET /adaptive-journey/api/learner/leaderboard-streaks/
 
+import type { MomentumInfo } from "./momentum";
+
 export type LeaderboardPeriod = "all" | "week";
 
 export interface LbRow {
@@ -45,6 +47,7 @@ export interface LeaderboardStreaks {
     current: number;
     longest: number;
     momentum: number;
+    momentumInfo: MomentumInfo;
     atRisk: boolean;
     forecast: string;
     atRiskTip: string;

--- a/lib/types/leaderboard-streaks.ts
+++ b/lib/types/leaderboard-streaks.ts
@@ -1,0 +1,54 @@
+// Payload for GET /adaptive-journey/api/learner/leaderboard-streaks/
+
+export type LeaderboardPeriod = "all" | "week";
+
+export interface LbRow {
+  rank: number;
+  name: string;
+  score: number;
+  trend: "up" | "down" | "flat";
+  rankDelta: number;
+  profile_pic_url: string | null;
+  is_current_user: boolean;
+}
+
+export interface LbMe {
+  rank: number;
+  score: number;
+  trend: "up" | "down" | "flat";
+  percentile: number;
+  rankDelta: number;
+}
+
+export interface CalendarDay {
+  day: number;
+  active: boolean;
+}
+
+export interface StreakCalendar {
+  label: string;
+  firstWeekday: number; // 0 = Monday
+  todayDay: number;
+  days: CalendarDay[];
+}
+
+export interface LeaderboardStreaks {
+  period: LeaderboardPeriod;
+  leaderboard: {
+    me: LbMe | null;
+    rows: LbRow[];
+    total: number;
+    climbText: string;
+    rankDelta: number;
+  };
+  streak: {
+    current: number;
+    longest: number;
+    momentum: number;
+    atRisk: boolean;
+    forecast: string;
+    atRiskTip: string;
+    bestDay: string | null;
+  };
+  calendar: StreakCalendar;
+}

--- a/lib/types/momentum.ts
+++ b/lib/types/momentum.ts
@@ -1,0 +1,12 @@
+// Shared momentum breakdown (GET dashboard aggregate + leaderboard-streaks streak).
+// Mirrors adaptive_journey/scoring/momentum.py::momentum_breakdown.
+
+export interface MomentumInfo {
+  value: number;
+  current: number; // current streak days
+  perDay: number;
+  cap: number;
+  daysToMax: number;
+  atMax: boolean;
+  formula: string;
+}

--- a/lib/types/points-system.ts
+++ b/lib/types/points-system.ts
@@ -1,0 +1,74 @@
+// Payload for GET /adaptive-journey/api/points-system/ (derived from the scoring engine).
+
+export interface PointsActivity {
+  key: string;
+  icon: string;
+  accent: string;
+  label: string;
+  sub: string;
+  points: string;
+  unit: string;
+}
+
+export interface DecayCurvePoint {
+  t: number;
+  pts: number;
+}
+
+export interface DecaySpec {
+  title: string;
+  base: number;
+  grace: number;
+  dec: number;
+  iv: number;
+  floor: number;
+  tMax: number;
+  curve: DecayCurvePoint[];
+}
+
+export interface DifficultyRow {
+  label: string;
+  mult: number;
+  quiz: number;
+  coding: number;
+}
+
+export interface LateBand {
+  label: string;
+  note: string;
+  mult: number;
+  caption: string;
+}
+
+export interface PointsLate {
+  windowDays: number;
+  halfWindowDays: number;
+  staggerDays: number;
+  bands: LateBand[];
+}
+
+export interface WorkedExampleRow {
+  label: string;
+  raw: number;
+  late: boolean;
+  final: number;
+}
+
+export interface WorkedExample {
+  summary: string;
+  latePct: number;
+  rows: WorkedExampleRow[];
+  total: number;
+}
+
+export interface PointsSystem {
+  title: string;
+  subtitle: string;
+  formula: string;
+  formulaNote: string;
+  activities: PointsActivity[];
+  decay: { quizEasy: DecaySpec; codingHard: DecaySpec };
+  difficulty: DifficultyRow[];
+  late: PointsLate;
+  workedExample: WorkedExample;
+}


### PR DESCRIPTION
…page

A learner-facing generator on every topic: pick a content type (Article / Quiz / Coding), difficulty (Easy/Medium/Hard or "Match me"), and how many, then generate extra practice tuned to their level. Practice earns no points.

- service + types: getSubmodulePractice + generatePractice (quota + items).
- AdditionalPractice component matching the design: gradient header with an X/20-generated quota meter + "N left", the 3 content-type cards, difficulty + count pickers (count hidden for articles, options disabled past the remaining quota), an optional focus prompt, generate button (disabled at the cap), and a "Your generated practice" list with Open links + a "Practice · no points" badge.
- wired below the learning path on the submodule page.