### PR TITLE
Adaptive flow fixes: points-burst auto-dismiss, Week-label dedup, locked-submodule state

### DIFF
--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -114,6 +114,7 @@ export default function AdaptiveCourseSubmodulePage() {
   const [points, setPoints] = useState<SubmodulePointsBreakdown | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [locked, setLocked] = useState<string | null>(null);  // server-enforced journey lock reason
 
   useEffect(() => {
     if (!Number.isFinite(courseId) || !Number.isFinite(submoduleId)) return;
@@ -123,7 +124,13 @@ export default function AdaptiveCourseSubmodulePage() {
         const data = await adaptiveCourseService.getSubmodule(courseId, submoduleId);
         if (!cancelled) setSubmodule(data);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load submodule.");
+        if (cancelled) return;
+        const resp = (e as { response?: { status?: number; data?: { locked?: boolean; detail?: string } } })?.response;
+        if (resp?.status === 403 && resp?.data?.locked) {
+          setLocked(resp.data.detail || "Complete the calibration assessment first.");
+        } else {
+          setError(e instanceof Error ? e.message : "Failed to load submodule.");
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -198,6 +205,21 @@ export default function AdaptiveCourseSubmodulePage() {
         {loading && <AdaptiveSubmoduleSkeleton />}
         {error && (
           <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 6 }}>{error}</Typography>
+        )}
+        {locked && (
+          <Box sx={{ textAlign: "center", py: 8, px: 2, maxWidth: 520, mx: "auto" }}>
+            <Box sx={{ width: 56, height: 56, mx: "auto", mb: 1.5, borderRadius: "50%", display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}>
+              <Icon icon="mdi:lock-outline" width={28} />
+            </Box>
+            <Typography sx={{ fontWeight: 800, fontSize: "1.15rem" }}>This step is locked</Typography>
+            <Typography sx={{ color: "text.secondary", mt: 0.75, lineHeight: 1.5 }}>{locked}</Typography>
+            <ButtonBase
+              onClick={() => router.push(`/adaptive-courses/${courseId}`)}
+              sx={{ mt: 2.5, px: 2.5, py: 1, borderRadius: 999, fontWeight: 800, color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
+            >
+              Go to course
+            </ButtonBase>
+          </Box>
         )}
 
         {submodule && (

--- a/components/adaptive-journey/JourneyBoard.tsx
+++ b/components/adaptive-journey/JourneyBoard.tsx
@@ -207,6 +207,12 @@ function WeekCard({ week, courseId, startStep }: { week: JourneyWeekView; course
   const dl = daysLeft(week.schedule?.dueAt);
   const locked = week.nodes.every((n) => n.status === "locked");
 
+  // "Week N" header label; only append the module title when it adds something — modules are often
+  // literally titled "Week 1", which would otherwise render "Week 1 · Week 1".
+  const autoLabel = week.weekNo === 0 ? "Get started" : `Week ${week.weekNo}`;
+  const title = (week.title || "").trim();
+  const showTitle = !!title && title.toLowerCase() !== autoLabel.toLowerCase() && !/^week\s*\d+$/i.test(title);
+
   return (
     <Box sx={{ border: "1px solid #e9e6f7", borderRadius: 4, overflow: "hidden", bgcolor: "#fff", mb: 2, boxShadow: "0 12px 30px -24px rgba(99,102,241,0.45)" }}>
       <Box sx={{ p: { xs: 2, md: 2.5 }, borderBottom: "1px solid #eef2f7", backgroundImage: "linear-gradient(135deg, #f5f3ff 0%, #fdf2f8 100%)" }}>
@@ -216,7 +222,7 @@ function WeekCard({ week, courseId, startStep }: { week: JourneyWeekView; course
               <Icon icon="mdi:calendar-month" width={18} />
             </Box>
             <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a" }}>
-              {week.weekNo === 0 ? "Get started" : `Week ${week.weekNo}`}{week.title ? ` · ${week.title}` : ""}
+              {autoLabel}{showTitle ? ` · ${title}` : ""}
             </Typography>
             <Typography sx={{ fontSize: "0.8rem", color: "#64748b", fontWeight: 600 }}>
               {week.stepsDone} of {week.stepsTotal} steps done

--- a/components/adaptive-quiz/mid/PointsRewardBurst.tsx
+++ b/components/adaptive-quiz/mid/PointsRewardBurst.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { AnimatePresence, motion } from "framer-motion";
@@ -10,26 +11,43 @@ export interface RewardBurst {
   base: number;
 }
 
+const BURST_MS = 1300;  // a touch past the float-up animation, then unmount so it never lingers
+
 /**
  * "+N pts" reward that pops on a points-earning answer and floats up as it fades. Keyed by an
  * ever-incrementing reward id so each submit re-fires. Only fires for a positive reward — a
  * wrong answer (0 pts) or a practice quiz stays silent (correctness feedback lives elsewhere).
+ *
+ * Self-dismisses: the parent's `reward` state is never reset (it pins the last submit), so the pill
+ * would otherwise sit on screen at the end of its animation and overlap the NEXT question. We mirror
+ * `reward` into local state, animate it to a full fade-out, and drop it on a timer.
  */
 export function PointsRewardBurst({ reward }: { reward: RewardBurst | null }) {
+  // Track which reward id has elapsed; derive visibility during render (no sync setState in effect).
+  const [dismissedId, setDismissedId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!reward || reward.points <= 0) return;
+    const t = setTimeout(() => setDismissedId(reward.id), BURST_MS);
+    return () => clearTimeout(t);
+  }, [reward]);
+
+  const active = reward && reward.points > 0 && reward.id !== dismissedId ? reward : null;
+
   return (
     <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", pointerEvents: "none", zIndex: 5, overflow: "visible" }}>
       <AnimatePresence>
-        {reward && reward.points > 0 && (
+        {active && active.points > 0 && (
           <motion.div
-            key={reward.id}
+            key={active.id}
             initial={{ opacity: 0, y: 16, scale: 0.6 }}
-            animate={{ opacity: 1, y: -56, scale: 1.05 }}
+            animate={{ opacity: [0, 1, 1, 0], y: [16, -30, -52, -78], scale: [0.6, 1.06, 1, 0.92] }}
             exit={{ opacity: 0, y: -96, scale: 0.9 }}
-            transition={{ duration: 1.1, ease: [0.16, 1, 0.3, 1] }}
+            transition={{ duration: 1.2, ease: "easeOut", times: [0, 0.2, 0.7, 1] }}
           >
             <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 2, py: 1, borderRadius: 999, color: "white", fontWeight: 900, fontSize: "1.5rem", background: "linear-gradient(135deg, #10b981 0%, #22c55e 100%)", boxShadow: "0 16px 36px -14px rgba(16,185,129,0.7)" }}>
               <Icon icon="mdi:star-four-points" width={22} />
-              +{reward.points}
+              +{active.points}
               <Typography component="span" sx={{ fontSize: "0.85rem", fontWeight: 800, opacity: 0.9 }}>pts</Typography>
             </Box>
           </motion.div>


### PR DESCRIPTION
Three independent fixes:

1. **Quiz "+pts" burst auto-dismiss** (`PointsRewardBurst.tsx`) — the reward pill never cleared (parent state isn't reset; enter animation ended at opacity:1), so it sat over the **next question**. It now fully fades out and self-dismisses on a timer.
2. **"Week 1 · Week 1" dedup** (`JourneyBoard.tsx`) — modules are often literally titled "Week N"; only append the module title when it adds info.
3. **Locked-submodule state** (`submodule/[submoduleId]/page.tsx`) — pairs with the BE journey-lock enforcement (ai-linc-backend `fix/journey-lock-enforcement`): on a 403 `{locked:true}` it shows a "This step is locked" card + "Go to course" instead of a generic error.

(The coding-mentor horizontal-overflow-after-submit fix went to its sibling PR #928, same component.)

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)