### PR TITLE
feat(course-builder): stall detection + resume/retry for AI course builder

### DIFF
--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
@@ -58,7 +58,7 @@ export default function AdaptiveArticleReaderPage() {
   });
   const [headings, setHeadings] = useState<ArticleHeading[]>([]);
   const [activeHeading, setActiveHeading] = useState<string>("");
-  const [tocOpen, setTocOpen] = useState(true);
+  const [tocOpen, setTocOpen] = useState(false);
   const [progress, setProgress] = useState(0);
   const bodyWrapRef = useRef<HTMLDivElement | null>(null);
   // Reading marks the article complete on the server (on load), but we defer the streak

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Box, ButtonBase, CircularProgress, Popover, Typography } from "@mui/material";
+import { Box, ButtonBase, Dialog, IconButton, Popover, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
@@ -58,6 +58,7 @@ export default function AdaptiveArticleReaderPage() {
   });
   const [headings, setHeadings] = useState<ArticleHeading[]>([]);
   const [activeHeading, setActiveHeading] = useState<string>("");
+  const [tocOpen, setTocOpen] = useState(true);
   const [progress, setProgress] = useState(0);
   const bodyWrapRef = useRef<HTMLDivElement | null>(null);
   // Reading marks the article complete on the server (on load), but we defer the streak
@@ -285,9 +286,9 @@ export default function AdaptiveArticleReaderPage() {
                 />
               </Box>
 
-              <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "232px minmax(0, 1fr) 320px" }, gap: { xs: 2, lg: 3 }, alignItems: "start" }}>
-                {/* Table of contents (left rail) */}
-                <TocRail headings={headings} activeId={activeHeading} onJump={goToHeading} />
+              <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: `${tocOpen ? "232px" : "40px"} minmax(0, 1fr) 320px` }, gap: { xs: 2, lg: 3 }, alignItems: "start", transition: "grid-template-columns 0.28s cubic-bezier(0.16,1,0.3,1)" }}>
+                {/* Table of contents (left rail) — collapsible to give the reading column more room */}
+                <TocRail headings={headings} activeId={activeHeading} onJump={goToHeading} open={tocOpen} onToggle={() => setTocOpen((v) => !v)} />
 
                 {/* Body */}
                 <Box ref={bodyWrapRef} sx={{ position: "relative", borderRadius: 4, p: { xs: 2, md: 3.5 }, bgcolor: "color-mix(in srgb, var(--card-bg) 75%, transparent)", border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)", minHeight: 240 }}>
@@ -424,39 +425,58 @@ export default function AdaptiveArticleReaderPage() {
         )}
       </Popover>
 
-      {/* Summarise dialog (lightweight popover-less panel) */}
-      <Popover
+      {/* Summarise dialog — centered, polished recap of the article so far */}
+      <Dialog
         open={summary.open}
-        anchorReference="anchorPosition"
-        anchorPosition={{ top: 120, left: typeof window !== "undefined" ? window.innerWidth / 2 : 400 }}
-        transformOrigin={{ vertical: "top", horizontal: "center" }}
         onClose={() => setSummary((s) => ({ ...s, open: false }))}
-        slotProps={{ paper: { sx: { p: 2.5, maxWidth: 520, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)" } } }}
+        maxWidth="sm"
+        fullWidth
+        slotProps={{ paper: { sx: { borderRadius: 4, overflow: "hidden", bgcolor: "var(--card-bg)", border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)", boxShadow: "0 28px 70px -30px rgba(124,58,237,0.55)" } } }}
       >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1 }}>
-          <Icon icon="mdi:text-box-outline" width={16} style={{ color: "#a855f7" }} />
-          <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>Summary so far</Typography>
-        </Box>
-        {summary.loading ? (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, py: 1 }}><CircularProgress size={16} /> <Typography sx={{ fontSize: "0.85rem", color: "text.secondary" }}>Summarising…</Typography></Box>
-        ) : (
-          <Box sx={{ fontSize: "0.88rem" }}>
-            {/* word-by-word reveal of the recap */}
-            <AdaptiveArticleBody html={summary.html} explainTerms={[]} onExplain={() => {}} reveal />
-            {summary.bullets.length > 0 && (
-              <Box component="ul" sx={{ pl: 2.5, mt: 1, mb: 0 }}>
-                {summary.bullets.map((b, i) => (
-                  <Box component="li" key={i}
-                    sx={{ mb: 0.5, fontSize: "0.85rem", opacity: 0, animation: "acb-fade-in 0.4s ease forwards", animationDelay: `${0.5 + i * 0.35}s` }}>
-                    {b}
-                  </Box>
-                ))}
-              </Box>
-            )}
-            <style jsx global>{`@keyframes acb-fade-in { to { opacity: 1; } }`}</style>
+        {/* Gradient header */}
+        <Box sx={{ position: "relative", px: 3, py: 2.25, color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 55%, #ec4899 100%)" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
+            <AIBeacon size={26} />
+            <Box>
+              <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.15 }}>Summary so far</Typography>
+              <Typography sx={{ fontSize: "0.74rem", opacity: 0.9 }}>The key ideas, condensed · {tier} level</Typography>
+            </Box>
           </Box>
-        )}
-      </Popover>
+          <IconButton
+            onClick={() => setSummary((s) => ({ ...s, open: false }))}
+            aria-label="Close"
+            sx={{ position: "absolute", top: 10, right: 10, color: "white", "&:hover": { bgcolor: "rgba(255,255,255,0.18)" } }}
+          >
+            <Icon icon="mdi:close" width={18} />
+          </IconButton>
+        </Box>
+
+        <Box sx={{ p: 3, maxHeight: "60vh", overflowY: "auto" }}>
+          {summary.loading ? (
+            <GeneratingShimmer label="Summarising what you've read…" />
+          ) : (
+            <Box sx={{ fontSize: "0.9rem" }}>
+              {/* word-by-word reveal of the recap */}
+              <AdaptiveArticleBody html={summary.html} explainTerms={[]} onExplain={() => {}} reveal />
+              {summary.bullets.length > 0 && (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 0.85, mt: 2 }}>
+                  <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.1em", textTransform: "uppercase", color: "text.secondary" }}>Key takeaways</Typography>
+                  {summary.bullets.map((b, i) => (
+                    <Box key={i} sx={{ display: "flex", gap: 1, alignItems: "flex-start", p: 1.1, borderRadius: 2.5,
+                      bgcolor: "color-mix(in srgb, #a855f7 7%, transparent)",
+                      border: "1px solid color-mix(in srgb, #a855f7 16%, transparent)",
+                      opacity: 0, animation: "acb-fade-in 0.4s ease forwards", animationDelay: `${0.4 + i * 0.3}s` }}>
+                      <Icon icon="mdi:check-circle" width={17} style={{ color: "#a855f7", flexShrink: 0, marginTop: 1 }} />
+                      <Typography sx={{ fontSize: "0.85rem", lineHeight: 1.45 }}>{b}</Typography>
+                    </Box>
+                  ))}
+                </Box>
+              )}
+              <style jsx global>{`@keyframes acb-fade-in { to { opacity: 1; } }`}</style>
+            </Box>
+          )}
+        </Box>
+      </Dialog>
     </MainLayout>
   );
 }
@@ -614,13 +634,46 @@ function RailLabel({ icon, text, noMargin }: { icon: string; text: string; noMar
 }
 
 /** Sticky table-of-contents rail (left), built from the article's headings with
- *  scroll-spy. Hidden below lg, where the reading column goes full width. */
-function TocRail({ headings, activeId, onJump }: { headings: ArticleHeading[]; activeId: string; onJump: (id: string) => void }) {
+ *  scroll-spy. Collapsible (horizontal toggle) so the reading column can take the
+ *  freed width. Hidden below lg, where the reading column goes full width. */
+function TocRail({ headings, activeId, onJump, open, onToggle }: { headings: ArticleHeading[]; activeId: string; onJump: (id: string) => void; open: boolean; onToggle: () => void }) {
+  if (!headings.length) return <Box sx={{ display: { xs: "none", lg: "block" } }} />;
+  // Collapsed: a slim sticky pill that re-opens the contents and reclaims the column width.
+  if (!open) {
+    return (
+      <Box sx={{ display: { xs: "none", lg: "block" }, position: "sticky", top: 24 }}>
+        <IconButton
+          onClick={onToggle}
+          title="Show contents"
+          aria-label="Show contents"
+          sx={{
+            width: 36, height: 36, borderRadius: 2.5, color: "#a855f7",
+            bgcolor: "color-mix(in srgb, #a855f7 10%, transparent)",
+            border: "1px solid color-mix(in srgb, #a855f7 28%, transparent)",
+            "&:hover": { bgcolor: "color-mix(in srgb, #a855f7 18%, transparent)" },
+          }}
+        >
+          <Icon icon="mdi:format-list-bulleted" width={18} />
+        </IconButton>
+      </Box>
+    );
+  }
   return (
     <Box sx={{ display: { xs: "none", lg: "block" }, position: "sticky", top: 24, maxHeight: "calc(100vh - 48px)", overflowY: "auto" }}>
       {headings.length > 0 && (
         <>
-          <RailLabel icon="mdi:format-list-bulleted" text="On this page" />
+          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1, pr: 0.5 }}>
+            <RailLabel icon="mdi:format-list-bulleted" text="On this page" />
+            <IconButton
+              onClick={onToggle}
+              title="Hide contents"
+              aria-label="Hide contents"
+              size="small"
+              sx={{ color: "text.secondary", mt: -1, "&:hover": { color: "#a855f7" } }}
+            >
+              <Icon icon="mdi:chevron-left" width={18} />
+            </IconButton>
+          </Box>
           <Box component="nav" sx={{ display: "flex", flexDirection: "column", borderLeft: "2px solid color-mix(in srgb, var(--border-default) 70%, transparent)" }}>
             {headings.map((h) => {
               const active = h.id === activeId;

--- a/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
+++ b/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
@@ -20,6 +20,7 @@ import { MisconceptionCallout } from "@/components/adaptive-quiz/results/Misconc
 import { PerQuestionBreakdown } from "@/components/adaptive-quiz/results/PerQuestionBreakdown";
 import { NarrationComposer } from "@/components/adaptive-quiz/results/NarrationComposer";
 import { TargetOutcomeBanner } from "@/components/adaptive-quiz/results/TargetOutcomeBanner";
+import { RequizOutcomeBanner } from "@/components/adaptive-quiz/results/RequizOutcomeBanner";
 import {
   QuizResultSkeleton,
   SkillMasterySkeleton,
@@ -27,7 +28,7 @@ import {
   MisconceptionSkeleton,
   PerQuestionSkeleton,
 } from "@/components/adaptive-quiz/results/ResultSkeletons";
-import type { AdaptiveSessionDetail } from "@/lib/types/adaptive-quiz";
+import type { AdaptiveSessionDetail, RequizOutcome } from "@/lib/types/adaptive-quiz";
 
 /** Pull DRF's ``response.data.detail`` from an axios error if present —
  *  otherwise fall through to the standard Error.message — otherwise the
@@ -51,6 +52,7 @@ export default function AdaptiveQuizResultsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [startingRequiz, setStartingRequiz] = useState(false);
+  const [requizOutcome, setRequizOutcome] = useState<RequizOutcome | null>(null);
 
   async function handleStartPath() {
     if (startingRequiz) return;
@@ -87,6 +89,17 @@ export default function AdaptiveQuizResultsPage() {
       cancelled = true;
     };
   }, [params.sessionId]);
+
+  // If this is a re-quiz (seeded from an earlier attempt), pull how it compares — closes the
+  // remediation loop with a "gap closed / narrowed / still weak" verdict.
+  useEffect(() => {
+    if (!session?.source_attempt) return;
+    let cancelled = false;
+    adaptiveQuizService.getRequizOutcome(params.sessionId)
+      .then((o) => { if (!cancelled) setRequizOutcome(o); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [session?.source_attempt, params.sessionId]);
 
   const mcqDirectory = useMemo(() => {
     if (!session) return {};
@@ -208,6 +221,7 @@ export default function AdaptiveQuizResultsPage() {
               <SourceAttemptBreadcrumb source={session.source_attempt} />
             </Box>
           )}
+          {requizOutcome?.has_source && <RequizOutcomeBanner outcome={requizOutcome} />}
           <AdaptiveSectionHero
             chapter={session.source_attempt ? "Re-quiz · Diagnostic" : "Results · Diagnostic"}
             title={session.config.quiz_title}

--- a/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
+++ b/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
@@ -296,6 +296,7 @@ export default function AdaptiveQuizResultsPage() {
                     {remediationReady ? (
                       <RemediationPathCard
                         steps={narration.remediation_path}
+                        sessionId={params.sessionId}
                         onStartPath={() => void handleStartPath()}
                       />
                     ) : remediationGen ? (

--- a/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
+++ b/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
@@ -20,6 +20,13 @@ import { MisconceptionCallout } from "@/components/adaptive-quiz/results/Misconc
 import { PerQuestionBreakdown } from "@/components/adaptive-quiz/results/PerQuestionBreakdown";
 import { NarrationComposer } from "@/components/adaptive-quiz/results/NarrationComposer";
 import { TargetOutcomeBanner } from "@/components/adaptive-quiz/results/TargetOutcomeBanner";
+import {
+  QuizResultSkeleton,
+  SkillMasterySkeleton,
+  RemediationSkeleton,
+  MisconceptionSkeleton,
+  PerQuestionSkeleton,
+} from "@/components/adaptive-quiz/results/ResultSkeletons";
 import type { AdaptiveSessionDetail } from "@/lib/types/adaptive-quiz";
 
 /** Pull DRF's ``response.data.detail`` from an axios error if present —
@@ -131,8 +138,10 @@ export default function AdaptiveQuizResultsPage() {
   if (loading) {
     return (
       <MainLayout>
-        <Container sx={{ py: 8 }}>
-          <Typography sx={{ color: "text.secondary", textAlign: "center" }}>Loading your results…</Typography>
+        <Container maxWidth="xl" sx={{ py: { xs: 2, md: 4 } }}>
+          <AdaptiveSectionShell>
+            <QuizResultSkeleton />
+          </AdaptiveSectionShell>
         </Container>
       </MainLayout>
     );
@@ -169,6 +178,16 @@ export default function AdaptiveQuizResultsPage() {
   const misconceptionsReady = narration.status.misconceptions === "ready";
   const remediationReady = narration.status.remediation_path === "ready";
   const skillMasteryReady = narration.skill_mastery.length > 0;
+
+  // A section is "generating" while still pending/loading — show a shimmer placeholder for it
+  // so the page reads as actively building, not broken/empty. (skill mastery rides the
+  // headline payload, so its skeleton tracks the headline status.)
+  const generating = (s: "headline" | "per_question" | "misconceptions" | "remediation_path") =>
+    narration.status[s] === "pending" || narration.status[s] === "loading";
+  const skillGen = !skillMasteryReady && generating("headline");
+  const remediationGen = !remediationReady && generating("remediation_path");
+  const misconceptionGen = !misconceptionsReady && generating("misconceptions");
+  const perQuestionGen = !perQuestionReady && generating("per_question");
   // Some section failed terminally (after its auto-retry). Keep the composer's
   // per-section retry visible so the component isn't silently missing.
   const hasFailedSection = Object.values(narration.status).some((s) => s === "failed");
@@ -259,7 +278,7 @@ export default function AdaptiveQuizResultsPage() {
                 />
               </RevealBlock>
 
-              {(skillMasteryReady || remediationReady) && (
+              {(skillMasteryReady || remediationReady || skillGen || remediationGen) && (
                 <RevealBlock key="grid">
                   <Box
                     sx={{
@@ -269,29 +288,37 @@ export default function AdaptiveQuizResultsPage() {
                       alignItems: "flex-start",
                     }}
                   >
-                    {skillMasteryReady && (
+                    {skillMasteryReady ? (
                       <SkillMasteryHeatmap skills={narration.skill_mastery} />
-                    )}
-                    {remediationReady && (
+                    ) : skillGen ? (
+                      <SkillMasterySkeleton />
+                    ) : null}
+                    {remediationReady ? (
                       <RemediationPathCard
                         steps={narration.remediation_path}
                         onStartPath={() => void handleStartPath()}
                       />
-                    )}
+                    ) : remediationGen ? (
+                      <RemediationSkeleton />
+                    ) : null}
                   </Box>
                 </RevealBlock>
               )}
 
-              {misconceptionsReady && narration.misconceptions.length > 0 && (
+              {misconceptionsReady && narration.misconceptions.length > 0 ? (
                 <RevealBlock key="misc">
                   <MisconceptionCallout
                     misconceptions={narration.misconceptions}
                     responses={session.responses}
                   />
                 </RevealBlock>
-              )}
+              ) : misconceptionGen ? (
+                <RevealBlock key="misc-skel">
+                  <MisconceptionSkeleton />
+                </RevealBlock>
+              ) : null}
 
-              {perQuestionReady && (
+              {perQuestionReady ? (
                 <RevealBlock key="per-q">
                   <PerQuestionBreakdown
                     responses={session.responses}
@@ -307,7 +334,11 @@ export default function AdaptiveQuizResultsPage() {
                     mcqDirectory={mcqDirectory}
                   />
                 </RevealBlock>
-              )}
+              ) : perQuestionGen ? (
+                <RevealBlock key="per-q-skel">
+                  <PerQuestionSkeleton rows={Math.min(session.responses.length || 4, 6)} />
+                </RevealBlock>
+              ) : null}
             </AnimatePresence>
           </Box>
         </AdaptiveSectionShell>

--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -52,8 +52,9 @@ export default function GenerateAdaptiveCoursePage() {
   const [difficulties, setDifficulties] = useState<Difficulty[]>(["Easy", "Medium", "Hard"]);
   const [questionsPerCell, setQuestionsPerCell] = useState(3);
   const [articlesPerSubmodule, setArticlesPerSubmodule] = useState(1);
-  const [minQuestions, setMinQuestions] = useState(8);
-  const [maxQuestions, setMaxQuestions] = useState(20);
+  // Default to a fixed 15-question quiz (min === max): every quiz asks 15, difficulty adapts.
+  const [minQuestions, setMinQuestions] = useState(15);
+  const [maxQuestions, setMaxQuestions] = useState(15);
   const [confidence, setConfidence] = useState(true);
   // All four content types auto-selected by default (quiz + article + AI Coding
   // Mentor + Video Companion); admins can deselect in Advanced options.

--- a/app/admin/ai-course-builder/jobs/[jobId]/page.tsx
+++ b/app/admin/ai-course-builder/jobs/[jobId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import {
@@ -20,6 +20,9 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Alert,
+  AlertTitle,
+  Chip,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useTranslation } from "react-i18next";
@@ -38,6 +41,17 @@ import {
 import { OutlinePreview } from "@/components/admin/ai-course-builder/OutlinePreview";
 
 const POLL_INTERVAL_MS = 10000;
+const POLL_INTERVAL_STALLED_MS = 30000;
+// Poll while the job is still working; stop on terminal states.
+const NON_TERMINAL_STATUSES = [
+  "pending",
+  "generating_outline",
+  "creating_structure",
+  "generating_content",
+];
+const TERMINAL_STATUSES = ["completed", "failed"];
+// Client-side fallback: treat as stalled if no progress change for this long.
+const CLIENT_STALL_MS = 120000;
 
 export default function JobDetailPage() {
   const params = useParams();
@@ -54,9 +68,17 @@ export default function JobDetailPage() {
   const [approvePublished, setApprovePublished] = useState(false);
   const [regenerating, setRegenerating] = useState(false);
   const [generatingContent, setGeneratingContent] = useState(false);
+  const [resuming, setResuming] = useState(false);
+  const [retryingFailed, setRetryingFailed] = useState(false);
   const [regeneratingTaskId, setRegeneratingTaskId] = useState<number | null>(null);
   const [regeneratingSubmoduleId, setRegeneratingSubmoduleId] = useState<number | null>(null);
   const [regeneratingContentId, setRegeneratingContentId] = useState<number | null>(null);
+
+  // Client-side stall fallback: remember the last progress value we saw and
+  // when it last changed, so we can flag a wedge even if the server flag lags.
+  const lastProgressRef = useRef<string | null>(null);
+  const lastProgressAtRef = useRef<number>(Date.now());
+  const [clientStalled, setClientStalled] = useState(false);
 
   const loadJob = useCallback(async () => {
     if (!jobId) return;
@@ -77,17 +99,46 @@ export default function JobDetailPage() {
     loadJob();
   }, [loadJob]);
 
+  // (A) Track progress changes to drive the client-side stall fallback.
   useEffect(() => {
-    if (!data?.job || data.job.status !== "generating_content") return;
-    const id = setInterval(loadJob, POLL_INTERVAL_MS);
+    if (!data?.job) return;
+    const sig = `${data.job.completed_content_items ?? 0}:${data.job.progress_percentage ?? 0}`;
+    if (lastProgressRef.current !== sig) {
+      lastProgressRef.current = sig;
+      lastProgressAtRef.current = Date.now();
+      setClientStalled(false);
+    }
+  }, [data?.job?.completed_content_items, data?.job?.progress_percentage, data?.job]);
+
+  // (A) Poll on ALL non-terminal statuses; back off while stalled. The recovery
+  // banner — not fast polling — is the path out of a wedge.
+  const serverStalled = data?.is_stalled === true;
+  const pollStatus = data?.job?.status;
+  const isStalled = serverStalled || clientStalled;
+  useEffect(() => {
+    if (!pollStatus || !NON_TERMINAL_STATUSES.includes(pollStatus)) return;
+    const interval = isStalled ? POLL_INTERVAL_STALLED_MS : POLL_INTERVAL_MS;
+    const tick = () => {
+      // Client-side fallback: while generating with no progress change, flag stalled.
+      if (
+        data?.job?.status === "generating_content" &&
+        Date.now() - lastProgressAtRef.current > CLIENT_STALL_MS
+      ) {
+        setClientStalled(true);
+      }
+      loadJob();
+    };
+    const id = setInterval(tick, interval);
     return () => clearInterval(id);
-  }, [data?.job?.status, loadJob]);
+  }, [pollStatus, isStalled, loadJob, data?.job?.status]);
 
   const hasFailedTasks = (data?.failed_tasks ?? 0) > 0;
   const hasContentTasks = (data?.content_tasks?.length ?? 0) > 0;
   const isLive = data?.job?.status === "generating_content";
+  const canResume = data?.can_resume === true;
+  // (C) Recovery section is no longer hidden while live — show whenever a course
+  // exists and there are tasks (or failures) to act on.
   const showRegenerateSection =
-    !isLive &&
     data?.job?.generated_course_id != null &&
     (hasContentTasks || hasFailedTasks);
 
@@ -133,7 +184,7 @@ export default function JobDetailPage() {
   const handleGenerateAllContent = async () => {
     try {
       setGeneratingContent(true);
-      await aiCourseBuilderService.generateAllContent(jobId);
+      await aiCourseBuilderService.generateAllContent(jobId, {});
       showToast(t("adminAICourseBuilder.contentGenerationStarted"), "success");
       await loadJob();
     } catch (error: unknown) {
@@ -143,6 +194,46 @@ export default function JobDetailPage() {
       );
     } finally {
       setGeneratingContent(false);
+    }
+  };
+
+  // (C) Resume even when status === 'generating_content'; force reclaims orphans.
+  const handleResume = async () => {
+    try {
+      setResuming(true);
+      const res = await aiCourseBuilderService.resumeGeneration(jobId, {
+        force: true,
+      });
+      showToast(res.message ?? t("adminAICourseBuilder.resumeStarted"), "success");
+      setClientStalled(false);
+      lastProgressAtRef.current = Date.now();
+      await loadJob();
+    } catch (error: unknown) {
+      showToast(
+        error instanceof Error ? error.message : t("adminAICourseBuilder.resumeFailed"),
+        "error"
+      );
+    } finally {
+      setResuming(false);
+    }
+  };
+
+  // (C) Resume AND retry previously-failed items.
+  const handleRetryFailed = async () => {
+    try {
+      setRetryingFailed(true);
+      const res = await aiCourseBuilderService.regenerateFailed(jobId);
+      showToast(res.message ?? t("adminAICourseBuilder.retryFailedStarted"), "success");
+      setClientStalled(false);
+      lastProgressAtRef.current = Date.now();
+      await loadJob();
+    } catch (error: unknown) {
+      showToast(
+        error instanceof Error ? error.message : t("adminAICourseBuilder.retryFailedFailed"),
+        "error"
+      );
+    } finally {
+      setRetryingFailed(false);
     }
   };
 
@@ -231,6 +322,151 @@ export default function JobDetailPage() {
   const outlineReady = status === "outline_ready";
   const progress = job.progress_percentage ?? 0;
   const isPolling = status === "generating_content";
+  const isTerminal = TERMINAL_STATUSES.includes(status);
+
+  // Recovery signals.
+  const pendingTasks = data.pending_tasks ?? 0;
+  const generatingTasks = data.generating_tasks ?? 0;
+  const completedTasks = data.completed_tasks ?? 0;
+  const failedTasks = data.failed_tasks ?? 0;
+  const totalTasks =
+    data.total_tasks ??
+    pendingTasks + generatingTasks + completedTasks + failedTasks;
+  const staleSeconds = data.stale_seconds ?? 0;
+  // Prefer server staleness; fall back to client timer.
+  const staleMs = serverStalled
+    ? staleSeconds * 1000
+    : Date.now() - lastProgressAtRef.current;
+  const staleMinutes = Math.max(1, Math.round(staleMs / 60000));
+  const hasCourse = job.generated_course_id != null;
+  // Resume should be offered whenever the job is stalled OR the server says it
+  // can be resumed — INCLUDING while status === 'generating_content'.
+  const showResume = !isTerminal && hasCourse && (isStalled || canResume);
+
+  // (E) Build a per-task failure-reason lookup from the job error log.
+  const taskErrorMessages: Record<number, string> = {};
+  if (Array.isArray(job.error_log)) {
+    for (const entry of job.error_log as unknown[]) {
+      if (entry && typeof entry === "object") {
+        const e = entry as {
+          message?: string;
+          details?: { task_id?: number };
+        };
+        const tid = e.details?.task_id;
+        if (tid != null && e.message) {
+          taskErrorMessages[tid] = taskErrorMessages[tid]
+            ? `${taskErrorMessages[tid]} · ${e.message}`
+            : e.message;
+        }
+      }
+    }
+  }
+
+  // (E) Status chip helper.
+  const renderStatusChip = (taskStatus: string) => {
+    const s = taskStatus.toLowerCase();
+    let color: "default" | "primary" | "success" | "error" = "default";
+    if (s === "generating" || s === "validating") color = "primary";
+    else if (s === "completed") color = "success";
+    else if (s === "failed") color = "error";
+    return (
+      <Chip
+        label={taskStatus}
+        size="small"
+        color={color}
+        variant={color === "default" ? "outlined" : "filled"}
+        sx={{ height: 20, fontSize: "0.7rem" }}
+      />
+    );
+  };
+
+  // (E) Single task row — status chip, failure reason, attempts, and actions.
+  // Destructive regenerate is disabled while a task is actively generating to
+  // avoid double-runs.
+  const renderTaskRow = (task: ContentTask) => {
+    const loadingTask = regeneratingTaskId === task.id;
+    const loadingContent =
+      task.content != null && regeneratingContentId === task.content;
+    const isPending = task.status === "pending";
+    const isActive =
+      task.status === "generating" || task.status === "validating";
+    const isFailed = task.status === "failed";
+    const failureReason = taskErrorMessages[task.id];
+    const attempts = task.attempts ?? 0;
+    return (
+      <Box
+        component="li"
+        key={task.id}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 1,
+          ...(isFailed && {
+            bgcolor:
+              "color-mix(in srgb, var(--error-500) 12%, var(--surface) 88%)",
+            borderLeft: "3px solid",
+            borderColor: "error.main",
+            pl: 0.75,
+            borderRadius: 0.5,
+          }),
+        }}
+      >
+        <Typography variant="caption" sx={{ mr: 0.5 }}>
+          {task.content_type}
+        </Typography>
+        {renderStatusChip(task.status)}
+        {attempts > 1 && (
+          <Typography variant="caption" color="text.secondary">
+            {t("adminAICourseBuilder.attemptsLabel", { count: attempts })}
+          </Typography>
+        )}
+        {isFailed && failureReason && (
+          <Typography
+            variant="caption"
+            color="error"
+            sx={{ flexBasis: "100%", wordBreak: "break-word" }}
+          >
+            {failureReason}
+          </Typography>
+        )}
+        <Button
+          size="small"
+          variant="text"
+          disabled={loadingTask || isActive}
+          onClick={() => handleRegenerateTask(task.id)}
+          startIcon={
+            loadingTask ? (
+              <CircularProgress size={12} />
+            ) : (
+              <IconWrapper icon={isPending ? "mdi:play" : "mdi:refresh"} size={12} />
+            )
+          }
+        >
+          {isPending
+            ? t("adminAICourseBuilder.generateTask")
+            : t("adminAICourseBuilder.regenerateTask")}
+        </Button>
+        {task.content != null && (
+          <Button
+            size="small"
+            variant="text"
+            disabled={loadingContent || isActive}
+            onClick={() => handleRegenerateContent(task.content!)}
+            startIcon={
+              loadingContent ? (
+                <CircularProgress size={12} />
+              ) : (
+                <IconWrapper icon="mdi:refresh" size={12} />
+              )
+            }
+          >
+            {t("adminAICourseBuilder.regenerateContent")}
+          </Button>
+        )}
+      </Box>
+    );
+  };
 
   return (
     <MainLayout>
@@ -293,8 +529,94 @@ export default function JobDetailPage() {
               </Box>
             )}
           </Box>
-          
+
         </Box>
+
+        {/* (B) Stall banner — prominent warning + primary Resume action. */}
+        {isStalled && (
+          <Alert
+            severity="warning"
+            sx={{ mb: 3 }}
+            action={
+              hasCourse ? (
+                <Button
+                  color="warning"
+                  variant="contained"
+                  size="small"
+                  onClick={handleResume}
+                  disabled={resuming}
+                  startIcon={
+                    resuming ? (
+                      <CircularProgress size={16} />
+                    ) : (
+                      <IconWrapper icon="mdi:play" size={16} />
+                    )
+                  }
+                >
+                  {resuming
+                    ? t("adminAICourseBuilder.resuming")
+                    : t("adminAICourseBuilder.resumeGeneration")}
+                </Button>
+              ) : undefined
+            }
+          >
+            <AlertTitle>{t("adminAICourseBuilder.generationStalled")}</AlertTitle>
+            {t("adminAICourseBuilder.generationStalledBody", { minutes: staleMinutes })}
+            <Typography variant="caption" sx={{ display: "block", mt: 0.5 }}>
+              {t("adminAICourseBuilder.completedLabel")} {completedTasks} •{" "}
+              {t("adminAICourseBuilder.failedLabel")} {failedTasks} •{" "}
+              {t("adminAICourseBuilder.total")} {totalTasks}
+            </Typography>
+          </Alert>
+        )}
+
+        {/* (C) Recovery actions — Resume / Retry failed. Visible even while live. */}
+        {(showResume || failedTasks > 0) && (
+          <Box sx={{ mb: 3, display: "flex", gap: 2, flexWrap: "wrap" }}>
+            {showResume && (
+              <Button
+                variant="contained"
+                onClick={handleResume}
+                disabled={resuming}
+                startIcon={
+                  resuming ? (
+                    <CircularProgress size={18} />
+                  ) : (
+                    <IconWrapper icon="mdi:play" size={18} />
+                  )
+                }
+                sx={{
+                  bgcolor: "var(--accent-indigo)",
+                  color: "var(--font-light)",
+                  "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+                }}
+              >
+                {resuming
+                  ? t("adminAICourseBuilder.resuming")
+                  : t("adminAICourseBuilder.resumeGeneration")}
+              </Button>
+            )}
+            {failedTasks > 0 && (
+              <Button
+                variant="outlined"
+                color="error"
+                onClick={handleRetryFailed}
+                disabled={retryingFailed}
+                startIcon={
+                  retryingFailed ? (
+                    <CircularProgress size={18} />
+                  ) : (
+                    <IconWrapper icon="mdi:refresh" size={18} />
+                  )
+                }
+              >
+                {retryingFailed
+                  ? t("adminAICourseBuilder.retrying")
+                  : t("adminAICourseBuilder.retryFailedItems", { count: failedTasks })}
+              </Button>
+            )}
+          </Box>
+        )}
 
         {outlineReady && job.generated_course_id == null && (
           <Box sx={{ mb: 3, display: "flex", gap: 2, flexWrap: "wrap" }}>
@@ -329,54 +651,54 @@ export default function JobDetailPage() {
           </Box>
         )}
         
+        {/* (D) Progress card — never freeze silently. Always shown while a
+            generated course exists in a non-terminal state, and on completion. */}
         {(() => {
-          const hasContentProgress =
-            job.total_content_items != null && job.total_content_items > 0;
-          const completed = job.completed_content_items ?? 0;
-          const pct = job.progress_percentage ?? 0;
-          const bothZero = completed === 0 && pct === 0;
-          const hasTaskBreakdown =
-            (data.pending_tasks ?? 0) +
-              (data.generating_tasks ?? 0) +
-              (data.completed_tasks ?? 0) +
-              (data.failed_tasks ?? 0) >
-            0;
+          const totalItems = job.total_content_items ?? 0;
           const showProgress =
             status !== "outline_ready" &&
-            hasContentProgress &&
-            !bothZero &&
-            (status === "generating_content" ||
-              status === "completed" ||
-              status === "creating_structure");
+            ((hasCourse && !isTerminal) || status === "completed");
           if (!showProgress) return null;
+          const indeterminate = totalItems === 0 && status !== "completed";
           return (
             <Paper sx={{ p: 2, mb: 3, borderRadius: 2 }}>
               <Typography variant="subtitle2" sx={{ mb: 1 }}>
                 {t("adminAICourseBuilder.progress")}
               </Typography>
-              <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-                <LinearProgress
-                  variant="determinate"
-                  value={progress}
-                  sx={{ flex: 1, height: 8, borderRadius: 1 }}
-                />
-                <Typography variant="body2" sx={{ minWidth: 80 }}>
-                  {job.completed_content_items ?? 0} / {job.total_content_items} (
-                  {progress}%)
-                </Typography>
-              </Box>
-              {hasTaskBreakdown && (
-                <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mt: 0.5 }}>
-                  {t("adminAICourseBuilder.pendingLabel")} {data.pending_tasks ?? 0} • {t("adminAICourseBuilder.generatingLabel")}{" "}
-                  {data.generating_tasks ?? 0} • {t("adminAICourseBuilder.completedLabel")} {data.completed_tasks}{" "}
-                  • {t("adminAICourseBuilder.failedLabel")} {data.failed_tasks ?? 0}
-                </Typography>
+              {indeterminate ? (
+                <Box>
+                  <LinearProgress sx={{ height: 8, borderRadius: 1 }} />
+                  <Typography
+                    variant="body2"
+                    sx={{ color: "var(--font-secondary)", mt: 0.5 }}
+                  >
+                    {t("adminAICourseBuilder.preparingContentTasks")}
+                  </Typography>
+                </Box>
+              ) : (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                  <LinearProgress
+                    variant="determinate"
+                    value={progress}
+                    sx={{ flex: 1, height: 8, borderRadius: 1 }}
+                  />
+                  <Typography variant="body2" sx={{ minWidth: 80 }}>
+                    {job.completed_content_items ?? 0} / {totalItems} ({progress}%)
+                  </Typography>
+                </Box>
               )}
+              <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mt: 0.5 }}>
+                {t("adminAICourseBuilder.pendingLabel")} {pendingTasks} • {t("adminAICourseBuilder.generatingLabel")}{" "}
+                {generatingTasks} • {t("adminAICourseBuilder.completedLabel")} {completedTasks}{" "}
+                • {t("adminAICourseBuilder.failedLabel")} {failedTasks}
+              </Typography>
             </Paper>
           );
         })()}
 
-        {job.generated_course_id != null && !isLive && (
+        {/* Fresh-start / "all generated" indicator. Hidden when the dedicated
+            Resume action above is offered (it supersedes this for a wedge). */}
+        {job.generated_course_id != null && !isLive && !showResume && (
           <Box sx={{ mb: 3 }}>
             <Button
               variant="contained"
@@ -532,67 +854,7 @@ export default function JobDetailPage() {
                                     <AccordionDetails sx={{ pt: 0, pl: 2, borderTop: "1px solid", borderColor: "divider" }}>
                                       {subTasks.length > 0 ? (
                                         <Box component="ul" sx={{ m: 0, pl: 2.5, display: "flex", flexDirection: "column", gap: 0.5 }}>
-                                          {subTasks.map((task) => {
-                                            const loadingTask = regeneratingTaskId === task.id;
-                                            const loadingContent = task.content != null && regeneratingContentId === task.content;
-                                            const isPending = task.status === "pending";
-                                            return (
-                                              <Box
-                                                component="li"
-                                                key={task.id}
-                                                sx={{
-                                                  display: "flex",
-                                                  alignItems: "center",
-                                                  flexWrap: "wrap",
-                                                  gap: 1,
-                                                  ...(task.status === "failed" && {
-                                                    bgcolor:
-                                                      "color-mix(in srgb, var(--error-500) 12%, var(--surface) 88%)",
-                                                    borderLeft: "3px solid",
-                                                    borderColor: "error.main",
-                                                    pl: 0.75,
-                                                    borderRadius: 0.5,
-                                                  }),
-                                                }}
-                                              >
-                                                <Typography variant="caption" sx={{ mr: 0.5 }} color={task.status === "failed" ? "error" : undefined}>
-                                                  {task.content_type} — {task.status}
-                                                </Typography>
-                                                <Button
-                                                  size="small"
-                                                  variant="text"
-                                                  disabled={loadingTask}
-                                                  onClick={() => handleRegenerateTask(task.id)}
-                                                  startIcon={
-                                                    loadingTask ? (
-                                                      <CircularProgress size={12} />
-                                                    ) : (
-                                                      <IconWrapper icon={isPending ? "mdi:play" : "mdi:refresh"} size={12} />
-                                                    )
-                                                  }
-                                                >
-                                                  {isPending ? t("adminAICourseBuilder.generateTask") : t("adminAICourseBuilder.regenerateTask")}
-                                                </Button>
-                                                {task.content != null && (
-                                                  <Button
-                                                    size="small"
-                                                    variant="text"
-                                                    disabled={loadingContent}
-                                                    onClick={() => handleRegenerateContent(task.content!)}
-                                                    startIcon={
-                                                      loadingContent ? (
-                                                        <CircularProgress size={12} />
-                                                      ) : (
-                                                        <IconWrapper icon="mdi:refresh" size={12} />
-                                                      )
-                                                    }
-                                                  >
-                                                    {t("adminAICourseBuilder.regenerateContent")}
-                                                  </Button>
-                                                )}
-                                              </Box>
-                                            );
-                                          })}
+                                          {subTasks.map((task) => renderTaskRow(task))}
                                         </Box>
                                       ) : (
                                         <Typography variant="caption" color="text.secondary">
@@ -663,67 +925,7 @@ export default function JobDetailPage() {
                           </AccordionSummary>
                           <AccordionDetails sx={{ pt: 0, borderTop: "1px solid", borderColor: "divider" }}>
                             <Box component="ul" sx={{ m: 0, pl: 2.5, display: "flex", flexDirection: "column", gap: 0.5 }}>
-                              {subTasks.map((task) => {
-                                const loadingTask = regeneratingTaskId === task.id;
-                                const loadingContent = task.content != null && regeneratingContentId === task.content;
-                                const isPending = task.status === "pending";
-                                return (
-                                  <Box
-                                    component="li"
-                                    key={task.id}
-                                    sx={{
-                                      display: "flex",
-                                      alignItems: "center",
-                                      flexWrap: "wrap",
-                                      gap: 1,
-                                      ...(task.status === "failed" && {
-                                        bgcolor:
-                                          "color-mix(in srgb, var(--error-500) 12%, var(--surface) 88%)",
-                                        borderLeft: "3px solid",
-                                        borderColor: "error.main",
-                                        pl: 0.75,
-                                        borderRadius: 0.5,
-                                      }),
-                                    }}
-                                  >
-                                    <Typography variant="caption" sx={{ mr: 0.5 }} color={task.status === "failed" ? "error" : undefined}>
-                                      {task.content_type} — {task.status}
-                                    </Typography>
-                                    <Button
-                                      size="small"
-                                      variant="text"
-                                      disabled={loadingTask}
-                                      onClick={() => handleRegenerateTask(task.id)}
-                                      startIcon={
-                                        loadingTask ? (
-                                          <CircularProgress size={12} />
-                                        ) : (
-                                          <IconWrapper icon={isPending ? "mdi:play" : "mdi:refresh"} size={12} />
-                                        )
-                                      }
-                                    >
-                                      {isPending ? t("adminAICourseBuilder.generateTask") : t("adminAICourseBuilder.regenerateTask")}
-                                    </Button>
-                                    {task.content != null && (
-                                      <Button
-                                        size="small"
-                                        variant="text"
-                                        disabled={loadingContent}
-                                        onClick={() => handleRegenerateContent(task.content!)}
-                                        startIcon={
-                                          loadingContent ? (
-                                            <CircularProgress size={12} />
-                                          ) : (
-                                            <IconWrapper icon="mdi:refresh" size={12} />
-                                          )
-                                        }
-                                      >
-                                        {t("adminAICourseBuilder.regenerateContent")}
-                                      </Button>
-                                    )}
-                                  </Box>
-                                );
-                              })}
+                              {subTasks.map((task) => renderTaskRow(task))}
                             </Box>
                           </AccordionDetails>
                         </Accordion>

--- a/components/adaptive-quiz/AdaptiveQuizLayout.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizLayout.tsx
@@ -183,6 +183,7 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
               key={`${q.mcq_id}-${notStarted ? "paused" : "run"}`}
               decay={q.points}
               running={!notStarted}
+              hints={ctx.hintRevealed !== null ? 1 : 0}
             />
           )}
           <SkillConfidenceCard

--- a/components/adaptive-quiz/AdaptiveQuizLayout.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizLayout.tsx
@@ -144,6 +144,7 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
         targetSkill={q.target_skill}
         avgSe={avgSe}
         difficultyLabel={q.difficulty_label}
+        theta={Number(session.ability_state[q.target_skill] ?? 0)}
       />
 
       <Box

--- a/components/adaptive-quiz/AdaptiveQuizLayout.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizLayout.tsx
@@ -14,6 +14,8 @@ import { QuestionCard } from "./mid/QuestionCard";
 import { AITutorSidecar } from "./mid/AITutorSidecar";
 import { QuizMetaStrip } from "./mid/QuizMetaStrip";
 import { LiveTimerRing } from "./mid/LiveTimerRing";
+import { LiveQuizPoints } from "./mid/LiveQuizPoints";
+import { PointsRewardBurst } from "./mid/PointsRewardBurst";
 
 interface AdaptiveQuizLayoutProps {
   sessionId: string;
@@ -170,7 +172,19 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
             }}
           >
             <LiveTimerRing key={`${q.mcq_id}-${notStarted ? "paused" : "run"}`} resetKey={q.mcq_id} running={!notStarted} />
+            {ctx.sessionPoints > 0 && (
+              <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.25, py: 0.5, borderRadius: 999, bgcolor: "color-mix(in srgb, #7c3aed 10%, transparent)", color: "#6d28d9", fontSize: "0.74rem", fontWeight: 800 }}>
+                <Icon icon="mdi:star-four-points" width={13} /> {ctx.sessionPoints} pts banked
+              </Box>
+            )}
           </Box>
+          {q.points && (
+            <LiveQuizPoints
+              key={`${q.mcq_id}-${notStarted ? "paused" : "run"}`}
+              decay={q.points}
+              running={!notStarted}
+            />
+          )}
           <SkillConfidenceCard
             skills={skillRows}
             activeSkill={q.target_skill}
@@ -179,7 +193,8 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
         </Box>
 
         {/* CENTER — the begin gate (fresh session) sits in the question slot, then the question */}
-        <Box>
+        <Box sx={{ position: "relative" }}>
+          <PointsRewardBurst reward={ctx.lastReward} />
           {notStarted ? (
             <BeginGate
               minQ={session.config.min_questions}
@@ -251,8 +266,9 @@ function BeginGate({ minQ, maxQ, onBegin }: { minQ: number; maxQ: number; onBegi
       </Box>
       <Typography sx={{ fontWeight: 800, fontSize: "1.4rem" }}>Ready when you are</Typography>
       <Typography sx={{ color: "text.secondary", mt: 1, lineHeight: 1.6, maxWidth: 460 }}>
-        {minQ}–{maxQ} questions · the difficulty adapts to each answer. Your timer starts when
-        you click begin — take a breath first.
+        {minQ === maxQ ? `${maxQ} questions` : `${minQ}–${maxQ} questions`} · difficulty adapts to
+        each answer, and each one is worth more the faster you nail it. Your timer + points start
+        when you click begin — take a breath first.
       </Typography>
       <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, mt: 2, px: 1.5, py: 0.6, borderRadius: 999, bgcolor: "color-mix(in srgb, #6366f1 10%, transparent)", color: "#6366f1", fontSize: "0.74rem", fontWeight: 800 }}>
         <Icon icon="mdi:timer-sand" width={14} /> Timer starts on “Begin”

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -142,14 +142,18 @@ export function SharedGenerationConfig({
               label="Min questions / quiz"
               type="number"
               value={minQuestions}
-              onChange={(e) => onMinQuestionsChange(clamp(Number(e.target.value), 1, 50))}
+              // Floor can't exceed the cap, so the stopping rule stays consistent.
+              onChange={(e) => onMinQuestionsChange(clamp(Number(e.target.value), 1, maxQuestions))}
+              helperText="Floor — fewest asked before it can stop early"
               sx={{ width: 200 }}
             />
             <TextField
               label="Max questions / quiz"
               type="number"
               value={maxQuestions}
-              onChange={(e) => onMaxQuestionsChange(clamp(Number(e.target.value), 1, 100))}
+              // Cap can't drop below the floor.
+              onChange={(e) => onMaxQuestionsChange(clamp(Number(e.target.value), minQuestions, 100))}
+              helperText="Cap — always ends by here · set = min for fixed length"
               sx={{ width: 200 }}
             />
           </Box>

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -30,7 +30,8 @@ export function SharedGenerationConfig({
   onQuestionsPerCellChange,
   articlesPerSubmodule,
   onArticlesPerSubmoduleChange,
-  minQuestions,
+  // minQuestions intentionally not read — the single "Questions per quiz" field drives both
+  // min and max (fixed-length quizzes) via the change handlers below.
   onMinQuestionsChange,
   maxQuestions,
   onMaxQuestionsChange,
@@ -138,23 +139,19 @@ export function SharedGenerationConfig({
           </Box>
 
           <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+            {/* Fixed length: every quiz asks exactly this many questions (difficulty still
+                adapts). Sets min === max so each question can carry its own time-decayed points. */}
             <TextField
-              label="Min questions / quiz"
-              type="number"
-              value={minQuestions}
-              // Floor can't exceed the cap, so the stopping rule stays consistent.
-              onChange={(e) => onMinQuestionsChange(clamp(Number(e.target.value), 1, maxQuestions))}
-              helperText="Floor — fewest asked before it can stop early"
-              sx={{ width: 200 }}
-            />
-            <TextField
-              label="Max questions / quiz"
+              label="Questions per quiz"
               type="number"
               value={maxQuestions}
-              // Cap can't drop below the floor.
-              onChange={(e) => onMaxQuestionsChange(clamp(Number(e.target.value), minQuestions, 100))}
-              helperText="Cap — always ends by here · set = min for fixed length"
-              sx={{ width: 200 }}
+              onChange={(e) => {
+                const v = clamp(Number(e.target.value), 1, 100);
+                onMinQuestionsChange(v);
+                onMaxQuestionsChange(v);
+              }}
+              helperText="Fixed length — every learner answers this many; each is worth points"
+              sx={{ width: 240 }}
             />
           </Box>
 

--- a/components/adaptive-quiz/mid/AITutorSidecar.tsx
+++ b/components/adaptive-quiz/mid/AITutorSidecar.tsx
@@ -6,6 +6,7 @@ import { AIBeacon } from "../shared/AIBeacon";
 import { AIPill } from "../shared/AIPill";
 import { AdaptiveInfoTip } from "../shared/AdaptiveInfoTip";
 import { certaintyBand } from "@/lib/utils/adaptive-confidence";
+import { prettySkill } from "@/lib/utils/skill-label.utils";
 
 interface AITutorSidecarProps {
   /** Pre-truncated hint teaser; full hint appears once the student spends a token. */
@@ -24,11 +25,6 @@ interface AITutorSidecarProps {
   avgSe: number | null;
 }
 
-function prettySkill(s: string): string {
-  if (!s) return "current topic";
-  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
 export function AITutorSidecar({
   hintTeaser,
   hintRevealed,
@@ -40,7 +36,7 @@ export function AITutorSidecar({
   targetSkill,
   avgSe,
 }: AITutorSidecarProps) {
-  const skillLabel = prettySkill(targetSkill);
+  const skillLabel = prettySkill(targetSkill, "current topic");
   const certainty = certaintyBand(avgSe);
   const predictedPct = Math.round(predictedPCorrect * 100);
 
@@ -131,7 +127,7 @@ export function AITutorSidecar({
           </Box>
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
             <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", fontWeight: 600 }}>
-              AI's read:
+              AI&apos;s read:
             </Typography>
             <Typography sx={{ fontSize: "0.78rem", color: certainty.accent, fontWeight: 800 }}>
               {certainty.label}
@@ -156,7 +152,7 @@ export function AITutorSidecar({
               </p>
             </AdaptiveInfoTip>
             <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", fontWeight: 600 }}>
-              · ~{predictedPct}% chance you'll get this right.
+              · ~{predictedPct}% chance you&apos;ll get this right.
             </Typography>
           </Box>
         </Box>

--- a/components/adaptive-quiz/mid/DifficultyPulse.tsx
+++ b/components/adaptive-quiz/mid/DifficultyPulse.tsx
@@ -7,6 +7,7 @@ import { AIBeacon } from "../shared/AIBeacon";
 import { AIPill } from "../shared/AIPill";
 import { AdaptiveInfoTip } from "../shared/AdaptiveInfoTip";
 import { certaintyBand } from "@/lib/utils/adaptive-confidence";
+import { prettySkill } from "@/lib/utils/skill-label.utils";
 
 interface DifficultyPulseProps {
   /** Selector's predicted P(correct) for the *current* question. 0..1. */
@@ -23,11 +24,6 @@ interface DifficultyPulseProps {
 
 const GRADIENT = "linear-gradient(90deg, #10b981 0%, #6366f1 50%, #ef4444 100%)";
 
-function prettySkill(s: string): string {
-  if (!s) return "this skill";
-  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
 export function DifficultyPulse({
   predictedPCorrect,
   targetSkill,
@@ -36,7 +32,7 @@ export function DifficultyPulse({
   theta,
 }: DifficultyPulseProps) {
   const certainty = certaintyBand(avgSe);
-  const skillLabel = prettySkill(targetSkill);
+  const skillLabel = prettySkill(targetSkill, "this skill");
   const predictedPct = Math.round(predictedPCorrect * 100);
   // The track maps Easy (left) → Hard (right) and shows the *question's* difficulty, NOT your
   // odds of getting it right. Item difficulty b = θ − logit(P): as you answer well your θ rises

--- a/components/adaptive-quiz/mid/DifficultyPulse.tsx
+++ b/components/adaptive-quiz/mid/DifficultyPulse.tsx
@@ -9,13 +9,16 @@ import { AdaptiveInfoTip } from "../shared/AdaptiveInfoTip";
 import { certaintyBand } from "@/lib/utils/adaptive-confidence";
 
 interface DifficultyPulseProps {
-  /** Selector's predicted P(correct) for the *current* question. 0..1 — used to position the marker. */
+  /** Selector's predicted P(correct) for the *current* question. 0..1. */
   predictedPCorrect: number;
   /** Sub-skill being probed this turn. Rendered as its own chip. */
   targetSkill: string;
   /** Average standard error across target skills — drives the certainty label. */
   avgSe: number | null;
   difficultyLabel: "Easy" | "Medium" | "Hard" | string;
+  /** Current ability estimate (θ, logit) for the target skill — positions the marker by the
+   *  *question's* difficulty rather than your odds of getting it right. */
+  theta?: number;
 }
 
 const GRADIENT = "linear-gradient(90deg, #10b981 0%, #6366f1 50%, #ef4444 100%)";
@@ -30,14 +33,19 @@ export function DifficultyPulse({
   targetSkill,
   avgSe,
   difficultyLabel,
+  theta,
 }: DifficultyPulseProps) {
   const certainty = certaintyBand(avgSe);
   const skillLabel = prettySkill(targetSkill);
   const predictedPct = Math.round(predictedPCorrect * 100);
-  // The track maps Easy (left) → Hard (right). A *lower* predicted P(correct)
-  // means the engine picked a harder item relative to the student's θ, so we
-  // map P=1 → 0% (Easy) and P=0 → 100% (Hard).
-  const markerPct = Math.max(2, Math.min(98, (1 - predictedPCorrect) * 100));
+  // The track maps Easy (left) → Hard (right) and shows the *question's* difficulty, NOT your
+  // odds of getting it right. Item difficulty b = θ − logit(P): as you answer well your θ rises
+  // and the engine serves higher-b items, so the marker climbs toward Hard; a miss lowers θ and
+  // it eases toward Easy. (Positioning by P alone slid it the opposite, counterintuitive way —
+  // doing well made questions look "easier" even as they got harder.)
+  const pSafe = Math.min(0.97, Math.max(0.03, predictedPCorrect));
+  const difficultyLogit = (theta ?? 0) - Math.log(pSafe / (1 - pSafe));
+  const markerPct = Math.max(3, Math.min(97, ((difficultyLogit + 3) / 6) * 100));
 
   return (
     <Box
@@ -60,9 +68,26 @@ export function DifficultyPulse({
       <Box sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 0.75, minWidth: 0 }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
           <AIPill icon={<Icon icon="mdi:robot-happy-outline" width={14} />}>Adaptive engine</AIPill>
-          <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", fontWeight: 600 }}>
-            Current question · {difficultyLabel}
-          </Typography>
+          <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.3 }}>
+            <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", fontWeight: 600 }}>
+              Current question · {difficultyLabel}
+            </Typography>
+            <AdaptiveInfoTip title="What the difficulty bar means" placement="bottom">
+              <p>
+                The bar below shows how hard <strong>this question</strong> is —{" "}
+                <strong>Easy</strong> on the left, <strong>Hard</strong> on the right.
+              </p>
+              <p>
+                It adapts to you. Answer one <strong>correctly</strong> and the engine steps you
+                up, so the next question is harder and the marker slides <strong>right →</strong>.
+                Get one <strong>wrong</strong> and it eases off, sliding <strong>← left</strong>.
+              </p>
+              <p style={{ opacity: 0.7, fontSize: "0.74rem" }}>
+                The aim is to keep you at the edge of your ability — challenged, but not
+                overwhelmed.
+              </p>
+            </AdaptiveInfoTip>
+          </Box>
         </Box>
 
         {/* Plain-English line: skill chip + how sure the AI is + predicted % */}
@@ -112,19 +137,19 @@ export function DifficultyPulse({
                 <br />
                 <strong>Building a picture</strong> — it has a rough sense.
                 <br />
-                <strong>Getting clearer</strong> — it's narrowing in.
+                <strong>Getting clearer</strong> — it&apos;s narrowing in.
                 <br />
                 <strong>Confident read</strong> — it can stop soon.
               </p>
               <p style={{ opacity: 0.7, fontSize: "0.74rem" }}>
-                You don't need to do anything special — answer honestly and the
+                You don&apos;t need to do anything special — answer honestly and the
                 next question adapts to where you are.
               </p>
             </AdaptiveInfoTip>
           </Box>
           <Typography sx={{ fontSize: "0.88rem", color: "text.secondary", fontWeight: 600 }}>·</Typography>
           <Typography sx={{ fontSize: "0.88rem", color: "text.secondary", fontWeight: 600 }}>
-            ~{predictedPct}% chance you'll get this right
+            ~{predictedPct}% chance you&apos;ll get this right
           </Typography>
         </Box>
 
@@ -175,6 +200,12 @@ export function DifficultyPulse({
             Hard
           </Typography>
         </Box>
+
+        {/* Always-visible reminder of which way the bar moves and why. */}
+        <Typography sx={{ fontSize: "0.7rem", color: "text.secondary", textAlign: "center", mt: 0.5, lineHeight: 1.45 }}>
+          Answer <Box component="span" sx={{ fontWeight: 800, color: "#10b981" }}>correctly</Box> → steps up toward Hard ·{" "}
+          <Box component="span" sx={{ fontWeight: 800, color: "#ef4444" }}>miss one</Box> → eases toward Easy
+        </Typography>
       </Box>
     </Box>
   );

--- a/components/adaptive-quiz/mid/LiveQuizPoints.tsx
+++ b/components/adaptive-quiz/mid/LiveQuizPoints.tsx
@@ -26,7 +26,7 @@ function fmtSecs(s: number): string {
  * Display-only (the scored time is tracked precisely in the session hook); paused until the
  * learner begins, and remounted (key) per question by the caller so it resets to full.
  */
-export function LiveQuizPoints({ decay, running = true }: { decay: QuestionPointsDecay; running?: boolean }) {
+export function LiveQuizPoints({ decay, running = true, hints = 0 }: { decay: QuestionPointsDecay; running?: boolean; hints?: number }) {
   const [elapsedMs, setElapsedMs] = useState(0);
 
   useEffect(() => {
@@ -37,8 +37,10 @@ export function LiveQuizPoints({ decay, running = true }: { decay: QuestionPoint
   }, [running]);
 
   const elapsedSec = elapsedMs / 1000;
-  const pts = Math.round(pointsAfterDecay(elapsedSec, decay));
-  const inGrace = elapsedSec < decay.grace;
+  // Hint penalty mirrors the engine: each hint shaves decay.hint_penalty off the points.
+  const hintMult = Math.max(0, 1 - (decay.hint_penalty ?? 0) * Math.max(0, hints));
+  const pts = Math.round(pointsAfterDecay(elapsedSec, decay) * hintMult);
+  const inGrace = elapsedSec < decay.grace && hints === 0;
   const atFloor = pts <= decay.floor;
   const pct = decay.base > 0 ? Math.max(0, Math.min(100, (pts / decay.base) * 100)) : 0;
   const color = inGrace ? "#10b981" : atFloor ? "#ef4444" : "#f59e0b";
@@ -83,9 +85,12 @@ export function LiveQuizPoints({ decay, running = true }: { decay: QuestionPoint
           : atFloor
             ? `At the ${decay.floor}-pt floor`
             : `Decaying −${decay.dec} every ${decay.iv}s`}
+        {hints > 0 && (decay.hint_penalty ?? 0) > 0
+          ? ` · −${Math.round((decay.hint_penalty ?? 0) * 100 * hints)}% from hint`
+          : ""}
       </Typography>
       <Typography sx={{ fontSize: "0.64rem", color: "text.secondary", mt: 0.25 }}>
-        Answer fast &amp; right to keep more
+        {hints > 0 ? "A hint trims your points — but a right answer still counts" : "Answer fast & right to keep more"}
       </Typography>
     </Box>
   );

--- a/components/adaptive-quiz/mid/LiveQuizPoints.tsx
+++ b/components/adaptive-quiz/mid/LiveQuizPoints.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, LinearProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { QuestionPointsDecay } from "@/lib/types/adaptive-quiz";
+
+/** Mirror of the backend engine.points_after_decay — keep in lockstep so the live number
+ *  matches what gets awarded. */
+function pointsAfterDecay(elapsedSec: number, d: QuestionPointsDecay): number {
+  if (elapsedSec <= d.grace) return d.base;
+  const intervals = Math.floor((elapsedSec - d.grace) / d.iv);
+  return Math.max(d.floor, d.base - d.dec * intervals);
+}
+
+function fmtSecs(s: number): string {
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return r ? `${m}m ${r}s` : `${m}m`;
+}
+
+/**
+ * Live, decaying points meter for the current question. Holds full points through the grace
+ * window, then ticks down step-by-step — the visible incentive to answer well *and* quickly.
+ * Display-only (the scored time is tracked precisely in the session hook); paused until the
+ * learner begins, and remounted (key) per question by the caller so it resets to full.
+ */
+export function LiveQuizPoints({ decay, running = true }: { decay: QuestionPointsDecay; running?: boolean }) {
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  useEffect(() => {
+    if (!running) return; // paused preview — hold at full points until the learner begins
+    const startedAt = Date.now();
+    const id = window.setInterval(() => setElapsedMs(Date.now() - startedAt), 200);
+    return () => window.clearInterval(id);
+  }, [running]);
+
+  const elapsedSec = elapsedMs / 1000;
+  const pts = Math.round(pointsAfterDecay(elapsedSec, decay));
+  const inGrace = elapsedSec < decay.grace;
+  const atFloor = pts <= decay.floor;
+  const pct = decay.base > 0 ? Math.max(0, Math.min(100, (pts / decay.base) * 100)) : 0;
+  const color = inGrace ? "#10b981" : atFloor ? "#ef4444" : "#f59e0b";
+  const graceLeft = Math.max(0, Math.ceil(decay.grace - elapsedSec));
+
+  return (
+    <Box
+      sx={{
+        p: 1.75, borderRadius: 3,
+        bgcolor: "color-mix(in srgb, var(--card-bg, #ffffff) 60%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--border-default, #e5e7eb) 70%, transparent)",
+        textAlign: "center",
+      }}
+    >
+      <Stack direction="row" spacing={0.5} alignItems="center" justifyContent="center">
+        <Icon icon="mdi:star-four-points" width={13} color="#7c3aed" />
+        <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: "0.12em", textTransform: "uppercase", color: "text.secondary" }}>
+          Points on offer
+        </Typography>
+      </Stack>
+
+      {/* Updates in place as it decays — no per-tick remount, so the number ticks down
+          smoothly instead of re-popping every interval. */}
+      <Box sx={{ mt: 0.5, lineHeight: 1 }}>
+        <Typography component="span" sx={{ fontWeight: 900, fontSize: "2.1rem", color, fontVariantNumeric: "tabular-nums", transition: "color .3s" }}>
+          {pts}
+        </Typography>
+        <Typography component="span" sx={{ fontSize: "0.8rem", fontWeight: 700, color: "text.secondary", ml: 0.5 }}>
+          / {decay.base} pts
+        </Typography>
+      </Box>
+
+      <LinearProgress
+        variant="determinate"
+        value={pct}
+        sx={{ mt: 1, height: 7, borderRadius: 4, bgcolor: "rgba(148,163,184,0.2)", "& .MuiLinearProgress-bar": { bgcolor: color, borderRadius: 4, transition: "transform .3s ease, background-color .3s" } }}
+      />
+
+      <Typography sx={{ fontSize: "0.72rem", color: inGrace ? "#15803d" : atFloor ? "#b91c1c" : "#b45309", fontWeight: 700, mt: 0.85, lineHeight: 1.4 }}>
+        {inGrace
+          ? `Full points for ${fmtSecs(graceLeft)} more`
+          : atFloor
+            ? `At the ${decay.floor}-pt floor`
+            : `Decaying −${decay.dec} every ${decay.iv}s`}
+      </Typography>
+      <Typography sx={{ fontSize: "0.64rem", color: "text.secondary", mt: 0.25 }}>
+        Answer fast &amp; right to keep more
+      </Typography>
+    </Box>
+  );
+}

--- a/components/adaptive-quiz/mid/PointsRewardBurst.tsx
+++ b/components/adaptive-quiz/mid/PointsRewardBurst.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { AnimatePresence, motion } from "framer-motion";
+
+export interface RewardBurst {
+  id: number;
+  points: number;
+  base: number;
+}
+
+/**
+ * "+N pts" reward that pops on a points-earning answer and floats up as it fades. Keyed by an
+ * ever-incrementing reward id so each submit re-fires. Only fires for a positive reward — a
+ * wrong answer (0 pts) or a practice quiz stays silent (correctness feedback lives elsewhere).
+ */
+export function PointsRewardBurst({ reward }: { reward: RewardBurst | null }) {
+  return (
+    <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", pointerEvents: "none", zIndex: 5, overflow: "visible" }}>
+      <AnimatePresence>
+        {reward && reward.points > 0 && (
+          <motion.div
+            key={reward.id}
+            initial={{ opacity: 0, y: 16, scale: 0.6 }}
+            animate={{ opacity: 1, y: -56, scale: 1.05 }}
+            exit={{ opacity: 0, y: -96, scale: 0.9 }}
+            transition={{ duration: 1.1, ease: [0.16, 1, 0.3, 1] }}
+          >
+            <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 2, py: 1, borderRadius: 999, color: "white", fontWeight: 900, fontSize: "1.5rem", background: "linear-gradient(135deg, #10b981 0%, #22c55e 100%)", boxShadow: "0 16px 36px -14px rgba(16,185,129,0.7)" }}>
+              <Icon icon="mdi:star-four-points" width={22} />
+              +{reward.points}
+              <Typography component="span" sx={{ fontSize: "0.85rem", fontWeight: 800, opacity: 0.9 }}>pts</Typography>
+            </Box>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </Box>
+  );
+}

--- a/components/adaptive-quiz/mid/QuestionCard.tsx
+++ b/components/adaptive-quiz/mid/QuestionCard.tsx
@@ -3,6 +3,7 @@
 import { Box, ButtonBase, Chip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { ConfidenceInput } from "./ConfidenceInput";
+import { prettySkill } from "@/lib/utils/skill-label.utils";
 import type {
   AdaptiveQuestion,
   ConfidenceLevel,
@@ -34,11 +35,6 @@ function difficultyColor(label: string): string {
     default:
       return "#6366f1";
   }
-}
-
-function prettySkill(s: string): string {
-  if (!s) return "General";
-  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 export function QuestionCard({

--- a/components/adaptive-quiz/mid/QuizMetaStrip.tsx
+++ b/components/adaptive-quiz/mid/QuizMetaStrip.tsx
@@ -68,12 +68,12 @@ export function QuizMetaStrip({
           <Box component="span" sx={{ color: "text.primary", fontWeight: 800, fontVariantNumeric: "tabular-nums" }}>
             {answered + 1}
           </Box>{" "}
-          · ~{minQuestions}–{maxQuestions}
+          · {minQuestions === maxQuestions ? `of ${maxQuestions}` : `~${minQuestions}–${maxQuestions}`}
         </Typography>
 
         <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}>
           <Typography sx={{ fontSize: "0.74rem", color: "text.secondary", fontWeight: 600 }}>
-            AI's read:{" "}
+            AI&apos;s read:{" "}
             <Box component="span" sx={{ color: certainty.accent, fontWeight: 800 }}>
               {certainty.label}
             </Box>

--- a/components/adaptive-quiz/mid/SkillConfidenceCard.tsx
+++ b/components/adaptive-quiz/mid/SkillConfidenceCard.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 import { Icon } from "@iconify/react";
 import { AIPill } from "../shared/AIPill";
 import { certaintyBand } from "@/lib/utils/adaptive-confidence";
+import { prettySkill } from "@/lib/utils/skill-label.utils";
 
 interface SkillRow {
   skill: string;
@@ -35,10 +36,6 @@ function thetaToMastery(theta: number): number {
   return 1 / (1 + Math.exp(-theta * 0.9));
 }
 
-function prettySkill(s: string): string {
-  if (!s) return "General";
-  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
 
 export function SkillConfidenceCard({ skills, activeSkill, nudge }: SkillConfidenceCardProps) {
   return (

--- a/components/adaptive-quiz/results/RemediationPathCard.tsx
+++ b/components/adaptive-quiz/results/RemediationPathCard.tsx
@@ -19,12 +19,14 @@ const ACTION_ICON: Record<string, string> = {
   read: "mdi:book-open-page-variant-outline",
   watch: "mdi:play-circle-outline",
   practice: "mdi:dumbbell",
+  requiz: "mdi:tune-vertical",
 };
 
 const ACTION_VERB: Record<string, string> = {
   read: "Read",
   watch: "Watch",
   practice: "Practice",
+  requiz: "Take quiz",
 };
 
 function prettySkill(s: string): string {
@@ -32,13 +34,22 @@ function prettySkill(s: string): string {
   return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Deep-link to the real course item a step maps to, or null when the step is a
- *  re-quiz (handled by onStartPath) or carries no link metadata. */
+const isRequiz = (step: RemediationStep) =>
+  step.content_type === "requiz" || step.action_kind === "requiz";
+
+/** Deep-link to the EXACT course item a step maps to, or null when it's the follow-up
+ *  re-quiz (spawned via onStartPath). Video/article link straight to the item; only when the
+ *  specific id is missing do we fall back to the submodule page. */
 function stepHref(step: RemediationStep): string | null {
+  if (isRequiz(step)) return null;
   if (step.content_type === "article" && step.course_id && step.submodule_id && step.article_id) {
     return `/adaptive-courses/${step.course_id}/submodule/${step.submodule_id}/article/${step.article_id}`;
   }
-  if ((step.content_type === "video" || step.content_type === "coding") && step.course_id && step.submodule_id) {
+  if (step.content_type === "video" && step.course_id && step.submodule_id && step.content_id) {
+    return `/adaptive-courses/${step.course_id}/submodule/${step.submodule_id}/video/${step.content_id}`;
+  }
+  // Known item but no specific id → land on the submodule (better than nothing).
+  if ((step.content_type === "video" || step.content_type === "article") && step.course_id && step.submodule_id) {
     return `/adaptive-courses/${step.course_id}/submodule/${step.submodule_id}`;
   }
   return null;
@@ -51,9 +62,13 @@ export function RemediationPathCard({ steps, onStartPath }: RemediationPathCardP
   }
   const totalMinutes = steps.reduce((acc, s) => acc + (s.est_minutes ?? 5), 0);
   const openStep = (step: RemediationStep) => {
+    if (isRequiz(step)) {
+      onStartPath?.(); // follow-up adaptive quiz → spawn the targeted re-quiz
+      return;
+    }
     const href = stepHref(step);
     if (href) router.push(href);
-    else onStartPath?.(); // re-quiz / no link → spawn the targeted re-quiz
+    else onStartPath?.();
   };
   return (
     <Box

--- a/components/adaptive-quiz/results/RemediationPathCard.tsx
+++ b/components/adaptive-quiz/results/RemediationPathCard.tsx
@@ -1,17 +1,21 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
 import { Box, ButtonBase, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 import { Icon } from "@iconify/react";
 import { useRouter } from "next/navigation";
 import { gridStagger, fadeRise } from "@/components/scorecard/shared/motion";
 import { AIPill } from "../shared/AIPill";
-import type { AdaptiveAINarration } from "@/lib/types/adaptive-quiz";
+import { adaptiveQuizService } from "@/lib/services/adaptive-quiz.service";
+import type { AdaptiveAINarration, RemediationProgress } from "@/lib/types/adaptive-quiz";
 
 type RemediationStep = AdaptiveAINarration["remediation_path"][number];
 
 interface RemediationPathCardProps {
   steps: AdaptiveAINarration["remediation_path"];
+  /** The source session — used to read live step-completion + spawn the re-quiz. */
+  sessionId?: string;
   onStartPath?: () => void;
 }
 
@@ -48,28 +52,59 @@ function stepHref(step: RemediationStep): string | null {
   if (step.content_type === "video" && step.course_id && step.submodule_id && step.content_id) {
     return `/adaptive-courses/${step.course_id}/submodule/${step.submodule_id}/video/${step.content_id}`;
   }
-  // Known item but no specific id → land on the submodule (better than nothing).
   if ((step.content_type === "video" || step.content_type === "article") && step.course_id && step.submodule_id) {
     return `/adaptive-courses/${step.course_id}/submodule/${step.submodule_id}`;
   }
   return null;
 }
 
-export function RemediationPathCard({ steps, onStartPath }: RemediationPathCardProps) {
+export function RemediationPathCard({ steps, sessionId, onStartPath }: RemediationPathCardProps) {
   const router = useRouter();
-  if (!steps.length) {
-    return null;
-  }
+  const [progress, setProgress] = useState<RemediationProgress | null>(null);
+
+  // Pull live completion + re-fetch when the tab regains focus, so finishing a step in another
+  // tab (or returning from the article/video) ticks it done without a manual refresh.
+  const refresh = useCallback(() => {
+    if (!sessionId) return;
+    adaptiveQuizService.getRemediationProgress(sessionId).then(setProgress).catch(() => {});
+  }, [sessionId]);
+
+  useEffect(() => {
+    refresh();
+    const onVis = () => { if (document.visibilityState === "visible") refresh(); };
+    document.addEventListener("visibilitychange", onVis);
+    window.addEventListener("focus", refresh);
+    return () => {
+      document.removeEventListener("visibilitychange", onVis);
+      window.removeEventListener("focus", refresh);
+    };
+  }, [refresh]);
+
+  if (!steps.length) return null;
+
+  const doneByStep: Record<number, boolean> = {};
+  for (const s of progress?.steps ?? []) doneByStep[s.step] = s.done;
+  const contentDone = progress?.content_done ?? false;
+  const requizSessionId = progress?.requiz.session_id ?? null;
+  const requizActive = progress?.requiz.status === "active";
+  // Lock the re-quiz only once we KNOW content isn't done (avoids a flicker before load).
+  const requizLocked = progress !== null && !contentDone;
+
   const totalMinutes = steps.reduce((acc, s) => acc + (s.est_minutes ?? 5), 0);
+  const allDone = !!progress && steps.every((s) => doneByStep[s.step]);
+  const firstActionable = steps.find((s) => !doneByStep[s.step] && (!isRequiz(s) || contentDone));
+
+  const openRequiz = () => {
+    if (requizActive && requizSessionId) router.push(`/adaptive-quizzes/session/${requizSessionId}`);
+    else onStartPath?.();
+  };
   const openStep = (step: RemediationStep) => {
-    if (isRequiz(step)) {
-      onStartPath?.(); // follow-up adaptive quiz → spawn the targeted re-quiz
-      return;
-    }
+    if (isRequiz(step)) { openRequiz(); return; }
     const href = stepHref(step);
     if (href) router.push(href);
     else onStartPath?.();
   };
+
   return (
     <Box
       sx={{
@@ -90,16 +125,9 @@ export function RemediationPathCard({ steps, onStartPath }: RemediationPathCardP
       <Box
         aria-hidden
         sx={{
-          position: "absolute",
-          top: -80,
-          right: -80,
-          width: 220,
-          height: 220,
-          borderRadius: "50%",
+          position: "absolute", top: -80, right: -80, width: 220, height: 220, borderRadius: "50%",
           background: "radial-gradient(circle, #ec4899 0%, transparent 70%)",
-          opacity: 0.35,
-          filter: "blur(20px)",
-          pointerEvents: "none",
+          opacity: 0.35, filter: "blur(20px)", pointerEvents: "none",
         }}
       />
       <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
@@ -111,6 +139,16 @@ export function RemediationPathCard({ steps, onStartPath }: RemediationPathCardP
             A path picked for your weak spots.
           </Typography>
         </Box>
+        {progress && (
+          <Box sx={{ textAlign: "right", flexShrink: 0 }}>
+            <Typography sx={{ fontSize: "1.4rem", fontWeight: 900, lineHeight: 1, color: "#7c3aed" }}>
+              {steps.filter((s) => doneByStep[s.step]).length}/{steps.length}
+            </Typography>
+            <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: "0.12em", textTransform: "uppercase", color: "text.secondary" }}>
+              done
+            </Typography>
+          </Box>
+        )}
       </Box>
 
       <Box
@@ -121,95 +159,128 @@ export function RemediationPathCard({ steps, onStartPath }: RemediationPathCardP
         viewport={{ once: true, margin: "0px 0px -10% 0px" }}
         sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}
       >
-        {steps.map((step) => (
-          <Box
-            key={step.step}
-            component={motion.div}
-            variants={fadeRise}
-            sx={{
-              display: "flex",
-              alignItems: "flex-start",
-              gap: 1.5,
-              p: 1.5,
-              borderRadius: 3,
-              bgcolor: "color-mix(in srgb, white 60%, transparent)",
-              border: "1px solid color-mix(in srgb, #a855f7 18%, transparent)",
-            }}
-          >
+        {steps.map((step) => {
+          const done = !!doneByStep[step.step];
+          const reqStep = isRequiz(step);
+          const locked = reqStep && !done && requizLocked;
+          return (
             <Box
+              key={step.step}
+              component={motion.div}
+              variants={fadeRise}
               sx={{
-                width: 36,
-                height: 36,
-                borderRadius: 999,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
-                color: "white",
-                flexShrink: 0,
+                display: "flex", alignItems: "flex-start", gap: 1.5, p: 1.5, borderRadius: 3,
+                bgcolor: done ? "color-mix(in srgb, #10b981 9%, white)" : "color-mix(in srgb, white 60%, transparent)",
+                border: `1px solid ${done ? "color-mix(in srgb, #10b981 32%, transparent)" : "color-mix(in srgb, #a855f7 18%, transparent)"}`,
+                opacity: locked ? 0.65 : 1,
+                transition: "background-color .25s, border-color .25s, opacity .25s",
               }}
             >
-              <Icon icon={ACTION_ICON[step.action_kind] ?? "mdi:book-open-page-variant-outline"} width={18} />
-            </Box>
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Typography sx={{ fontSize: "0.95rem", fontWeight: 800, color: "text.primary", lineHeight: 1.3 }}>
-                Step {step.step} · {step.title}
-              </Typography>
-              <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", lineHeight: 1.5, mt: 0.5 }}>
-                {step.why}
-              </Typography>
-              <Box sx={{ display: "flex", gap: 1, mt: 0.75, flexWrap: "wrap" }}>
-                <Chip label={`${step.est_minutes} min`} />
-                <Chip label={prettySkill(step.target_skill)} />
-                <Chip label={step.action_kind.toUpperCase()} accent />
+              <Box
+                sx={{
+                  width: 36, height: 36, borderRadius: 999, display: "flex", alignItems: "center",
+                  justifyContent: "center", color: "white", flexShrink: 0,
+                  background: done
+                    ? "linear-gradient(135deg, #10b981 0%, #22c55e 100%)"
+                    : locked
+                      ? "color-mix(in srgb, #64748b 55%, white)"
+                      : "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
+                }}
+              >
+                <Icon icon={done ? "mdi:check" : locked ? "mdi:lock-outline" : (ACTION_ICON[step.action_kind] ?? "mdi:book-open-page-variant-outline")} width={18} />
               </Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography sx={{ fontSize: "0.95rem", fontWeight: 800, color: "text.primary", lineHeight: 1.3 }}>
+                  Step {step.step} · {step.title}
+                </Typography>
+                <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", lineHeight: 1.5, mt: 0.5 }}>
+                  {step.why}
+                </Typography>
+                <Box sx={{ display: "flex", gap: 1, mt: 0.75, flexWrap: "wrap" }}>
+                  <Chip label={`${step.est_minutes} min`} />
+                  <Chip label={prettySkill(step.target_skill)} />
+                  <Chip label={reqStep ? "RE-QUIZ" : step.action_kind.toUpperCase()} accent />
+                </Box>
+                {locked && (
+                  <Typography sx={{ fontSize: "0.72rem", color: "#b45309", fontWeight: 700, mt: 0.75 }}>
+                    Finish the steps above to unlock your follow-up quiz.
+                  </Typography>
+                )}
+              </Box>
+              <StepButton
+                done={done}
+                locked={locked}
+                reqStep={reqStep}
+                requizActive={requizActive}
+                actionKind={step.action_kind}
+                onClick={() => {
+                  if (locked) return;
+                  if (done && reqStep && requizSessionId) {
+                    router.push(`/adaptive-quizzes/session/${requizSessionId}/results`);
+                    return;
+                  }
+                  openStep(step);
+                }}
+              />
             </Box>
-            <ButtonBase
-              onClick={() => openStep(step)}
-              sx={{
-                alignSelf: "center",
-                flexShrink: 0,
-                px: 1.75,
-                py: 0.8,
-                borderRadius: 999,
-                fontWeight: 800,
-                fontSize: "0.8rem",
-                gap: 0.5,
-                color: "#7c3aed",
-                bgcolor: "color-mix(in srgb, #a855f7 14%, white)",
-                border: "1px solid color-mix(in srgb, #a855f7 35%, transparent)",
-                "&:hover": { bgcolor: "color-mix(in srgb, #a855f7 22%, white)" },
-              }}
-            >
-              <Icon icon={ACTION_ICON[step.action_kind] ?? "mdi:arrow-right"} width={15} />
-              {ACTION_VERB[step.action_kind] ?? "Open"}
-            </ButtonBase>
-          </Box>
-        ))}
+          );
+        })}
       </Box>
 
-      <ButtonBase
-        onClick={() => openStep(steps[0])}
-        disabled={!onStartPath}
-        sx={{
-          alignSelf: "flex-end",
-          mt: 0.5,
-          px: 3,
-          py: 1.4,
-          borderRadius: 999,
-          fontWeight: 800,
-          color: "white",
-          background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
-          boxShadow: "0 14px 30px -14px rgba(168, 85, 247, 0.55)",
-          fontSize: "0.92rem",
-          "&:hover": { transform: "translateY(-1px)" },
-          transition: "transform 120ms ease",
-          "&:disabled": { opacity: 0.7 },
-        }}
-      >
-        Start your remediation path →
-      </ButtonBase>
+      {allDone ? (
+        <Box sx={{ alignSelf: "flex-end", mt: 0.5, display: "inline-flex", alignItems: "center", gap: 0.75, px: 3, py: 1.4, borderRadius: 999, fontWeight: 800, color: "white", fontSize: "0.92rem", background: "linear-gradient(135deg, #10b981 0%, #22c55e 100%)", boxShadow: "0 14px 30px -14px rgba(16,185,129,0.5)" }}>
+          <Icon icon="mdi:check-circle" width={18} /> Remediation complete
+        </Box>
+      ) : (
+        <ButtonBase
+          onClick={() => { if (firstActionable) openStep(firstActionable); }}
+          disabled={!firstActionable}
+          sx={{
+            alignSelf: "flex-end", mt: 0.5, px: 3, py: 1.4, borderRadius: 999, fontWeight: 800,
+            color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
+            boxShadow: "0 14px 30px -14px rgba(168, 85, 247, 0.55)", fontSize: "0.92rem",
+            "&:hover": { transform: "translateY(-1px)" }, transition: "transform 120ms ease",
+            "&:disabled": { opacity: 0.5 },
+          }}
+        >
+          {progress && steps.some((s) => doneByStep[s.step]) ? "Continue your path →" : "Start your remediation path →"}
+        </ButtonBase>
+      )}
     </Box>
+  );
+}
+
+function StepButton({
+  done, locked, reqStep, requizActive, actionKind, onClick,
+}: {
+  done: boolean; locked: boolean; reqStep: boolean; requizActive: boolean; actionKind: string; onClick: () => void;
+}) {
+  let icon: string;
+  let label: string;
+  if (locked) { icon = "mdi:lock-outline"; label = "Locked"; }
+  else if (done && reqStep) { icon = "mdi:chart-box-outline"; label = "View result"; }
+  else if (done) { icon = "mdi:refresh"; label = "Review"; }
+  else if (reqStep) { icon = "mdi:tune-vertical"; label = requizActive ? "Resume quiz" : "Take quiz"; }
+  else { icon = ACTION_ICON[actionKind] ?? "mdi:arrow-right"; label = ACTION_VERB[actionKind] ?? "Open"; }
+
+  const success = done;
+  return (
+    <ButtonBase
+      onClick={onClick}
+      disabled={locked}
+      sx={{
+        alignSelf: "center", flexShrink: 0, px: 1.75, py: 0.8, borderRadius: 999, fontWeight: 800,
+        fontSize: "0.8rem", gap: 0.5,
+        color: success ? "#15803d" : "#7c3aed",
+        bgcolor: success ? "color-mix(in srgb, #10b981 14%, white)" : "color-mix(in srgb, #a855f7 14%, white)",
+        border: `1px solid ${success ? "color-mix(in srgb, #10b981 35%, transparent)" : "color-mix(in srgb, #a855f7 35%, transparent)"}`,
+        "&:hover": { bgcolor: success ? "color-mix(in srgb, #10b981 22%, white)" : "color-mix(in srgb, #a855f7 22%, white)" },
+        "&:disabled": { opacity: 0.55, color: "text.secondary", bgcolor: "color-mix(in srgb, #64748b 10%, transparent)" },
+      }}
+    >
+      <Icon icon={icon} width={15} />
+      {label}
+    </ButtonBase>
   );
 }
 
@@ -217,12 +288,7 @@ function Chip({ label, accent }: { label: string; accent?: boolean }) {
   return (
     <Box
       sx={{
-        px: 1,
-        py: 0.3,
-        borderRadius: 999,
-        fontSize: "0.66rem",
-        fontWeight: 800,
-        letterSpacing: "0.1em",
+        px: 1, py: 0.3, borderRadius: 999, fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.1em",
         textTransform: "uppercase",
         bgcolor: accent ? "color-mix(in srgb, #a855f7 18%, transparent)" : "color-mix(in srgb, currentColor 10%, transparent)",
         color: accent ? "#a855f7" : "text.secondary",

--- a/components/adaptive-quiz/results/RequizOutcomeBanner.tsx
+++ b/components/adaptive-quiz/results/RequizOutcomeBanner.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Box, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { RequizOutcome } from "@/lib/types/adaptive-quiz";
+
+function prettySkill(s: string): string {
+  if (!s) return "this skill";
+  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+const VERDICT: Record<string, { icon: string; accent: string; bg: string; border: string; title: (s: string) => string; sub: string }> = {
+  closed: {
+    icon: "mdi:check-circle",
+    accent: "#15803d",
+    bg: "color-mix(in srgb, #10b981 12%, transparent)",
+    border: "color-mix(in srgb, #10b981 35%, transparent)",
+    title: (s) => `Gap closed — you've got ${s} now.`,
+    sub: "Your follow-up quiz shows real improvement. Nice work.",
+  },
+  narrowed: {
+    icon: "mdi:trending-up",
+    accent: "#b45309",
+    bg: "color-mix(in srgb, #f59e0b 14%, transparent)",
+    border: "color-mix(in srgb, #f59e0b 38%, transparent)",
+    title: (s) => `Closing in on ${s}.`,
+    sub: "You improved — one more pass should lock it in.",
+  },
+  still_weak: {
+    icon: "mdi:alert-circle-outline",
+    accent: "#b91c1c",
+    bg: "color-mix(in srgb, #ef4444 12%, transparent)",
+    border: "color-mix(in srgb, #ef4444 35%, transparent)",
+    title: (s) => `${s} still needs another pass.`,
+    sub: "No jump yet — revisit the step above, then retry.",
+  },
+};
+
+/** Closes the loop on a re-quiz: how it compares to the original attempt on the targeted skill. */
+export function RequizOutcomeBanner({ outcome }: { outcome: RequizOutcome }) {
+  if (!outcome.has_source || !outcome.verdict || !outcome.original || !outcome.requiz) return null;
+  const v = VERDICT[outcome.verdict] ?? VERDICT.narrowed;
+  const skill = prettySkill(outcome.skill || "");
+  const oPct = Math.round(outcome.original.accuracy * 100);
+  const rPct = Math.round(outcome.requiz.accuracy * 100);
+
+  return (
+    <Box
+      sx={{
+        p: { xs: 2, md: 2.5 }, borderRadius: 4, mb: 2.5,
+        bgcolor: v.bg, border: `1px solid ${v.border}`,
+        display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap",
+      }}
+    >
+      <Box sx={{ width: 44, height: 44, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: v.accent }}>
+        <Icon icon={v.icon} width={26} />
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.12em", textTransform: "uppercase", color: v.accent }}>
+          Follow-up result
+        </Typography>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "text.primary", lineHeight: 1.3 }}>
+          {v.title(skill)}
+        </Typography>
+        <Typography sx={{ fontSize: "0.84rem", color: "text.secondary", mt: 0.25 }}>{v.sub}</Typography>
+      </Box>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ flexShrink: 0 }}>
+        <Pill label="First attempt" value={`${oPct}%`} color="#94a3b8" />
+        <Icon icon="mdi:arrow-right" width={18} color={v.accent} />
+        <Pill label="Re-quiz" value={`${rPct}%`} color={v.accent} />
+      </Stack>
+    </Box>
+  );
+}
+
+function Pill({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <Box sx={{ px: 1.5, py: 0.75, borderRadius: 2.5, bgcolor: "color-mix(in srgb, white 65%, transparent)", textAlign: "center", minWidth: 76 }}>
+      <Typography sx={{ fontWeight: 900, fontSize: "1.15rem", color, lineHeight: 1 }}>{value}</Typography>
+      <Typography sx={{ fontSize: "0.6rem", fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "text.secondary", mt: 0.4 }}>{label}</Typography>
+    </Box>
+  );
+}

--- a/components/adaptive-quiz/results/ResultSkeletons.tsx
+++ b/components/adaptive-quiz/results/ResultSkeletons.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { Box, Stack } from "@mui/material";
+import { keyframes } from "@mui/system";
+
+/** Grey gradient-sweep shimmer (no purple), matching the dashboard skeleton. */
+const sweep = keyframes`
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+`;
+
+export function Shimmer({ h = 14, w = "100%", r = 1.5, sx }: { h?: number | string; w?: number | string; r?: number; sx?: object }) {
+  return (
+    <Box
+      sx={{
+        height: h,
+        width: w,
+        borderRadius: r,
+        background: "linear-gradient(90deg, #eef2f7 25%, #f8fafc 50%, #eef2f7 75%)",
+        backgroundSize: "200% 100%",
+        animation: `${sweep} 1.5s ease-in-out infinite`,
+        "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+        ...sx,
+      }}
+    />
+  );
+}
+
+const CARD = {
+  p: { xs: 2, md: 2.5 },
+  borderRadius: 4,
+  border: "1px solid color-mix(in srgb, var(--border-default, #e5e7eb) 65%, transparent)",
+  bgcolor: "color-mix(in srgb, var(--card-bg, #ffffff) 60%, transparent)",
+};
+
+function SectionHead() {
+  return (
+    <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 2 }}>
+      <Shimmer h={32} w={32} r={2} />
+      <Box sx={{ flex: 1 }}>
+        <Shimmer h={14} w="42%" />
+        <Shimmer h={10} w="62%" sx={{ mt: 0.75 }} />
+      </Box>
+    </Stack>
+  );
+}
+
+export function SkillMasterySkeleton() {
+  return (
+    <Box sx={CARD}>
+      <SectionHead />
+      <Stack spacing={1.5}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Box key={i}>
+            <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.75 }}>
+              <Shimmer h={12} w="38%" />
+              <Shimmer h={12} w={42} />
+            </Stack>
+            <Shimmer h={8} r={4} />
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+export function RemediationSkeleton() {
+  return (
+    <Box sx={CARD}>
+      <SectionHead />
+      <Stack spacing={1.25}>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Stack key={i} direction="row" spacing={1.25} alignItems="center">
+            <Shimmer h={26} w={26} r={999} />
+            <Box sx={{ flex: 1 }}>
+              <Shimmer h={12} w="70%" />
+              <Shimmer h={9} w="45%" sx={{ mt: 0.6 }} />
+            </Box>
+          </Stack>
+        ))}
+      </Stack>
+      <Shimmer h={40} r={2.5} sx={{ mt: 2 }} />
+    </Box>
+  );
+}
+
+export function MisconceptionSkeleton() {
+  return (
+    <Box sx={CARD}>
+      <SectionHead />
+      <Stack spacing={1.25}>
+        {Array.from({ length: 2 }).map((_, i) => (
+          <Box key={i} sx={{ p: 1.5, borderRadius: 2.5, border: "1px solid color-mix(in srgb, var(--border-default, #e5e7eb) 50%, transparent)" }}>
+            <Shimmer h={12} w="55%" />
+            <Shimmer h={10} w="90%" sx={{ mt: 0.75 }} />
+            <Shimmer h={10} w="80%" sx={{ mt: 0.4 }} />
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+export function PerQuestionSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <Box sx={CARD}>
+      <SectionHead />
+      <Stack spacing={1.25}>
+        {Array.from({ length: rows }).map((_, i) => (
+          <Box key={i} sx={{ p: 1.5, borderRadius: 2.5, border: "1px solid color-mix(in srgb, var(--border-default, #e5e7eb) 50%, transparent)" }}>
+            <Stack direction="row" spacing={1.25} alignItems="center">
+              <Shimmer h={28} w={28} r={999} />
+              <Box sx={{ flex: 1 }}>
+                <Shimmer h={12} w="85%" />
+                <Shimmer h={10} w="50%" sx={{ mt: 0.6 }} />
+              </Box>
+              <Shimmer h={22} w={56} r={999} />
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+/** Full-page placeholder shown while the session itself loads (before any data). */
+export function QuizResultSkeleton() {
+  return (
+    <Box>
+      {/* hero band */}
+      <Box sx={{ ...CARD, mb: 2.5 }}>
+        <Shimmer h={12} w={120} />
+        <Shimmer h={26} w="55%" sx={{ mt: 1.25 }} />
+        <Shimmer h={12} w="80%" sx={{ mt: 1 }} />
+      </Box>
+
+      {/* KPI rail */}
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2,1fr)", sm: "repeat(3,1fr)", md: "repeat(5,1fr)" }, gap: 1.5, mb: 2.5 }}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Box key={i} sx={{ ...CARD, p: 2, textAlign: "center" }}>
+            <Shimmer h={26} w="50%" sx={{ mx: "auto" }} />
+            <Shimmer h={10} w="70%" sx={{ mx: "auto", mt: 1 }} />
+          </Box>
+        ))}
+      </Box>
+
+      {/* result strip */}
+      <Box sx={{ ...CARD, mb: 2.5 }}>
+        <Shimmer h={14} w="40%" />
+        <Shimmer h={11} w="92%" sx={{ mt: 1 }} />
+        <Shimmer h={11} w="76%" sx={{ mt: 0.5 }} />
+      </Box>
+
+      {/* heatmap + remediation grid */}
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1.4fr) minmax(0,1fr)" }, gap: 2.5, mb: 2.5, alignItems: "flex-start" }}>
+        <SkillMasterySkeleton />
+        <RemediationSkeleton />
+      </Box>
+
+      <Box sx={{ mb: 2.5 }}><PerQuestionSkeleton /></Box>
+    </Box>
+  );
+}

--- a/components/adaptive-quiz/results/SkillMasteryHeatmap.tsx
+++ b/components/adaptive-quiz/results/SkillMasteryHeatmap.tsx
@@ -4,6 +4,7 @@ import { Box, Stack, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 import { Icon } from "@iconify/react";
 import { CountUp } from "@/components/scorecard/shared/CountUp";
+import { prettySkill } from "@/lib/utils/skill-label.utils";
 import type { AdaptiveAINarration } from "@/lib/types/adaptive-quiz";
 
 interface SkillMasteryHeatmapProps {
@@ -24,13 +25,6 @@ const BAND_COLOR: Record<string, string> = {
   mastered: "#10b981",
 };
 
-/** Clean a skill label: strip the Python-list-repr artifacts ('[', ']', quotes) that leaked
- *  into some stored skill keys, then humanise + title-case. */
-function prettySkill(s: string): string {
-  const cleaned = (s || "").trim().replace(/^[\s[\]'"]+|[\s[\]'"]+$/g, "").trim();
-  if (!cleaned) return "General";
-  return cleaned.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
 
 function BandPill({ band }: { band: string }) {
   const color = BAND_COLOR[band] ?? "#6366f1";

--- a/components/adaptive-quiz/results/SkillMasteryHeatmap.tsx
+++ b/components/adaptive-quiz/results/SkillMasteryHeatmap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 import { Icon } from "@iconify/react";
 import { CountUp } from "@/components/scorecard/shared/CountUp";
@@ -24,15 +24,32 @@ const BAND_COLOR: Record<string, string> = {
   mastered: "#10b981",
 };
 
+/** Clean a skill label: strip the Python-list-repr artifacts ('[', ']', quotes) that leaked
+ *  into some stored skill keys, then humanise + title-case. */
 function prettySkill(s: string): string {
-  if (!s) return "General";
-  return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  const cleaned = (s || "").trim().replace(/^[\s[\]'"]+|[\s[\]'"]+$/g, "").trim();
+  if (!cleaned) return "General";
+  return cleaned.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function BandPill({ band }: { band: string }) {
+  const color = BAND_COLOR[band] ?? "#6366f1";
+  return (
+    <Box
+      sx={{
+        px: 0.9, py: 0.25, borderRadius: 999, fontSize: "0.6rem", fontWeight: 800,
+        letterSpacing: "0.06em", textTransform: "uppercase", whiteSpace: "nowrap",
+        color, bgcolor: `color-mix(in srgb, ${color} 13%, transparent)`,
+        border: `1px solid color-mix(in srgb, ${color} 30%, transparent)`,
+      }}
+    >
+      {BAND_LABEL[band] ?? band}
+    </Box>
+  );
 }
 
 export function SkillMasteryHeatmap({ skills }: SkillMasteryHeatmapProps) {
-  if (!skills.length) {
-    return null;
-  }
+  if (!skills.length) return null;
   return (
     <Box
       sx={{
@@ -46,106 +63,79 @@ export function SkillMasteryHeatmap({ skills }: SkillMasteryHeatmapProps) {
         gap: 2,
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
-          <Icon icon="mdi:chart-line-variant" width={20} style={{ color: "#6366f1" }} />
-          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", letterSpacing: "-0.01em" }}>
-            Skill mastery
-          </Typography>
-        </Box>
-        <Typography sx={{ fontSize: "0.74rem", color: "text.secondary", fontWeight: 600 }}>
-          Dashed marker = where you ended your last attempt
-        </Typography>
-      </Box>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
+        <Stack direction="row" alignItems="center" spacing={1.25}>
+          <Box sx={{ width: 34, height: 34, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1, #a855f7)", boxShadow: "0 8px 18px -10px rgba(124,58,237,0.6)" }}>
+            <Icon icon="mdi:chart-line-variant" width={19} />
+          </Box>
+          <Box>
+            <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", letterSpacing: "-0.01em", lineHeight: 1.15 }}>Skill mastery</Typography>
+            <Typography sx={{ fontSize: "0.74rem", color: "text.secondary" }}>Where each sub-skill landed this attempt</Typography>
+          </Box>
+        </Stack>
+        <Stack direction="row" spacing={0.5} alignItems="center" sx={{ color: "text.secondary" }}>
+          <Box sx={{ width: 14, borderTop: "2px dashed currentColor" }} />
+          <Typography sx={{ fontSize: "0.68rem", fontWeight: 600 }}>= last attempt</Typography>
+        </Stack>
+      </Stack>
 
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
         {skills.map((row) => {
           const color = BAND_COLOR[row.band] ?? "#6366f1";
           const hasBaseline = row.delta_pct !== null && row.delta_pct !== undefined;
+          const delta = row.delta_pct as number;
           const previousMastery =
             typeof row.previous_mastery_pct === "number"
               ? Math.max(0, Math.min(100, row.previous_mastery_pct))
               : null;
           return (
-            <Box key={row.skill}>
-              <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", mb: 0.5 }}>
-                <Typography sx={{ fontSize: "0.88rem", fontWeight: 700 }}>{prettySkill(row.skill)}</Typography>
-                <Box sx={{ display: "flex", alignItems: "baseline", gap: 1.25 }}>
-                  <Typography sx={{ fontSize: "0.62rem", color: "text.secondary", letterSpacing: "0.14em", textTransform: "uppercase", fontWeight: 800 }}>
-                    {BAND_LABEL[row.band] ?? row.band}
-                  </Typography>
-                  {hasBaseline && row.delta_pct !== 0 ? (
-                    <Typography
-                      sx={{
-                        fontSize: "0.7rem",
-                        fontWeight: 800,
-                        color: (row.delta_pct as number) > 0 ? "#10b981" : "#ef4444",
-                      }}
-                    >
-                      {(row.delta_pct as number) > 0 ? "+" : ""}
-                      {row.delta_pct} pts
-                    </Typography>
+            <Box
+              key={row.skill}
+              sx={{
+                p: 1.5, borderRadius: 3,
+                border: "1px solid color-mix(in srgb, var(--border-default, #e5e7eb) 55%, transparent)",
+                bgcolor: "color-mix(in srgb, var(--card-bg, #ffffff) 45%, transparent)",
+              }}
+            >
+              <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={1} sx={{ mb: 0.85 }}>
+                <Typography sx={{ fontSize: "0.9rem", fontWeight: 700, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {prettySkill(row.skill)}
+                </Typography>
+                <Stack direction="row" alignItems="center" spacing={1} sx={{ flexShrink: 0 }}>
+                  <BandPill band={row.band} />
+                  {hasBaseline && delta !== 0 ? (
+                    <Stack direction="row" spacing={0.2} alignItems="center" sx={{ color: delta > 0 ? "#15803d" : "#b91c1c" }}>
+                      <Icon icon={delta > 0 ? "mdi:arrow-up" : "mdi:arrow-down"} width={13} />
+                      <Typography sx={{ fontSize: "0.72rem", fontWeight: 800 }}>{Math.abs(delta)}</Typography>
+                    </Stack>
                   ) : !hasBaseline ? (
-                    <Box
-                      sx={{
-                        px: 0.7,
-                        py: 0.15,
-                        borderRadius: 999,
-                        fontSize: "0.6rem",
-                        fontWeight: 800,
-                        letterSpacing: "0.08em",
-                        textTransform: "uppercase",
-                        color: "#a855f7",
-                        bgcolor: "color-mix(in srgb, #a855f7 12%, transparent)",
-                        border: "1px solid color-mix(in srgb, #a855f7 25%, transparent)",
-                      }}
-                    >
-                      First attempt
+                    <Box sx={{ px: 0.7, py: 0.15, borderRadius: 999, fontSize: "0.58rem", fontWeight: 800, letterSpacing: "0.06em", textTransform: "uppercase", color: "#a855f7", bgcolor: "color-mix(in srgb, #a855f7 12%, transparent)", border: "1px solid color-mix(in srgb, #a855f7 25%, transparent)" }}>
+                      New
                     </Box>
                   ) : null}
-                  <Typography
-                    sx={{
-                      fontSize: "0.95rem",
-                      fontWeight: 900,
-                      color,
-                      fontVariantNumeric: "tabular-nums",
-                    }}
-                  >
+                  <Typography sx={{ fontSize: "1.05rem", fontWeight: 900, color, fontVariantNumeric: "tabular-nums", minWidth: 44, textAlign: "right" }}>
                     <CountUp value={row.mastery_pct} duration={1.2} suffix="%" />
                   </Typography>
-                </Box>
-              </Box>
-              <Box sx={{ position: "relative", height: 12, borderRadius: 999, bgcolor: "color-mix(in srgb, currentColor 8%, transparent)", overflow: "hidden" }}>
-                {previousMastery !== null && previousMastery !== row.mastery_pct && (
-                  <Box
-                    aria-hidden
-                    sx={{
-                      position: "absolute",
-                      top: 0,
-                      bottom: 0,
-                      left: `${previousMastery}%`,
-                      width: "0px",
-                      borderLeft: "2px dashed color-mix(in srgb, currentColor 50%, transparent)",
-                    }}
-                  />
-                )}
+                </Stack>
+              </Stack>
+
+              <Box sx={{ position: "relative", height: 10, borderRadius: 999, color, bgcolor: "color-mix(in srgb, currentColor 10%, transparent)", overflow: "hidden" }}>
                 <Box
                   component={motion.div}
                   initial={{ width: 0 }}
                   whileInView={{ width: `${row.mastery_pct}%` }}
                   viewport={{ once: true, margin: "0px 0px -10% 0px" }}
                   transition={{ duration: 1.2, ease: [0.16, 1, 0.3, 1] }}
-                  sx={{
-                    position: "absolute",
-                    inset: 0,
-                    borderRadius: 999,
-                    background: `linear-gradient(90deg, color-mix(in srgb, ${color} 60%, transparent) 0%, ${color} 100%)`,
-                  }}
+                  sx={{ position: "absolute", inset: 0, borderRadius: 999, background: `linear-gradient(90deg, color-mix(in srgb, ${color} 55%, transparent) 0%, ${color} 100%)` }}
                 />
+                {previousMastery !== null && previousMastery !== row.mastery_pct && (
+                  <Box aria-hidden title={`Last attempt: ${previousMastery}%`} sx={{ position: "absolute", top: -1, bottom: -1, left: `${previousMastery}%`, borderLeft: "2px dashed color-mix(in srgb, #0f172a 45%, transparent)", zIndex: 1 }} />
+                )}
               </Box>
-              <Typography sx={{ fontSize: "0.62rem", color: "text.secondary", mt: 0.5 }}>
-                SE {row.se.toFixed(2)} · θ {row.theta.toFixed(2)}
-                {previousMastery !== null && ` · was ${previousMastery}%`}
+
+              <Typography sx={{ fontSize: "0.62rem", color: "text.secondary", mt: 0.6 }}>
+                {previousMastery !== null ? `Was ${previousMastery}%` : "First attempt"}
+                <Box component="span" sx={{ opacity: 0.6 }}> · confidence {row.se < 0.5 ? "high" : row.se < 0.9 ? "building" : "early"}</Box>
               </Typography>
             </Box>
           );

--- a/components/adaptive-video/CheckpointOverlay.tsx
+++ b/components/adaptive-video/CheckpointOverlay.tsx
@@ -36,8 +36,9 @@ export function CheckpointOverlay({ timestamp, onAsk, onResume }: Props) {
     try {
       const r = await onAsk(question, timestamp);
       setAnswer(r.answer);
-    } catch {
-      setAnswer("Couldn't answer just now — resume and try the Ask box any time.");
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setAnswer(detail || "Couldn't answer just now — resume and try the Ask box any time.");
     } finally {
       setLoading(false);
     }

--- a/components/adaptive-video/CheckpointOverlay.tsx
+++ b/components/adaptive-video/CheckpointOverlay.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Box, Button, CircularProgress, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useState } from "react";
+import { AIPill } from "@/components/adaptive-quiz/shared/AIPill";
+import type { AskResult } from "@/lib/services/adaptive-video.service";
+
+interface Props {
+  timestamp: number;
+  onAsk: (question: string, ts: number) => Promise<AskResult>;
+  onResume: () => void;
+}
+
+function fmt(s: number) {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${String(sec).padStart(2, "0")}`;
+}
+
+/**
+ * The "Pause & ask every 60s" checkpoint (watch mode `pause_60s`). Every minute of playback the
+ * player pauses and surfaces this reflection prompt — the student can ask about the moment they're
+ * on (reusing the timestamp Q&A) or resume. A lightweight comprehension nudge between the fixed,
+ * concept-boundary check-ins.
+ */
+export function CheckpointOverlay({ timestamp, onAsk, onResume }: Props) {
+  const [q, setQ] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const ask = async () => {
+    const question = q.trim();
+    if (!question || loading) return;
+    setLoading(true);
+    try {
+      const r = await onAsk(question, timestamp);
+      setAnswer(r.answer);
+    } catch {
+      setAnswer("Couldn't answer just now — resume and try the Ask box any time.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "absolute", inset: 0, display: "flex", alignItems: "center", justifyContent: "center",
+        background: "rgba(15, 12, 41, 0.82)", backdropFilter: "blur(6px)", zIndex: 20, p: 2,
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 480, bgcolor: "var(--card-bg, #fff)", borderRadius: 3, p: 2.5,
+        boxShadow: "0 24px 60px -24px rgba(0,0,0,0.5)" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+          <AIPill icon={<Icon icon="mdi:timer-sand" />}>Checkpoint</AIPill>
+          <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>Paused at {fmt(timestamp)}</Typography>
+        </Box>
+        <Typography sx={{ fontWeight: 800, fontSize: "1rem", mb: 0.5 }}>Still with it?</Typography>
+        <Typography sx={{ fontSize: "0.85rem", color: "text.secondary", mb: 1.5 }}>
+          Anything unclear about this part? Ask now, or resume.
+        </Typography>
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <TextField
+            fullWidth size="small" placeholder="Ask about this moment…" value={q}
+            onChange={(e) => setQ(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") void ask(); }}
+            disabled={loading}
+          />
+          <Button
+            onClick={() => void ask()} disabled={loading || !q.trim()} variant="contained"
+            sx={{ borderRadius: 2, background: "linear-gradient(135deg,#6366f1,#a855f7)", minWidth: 64, fontWeight: 800 }}
+          >
+            {loading ? <CircularProgress size={16} sx={{ color: "#fff" }} /> : "Ask"}
+          </Button>
+        </Box>
+        {answer && (
+          <Box sx={{ mt: 1.5, p: 1.5, borderRadius: 2, bgcolor: "color-mix(in srgb,#a855f7 8%,transparent)",
+            border: "1px solid color-mix(in srgb,#a855f7 18%,transparent)" }}>
+            <Typography sx={{ fontSize: "0.85rem", lineHeight: 1.5, whiteSpace: "pre-wrap" }}>{answer}</Typography>
+          </Box>
+        )}
+        <Button fullWidth onClick={onResume} variant="text" sx={{ mt: 1.5, fontWeight: 800, color: "#6366f1", gap: 0.5 }}>
+          <Icon icon="mdi:play" width={18} /> Resume
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/components/adaptive-video/ReExplainPanel.tsx
+++ b/components/adaptive-video/ReExplainPanel.tsx
@@ -13,6 +13,7 @@ interface Props {
 }
 
 const STYLES: { key: ReExplainStyle; label: string; icon: string }[] = [
+  { key: "plain", label: "Plain English", icon: "mdi:translate" },
   { key: "analogy", label: "Analogies", icon: "mdi:lightbulb-on-outline" },
   { key: "code", label: "Code", icon: "mdi:code-tags" },
   { key: "formal", label: "Formal", icon: "mdi:script-text-outline" },

--- a/components/adaptive-video/TimestampQA.tsx
+++ b/components/adaptive-video/TimestampQA.tsx
@@ -22,13 +22,19 @@ export function TimestampQA({
   const [question, setQuestion] = useState("");
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<AskResult | null>(null);
+  const [error, setError] = useState("");
 
   const submit = async () => {
     if (!question.trim()) return;
     setLoading(true);
+    setError("");
     try {
       setResult(await onAsk(question.trim(), currentTime));
       setQuestion("");
+    } catch (e) {
+      // A rejected (malicious/abusive) question comes back as a 400 with a reason; surface it.
+      const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setError(detail || "Couldn't answer that just now. Try again in a moment.");
     } finally {
       setLoading(false);
     }
@@ -67,6 +73,13 @@ export function TimestampQA({
           {loading ? <CircularProgress size={18} color="inherit" /> : "Ask"}
         </Button>
       </Box>
+
+      {error && (
+        <Box sx={{ mt: 1.25, display: "flex", alignItems: "flex-start", gap: 0.6, color: "#b91c1c" }}>
+          <Icon icon="mdi:shield-alert-outline" width={15} style={{ marginTop: 2, flexShrink: 0 }} />
+          <Typography sx={{ fontSize: "0.8rem", fontWeight: 600 }}>{error}</Typography>
+        </Box>
+      )}
 
       {result && (
         <Box sx={{ mt: 1.5, p: 1.75, borderRadius: 2.5, bgcolor: "var(--card-bg, #fff)",

--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -43,8 +43,9 @@ export function VideoCompanion({ configId }: { configId: number }) {
   const [genDesc, setGenDesc] = useState("");
   const [descLoading, setDescLoading] = useState(false);
   const descTriedRef = useRef(false);
-  // "Pause & ask every 60s" watch mode — checkpoint overlay state + last minute we paused at.
-  const [checkpoint, setCheckpoint] = useState(false);
+  // "Pause & ask every 60s" watch mode — the second we paused at for a checkpoint (null = none) +
+  // the last minute boundary we fired on.
+  const [checkpoint, setCheckpoint] = useState<number | null>(null);
   const lastCheckpointRef = useRef(0);
   const [activeCheckIn, setActiveCheckIn] = useState<CheckInMarker | null>(null);
   // Reactive set of answered check-in ids — drives the counter chip + the green
@@ -53,8 +54,10 @@ export function VideoCompanion({ configId }: { configId: number }) {
   const [answered, setAnswered] = useState<Set<number>>(new Set());
   const shownRef = useRef<Set<number>>(new Set());
 
-  const ctl = useVimeoController();
-  const { currentTime, duration } = ctl;
+  // Destructure the controller into stable locals — passing `setIframe` to a ref taints the
+  // whole object for the react-hooks/refs rule, so we never read `ctl.<member>` during render.
+  const { setIframe, currentTime, duration, playbackRate, rewinds, play, pause, seekTo, setRate } =
+    useVimeoController();
 
   // --- Session bootstrap -----------------------------------------------------
   useEffect(() => {
@@ -84,39 +87,31 @@ export function VideoCompanion({ configId }: { configId: number }) {
     );
     if (due) {
       shownRef.current.add(due.id);
-      ctl.pause();
+      pause();
       setActiveCheckIn(due);
     }
-  }, [currentTime, companion, activeCheckIn, ctl, answered]);
+  }, [currentTime, companion, activeCheckIn, pause, answered]);
 
   // --- Watch mode: plain English → slower, scaffolded playback --------------
   useEffect(() => {
-    ctl.setRate(watchMode === "plain_english" ? 0.9 : 1);
-  }, [watchMode, ctl.setRate]);
+    setRate(watchMode === "plain_english" ? 0.9 : 1);
+  }, [watchMode, setRate]);
 
   // --- Watch mode: pause & ask every 60s ------------------------------------
+  // Mirrors the check-in auto-pause above: a ref gates re-fires (advances to the current minute),
+  // so this never loops, and we don't depend on the `checkpoint` state it sets.
   useEffect(() => {
-    if (watchMode !== "pause_60s" || !companion || activeCheckIn || checkpoint) return;
+    if (watchMode !== "pause_60s" || !companion || activeCheckIn) return;
     const minute = Math.floor(currentTime / 60);
     if (minute >= 1 && minute > lastCheckpointRef.current) {
       lastCheckpointRef.current = minute;
-      ctl.pause();
-      setCheckpoint(true);
+      pause();
+      // Player-time-driven external sync (same shape as the check-in auto-pause above); the ref
+      // gate makes it fire at most once per minute, so there's no cascade.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setCheckpoint(currentTime);
     }
-  }, [currentTime, watchMode, companion, activeCheckIn, checkpoint, ctl.pause]);
-
-  // --- Lazy auto-generate the description when its tab is first opened -------
-  useEffect(() => {
-    if (tab !== 2 || !companion) return;
-    if (companion.description || genDesc || descLoading || descTriedRef.current) return;
-    descTriedRef.current = true;
-    setDescLoading(true);
-    adaptiveVideoService
-      .generateDescription(configId)
-      .then(setGenDesc)
-      .catch(() => {})
-      .finally(() => setDescLoading(false));
-  }, [tab, companion, genDesc, descLoading, configId]);
+  }, [currentTime, watchMode, companion, activeCheckIn, pause]);
 
   // --- Periodic sync of watch signals ---------------------------------------
   const completeness = useMemo(
@@ -130,14 +125,14 @@ export function VideoCompanion({ configId }: { configId: number }) {
         .sync(sessionId, {
           current_timestamp: currentTime,
           completeness_pct: completeness,
-          max_speed: ctl.playbackRate,
+          max_speed: playbackRate,
           watch_mode: watchMode,
-          rewinds: ctl.rewinds.length ? ctl.rewinds : undefined,
+          rewinds: rewinds.length ? rewinds : undefined,
         })
         .catch(() => {});
     }, 10000);
     return () => clearInterval(t);
-  }, [sessionId, currentTime, completeness, watchMode, ctl.playbackRate, ctl.rewinds]);
+  }, [sessionId, currentTime, completeness, watchMode, playbackRate, rewinds]);
 
   // End the session when the surface unmounts (finalizes comprehension → quiz seed).
   // The server scores the watch on end → notify the streak celebration once it's recorded.
@@ -175,6 +170,22 @@ export function VideoCompanion({ configId }: { configId: number }) {
       return adaptiveVideoService.ask(sessionId, q, ts);
     },
     [sessionId]
+  );
+  // Switch tabs; lazily generate the description the first time its tab is opened (event-driven, so
+  // the generation kick-off isn't a synchronous setState inside an effect).
+  const onTabChange = useCallback(
+    (v: number) => {
+      setTab(v);
+      if (v !== 2 || !companion || companion.description || genDesc || descLoading || descTriedRef.current) return;
+      descTriedRef.current = true;
+      setDescLoading(true);
+      adaptiveVideoService
+        .generateDescription(configId)
+        .then(setGenDesc)
+        .catch(() => {})
+        .finally(() => setDescLoading(false));
+    },
+    [companion, genDesc, descLoading, configId]
   );
 
   if (loadError)
@@ -234,9 +245,8 @@ export function VideoCompanion({ configId }: { configId: number }) {
             }}
           >
             <iframe
-              ref={ctl.iframeRef}
+              ref={setIframe}
               src={embed}
-              onLoad={ctl.onIframeLoad}
               allow="autoplay; fullscreen; picture-in-picture"
               allowFullScreen
               style={{ width: "100%", height: "100%", border: 0 }}
@@ -248,22 +258,22 @@ export function VideoCompanion({ configId }: { configId: number }) {
                 onAnswer={onAnswer}
                 onContinue={() => {
                   setActiveCheckIn(null);
-                  ctl.play();
+                  play();
                 }}
                 onRewind={(s) => {
-                  ctl.seekTo(s);
+                  seekTo(s);
                   setActiveCheckIn(null);
-                  ctl.play();
+                  play();
                 }}
               />
             )}
-            {checkpoint && !activeCheckIn && (
+            {checkpoint !== null && !activeCheckIn && (
               <CheckpointOverlay
-                timestamp={currentTime}
+                timestamp={checkpoint}
                 onAsk={onAsk}
                 onResume={() => {
-                  setCheckpoint(false);
-                  ctl.play();
+                  setCheckpoint(null);
+                  play();
                 }}
               />
             )}
@@ -280,7 +290,7 @@ export function VideoCompanion({ configId }: { configId: number }) {
                 return (
                   <Tooltip key={c.id} title={`${fmt(c.timestamp_seconds)} · ${c.concept || "Check-in"}`} arrow>
                     <Box
-                      onClick={() => ctl.seekTo(Math.max(c.timestamp_seconds - 2, 0))}
+                      onClick={() => seekTo(Math.max(c.timestamp_seconds - 2, 0))}
                       sx={{
                         position: "absolute", top: "50%", left: `${(c.timestamp_seconds / duration) * 100}%`,
                         transform: "translate(-50%, -50%)", width: 13, height: 13, borderRadius: 999, cursor: "pointer",
@@ -305,7 +315,7 @@ export function VideoCompanion({ configId }: { configId: number }) {
           {/* Companion tabs */}
           <Tabs
             value={tab}
-            onChange={(_, v) => setTab(v)}
+            onChange={(_, v) => onTabChange(v)}
             variant="scrollable"
             scrollButtons={false}
             sx={{
@@ -347,7 +357,7 @@ export function VideoCompanion({ configId }: { configId: number }) {
                   return (
                     <Box
                       key={i}
-                      onClick={() => ctl.seekTo(s.start_seconds)}
+                      onClick={() => seekTo(s.start_seconds)}
                       sx={{
                         display: "flex", gap: 1.5, mb: 0.5, px: 1, py: 0.6, borderRadius: 1.5, cursor: "pointer",
                         background: active ? "color-mix(in srgb, #6366f1 10%, transparent)" : "transparent",
@@ -396,7 +406,7 @@ export function VideoCompanion({ configId }: { configId: number }) {
             }}
           />
           <ReExplainPanel onReExplain={onReExplain} />
-          <AutoChapters chapters={companion.chapters} currentTime={currentTime} onJump={(s) => ctl.seekTo(s)} />
+          <AutoChapters chapters={companion.chapters} currentTime={currentTime} onJump={(s) => seekTo(s)} />
           <LiveTakeaways takeaways={companion.takeaways} currentTime={currentTime} chapters={companion.chapters} />
         </Box>
       </Box>

--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -38,6 +38,10 @@ export function VideoCompanion({ configId }: { configId: number }) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [tab, setTab] = useState(0);
   const [watchMode, setWatchMode] = useState<WatchMode>("normal");
+  // Auto-generated description (lazily fetched the first time the Description tab is opened).
+  const [genDesc, setGenDesc] = useState("");
+  const [descLoading, setDescLoading] = useState(false);
+  const descTriedRef = useRef(false);
   const [activeCheckIn, setActiveCheckIn] = useState<CheckInMarker | null>(null);
   // Reactive set of answered check-in ids — drives the counter chip + the green
   // timeline markers, so they update the instant an answer lands (a ref wouldn't
@@ -80,6 +84,19 @@ export function VideoCompanion({ configId }: { configId: number }) {
       setActiveCheckIn(due);
     }
   }, [currentTime, companion, activeCheckIn, ctl, answered]);
+
+  // --- Lazy auto-generate the description when its tab is first opened -------
+  useEffect(() => {
+    if (tab !== 2 || !companion) return;
+    if (companion.description || genDesc || descLoading || descTriedRef.current) return;
+    descTriedRef.current = true;
+    setDescLoading(true);
+    adaptiveVideoService
+      .generateDescription(configId)
+      .then(setGenDesc)
+      .catch(() => {})
+      .finally(() => setDescLoading(false));
+  }, [tab, companion, genDesc, descLoading, configId]);
 
   // --- Periodic sync of watch signals ---------------------------------------
   const completeness = useMemo(
@@ -319,9 +336,22 @@ export function VideoCompanion({ configId }: { configId: number }) {
           )}
           {tab === 2 && (
             <CompanionCard accent="#10b981" title="Description" icon="mdi:information-outline">
-              <Typography sx={{ fontSize: "0.9rem", color: "text.secondary", whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
-                {companion.instructions || companion.video.description || "No description."}
-              </Typography>
+              {(() => {
+                const description = companion.description || genDesc;
+                if (descLoading && !description) {
+                  return (
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, color: "text.secondary" }}>
+                      <CircularProgress size={15} thickness={5} sx={{ color: "#a855f7" }} />
+                      <Typography sx={{ fontSize: "0.85rem" }}>Generating a summary from the transcript…</Typography>
+                    </Box>
+                  );
+                }
+                return (
+                  <Typography sx={{ fontSize: "0.9rem", color: "text.secondary", whiteSpace: "pre-wrap", lineHeight: 1.6 }}>
+                    {description || companion.instructions || companion.video?.description || "No description."}
+                  </Typography>
+                );
+              })()}
             </CompanionCard>
           )}
         </Box>

--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -14,6 +14,7 @@ import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveS
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { useVimeoController } from "./useVimeoController";
 import { AutoPauseCheckIn } from "./AutoPauseCheckIn";
+import { CheckpointOverlay } from "./CheckpointOverlay";
 import { ReExplainPanel } from "./ReExplainPanel";
 import { ConceptMap } from "./ConceptMap";
 import { TimestampQA } from "./TimestampQA";
@@ -42,6 +43,9 @@ export function VideoCompanion({ configId }: { configId: number }) {
   const [genDesc, setGenDesc] = useState("");
   const [descLoading, setDescLoading] = useState(false);
   const descTriedRef = useRef(false);
+  // "Pause & ask every 60s" watch mode — checkpoint overlay state + last minute we paused at.
+  const [checkpoint, setCheckpoint] = useState(false);
+  const lastCheckpointRef = useRef(0);
   const [activeCheckIn, setActiveCheckIn] = useState<CheckInMarker | null>(null);
   // Reactive set of answered check-in ids — drives the counter chip + the green
   // timeline markers, so they update the instant an answer lands (a ref wouldn't
@@ -84,6 +88,22 @@ export function VideoCompanion({ configId }: { configId: number }) {
       setActiveCheckIn(due);
     }
   }, [currentTime, companion, activeCheckIn, ctl, answered]);
+
+  // --- Watch mode: plain English → slower, scaffolded playback --------------
+  useEffect(() => {
+    ctl.setRate(watchMode === "plain_english" ? 0.9 : 1);
+  }, [watchMode, ctl.setRate]);
+
+  // --- Watch mode: pause & ask every 60s ------------------------------------
+  useEffect(() => {
+    if (watchMode !== "pause_60s" || !companion || activeCheckIn || checkpoint) return;
+    const minute = Math.floor(currentTime / 60);
+    if (minute >= 1 && minute > lastCheckpointRef.current) {
+      lastCheckpointRef.current = minute;
+      ctl.pause();
+      setCheckpoint(true);
+    }
+  }, [currentTime, watchMode, companion, activeCheckIn, checkpoint, ctl.pause]);
 
   // --- Lazy auto-generate the description when its tab is first opened -------
   useEffect(() => {
@@ -233,6 +253,16 @@ export function VideoCompanion({ configId }: { configId: number }) {
                 onRewind={(s) => {
                   ctl.seekTo(s);
                   setActiveCheckIn(null);
+                  ctl.play();
+                }}
+              />
+            )}
+            {checkpoint && !activeCheckIn && (
+              <CheckpointOverlay
+                timestamp={currentTime}
+                onAsk={onAsk}
+                onResume={() => {
+                  setCheckpoint(false);
                   ctl.play();
                 }}
               />

--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -59,6 +59,15 @@ export function VideoCompanion({ configId }: { configId: number }) {
   const { setIframe, currentTime, duration, playbackRate, rewinds, play, pause, seekTo, setRate } =
     useVimeoController();
 
+  // Real watched-coverage tracking: each whole second actually PLAYED (not skipped) is marked, so
+  // points scale with genuine watching — skipping to the end earns little. Refs (not state): these
+  // feed the periodic + final sync without re-rendering. coverage = distinct watched secs / duration.
+  const watchedRef = useRef<Set<number>>(new Set());
+  const prevTimeRef = useRef(0);
+  const coverageRef = useRef(0);
+  const maxSpeedRef = useRef(1);
+  const rewindsRef = useRef(rewinds);
+
   // --- Session bootstrap -----------------------------------------------------
   useEffect(() => {
     let alive = true;
@@ -118,32 +127,57 @@ export function VideoCompanion({ configId }: { configId: number }) {
     () => (duration > 0 ? Math.min((currentTime / duration) * 100, 100) : 0),
     [currentTime, duration]
   );
+
+  // Mark each whole second actually played into watchedRef. A small forward delta is normal playback;
+  // a large jump is a seek/skip and is NOT counted — so skipping ahead doesn't earn coverage.
+  useEffect(() => {
+    const prev = prevTimeRef.current;
+    prevTimeRef.current = currentTime;
+    const delta = currentTime - prev;
+    if (delta > 0 && delta <= 1.5) {
+      for (let s = Math.floor(prev); s <= Math.floor(currentTime); s++) watchedRef.current.add(s);
+    }
+    coverageRef.current = duration > 0 ? Math.min((watchedRef.current.size / duration) * 100, 100) : 0;
+  }, [currentTime, duration]);
+
+  // Keep the max-speed + rewinds high-water marks in refs for the (ref-reading) syncs below.
+  useEffect(() => { if (playbackRate > maxSpeedRef.current) maxSpeedRef.current = playbackRate; }, [playbackRate]);
+  useEffect(() => { rewindsRef.current = rewinds; }, [rewinds]);
+
+  // Periodic save of watch signals. Reads everything from refs at fire time, so the interval isn't
+  // torn down on every timeupdate (it would never reach 10s otherwise) and the BE gets true coverage.
   useEffect(() => {
     if (!sessionId) return;
     const t = setInterval(() => {
       adaptiveVideoService
         .sync(sessionId, {
-          current_timestamp: currentTime,
-          completeness_pct: completeness,
-          max_speed: playbackRate,
+          current_timestamp: prevTimeRef.current,
+          completeness_pct: coverageRef.current,
+          max_speed: maxSpeedRef.current,
           watch_mode: watchMode,
-          rewinds: rewinds.length ? rewinds : undefined,
+          rewinds: rewindsRef.current.length ? rewindsRef.current : undefined,
         })
         .catch(() => {});
     }, 10000);
     return () => clearInterval(t);
-  }, [sessionId, currentTime, completeness, watchMode, playbackRate, rewinds]);
+  }, [sessionId, watchMode]);
 
-  // End the session when the surface unmounts (finalizes comprehension → quiz seed).
-  // The server scores the watch on end → notify the streak celebration once it's recorded.
+  // On unmount: flush the FINAL coverage/speed, THEN end + score (so the award reflects everything
+  // watched, including the last stretch the periodic sync may not have sent yet).
   useEffect(() => {
     return () => {
-      if (sessionId) {
-        adaptiveVideoService
-          .endSession(sessionId)
-          .then(() => notifyContentCompleted())
-          .catch(() => {});
-      }
+      if (!sessionId) return;
+      adaptiveVideoService
+        .sync(sessionId, {
+          current_timestamp: prevTimeRef.current,
+          completeness_pct: coverageRef.current,
+          max_speed: maxSpeedRef.current,
+          rewinds: rewindsRef.current.length ? rewindsRef.current : undefined,
+        })
+        .catch(() => {})
+        .finally(() => {
+          adaptiveVideoService.endSession(sessionId).then(() => notifyContentCompleted()).catch(() => {});
+        });
     };
   }, [sessionId]);
 

--- a/components/adaptive-video/useVimeoController.ts
+++ b/components/adaptive-video/useVimeoController.ts
@@ -9,7 +9,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
  * detection (a backwards seek = the confusion signal feeding comprehension).
  */
 export interface VimeoController {
-  iframeRef: React.RefObject<HTMLIFrameElement | null>;
+  /** Callback ref — wire onto `<iframe ref={...}>`. Stores the node and attaches the player
+   *  listeners on load itself, so the component never touches a ref value during render. */
+  setIframe: (node: HTMLIFrameElement | null) => void;
   currentTime: number;
   duration: number;
   isPlaying: boolean;
@@ -21,8 +23,6 @@ export interface VimeoController {
   seekTo: (seconds: number) => void;
   /** Set playback speed (e.g. 0.9 for the plain-English watch mode's slower pace). */
   setRate: (rate: number) => void;
-  /** Wire onto the iframe's onLoad. */
-  onIframeLoad: () => void;
 }
 
 function post(iframe: HTMLIFrameElement | null, method: string, value?: unknown) {
@@ -39,12 +39,19 @@ export function useVimeoController(): VimeoController {
   const [rewinds, setRewinds] = useState<{ from: number; to: number }[]>([]);
   const lastTimeRef = useRef(0);
 
-  const onIframeLoad = useCallback(() => {
-    const iframe = iframeRef.current;
-    ["ready", "play", "pause", "timeupdate", "seeked", "ended"].forEach((ev) =>
-      post(iframe, "addEventListener", ev)
-    );
-    post(iframe, "getDuration");
+  // Callback ref: store the node and register the Vimeo listeners once it loads. Doing the setup
+  // inside a `load` listener (instead of an onLoad prop + a ref object) keeps all ref access out of
+  // render, which the react-hooks/refs rule requires.
+  const setIframe = useCallback((node: HTMLIFrameElement | null) => {
+    iframeRef.current = node;
+    if (!node) return;
+    const wire = () => {
+      ["ready", "play", "pause", "timeupdate", "seeked", "ended"].forEach((ev) =>
+        post(node, "addEventListener", ev)
+      );
+      post(node, "getDuration");
+    };
+    node.addEventListener("load", wire);
   }, []);
 
   useEffect(() => {
@@ -108,5 +115,5 @@ export function useVimeoController(): VimeoController {
     setPlaybackRate(rate);
   }, []);
 
-  return { iframeRef, currentTime, duration, isPlaying, playbackRate, rewinds, play, pause, seekTo, setRate, onIframeLoad };
+  return { setIframe, currentTime, duration, isPlaying, playbackRate, rewinds, play, pause, seekTo, setRate };
 }

--- a/components/adaptive-video/useVimeoController.ts
+++ b/components/adaptive-video/useVimeoController.ts
@@ -19,6 +19,8 @@ export interface VimeoController {
   play: () => void;
   pause: () => void;
   seekTo: (seconds: number) => void;
+  /** Set playback speed (e.g. 0.9 for the plain-English watch mode's slower pace). */
+  setRate: (rate: number) => void;
   /** Wire onto the iframe's onLoad. */
   onIframeLoad: () => void;
 }
@@ -101,6 +103,10 @@ export function useVimeoController(): VimeoController {
     setCurrentTime(seconds);
     lastTimeRef.current = seconds;
   }, []);
+  const setRate = useCallback((rate: number) => {
+    post(iframeRef.current, "setPlaybackRate", rate);
+    setPlaybackRate(rate);
+  }, []);
 
-  return { iframeRef, currentTime, duration, isPlaying, playbackRate, rewinds, play, pause, seekTo, onIframeLoad };
+  return { iframeRef, currentTime, duration, isPlaying, playbackRate, rewinds, play, pause, seekTo, setRate, onIframeLoad };
 }

--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Box, Button, CircularProgress, FormControl, MenuItem, Select, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, FormControl, MenuItem, Select, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 
 import { CodeEditor } from "@/components/editor/MonacoEditor";
@@ -16,9 +16,11 @@ import {
 } from "@/components/coding/utils/languageUtils";
 import { MentorAnalysisCard } from "@/components/coding/MentorAnalysisCard";
 import { CodingMasteryPanel } from "@/components/coding/CodingMasteryPanel";
+import { CodingTimerPoints } from "@/components/coding/CodingTimerPoints";
 import {
   adaptiveCodingService,
   type CodingProblem,
+  type CodingSession,
   type CodingSubmissionRecord,
   type HintResult,
   type MasteryDelta,
@@ -44,6 +46,10 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
 
   const [problem, setProblem] = useState<CodingProblem | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionData, setSessionData] = useState<CodingSession | null>(null);
+  const [started, setStarted] = useState(false);   // false on a fresh problem → "ready to begin" gate
+  const [starting, setStarting] = useState(false);
+  const [pointsEarned, setPointsEarned] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -83,31 +89,34 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
     }
   }, []);
 
-  // Load problem + start (or reuse) a session.
+  // Load the problem + PEEK an existing session (no create). A fresh problem shows the "ready to
+  // begin" gate; an active session resumes the (still-ticking) timer; a completed one is solved.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         const prob = await adaptiveCodingService.getProblem(problemId);
         const langs = Object.keys(prob.template_code);
-        const session = await adaptiveCodingService.startSession({
-          config_id: configId,
-          problem_id: problemId,
-          language: langs[0],
-        });
+        const existing = await adaptiveCodingService.getActiveSession(configId, problemId);
         if (cancelled) return;
         setProblem(prob);
-        setSessionId(session.id);
-        const initialLang = session.language && langs.includes(session.language) ? session.language : langs[0];
-        setLanguage(initialLang);
-        // Re-entry: restore the last edited source if the session has one,
-        // else open the template.
-        setCode(session.last_source || prob.template_code[initialLang] || "");
-        setHintsRevealed(session.hints_revealed);
-        setSolvedAlready(session.passed || session.status === "completed");
-        setAllowClipboard(Boolean(session.allow_clipboard));
-        // Rehydrate the last mentor analysis so a reload doesn't reset to blank.
-        applySubmissionRecord(session.latest_submission);
+        if (existing) {
+          setSessionData(existing);
+          setSessionId(existing.id);
+          const lang = existing.language && langs.includes(existing.language) ? existing.language : langs[0];
+          setLanguage(lang);
+          setCode(existing.last_source || prob.template_code[lang] || "");
+          setHintsRevealed(existing.hints_revealed);
+          setSolvedAlready(existing.passed || existing.status === "completed");
+          setStarted(existing.status === "active");  // live timer only while active
+          setAllowClipboard(Boolean(existing.allow_clipboard));
+          applySubmissionRecord(existing.latest_submission);
+        } else {
+          // No session yet — open the template for preview; the timer/session start on "Begin".
+          const lang = langs[0];
+          setLanguage(lang);
+          setCode(prob.template_code[lang] || "");
+        }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load this problem.");
       } finally {
@@ -118,6 +127,27 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
       cancelled = true;
     };
   }, [configId, problemId, applySubmissionRecord]);
+
+  // "Begin" — create the session (server stamps started_at = the timer anchor) and reveal the editor.
+  const begin = useCallback(async () => {
+    if (starting || started || !problem) return;
+    setStarting(true);
+    try {
+      const session = await adaptiveCodingService.startSession({
+        config_id: configId,
+        problem_id: problemId,
+        language,
+      });
+      setSessionData(session);
+      setSessionId(session.id);
+      setAllowClipboard(Boolean(session.allow_clipboard));
+      setStarted(true);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't start the session.", "error");
+    } finally {
+      setStarting(false);
+    }
+  }, [starting, started, problem, configId, problemId, language, showToast]);
 
   const resetMentorState = useCallback(() => {
     setDiagnosis(null);
@@ -184,11 +214,12 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
         showToast(res.detail, "warning");
       } else if (res.grade.all_passed) {
         setSolvedAlready(true);
-        const skills = Object.entries(res.mastery_delta);
-        const gain = skills.length ? ` · ${skills[0][0]} ${skills[0][1].before}→${skills[0][1].after}%` : "";
-        showToast(`Passed — clean & correct${gain}`, "success");
+        setPointsEarned(res.points_earned ?? 0);  // freezes the timer HUD on the earned points
+        const pts = res.points_earned ? ` · +${res.points_earned} pts` : "";
+        showToast(`Passed — clean & correct${pts}`, "success");
       } else {
-        showToast(`${res.grade.passed}/${res.grade.total} passed — read the mentor's diagnosis.`, "warning");
+        const pts = res.points_earned ? ` (+${res.points_earned} pts)` : "";
+        showToast(`${res.grade.passed}/${res.grade.total} passed${pts} — read the mentor's diagnosis.`, "warning");
       }
       // A graded submit counts as a completion (server scores it) — fire the streak celebration.
       if (!res.detail) notifyContentCompleted();
@@ -288,8 +319,21 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
         <AdaptiveCodingSubmissions problemId={problemId} refreshKey={masteryRefresh} />
       </Box>
 
-      {/* Right — editor + toolbar */}
+      {/* Right — ready gate, then editor + live timer/points HUD + toolbar */}
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+        {!started && !solvedAlready ? (
+          <CodingReadyGate problem={problem} starting={starting} onBegin={begin} />
+        ) : (
+        <>
+        {sessionData?.points != null && started && (
+          <CodingTimerPoints
+            decay={sessionData.points}
+            startedAt={sessionData.started_at}
+            serverNow={sessionData.server_now}
+            running={!solvedAlready}
+            earned={solvedAlready ? pointsEarned : null}
+          />
+        )}
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
           <FormControl size="small" sx={{ minWidth: 130 }}>
             <Select
@@ -341,7 +385,60 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
         <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>
           The mentor reads your code on Run and Submit — it names the line and the concept, never writes the fix.
         </Typography>
+        </>
+        )}
       </Box>
+    </Box>
+  );
+}
+
+function CodingReadyGate({ problem, starting, onBegin }: { problem: CodingProblem; starting: boolean; onBegin: () => void }) {
+  const diffColor =
+    problem.difficulty_level === "Easy" ? "#10b981" : problem.difficulty_level === "Hard" ? "#ef4444" : "#f59e0b";
+  const points: { icon: string; text: string }[] = [
+    { icon: "mdi:timer-play-outline", text: "Your timer starts the moment you begin." },
+    { icon: "mdi:trending-down", text: "Points start full and decay the longer you take — submit fast to keep more." },
+    { icon: "mdi:clock-alert-outline", text: "Leave and come back? The clock keeps running — even days later." },
+  ];
+  return (
+    <Box
+      sx={{
+        borderRadius: 3, p: { xs: 3, md: 4 }, textAlign: "center",
+        border: "1px solid color-mix(in srgb, #6366f1 22%, transparent)",
+        background:
+          "linear-gradient(160deg, color-mix(in srgb,#6366f1 9%,var(--card-bg)) 0%, color-mix(in srgb,#a855f7 7%,var(--card-bg)) 100%)",
+      }}
+    >
+      <Box sx={{ width: 56, height: 56, mx: "auto", mb: 1.5, borderRadius: "50%", display: "grid", placeItems: "center",
+        color: "white", background: "linear-gradient(135deg,#6366f1,#a855f7)", boxShadow: "0 14px 30px -12px rgba(124,58,237,0.7)" }}>
+        <Icon icon="mdi:flash" width={28} />
+      </Box>
+      <Typography sx={{ fontWeight: 800, fontSize: "1.25rem" }}>Ready to begin?</Typography>
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="center" sx={{ mt: 0.5, mb: 2 }}>
+        <Typography sx={{ fontSize: "0.9rem", color: "text.secondary" }}>{problem.title}</Typography>
+        <Box sx={{ px: 0.9, py: 0.2, borderRadius: 999, fontSize: "0.66rem", fontWeight: 800, color: diffColor,
+          bgcolor: `color-mix(in srgb, ${diffColor} 14%, transparent)`, border: `1px solid color-mix(in srgb, ${diffColor} 30%, transparent)` }}>
+          {problem.difficulty_level}
+        </Box>
+      </Stack>
+      <Stack spacing={1} sx={{ maxWidth: 380, mx: "auto", mb: 2.5, textAlign: "left" }}>
+        {points.map((p) => (
+          <Stack key={p.icon} direction="row" spacing={1} alignItems="flex-start">
+            <Icon icon={p.icon} width={18} style={{ color: "#7c3aed", flexShrink: 0, marginTop: 2 }} />
+            <Typography sx={{ fontSize: "0.85rem", color: "text.secondary", lineHeight: 1.45 }}>{p.text}</Typography>
+          </Stack>
+        ))}
+      </Stack>
+      <Button
+        onClick={onBegin}
+        disabled={starting}
+        startIcon={starting ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:flash" width={18} />}
+        variant="contained"
+        sx={{ textTransform: "none", fontWeight: 800, color: "white", px: 3, py: 1,
+          background: "linear-gradient(135deg,#6366f1,#a855f7)" }}
+      >
+        Begin · start the timer
+      </Button>
     </Box>
   );
 }

--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -332,6 +332,7 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
             serverNow={sessionData.server_now}
             running={!solvedAlready}
             earned={solvedAlready ? pointsEarned : null}
+            hints={hintsRevealed}
           />
         )}
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>

--- a/components/coding/CodingTimerPoints.tsx
+++ b/components/coding/CodingTimerPoints.tsx
@@ -35,12 +35,14 @@ export function CodingTimerPoints({
   serverNow,
   running = true,
   earned = null,
+  hints = 0,
 }: {
   decay: CodingPointsDecay;
   startedAt: string;
   serverNow: string;
   running?: boolean;
   earned?: number | null;
+  hints?: number;
 }) {
   // Server-elapsed at fetch + a local anchor captured once → live elapsed without trusting the
   // client clock's absolute value (only its delta).
@@ -55,7 +57,9 @@ export function CodingTimerPoints({
   }, [running]);
 
   const elapsedSec = (baseMs + (running ? now - anchor : 0)) / 1000;
-  const livePts = Math.round(pointsAfterDecay(elapsedSec, decay));
+  // Hint penalty mirrors the engine: each hint shaves decay.hint_penalty off the points.
+  const hintMult = Math.max(0, 1 - (decay.hint_penalty ?? 0) * Math.max(0, hints));
+  const livePts = Math.round(pointsAfterDecay(elapsedSec, decay) * hintMult);
   const submitted = earned !== null && earned !== undefined;
   const pts = submitted ? (earned as number) : livePts;
   const inGrace = elapsedSec < decay.grace;
@@ -120,6 +124,9 @@ export function CodingTimerPoints({
               : atFloor
                 ? `At the ${decay.floor}-pt floor`
                 : `Decaying −${decay.dec} every ${decay.iv}s — submit soon`}
+          {!submitted && hints > 0 && (decay.hint_penalty ?? 0) > 0
+            ? ` · −${Math.round((decay.hint_penalty ?? 0) * 100 * hints)}% from ${hints} hint${hints > 1 ? "s" : ""}`
+            : ""}
         </Typography>
       </Box>
     </Box>

--- a/components/coding/CodingTimerPoints.tsx
+++ b/components/coding/CodingTimerPoints.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, LinearProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { CodingPointsDecay } from "@/lib/services/adaptive-coding.service";
+
+/** Mirror of engine.points_after_decay — keep in lockstep so the live number matches the award. */
+function pointsAfterDecay(elapsedSec: number, d: CodingPointsDecay): number {
+  if (elapsedSec <= d.grace) return d.base;
+  const intervals = Math.floor((elapsedSec - d.grace) / d.iv);
+  return Math.max(d.floor, d.base - d.dec * intervals);
+}
+
+function fmtElapsed(totalSec: number): string {
+  const s = Math.max(0, Math.floor(totalSec));
+  const days = Math.floor(s / 86400);
+  const hrs = Math.floor((s % 86400) / 3600);
+  const mins = Math.floor((s % 3600) / 60);
+  const secs = s % 60;
+  if (days > 0) return `${days}d ${hrs}h`;          // e.g. returned after 3 days
+  if (hrs > 0) return `${hrs}h ${mins}m`;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+/**
+ * Live, server-anchored timer + decaying points for a coding problem. The clock is the SESSION age:
+ * elapsed = (server_now − started_at) captured at fetch, then ticked locally — so it keeps running
+ * across reloads and even days away (clock-skew corrected via server_now). Holds full points through
+ * the grace window, then ticks down to the floor; once submitted it freezes on the earned points.
+ */
+export function CodingTimerPoints({
+  decay,
+  startedAt,
+  serverNow,
+  running = true,
+  earned = null,
+}: {
+  decay: CodingPointsDecay;
+  startedAt: string;
+  serverNow: string;
+  running?: boolean;
+  earned?: number | null;
+}) {
+  // Server-elapsed at fetch + a local anchor captured once → live elapsed without trusting the
+  // client clock's absolute value (only its delta).
+  const [baseMs] = useState(() => Math.max(0, Date.parse(serverNow) - Date.parse(startedAt)));
+  const [anchor] = useState(() => Date.now());
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!running) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [running]);
+
+  const elapsedSec = (baseMs + (running ? now - anchor : 0)) / 1000;
+  const livePts = Math.round(pointsAfterDecay(elapsedSec, decay));
+  const submitted = earned !== null && earned !== undefined;
+  const pts = submitted ? (earned as number) : livePts;
+  const inGrace = elapsedSec < decay.grace;
+  const atFloor = livePts <= decay.floor;
+  const pct = decay.base > 0 ? Math.max(0, Math.min(100, (pts / decay.base) * 100)) : 0;
+  const color = submitted ? "#7c3aed" : inGrace ? "#10b981" : atFloor ? "#ef4444" : "#f59e0b";
+  const graceLeft = Math.max(0, Math.ceil(decay.grace - elapsedSec));
+
+  return (
+    <Box
+      sx={{
+        p: 1.5, borderRadius: 3, display: "flex", alignItems: "center", gap: 2,
+        bgcolor: "color-mix(in srgb, var(--card-bg, #ffffff) 60%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--border-default, #e5e7eb) 70%, transparent)",
+      }}
+    >
+      {/* Timer */}
+      <Stack alignItems="center" sx={{ minWidth: 78 }}>
+        <Stack direction="row" spacing={0.4} alignItems="center" sx={{ color: "text.secondary" }}>
+          <Icon icon="mdi:timer-outline" width={13} />
+          <Typography sx={{ fontSize: "0.58rem", fontWeight: 800, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+            {submitted ? "Time" : "On the clock"}
+          </Typography>
+        </Stack>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.15rem", fontVariantNumeric: "tabular-nums", lineHeight: 1.1 }}>
+          {fmtElapsed(elapsedSec)}
+        </Typography>
+      </Stack>
+
+      <Box sx={{ width: "1px", alignSelf: "stretch", bgcolor: "color-mix(in srgb, var(--border-default) 70%, transparent)" }} />
+
+      {/* Points */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack direction="row" alignItems="baseline" justifyContent="space-between">
+          <Stack direction="row" spacing={0.4} alignItems="center" sx={{ color: "text.secondary" }}>
+            <Icon icon="mdi:star-four-points" width={12} color="#7c3aed" />
+            <Typography sx={{ fontSize: "0.58rem", fontWeight: 800, letterSpacing: "0.1em", textTransform: "uppercase" }}>
+              {submitted ? "Earned" : "Points on offer"}
+            </Typography>
+          </Stack>
+          <Box>
+            <Typography component="span" sx={{ fontWeight: 900, fontSize: "1.4rem", color, fontVariantNumeric: "tabular-nums", transition: "color .3s" }}>
+              {pts}
+            </Typography>
+            <Typography component="span" sx={{ fontSize: "0.72rem", fontWeight: 700, color: "text.secondary", ml: 0.4 }}>
+              / {decay.base}
+            </Typography>
+          </Box>
+        </Stack>
+        <LinearProgress
+          variant="determinate"
+          value={pct}
+          sx={{ mt: 0.6, height: 6, borderRadius: 4, bgcolor: "rgba(148,163,184,0.2)",
+            "& .MuiLinearProgress-bar": { bgcolor: color, borderRadius: 4, transition: "transform .4s ease, background-color .3s" } }}
+        />
+        <Typography sx={{ fontSize: "0.68rem", fontWeight: 700, mt: 0.5,
+          color: submitted ? "#6d28d9" : inGrace ? "#15803d" : atFloor ? "#b91c1c" : "#b45309" }}>
+          {submitted
+            ? "Locked in on submit"
+            : inGrace
+              ? `Full points for ${graceLeft}s more`
+              : atFloor
+                ? `At the ${decay.floor}-pt floor`
+                : `Decaying −${decay.dec} every ${decay.iv}s — submit soon`}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/hooks/useAdaptiveSession.ts
+++ b/hooks/useAdaptiveSession.ts
@@ -43,6 +43,11 @@ interface UseAdaptiveSessionReturn {
 
   /** ✓/✗ flash from the most recent answer; null until first answer. */
   lastAnswerCorrect: boolean | null;
+
+  /** Running points banked this sitting (sum of per-question earned). */
+  sessionPoints: number;
+  /** Latest per-question reward — drives the "+N pts" burst. `id` bumps on every submit. */
+  lastReward: { id: number; points: number; base: number } | null;
 }
 
 export function useAdaptiveSession({
@@ -57,6 +62,9 @@ export function useAdaptiveSession({
   const [submitting, setSubmitting] = useState(false);
   const [abandoning, setAbandoning] = useState(false);
   const [lastAnswerCorrect, setLastAnswerCorrect] = useState<boolean | null>(null);
+  const [sessionPoints, setSessionPoints] = useState(0);
+  const [lastReward, setLastReward] = useState<{ id: number; points: number; base: number } | null>(null);
+  const rewardIdRef = useRef(0);
   // Per-question hint state. `hintTeaser` shows a generic pre-spend nudge;
   // `hintRevealed` is the full AI-generated paragraph (null until spent).
   const [hintTeaser, setHintTeaser] = useState<string>("");
@@ -130,8 +138,14 @@ export function useAdaptiveSession({
         selected_option: selectedOption,
         confidence: session.config.confidence_prompt_enabled ? confidence : null,
         time_ms: elapsedMs,
+        // A revealed hint pauses the decay clock server-side — tell the backend it was used.
+        hint_used: hintRevealed !== null,
       });
       setLastAnswerCorrect(result.is_correct);
+      // Per-question points: bank the running total + fire the "+N pts" burst.
+      rewardIdRef.current += 1;
+      setLastReward({ id: rewardIdRef.current, points: result.points_earned ?? 0, base: result.points_base ?? 0 });
+      setSessionPoints((p) => p + (result.points_earned ?? 0));
       // Capture previous theta map for ghost markers BEFORE we replace session state.
       setThetaHistory(session.ability_state);
       // Update the session with the new pending question and counters.
@@ -156,7 +170,7 @@ export function useAdaptiveSession({
     } finally {
       setSubmitting(false);
     }
-  }, [session, currentQuestion, selectedOption, confidence, sessionId, resetForNextQuestion]);
+  }, [session, currentQuestion, selectedOption, confidence, hintRevealed, sessionId, resetForNextQuestion]);
 
   const askHint = useCallback(async () => {
     if (!session || askingHint) return;
@@ -216,6 +230,8 @@ export function useAdaptiveSession({
       submitting,
       abandoning,
       lastAnswerCorrect,
+      sessionPoints,
+      lastReward,
     }),
     [
       loading,
@@ -237,6 +253,8 @@ export function useAdaptiveSession({
       submitting,
       abandoning,
       lastAnswerCorrect,
+      sessionPoints,
+      lastReward,
     ],
   );
 }

--- a/lib/services/adaptive-coding.service.ts
+++ b/lib/services/adaptive-coding.service.ts
@@ -79,6 +79,15 @@ export interface CodingSubmissionRecord {
   created_at: string;
 }
 
+/** Time-decay params for the live coding points HUD (mirrors the engine's coding decay). */
+export interface CodingPointsDecay {
+  base: number;
+  grace: number;
+  dec: number;
+  iv: number;
+  floor: number;
+}
+
 export interface CodingSession {
   id: string;
   config: number;
@@ -92,6 +101,10 @@ export interface CodingSession {
   last_source: string;
   /** Copy/paste policy for the editor, from the coding set (admin-controlled). */
   allow_clipboard: boolean;
+  /** Decay params for the live points HUD (null if the journey app is unavailable). */
+  points: CodingPointsDecay | null;
+  /** Server clock at fetch time — anchors the live timer against server time (clock-skew safe). */
+  server_now: string;
   started_at: string;
   completed_at: string | null;
   latest_submission: CodingSubmissionRecord | null;
@@ -149,6 +162,8 @@ export interface SubmitResult {
   diagnosis: MentorDiagnosis | null;
   optimization_challenge: OptimizationChallenge | null;
   mastery_delta: MasteryDelta;
+  /** Points awarded for this submit (time-decayed from the session's started_at). */
+  points_earned?: number;
   /** Set when the submit couldn't be graded (no test cases / runner outage). */
   detail?: string;
 }
@@ -192,6 +207,15 @@ export const adaptiveCodingService = {
   }): Promise<CodingSession> {
     const { data } = await apiClient.post<CodingSession>(`${BASE}/sessions/start/`, payload);
     return data;
+  },
+
+  /** Peek the learner's existing session for a problem WITHOUT creating one — null on a fresh
+   *  problem (so the UI can show a "ready to begin" gate before the timer starts). */
+  async getActiveSession(configId: number, problemId: number): Promise<CodingSession | null> {
+    const { data } = await apiClient.get<{ active: CodingSession | null }>(`${BASE}/sessions/active/`, {
+      params: { config_id: configId, problem_id: problemId },
+    });
+    return data.active;
   },
 
   /** Mode 2 — On Run: execute visible cases + line-level diagnosis (no grade). */

--- a/lib/services/adaptive-coding.service.ts
+++ b/lib/services/adaptive-coding.service.ts
@@ -86,6 +86,8 @@ export interface CodingPointsDecay {
   dec: number;
   iv: number;
   floor: number;
+  /** Fraction shaved per hint taken (so the HUD matches the awarded points). */
+  hint_penalty?: number;
 }
 
 export interface CodingSession {

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -93,6 +93,7 @@ export const adaptiveJourneyService = {
   async issueCertificate(courseId: number): Promise<AdaptiveCredential> {
     const { data } = await apiClient.post<AdaptiveCredential>(
       `${BASE}/courses/${courseId}/certificate/issue/`,
+      {},
     );
     return data;
   },

--- a/lib/services/adaptive-quiz.service.ts
+++ b/lib/services/adaptive-quiz.service.ts
@@ -50,6 +50,7 @@ export const adaptiveQuizService = {
       selected_option: string;
       confidence?: number | null;
       time_ms?: number;
+      hint_used?: boolean;
     },
   ): Promise<SubmitAnswerResponse> {
     const { data } = await apiClient.post<SubmitAnswerResponse>(

--- a/lib/services/adaptive-quiz.service.ts
+++ b/lib/services/adaptive-quiz.service.ts
@@ -105,20 +105,31 @@ export const adaptiveQuizService = {
     return data;
   },
 
-  /** Streams one narration section. The four sections — headline, per_question,
-   *  misconceptions, remediation_path — can be fired in parallel from the
-   *  results page. Each request returns cached output if available, otherwise
-   *  fires its own AI call and persists the result.
-   */
+  /** Resolve one narration section. The backend generates it OFF the request thread (daemon
+   *  worker) so HTTP workers never block on OpenAI: the POST kicks off (or returns cached) and
+   *  we poll the GET until it's ready. Resolves with the section value, throws on failure/timeout
+   *  so the caller's existing catch → retry path still works. The four sections are fired in
+   *  parallel from the results page; cached sections resolve on the first POST. */
   async generateNarrationSection<T = unknown>(
     sessionId: string,
     section: "headline" | "per_question" | "misconceptions" | "remediation_path",
   ): Promise<T> {
-    const { data } = await apiClient.post<{ section: string; value: T }>(
-      `${BASE}/sessions/${sessionId}/narration/${section}/`,
-      {},
-    );
-    return data.value;
+    const url = `${BASE}/sessions/${sessionId}/narration/${section}/`;
+    type SectionState = { section: string; status: "ready" | "generating" | "failed" | "pending"; value?: T };
+
+    const kick = await apiClient.post<SectionState>(url, {});
+    if (kick.data.status === "ready") return kick.data.value as T;
+    if (kick.data.status === "failed") throw new Error(`narration section '${section}' failed`);
+
+    // Poll until ready/failed. Each poll is a fast request (no server-side AI blocking).
+    const deadline = Date.now() + 75000;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 1500));
+      const { data } = await apiClient.get<SectionState>(url);
+      if (data.status === "ready") return data.value as T;
+      if (data.status === "failed") throw new Error(`narration section '${section}' failed`);
+    }
+    throw new Error(`narration section '${section}' timed out`);
   },
 
   async listQuizzes(): Promise<Array<{

--- a/lib/services/adaptive-quiz.service.ts
+++ b/lib/services/adaptive-quiz.service.ts
@@ -2,6 +2,7 @@ import apiClient from "./api";
 import type {
   AdaptiveSessionDetail,
   RemediationProgress,
+  RequizOutcome,
   StartSessionResponse,
   SubmitAnswerResponse,
 } from "@/lib/types/adaptive-quiz";
@@ -47,6 +48,13 @@ export const adaptiveQuizService = {
   async getRemediationProgress(sessionId: string): Promise<RemediationProgress> {
     const { data } = await apiClient.get<RemediationProgress>(
       `${BASE}/sessions/${sessionId}/remediation-progress/`,
+    );
+    return data;
+  },
+
+  async getRequizOutcome(sessionId: string): Promise<RequizOutcome> {
+    const { data } = await apiClient.get<RequizOutcome>(
+      `${BASE}/sessions/${sessionId}/requiz-outcome/`,
     );
     return data;
   },

--- a/lib/services/adaptive-quiz.service.ts
+++ b/lib/services/adaptive-quiz.service.ts
@@ -1,6 +1,7 @@
 import apiClient from "./api";
 import type {
   AdaptiveSessionDetail,
+  RemediationProgress,
   StartSessionResponse,
   SubmitAnswerResponse,
 } from "@/lib/types/adaptive-quiz";
@@ -39,6 +40,13 @@ export const adaptiveQuizService = {
   async getSession(sessionId: string): Promise<AdaptiveSessionDetail> {
     const { data } = await apiClient.get<AdaptiveSessionDetail>(
       `${BASE}/sessions/${sessionId}/`,
+    );
+    return data;
+  },
+
+  async getRemediationProgress(sessionId: string): Promise<RemediationProgress> {
+    const { data } = await apiClient.get<RemediationProgress>(
+      `${BASE}/sessions/${sessionId}/remediation-progress/`,
     );
     return data;
   },

--- a/lib/services/adaptive-video.service.ts
+++ b/lib/services/adaptive-video.service.ts
@@ -60,6 +60,8 @@ export interface VideoCompanion {
   id: number;
   title: string;
   instructions: string;
+  /** AI-generated learner-facing summary, derived from the transcript (cached server-side). */
+  description: string;
   video: VimeoVideoWire | null;
   concept_map: ConceptMap;
   chapters: Chapter[];
@@ -128,6 +130,16 @@ export const adaptiveVideoService = {
   async getCompanion(configId: number): Promise<VideoCompanion> {
     const { data } = await apiClient.get<VideoCompanion>(`${BASE}/configs/${configId}/`);
     return data;
+  },
+
+  /** Fetch (or generate-and-cache) the AI description for a companion, distilled from its
+   *  transcript. Cached server-side and shared across learners — first viewer pays the generation. */
+  async generateDescription(configId: number): Promise<string> {
+    const { data } = await apiClient.post<{ description: string }>(
+      `${BASE}/configs/${configId}/description/`,
+      {},
+    );
+    return data.description;
   },
 
   async startSession(configId: number, watchMode: WatchMode = "normal"): Promise<StartSessionResult> {

--- a/lib/services/adaptive-video.service.ts
+++ b/lib/services/adaptive-video.service.ts
@@ -72,7 +72,7 @@ export interface VideoCompanion {
 }
 
 export type WatchMode = "normal" | "pause_60s" | "plain_english";
-export type ReExplainStyle = "analogy" | "code" | "formal";
+export type ReExplainStyle = "analogy" | "code" | "formal" | "plain";
 
 export interface VideoSession {
   id: string;

--- a/lib/services/admin/ai-course-builder.service.ts
+++ b/lib/services/admin/ai-course-builder.service.ts
@@ -132,6 +132,7 @@ export interface ContentTask {
   topic_context?: string;
   validation_status?: string;
   validation_errors?: string[];
+  attempts?: number;
   created_at: string;
   started_at: string | null;
   completed_at: string | null;
@@ -144,6 +145,18 @@ export interface JobDetailResponse {
   generating_tasks: number;
   completed_tasks: number;
   failed_tasks: number;
+  total_tasks?: number;
+  // Stall / recovery signals (server-computed)
+  is_stalled?: boolean;
+  stale_seconds?: number;
+  orphaned_tasks?: number;
+  can_resume?: boolean;
+}
+
+// Body for generate-all-content (resume / retry-failed)
+export interface ResumeGenerationBody {
+  force?: boolean;
+  include_failed?: boolean;
 }
 
 // Approve outline body
@@ -243,22 +256,50 @@ export const aiCourseBuilderService = {
   },
 
   generateAllContent: async (
-    jobId: string
+    jobId: string,
+    body?: ResumeGenerationBody
   ): Promise<{
     message: string;
-    job_id: string;
-    pending_tasks: number;
+    job_id?: string;
+    resumed?: boolean;
+    pending_tasks?: number;
+    submodules_enqueued?: number;
     status: string;
   }> => {
     try {
       const res = await apiClient.post(
         `${getBasePath()}/jobs/${encodeURIComponent(jobId)}/generate-all-content/`,
-        {}
+        body ?? {}
       );
       return res.data;
     } catch (error) {
       throw new Error(getErrorMessage(error));
     }
+  },
+
+  // Resume (or retry-failed) a stalled / partial generation. Posts a body to
+  // generate-all-content; force lets it reclaim orphaned tasks even when the
+  // job still reports status === 'generating_content'.
+  resumeGeneration: async (
+    jobId: string,
+    body?: ResumeGenerationBody
+  ): Promise<{
+    message: string;
+    job_id?: string;
+    resumed?: boolean;
+    pending_tasks?: number;
+    submodules_enqueued?: number;
+    status: string;
+  }> => {
+    return aiCourseBuilderService.generateAllContent(jobId, body ?? {});
+  },
+
+  // Convenience: resume AND retry previously-failed items.
+  regenerateFailed: async (jobId: string) => {
+    return aiCourseBuilderService.resumeGeneration(jobId, {
+      force: true,
+      include_failed: true,
+    });
   },
 
   generateModuleContent: async (

--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -8,9 +8,13 @@ import Cookies from "js-cookie";
 import { config } from "../config";
 import { getClientDeviceClass } from "../utils/assessment-device";
 
-// Create axios instance
+// Create axios instance.
+// A request timeout is essential: without it a slow/hung prod endpoint (or a flaky network)
+// leaves the XHR pending forever, which surfaces to the UI as a confusing "Network Error"
+// while navigating. A bounded timeout fails fast so callers can show a real/retryable state.
 const apiClient: AxiosInstance = axios.create({
   baseURL: config.apiBaseUrl,
+  timeout: 45000,
 });
 
 // Module flag so the response interceptor and any caller can tell that a
@@ -25,6 +29,13 @@ export function setLoggingOut(value: boolean) {
 export function getIsLoggingOut() {
   return isLoggingOut;
 }
+
+// Single-flight token refresh. When many requests fire at once (e.g. navigating into adaptive
+// content fans out dashboard/journey/leaderboard calls) and the access token has expired, they
+// all 401 together. Without this gate each would POST /token/refresh independently — a stampede
+// that, with ROTATE_REFRESH_TOKENS on, races a rotated refresh token and logs the user out.
+// This collapses concurrent refreshes into one shared promise.
+let refreshPromise: Promise<string> | null = null;
 
 // Request interceptor to add auth token and fix FormData uploads
 apiClient.interceptors.request.use(
@@ -93,13 +104,20 @@ apiClient.interceptors.response.use(
       const refreshToken = Cookies.get("refresh_token");
       if (refreshToken) {
         try {
-          const response = await axios.post(
-            `${config.apiBaseUrl}/accounts/token/refresh/`,
-            { refresh: refreshToken }
-          );
-
-          const { access } = response.data;
-          Cookies.set("access_token", access, { expires: 7 });
+          // Reuse an in-flight refresh if one is already running (single-flight).
+          if (!refreshPromise) {
+            refreshPromise = axios
+              .post(`${config.apiBaseUrl}/accounts/token/refresh/`, { refresh: refreshToken })
+              .then((response) => {
+                const { access } = response.data;
+                Cookies.set("access_token", access, { expires: 7 });
+                return access as string;
+              })
+              .finally(() => {
+                refreshPromise = null;
+              });
+          }
+          const access = await refreshPromise;
 
           if (originalRequest.headers) {
             originalRequest.headers.Authorization = `Bearer ${access}`;

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -7,6 +7,15 @@ export interface AdaptiveOption {
   value: string;
 }
 
+/** Time-decay params for one quiz question — drives the live decaying-points countdown. */
+export interface QuestionPointsDecay {
+  base: number;  // full points if answered within the grace window
+  grace: number; // seconds of full credit
+  dec: number;   // points shed per interval past grace
+  iv: number;    // interval length, seconds
+  floor: number; // minimum points after decay
+}
+
 export interface AdaptiveQuestion {
   mcq_id: number;
   question_text: string;
@@ -15,6 +24,7 @@ export interface AdaptiveQuestion {
   difficulty_label: "Easy" | "Medium" | "Hard" | string;
   selector_rationale: string;
   predicted_p_correct: number; // 0..1
+  points?: QuestionPointsDecay | null;
 }
 
 export interface AdaptiveSessionMeta {
@@ -50,6 +60,8 @@ export interface SubmitAnswerResponse {
   };
   ability_state: Record<string, number>;
   se_state: Record<string, number>;
+  points_earned: number; // time-decayed points earned for the question just answered (0 if wrong)
+  points_base: number;   // full points that question was worth before decay
 }
 
 export interface AdaptiveResponseMcqDetail {

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -34,6 +34,16 @@ export interface RemediationProgress {
   requiz: { done: boolean; session_id: string | null; status: string | null };
 }
 
+/** Re-quiz vs its source attempt on the targeted skill (GET .../requiz-outcome/). */
+export interface RequizOutcome {
+  has_source: boolean;
+  skill?: string;
+  verdict?: "closed" | "narrowed" | "still_weak";
+  original?: { accuracy: number; theta: number };
+  requiz?: { accuracy: number; theta: number };
+  accuracy_delta?: number;
+}
+
 export interface AdaptiveSessionMeta {
   min_questions: number;
   max_questions: number;

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -27,6 +27,13 @@ export interface AdaptiveQuestion {
   points?: QuestionPointsDecay | null;
 }
 
+/** Live completion of a result-page remediation path (GET .../remediation-progress/). */
+export interface RemediationProgress {
+  steps: Array<{ step: number; content_type: string; done: boolean }>;
+  content_done: boolean;
+  requiz: { done: boolean; session_id: string | null; status: string | null };
+}
+
 export interface AdaptiveSessionMeta {
   min_questions: number;
   max_questions: number;

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -14,6 +14,7 @@ export interface QuestionPointsDecay {
   dec: number;   // points shed per interval past grace
   iv: number;    // interval length, seconds
   floor: number; // minimum points after decay
+  hint_penalty?: number; // fraction shaved per hint taken (so the live HUD matches the award)
 }
 
 export interface AdaptiveQuestion {

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -136,7 +136,7 @@ export interface AdaptiveAINarration {
     step: 1 | 2 | 3 | number;
     title: string;
     why: string;
-    action_kind: "read" | "practice" | "watch" | string;
+    action_kind: "read" | "practice" | "watch" | "requiz" | string;
     target_skill: string;
     est_minutes: number;
     /** Content-grounded link metadata (present when the step maps to a real
@@ -145,6 +145,8 @@ export interface AdaptiveAINarration {
     course_id?: number | null;
     submodule_id?: number | null;
     article_id?: number | null;
+    /** The specific item id (e.g. video config) so the step deep-links exactly. */
+    content_id?: number | null;
   }>;
 }
 

--- a/lib/utils/skill-label.utils.ts
+++ b/lib/utils/skill-label.utils.ts
@@ -1,0 +1,13 @@
+/** Humanise a raw skill key for display.
+ *
+ *  Strips the Python-list-repr artifacts (`[`, `]`, quotes) that leaked into some stored skill
+ *  keys — skills were sometimes saved as a stringified list (`"['A', 'B']"`) then split on commas,
+ *  so keys arrived as `['A'` / `'B']`. Then collapses underscores and title-cases.
+ *
+ *  `fallback` is returned for an empty/blank key (callers vary: "General", "this skill", …).
+ */
+export function prettySkill(raw: string | null | undefined, fallback = "General"): string {
+  const cleaned = (raw || "").trim().replace(/^[\s[\]'"]+|[\s[\]'"]+$/g, "").trim();
+  if (!cleaned) return fallback;
+  return cleaned.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -1922,7 +1922,19 @@
     "regenerateTaskFailed": "فشل إعادة إنشاء المهمة",
     "regenerateSubmoduleFailed": "فشل إعادة إنشاء الوحدة الفرعية",
     "regenerateContentFailed": "فشل إعادة إنشاء المحتوى",
-    "submoduleFallback": "الوحدة الفرعية {{id}}"
+    "submoduleFallback": "الوحدة الفرعية {{id}}",
+    "generationStalled": "توقف التوليد",
+    "generationStalledBody": "لا يوجد تقدم منذ {{minutes}} دقيقة — قد يكون العامل قد أُعيد تشغيله.",
+    "resumeGeneration": "استئناف التوليد",
+    "resuming": "جارٍ الاستئناف...",
+    "resumeStarted": "تم استئناف التوليد",
+    "resumeFailed": "تعذر استئناف التوليد",
+    "retryFailedItems": "إعادة محاولة العناصر الفاشلة ({{count}})",
+    "retrying": "جارٍ إعادة المحاولة...",
+    "retryFailedStarted": "إعادة محاولة العناصر الفاشلة",
+    "retryFailedFailed": "تعذرت إعادة محاولة العناصر الفاشلة",
+    "preparingContentTasks": "جارٍ تحضير مهام المحتوى…",
+    "attemptsLabel": "{{count}} محاولات"
   },
   "adminEmailJobs": {
     "title": "مهام البريد الإلكتروني",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -2058,7 +2058,19 @@
     "regenerateTaskFailed": "Regenerate task failed",
     "regenerateSubmoduleFailed": "Regenerate submodule failed",
     "regenerateContentFailed": "Regenerate content failed",
-    "submoduleFallback": "Submodule {{id}}"
+    "submoduleFallback": "Submodule {{id}}",
+    "generationStalled": "Generation stalled",
+    "generationStalledBody": "No progress for {{minutes}} min — the worker may have restarted.",
+    "resumeGeneration": "Resume generation",
+    "resuming": "Resuming...",
+    "resumeStarted": "Generation resumed",
+    "resumeFailed": "Failed to resume generation",
+    "retryFailedItems": "Retry failed items ({{count}})",
+    "retrying": "Retrying...",
+    "retryFailedStarted": "Retrying failed items",
+    "retryFailedFailed": "Failed to retry failed items",
+    "preparingContentTasks": "Preparing content tasks…",
+    "attemptsLabel": "{{count}} attempts"
   },
   "adminEmailJobs": {
     "title": "Email Jobs",


### PR DESCRIPTION
## Problem
When AI course generation stalled (worker died/redeployed mid-run), the job page **froze silently**: the progress bar showed nothing, polling only ran while `status==='generating_content'`, and every recovery control was hidden behind `!isLive` — so a wedged job offered **no way to resume or regenerate**.

## Fix
Make the job page never freeze silently and always offer recovery, matching the resumable backend (`AI-Linc-LMS/ai-linc-backend` PR #280).

- **Stall banner** — uses server `is_stalled` (with a client-side fallback) to show a "Generation stalled" warning with counts and a **Resume Generation** button that works **even while `status==='generating_content'`** (previously impossible), plus **Retry Failed Items**.
- **Polling lifecycle** — polls on all non-terminal statuses, stops on terminal, backs off when stalled.
- **Always-on progress** — progress card no longer hidden on 0/0 (indeterminate "Preparing content tasks…"); pending/generating/completed/failed breakdown always shown.
- **Actionable per-task table** — status chips, failure reasons (joined from `job.error_log` by `task_id`), attempt counts, targeted regenerate.
- **Service/types** — `resumeGeneration()` / `regenerateFailed()`; `generateAllContent()` forwards a body; job-detail types extended (`is_stalled`, `stale_seconds`, `orphaned_tasks`, `can_resume`, `total_tasks`, `attempts`). New i18n keys (en/ar).

## Verification
`tsc --noEmit` clean; eslint clean on changed files.

## Depends on
Backend PR: `AI-Linc-LMS/ai-linc-backend` #280 (the new API fields + resumable endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)