### PR TITLE
Adaptive course: always show the new journey UI (no legacy fallback) + better loading shimmer

### DIFF
--- a/app/adaptive-courses/[courseId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/page.tsx
@@ -9,9 +9,9 @@ import {
   type AdaptiveCourseDetail,
 } from "@/lib/services/adaptive-course.service";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { Reveal } from "@/components/scorecard/shared";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { JourneyBoard } from "@/components/adaptive-journey/JourneyBoard";
+import { JourneyBoardSkeleton } from "@/components/courses/CourseSkeletons";
 
 export default function AdaptiveCourseDetailPage() {
   const router = useRouter();
@@ -58,11 +58,7 @@ export default function AdaptiveCourseDetailPage() {
         </ButtonBase>
 
         <AdaptiveSectionShell meshOpacity={0.18}>
-          {loading && (
-            <Typography sx={{ color: "text.secondary", textAlign: "center", py: 6 }}>
-              Loading course…
-            </Typography>
-          )}
+          {loading && <JourneyBoardSkeleton />}
           {error && (
             <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>
               {error}
@@ -87,165 +83,12 @@ export default function AdaptiveCourseDetailPage() {
             </Box>
           )}
 
-          {course && (
-            <>
-              <JourneyBoard
-                courseId={courseId}
-                fallback={
-                  <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
-                {course.modules.map((mod, mIdx) => (
-                  <Reveal key={mod.id} delay={Math.min(mIdx, 8) * 0.05}>
-                    <Box
-                      sx={{
-                        borderRadius: 4,
-                        p: { xs: 2, md: 2.5 },
-                        bgcolor: "var(--card-bg, #fff)",
-                        border: "1px solid var(--border-default, #ececf1)", boxShadow: "0 1px 2px rgba(16,24,40,0.04), 0 10px 26px -22px rgba(16,24,40,0.18)",
-                      }}
-                    >
-                      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 1.75 }}>
-                        <Box
-                          sx={{
-                            width: 44,
-                            height: 44,
-                            borderRadius: 2.5,
-                            display: "grid",
-                            placeItems: "center",
-                            color: "white",
-                            flexShrink: 0,
-                            background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
-                            boxShadow: "0 12px 24px -14px rgba(168,85,247,0.6)",
-                          }}
-                        >
-                          <Icon icon="mdi:calendar-week-outline" width={22} />
-                        </Box>
-                        <Box sx={{ minWidth: 0 }}>
-                          <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.1em", textTransform: "uppercase", color: "#a855f7" }}>
-                            Week {mod.weekno}
-                          </Typography>
-                          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.25 }}>
-                            {mod.title}
-                          </Typography>
-                        </Box>
-                      </Box>
-
-                      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-                        {mod.submodules.map((sub) => (
-                          <ButtonBase
-                            key={sub.id}
-                            onClick={() =>
-                              router.push(`/adaptive-courses/${course.id}/submodule/${sub.id}`)
-                            }
-                            sx={{
-                              width: "100%",
-                              textAlign: "left",
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "space-between",
-                              gap: 1.5,
-                              borderRadius: 2.5,
-                              p: 1.75,
-                              bgcolor: "var(--bg-subtle, #fafafb)",
-                              border: "1px solid var(--border-default, #ececf1)",
-                              transition: "transform 120ms ease, border-color 120ms ease, background 120ms ease",
-                              "&:hover": {
-                                transform: "translateY(-1px)",
-                                borderColor: "color-mix(in srgb, #6366f1 45%, transparent)",
-                                bgcolor: "var(--card-bg, #fff)",
-                              },
-                            }}
-                          >
-                            <Box sx={{ minWidth: 0 }}>
-                              <Typography sx={{ fontWeight: 700, fontSize: "0.95rem" }}>
-                                {sub.title}
-                              </Typography>
-                              {sub.description && (
-                                <Typography
-                                  sx={{
-                                    color: "text.secondary",
-                                    fontSize: "0.82rem",
-                                    mt: 0.25,
-                                    display: "-webkit-box",
-                                    WebkitLineClamp: 1,
-                                    WebkitBoxOrient: "vertical",
-                                    overflow: "hidden",
-                                  }}
-                                >
-                                  {sub.description}
-                                </Typography>
-                              )}
-                            </Box>
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, flexShrink: 0 }}>
-                              {sub.articles.length > 0 && (
-                                <CountChip icon="mdi:book-open-variant" count={sub.articles.length} label="article" accent="#a855f7" />
-                              )}
-                              {sub.quizzes.length > 0 && (
-                                <CountChip icon="mdi:tune-vertical" count={sub.quizzes.length} label="quiz" accent="#6366f1" />
-                              )}
-                              {(sub.coding_sets ?? []).reduce((n, s) => n + s.problems.length, 0) > 0 && (
-                                <CountChip
-                                  icon="mdi:robot-happy-outline"
-                                  count={(sub.coding_sets ?? []).reduce((n, s) => n + s.problems.length, 0)}
-                                  label="coding"
-                                  accent="#ec4899"
-                                />
-                              )}
-                              {(sub.video_companions?.length ?? 0) > 0 && (
-                                <CountChip icon="mdi:play-circle-outline" count={sub.video_companions?.length ?? 0} label="video" accent="#0ea5e9" />
-                              )}
-                              <Icon icon="mdi:chevron-right" width={20} style={{ opacity: 0.4, flexShrink: 0 }} />
-                            </Box>
-                          </ButtonBase>
-                        ))}
-                      </Box>
-                    </Box>
-                  </Reveal>
-                ))}
-                  </Box>
-                }
-              />
-            </>
-          )}
+          {/* New adaptive journey UI only — the legacy week/submodule fallback has been removed; the
+              BE guarantees a topic node per submodule, and JourneyBoard renders a new-UI empty state
+              for any transient 0-node board. */}
+          {course && <JourneyBoard courseId={courseId} />}
         </AdaptiveSectionShell>
       </Box>
     </MainLayout>
-  );
-}
-
-/** Compact count chip — neutral pill, accent only on the icon, so a row of them
- *  (article / quiz / coding / video) reads as a tidy strip rather than a stack of
- *  coloured blobs. */
-function CountChip({
-  icon,
-  count,
-  label,
-  accent,
-}: {
-  icon: string;
-  count: number;
-  label: string;
-  accent: string;
-}) {
-  return (
-    <Box
-      component="span"
-      sx={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 0.5,
-        px: 1,
-        py: 0.4,
-        borderRadius: 999,
-        fontSize: "0.72rem",
-        fontWeight: 700,
-        whiteSpace: "nowrap",
-        color: "text.secondary",
-        bgcolor: "var(--bg-subtle, #f6f6f8)",
-        border: "1px solid var(--border-default, #ececf1)",
-      }}
-    >
-      <Icon icon={icon} width={14} style={{ color: accent }} />
-      {count} {label}
-    </Box>
   );
 }

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Box, Button, ButtonBase, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, Button, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
   adaptiveCourseService,
@@ -14,6 +14,7 @@ import {
 import { MainLayout } from "@/components/layout/MainLayout";
 import { AdditionalPractice } from "@/components/adaptive-journey/AdditionalPractice";
 import { PointsInfo } from "@/components/common/PointsInfo";
+import { AdaptiveSubmoduleSkeleton } from "@/components/courses/CourseSkeletons";
 
 type FlowKind = "video" | "article" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
@@ -194,11 +195,7 @@ export default function AdaptiveCourseSubmodulePage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 4 } }}>
-        {loading && (
-          <Box sx={{ display: "grid", placeItems: "center", py: 10 }}>
-            <CircularProgress sx={{ color: "#6366f1" }} />
-          </Box>
-        )}
+        {loading && <AdaptiveSubmoduleSkeleton />}
         {error && (
           <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 6 }}>{error}</Typography>
         )}

--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -24,6 +24,7 @@ import { KpiRail, Reveal } from "@/components/scorecard/shared";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
 import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
+import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
 import { CoursesNavTabs } from "@/components/courses/CoursesNavTabs";
 
 export default function AdaptiveCourseListPage() {
@@ -136,11 +137,7 @@ export default function AdaptiveCourseListPage() {
             />
           )}
 
-          {loading && (
-            <Typography sx={{ color: "text.secondary", textAlign: "center", py: 6 }}>
-              Loading adaptive courses…
-            </Typography>
-          )}
+          {loading && <AdaptiveCourseListSkeleton />}
 
           {error && (
             <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>

--- a/components/adaptive-journey/JourneyBoard.tsx
+++ b/components/adaptive-journey/JourneyBoard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Box, ButtonBase, Chip, CircularProgress, LinearProgress, Stack, Typography } from "@mui/material";
+import { Box, ButtonBase, Chip, LinearProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type {
@@ -12,6 +12,7 @@ import type {
 } from "@/lib/types/adaptive-journey";
 import { JourneySidePanels } from "./JourneySidePanels";
 import { JourneyTopCards } from "./JourneyTopCards";
+import { JourneyBoardSkeleton } from "@/components/courses/CourseSkeletons";
 
 function fmtDate(iso: string | null | undefined): string {
   if (!iso) return "";
@@ -345,7 +346,7 @@ function Hero({ board, courseId }: { board: JourneyBoardData; courseId: number }
   );
 }
 
-export function JourneyBoard({ courseId, fallback }: { courseId: number; fallback?: ReactNode; showHeader?: boolean }) {
+export function JourneyBoard({ courseId }: { courseId: number; showHeader?: boolean }) {
   const [board, setBoard] = useState<JourneyBoardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -383,13 +384,7 @@ export function JourneyBoard({ courseId, fallback }: { courseId: number; fallbac
     return starts;
   }, [board]);
 
-  if (loading) {
-    return (
-      <Box sx={{ display: "grid", placeItems: "center", py: 10 }}>
-        <CircularProgress sx={{ color: "#6366f1" }} />
-      </Box>
-    );
-  }
+  if (loading) return <JourneyBoardSkeleton />;
   if (notEnrolled) {
     return <Typography sx={{ color: "#64748b", py: 6, textAlign: "center" }}>You are not enrolled in this course.</Typography>;
   }
@@ -397,13 +392,25 @@ export function JourneyBoard({ courseId, fallback }: { courseId: number; fallbac
     return <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center" }}>{error || "Journey unavailable."}</Typography>;
   }
 
+  // Never fall back to the legacy week→submodule list. A 0-node board is only transient now
+  // (the BE backfills a topic node per submodule on every GET); render the new-UI shell with a
+  // calm "being set up" placeholder so the page never regresses to the old look.
   const hasNodes = board.weeks.some((w) => w.nodes.length > 0);
-  if (!hasNodes && fallback) {
+  if (!hasNodes) {
     return (
-      <>
+      <Box>
         <Hero board={board} courseId={courseId} />
-        {fallback}
-      </>
+        <JourneyTopCards courseId={courseId} calibration={board.calibration} interview={board.interview} />
+        <Box sx={{ mt: 2.5, p: { xs: 3, md: 5 }, borderRadius: 4, textAlign: "center", border: "1px solid #eef2f7", bgcolor: "#fff", boxShadow: "0 1px 2px rgba(16,24,40,0.04)" }}>
+          <Box sx={{ width: 52, height: 52, mx: "auto", mb: 1.5, borderRadius: "50%", display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}>
+            <Icon icon="mdi:map-marker-path" width={26} />
+          </Box>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a" }}>Your learning journey is being set up</Typography>
+          <Typography sx={{ fontSize: "0.85rem", color: "#64748b", mt: 0.5, maxWidth: 460, mx: "auto", lineHeight: 1.5 }}>
+            We&apos;re mapping this course&apos;s sections into your adaptive path. Refresh in a moment — your weeks and steps will appear here.
+          </Typography>
+        </Box>
+      </Box>
     );
   }
 

--- a/components/courses/CourseSkeletons.tsx
+++ b/components/courses/CourseSkeletons.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+/**
+ * Course loading shimmers — skeletons shaped like the real loaded layouts (course cards, the
+ * journey board, the submodule path). Uses the SAME grey gradient-sweep convention as
+ * DashboardSkeleton / ResultSkeletons (1.5s sweep, neutral grey) and respects reduced-motion.
+ */
+
+import { Box, Stack } from "@mui/material";
+import { keyframes } from "@mui/system";
+
+const sweep = keyframes`
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+`;
+
+/** Grey gradient-sweep shimmer box (no purple), with a reduced-motion gate. */
+export function Shimmer({ h = 14, w = "100%", r = 1.5, sx }: { h?: number | string; w?: number | string; r?: number; sx?: object }) {
+  return (
+    <Box
+      sx={{
+        height: h,
+        width: w,
+        borderRadius: r,
+        background: "linear-gradient(90deg, #eef2f7 25%, #f8fafc 50%, #eef2f7 75%)",
+        backgroundSize: "200% 100%",
+        animation: `${sweep} 1.5s ease-in-out infinite`,
+        "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+        ...sx,
+      }}
+    />
+  );
+}
+
+const CARD = {
+  border: "1px solid color-mix(in srgb, var(--border-default, #e5e7eb) 65%, transparent)",
+  bgcolor: "color-mix(in srgb, var(--card-bg, #ffffff) 60%, transparent)",
+};
+
+/** One card matching AdaptiveCourseCard: 16:9 image, icon badge + pill, title, 2 desc lines, metrics. */
+export function AdaptiveCourseCardSkeleton() {
+  return (
+    <Box sx={{ ...CARD, borderRadius: 3, p: 2.5, display: "flex", flexDirection: "column", gap: 1.25 }}>
+      <Shimmer h={0} w="100%" r={2.5} sx={{ pb: "56.25%", height: 0 }} />
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mt: 0.5 }}>
+        <Shimmer h={44} w={44} r={3} />
+        <Shimmer h={18} w={90} r={999} />
+      </Stack>
+      <Shimmer h={18} w="70%" sx={{ mt: 0.5 }} />
+      <Shimmer h={12} w="95%" />
+      <Shimmer h={12} w="80%" />
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.25, mt: 0.75 }}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Stack key={i} direction="row" spacing={0.6} alignItems="center">
+            <Shimmer h={14} w={14} r={999} />
+            <Shimmer h={10} w={42} />
+          </Stack>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+/** Responsive card grid (fills the card region beneath the page's static hero). */
+export function AdaptiveCourseListSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <Box
+      role="status"
+      aria-busy="true"
+      sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }, gap: 2, alignItems: "stretch" }}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <AdaptiveCourseCardSkeleton key={i} />
+      ))}
+    </Box>
+  );
+}
+
+/** One week card: header strip + progress bar + 3 node rows (timeline circle + bars + points pill). */
+export function WeekCardSkeleton() {
+  return (
+    <Box sx={{ ...CARD, borderRadius: 4, p: { xs: 2, md: 2.5 }, mb: 2.5 }}>
+      <Stack direction="row" spacing={1.25} alignItems="center">
+        <Shimmer h={34} w={34} r={2.5} />
+        <Box sx={{ flex: 1 }}>
+          <Shimmer h={16} w="45%" />
+          <Shimmer h={10} w="28%" sx={{ mt: 0.6 }} />
+        </Box>
+        <Shimmer h={22} w={90} r={999} />
+      </Stack>
+      <Shimmer h={8} r={4} sx={{ mt: 1.5, mb: 2 }} />
+      <Stack spacing={1.5}>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Stack key={i} direction="row" spacing={1.75} alignItems="center">
+            <Shimmer h={28} w={28} r={999} />
+            <Box sx={{ flex: 1 }}>
+              <Shimmer h={13} w="55%" />
+              <Shimmer h={10} w="35%" sx={{ mt: 0.6 }} />
+            </Box>
+            <Shimmer h={34} w={60} r={2} />
+          </Stack>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+/** Mirrors JourneyBoard's loaded layout: hero + top cards + (weeks | sidebar) grid. */
+export function JourneyBoardSkeleton() {
+  return (
+    <Box role="status" aria-busy="true">
+      <Shimmer h={200} r={5} sx={{ mb: 2.5 }} />
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)" }, gap: 2.5, mb: 2.5 }}>
+        <Shimmer h={150} r={4} />
+        <Shimmer h={150} r={4} />
+      </Box>
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5 }}>
+        <Box>
+          <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 2 }}>
+            <Shimmer h={34} w={34} r={2.5} />
+            <Box sx={{ flex: 1 }}>
+              <Shimmer h={16} w="35%" />
+              <Shimmer h={10} w="55%" sx={{ mt: 0.6 }} />
+            </Box>
+          </Stack>
+          <Shimmer h={48} r={2.5} sx={{ mb: 2 }} />
+          {Array.from({ length: 3 }).map((_, i) => (
+            <WeekCardSkeleton key={i} />
+          ))}
+        </Box>
+        <Stack spacing={2.5}>
+          <Shimmer h={320} r={4} />
+          <Shimmer h={200} r={4} />
+          <Shimmer h={220} r={4} />
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+/** Mirrors the submodule page: hero + section header + 4 path rows. */
+export function AdaptiveSubmoduleSkeleton() {
+  return (
+    <Box role="status" aria-busy="true">
+      <Shimmer h={180} r={5} sx={{ mb: 2.5 }} />
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 2 }}>
+        <Shimmer h={34} w={34} r={2.5} />
+        <Box sx={{ flex: 1 }}>
+          <Shimmer h={16} w="40%" />
+          <Shimmer h={10} w="58%" sx={{ mt: 0.6 }} />
+        </Box>
+        <Shimmer h={26} w={90} r={999} />
+      </Stack>
+      <Stack spacing={1.5}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Stack key={i} direction="row" spacing={1.75} alignItems="stretch">
+            <Shimmer h={28} w={28} r={999} sx={{ alignSelf: "center" }} />
+            <Box sx={{ ...CARD, flex: 1, borderRadius: 3, borderLeft: "4px solid color-mix(in srgb, var(--border-default, #e5e7eb) 65%, transparent)", p: 1.75, display: "flex", alignItems: "center", gap: 1.25 }}>
+              <Shimmer h={38} w={38} r={2} />
+              <Box sx={{ flex: 1 }}>
+                <Shimmer h={13} w="50%" />
+                <Shimmer h={10} w="70%" sx={{ mt: 0.6 }} />
+              </Box>
+              <Shimmer h={34} w={90} r={2.5} />
+            </Box>
+          </Stack>
+        ))}
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
Pairs with BE ai-linc-backend#285.

## 1. No more legacy fallback
On `/adaptive-courses/<id>`, the page sometimes rendered the **old** week→submodule list (the `fallback` prop) whenever the journey board returned 0 nodes. With the BE fix guaranteeing a topic node per submodule:
- `JourneyBoard` no longer renders the legacy list for a 0-node board — it shows the **new-UI shell**: Hero + calibration/interview top cards + a calm "your learning journey is being set up" placeholder (belt-and-suspenders for any transient empty board).
- The `[courseId]` page no longer wires in the legacy `fallback` (its dead week-list JSX + `CountChip` helper are removed).
- The `fallback` prop is dropped from `JourneyBoard`'s API.

## 2. Better loading shimmer
New `components/courses/CourseSkeletons.tsx` — skeletons **shaped like the real content** (course cards; journey hero + week cards + sidebar; submodule path), reusing the existing grey-sweep convention from `DashboardSkeleton`/`ResultSkeletons` and respecting `prefers-reduced-motion` (+ `role="status"`/`aria-busy`). Wired into:
- adaptive courses **list** → `AdaptiveCourseListSkeleton` (replaces "Loading adaptive courses…")
- course **detail** page → `JourneyBoardSkeleton` (replaces "Loading course…")
- `JourneyBoard` → `JourneyBoardSkeleton` (replaces the bare `CircularProgress`)
- **submodule** page → `AdaptiveSubmoduleSkeleton` (replaces the bare spinner)

Removed the now-unused `CircularProgress` imports. tsc + eslint clean.

> Note: the two concerns are bundled because they touch the same files (`JourneyBoard.tsx`, `[courseId]/page.tsx`) and share `CourseSkeletons.tsx`, so a clean commit split wasn't possible without breaking buildability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)