### PR TITLE
Promote Adaptive Courses to legacy-only students (banner + animated intro + bell) — FE

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -3,11 +3,14 @@
 import { Box } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { DashboardV2 } from "@/components/dashboard/v2/DashboardV2";
+import { AdaptivePromo } from "@/components/courses/AdaptivePromo";
 
 export default function DashboardPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1600, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 } }}>
+        {/* New-adaptive-courses banner + first-time intro guide (legacy-only students). */}
+        <AdaptivePromo />
         <DashboardV2 />
       </Box>
     </MainLayout>

--- a/components/courses/AdaptiveCourseIntroModal.tsx
+++ b/components/courses/AdaptiveCourseIntroModal.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Dialog, IconButton, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  course: { id: number; title: string; route: string };
+  onClose: () => void;   // called on X / Skip / final CTA — persists "seen forever"
+}
+
+const STEPS: { icon: string; accent: string; title: string; body: string }[] = [
+  {
+    icon: "mdi:auto-awesome",
+    accent: "#6366f1",
+    title: "Meet Adaptive Courses",
+    body: "A brand-new way to learn — find it under Courses → Adaptive Course. The course adjusts itself to you instead of one-size-fits-all.",
+  },
+  {
+    icon: "mdi:target-account",
+    accent: "#a855f7",
+    title: "It calibrates to your level",
+    body: "A quick calibration reads where you are, so you start at the right depth — no time wasted on what you already know.",
+  },
+  {
+    icon: "mdi:chart-line-variant",
+    accent: "#ec4899",
+    title: "Difficulty adapts in real time",
+    body: "Get a streak right and it steps up; struggle and it eases off and offers hints, a mentor, and re-explains — live.",
+  },
+  {
+    icon: "mdi:trophy-variant",
+    accent: "#10b981",
+    title: "Earn points & a certificate",
+    body: "Every quiz, video and coding problem earns time-decayed points and feeds your journey toward a shareable certificate.",
+  },
+];
+
+export function AdaptiveCourseIntroModal({ course, onClose }: Props) {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [dir, setDir] = useState(1);
+  const isLast = step === STEPS.length - 1;
+  const s = STEPS[step];
+
+  const go = (next: number) => { setDir(next > step ? 1 : -1); setStep(next); };
+  const finish = () => { onClose(); router.push(course.route); };
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      slotProps={{ paper: { sx: { borderRadius: 5, overflow: "hidden", position: "relative",
+        boxShadow: "0 30px 80px -30px rgba(124,58,237,0.6)" } } }}
+    >
+      <IconButton
+        aria-label="Skip"
+        onClick={onClose}
+        size="small"
+        sx={{ position: "absolute", top: 10, right: 10, zIndex: 2, color: "text.secondary" }}
+      >
+        <Icon icon="mdi:close" width={18} />
+      </IconButton>
+
+      {/* Animated illustration */}
+      <Box sx={{ pt: 5, pb: 3, display: "grid", placeItems: "center",
+        background: `linear-gradient(160deg, color-mix(in srgb, ${s.accent} 14%, var(--card-bg, #fff)) 0%, var(--card-bg, #fff) 100%)`,
+        transition: "background 0.4s ease" }}>
+        <AnimatePresence mode="wait" custom={dir}>
+          <Box
+            key={step}
+            component={motion.div}
+            custom={dir}
+            initial={{ opacity: 0, x: dir * 40, scale: 0.9 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: dir * -40, scale: 0.9 }}
+            transition={{ duration: 0.32, ease: [0.16, 1, 0.3, 1] }}
+            sx={{ display: "grid", placeItems: "center" }}
+          >
+            <Box
+              component={motion.div}
+              animate={{ y: [0, -7, 0] }}
+              transition={{ duration: 2.4, repeat: Infinity, ease: "easeInOut" }}
+              sx={{ width: 88, height: 88, borderRadius: "28%", display: "grid", placeItems: "center", color: "white",
+                background: `linear-gradient(135deg, ${s.accent}, color-mix(in srgb, ${s.accent} 55%, #ec4899))`,
+                boxShadow: `0 18px 40px -16px ${s.accent}` }}
+            >
+              <Icon icon={s.icon} width={44} />
+            </Box>
+          </Box>
+        </AnimatePresence>
+      </Box>
+
+      {/* Animated copy */}
+      <Box sx={{ px: 3, pb: 1, textAlign: "center", minHeight: 132 }}>
+        <AnimatePresence mode="wait">
+          <Box key={step} component={motion.div}
+            initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.28 }}>
+            <Typography sx={{ fontWeight: 800, fontSize: "1.2rem", mb: 0.75 }}>{s.title}</Typography>
+            <Typography sx={{ fontSize: "0.9rem", color: "text.secondary", lineHeight: 1.5 }}>{s.body}</Typography>
+          </Box>
+        </AnimatePresence>
+      </Box>
+
+      {/* Dots + nav */}
+      <Stack direction="row" spacing={0.75} justifyContent="center" sx={{ mt: 1 }}>
+        {STEPS.map((_, i) => (
+          <Box key={i} onClick={() => go(i)} sx={{ cursor: "pointer", height: 7, borderRadius: 999,
+            width: i === step ? 22 : 7, transition: "all 0.3s ease",
+            bgcolor: i === step ? s.accent : "color-mix(in srgb, var(--border-default,#cbd5e1) 90%, transparent)" }} />
+        ))}
+      </Stack>
+
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ p: 2.5, pt: 2 }}>
+        {step > 0 ? (
+          <Button onClick={() => go(step - 1)} sx={{ textTransform: "none", fontWeight: 700, color: "text.secondary" }}>
+            Back
+          </Button>
+        ) : (
+          <Button onClick={onClose} sx={{ textTransform: "none", fontWeight: 700, color: "text.secondary" }}>
+            Skip
+          </Button>
+        )}
+        <Button
+          onClick={() => (isLast ? finish() : go(step + 1))}
+          variant="contained"
+          endIcon={<Icon icon={isLast ? "mdi:arrow-right-circle" : "mdi:arrow-right"} width={18} />}
+          sx={{ textTransform: "none", fontWeight: 800, borderRadius: 999, px: 2.5,
+            background: "linear-gradient(135deg,#6366f1,#a855f7)" }}
+        >
+          {isLast ? "Open Adaptive Courses" : "Next"}
+        </Button>
+      </Stack>
+    </Dialog>
+  );
+}

--- a/components/courses/AdaptiveCoursePromoBanner.tsx
+++ b/components/courses/AdaptiveCoursePromoBanner.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Box, Button, IconButton, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { motion } from "framer-motion";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  course: { id: number; title: string; route: string };
+  onExplore?: () => void;   // optional: open the intro modal instead of routing
+  onDismiss: () => void;
+}
+
+/**
+ * Dismissible top banner announcing Adaptive Courses to students still on legacy courses. Routes to
+ * the promoted course (or opens the intro guide via onExplore). Dismissal persists server-side.
+ */
+export function AdaptiveCoursePromoBanner({ course, onExplore, onDismiss }: Props) {
+  const router = useRouter();
+  return (
+    <Box
+      component={motion.div}
+      initial={{ opacity: 0, y: -12 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -12 }}
+      transition={{ duration: 0.35, ease: [0.16, 1, 0.3, 1] }}
+      sx={{
+        position: "relative", mb: 2.5, px: { xs: 2, md: 3 }, py: { xs: 1.75, md: 2 }, borderRadius: 4,
+        display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap",
+        color: "white", overflow: "hidden",
+        background: "linear-gradient(120deg, #6366f1 0%, #a855f7 55%, #ec4899 100%)",
+        boxShadow: "0 18px 40px -22px rgba(124,58,237,0.65)",
+      }}
+    >
+      {/* sparkle accent */}
+      <Box sx={{ position: "absolute", inset: 0, opacity: 0.18, pointerEvents: "none",
+        background: "radial-gradient(circle at 90% -20%, #fff 0%, transparent 40%)" }} />
+      <Box sx={{ width: 42, height: 42, borderRadius: "50%", display: "grid", placeItems: "center", flexShrink: 0,
+        bgcolor: "rgba(255,255,255,0.18)", border: "1px solid rgba(255,255,255,0.35)" }}>
+        <Icon icon="mdi:auto-awesome" width={22} />
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 220 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.2 }}>
+          New: Adaptive Courses are here ✨
+        </Typography>
+        <Typography sx={{ fontSize: "0.85rem", opacity: 0.95, mt: 0.25 }}>
+          Your learning now adapts to you in real time — questions, difficulty and pacing meet you at your level.
+        </Typography>
+      </Box>
+      <Button
+        onClick={() => (onExplore ? onExplore() : router.push(course.route))}
+        variant="contained"
+        sx={{ flexShrink: 0, textTransform: "none", fontWeight: 800, borderRadius: 999, px: 2.5,
+          bgcolor: "white", color: "#6d28d9", "&:hover": { bgcolor: "rgba(255,255,255,0.9)" } }}
+      >
+        Explore Adaptive Courses
+      </Button>
+      <IconButton
+        aria-label="Dismiss"
+        onClick={onDismiss}
+        size="small"
+        sx={{ color: "white", flexShrink: 0, "&:hover": { bgcolor: "rgba(255,255,255,0.18)" } }}
+      >
+        <Icon icon="mdi:close" width={18} />
+      </IconButton>
+    </Box>
+  );
+}

--- a/components/courses/AdaptivePromo.tsx
+++ b/components/courses/AdaptivePromo.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { AnimatePresence } from "framer-motion";
+import { useAdaptivePromotion } from "@/lib/hooks/useAdaptivePromotion";
+import { AdaptiveCoursePromoBanner } from "./AdaptiveCoursePromoBanner";
+import { AdaptiveCourseIntroModal } from "./AdaptiveCourseIntroModal";
+
+/**
+ * Mounts the adaptive-course promotion surfaces for legacy-only students: a dismissible top banner
+ * and a first-time animated intro modal. Renders nothing for ineligible students / tenants without
+ * the feature (the hook skips the fetch). Mount ONCE near the top of the dashboard.
+ */
+export function AdaptivePromo() {
+  const { promotion, dismissBanner, dismissIntro } = useAdaptivePromotion();
+  if (!promotion?.eligible || !promotion.adaptive_course) return null;
+  const course = promotion.adaptive_course;
+  return (
+    <>
+      <AnimatePresence>
+        {promotion.show_banner && (
+          <AdaptiveCoursePromoBanner key="adaptive-promo-banner" course={course} onDismiss={dismissBanner} />
+        )}
+      </AnimatePresence>
+      {promotion.show_intro_modal && (
+        <AdaptiveCourseIntroModal course={course} onClose={dismissIntro} />
+      )}
+    </>
+  );
+}

--- a/components/notifications/NotificationPopover.tsx
+++ b/components/notifications/NotificationPopover.tsx
@@ -28,6 +28,11 @@ const NOTIFICATION_TYPE_CONFIG: Record<
     color: "var(--primary-500)",
     bgColor: "color-mix(in srgb, var(--primary-500) 12%, var(--surface) 88%)",
   },
+  adaptive_course_promotion: {
+    icon: "mdi:auto-awesome",
+    color: "var(--accent-purple)",
+    bgColor: "color-mix(in srgb, var(--accent-purple) 12%, var(--surface) 88%)",
+  },
   job_published: {
     icon: "mdi:briefcase-plus",
     color: "var(--success-500)",

--- a/lib/hooks/useAdaptivePromotion.ts
+++ b/lib/hooks/useAdaptivePromotion.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  adaptiveCourseService,
+  type AdaptivePromotion,
+} from "@/lib/services/adaptive-course.service";
+import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * One shared fetch of the adaptive-course promotion state for the current student. Skips the call
+ * entirely for tenants without the adaptive feature. Dismissals are optimistic (hide immediately)
+ * and persisted server-side, so "show once" holds across devices on the next load. Mount ONCE at the
+ * page level and pass results down, to avoid a double fetch / double notification race.
+ */
+export function useAdaptivePromotion() {
+  const enabled = useIsAdaptiveQuizEnabled();
+  const [promotion, setPromotion] = useState<AdaptivePromotion | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let alive = true;
+    adaptiveCourseService
+      .getPromotion()
+      .then((p) => alive && setPromotion(p))
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, [enabled]);
+
+  const dismissBanner = useCallback(() => {
+    setPromotion((p) => (p ? { ...p, show_banner: false } : p));
+    adaptiveCourseService.dismissPromotion("banner").catch(() => {});
+  }, []);
+
+  const dismissIntro = useCallback(() => {
+    setPromotion((p) => (p ? { ...p, show_intro_modal: false } : p));
+    adaptiveCourseService.dismissPromotion("intro_modal").catch(() => {});
+  }, []);
+
+  return { promotion, dismissBanner, dismissIntro };
+}

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -2,6 +2,14 @@ import apiClient from "./api";
 
 const BASE = "/adaptive-quiz/api";
 
+/** Promotion payload for nudging legacy-only students toward Adaptive Courses. */
+export interface AdaptivePromotion {
+  eligible: boolean;
+  adaptive_course?: { id: number; title: string; route: string };
+  show_banner?: boolean;
+  show_intro_modal?: boolean;
+}
+
 export interface AdaptiveCourseQuizSummary {
   config_id: number;
   quiz_title: string;
@@ -296,5 +304,17 @@ export const adaptiveCourseService = {
   async runSnippet(payload: { source: string; language: string; stdin?: string }): Promise<RunSnippetResult> {
     const { data } = await apiClient.post<RunSnippetResult>(`${BASE}/run-snippet/`, payload);
     return data;
+  },
+
+  /** Should this (legacy-only) student be nudged toward Adaptive Courses? Always resolves; an
+   *  ineligible student gets {eligible:false}. The first eligible call also drops a bell notification. */
+  async getPromotion(): Promise<AdaptivePromotion> {
+    const { data } = await apiClient.get<AdaptivePromotion>(`${BASE}/promotion/`);
+    return data;
+  },
+
+  /** Persist a dismissal server-side (so "show once" holds across devices). */
+  async dismissPromotion(target: "banner" | "intro_modal"): Promise<void> {
+    await apiClient.post(`${BASE}/promotion/dismiss/`, { target });
   },
 };


### PR DESCRIPTION
Frontend for the Adaptive Courses promotion. Surfaces the new capability to students still only on legacy courses, all gated on the BE eligibility endpoint (skipped entirely for tenants without the feature).

> Base: this targets `feat/adaptive-course-certificate-linkedin` (not `main`) because the adaptive dashboard infra it builds on isn't on `main` yet — retarget to `main` once that adaptive PR merges.

## What's new
- **Top banner** (`AdaptiveCoursePromoBanner`): dismissible gradient banner on the dashboard with a CTA to the promoted course.
- **First-time animated intro modal** (`AdaptiveCourseIntroModal`): a 4-step framer-motion carousel (meet it → calibrates to you → adapts in real time → points & certificate) deep-linking to Courses → Adaptive Course. X / Skip / final CTA all persist dismissal server-side, so it shows once (across devices).
- **Bell notification** styling: `NotificationPopover` config entry for `adaptive_course_promotion` (the BE drops the notification once on first eligible load).
- `useAdaptivePromotion` fetches once (guarded by `useIsAdaptiveQuizEnabled`) and optimistically hides on dismiss; `AdaptivePromo` mounts both surfaces once atop the dashboard.

tsc + eslint clean. Pairs with BE PR ai-linc-backend#282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)