### PR TITLE
Admin dashboard: drop the 'preview' banner (admins now see real data) — FE

### DIFF
--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { Box, Stack, Typography } from "@mui/material";
-import { Icon } from "@iconify/react";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import {
   useHideLeaderboardView,
@@ -68,20 +67,8 @@ export function DashboardV2() {
     (scorecardEnabled) || activeCourse?.certificate.enabled || courseEnabled || !hideLeaderboard;
 
   return (
-    <>
-    {data.preview && (
-      <Box sx={{ mb: 2, px: 2, py: 1.25, borderRadius: 3, display: "flex", alignItems: "center", gap: 1,
-        bgcolor: "color-mix(in srgb, var(--accent-purple, #a855f7) 10%, var(--surface, #fff))",
-        border: "1px solid color-mix(in srgb, var(--accent-purple, #a855f7) 28%, transparent)",
-        color: "var(--accent-purple, #7c3aed)" }}>
-        <Icon icon="mdi:eye-outline" width={18} />
-        <Typography sx={{ fontSize: "0.85rem", fontWeight: 700 }}>
-          Admin preview — showing this tenant&apos;s published adaptive courses (progress &amp; points are illustrative, not your own).
-        </Typography>
-      </Box>
-    )}
-    {/* Two columns like the mockup: AI briefing + stats + readiness + continue on the
-        left; skill profile + certificate + up-next + leaderboard on the right. */}
+    // Two columns like the mockup: AI briefing + stats + readiness + continue on the
+    // left; skill profile + certificate + up-next + leaderboard on the right.
     <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: showSidebar ? "minmax(0,1fr) 390px" : "1fr" }, gap: 2.5, alignItems: "start" }}>
       <Box sx={{ minWidth: 0 }}>
         {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
@@ -108,6 +95,5 @@ export function DashboardV2() {
         </Stack>
       )}
     </Box>
-    </>
   );
 }

--- a/lib/types/dashboard.ts
+++ b/lib/types/dashboard.ts
@@ -129,8 +129,5 @@ export interface LearnerDashboard {
   crossCourseUpNext: CrossCourseUpNext[];
   leaderboard: DashboardLeaderboard;
   briefing: AiBriefing | null;
-  /** True when an admin/instructor is previewing the tenant's published adaptive courses
-   *  (their own progress/points are empty). */
-  preview?: boolean;
   generatedAt: string;
 }


### PR DESCRIPTION
Pairs with BE ai-linc-backend (admin real-data PR). The BE now serves admins their real adaptive data (their engaged courses), so the "Admin preview — progress & points are illustrative, not your own" banner is removed (plus the now-unused `Icon` import and the `preview` field on the `LearnerDashboard` type). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)