### PR TITLE
Adaptive courses: lightning-fast navigation (instant transitions + shimmer everywhere)

### DIFF
--- a/app/adaptive-courses/[courseId]/interview/[interviewId]/loading.tsx
+++ b/app/adaptive-courses/[courseId]/interview/[interviewId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, Button, Chip, CircularProgress, Stack, TextField, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import mockInterviewService, {
@@ -59,7 +60,7 @@ const fmtClock = (s: number) => `${String(Math.floor(s / 60)).padStart(2, "0")}:
 type Bubble = { role: "ai" | "student"; text: string };
 
 function CourseInterviewInner() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const sp = useSearchParams();
   const courseId = Number(params.courseId);
@@ -480,7 +481,7 @@ function CourseInterviewInner() {
           )}
 
           <Stack alignItems="center" sx={{ mt: 3 }}>
-            <Button variant="contained" onClick={() => router.push(`/adaptive-courses/${courseId}`)}
+            <Button variant="contained" onClick={() => push(`/adaptive-courses/${courseId}`)}
               sx={{ textTransform: "none", fontWeight: 800, borderRadius: 2, px: 4, py: 1.1, color: "white", background: "linear-gradient(135deg, #7c3aed, #db2777)" }}>
               Start my personalized journey →
             </Button>
@@ -502,7 +503,7 @@ function CourseInterviewInner() {
               sx={{ textTransform: "none", fontWeight: 800, borderRadius: 2, background: "linear-gradient(135deg, #7c3aed, #db2777)" }}>
               Try again
             </Button>
-            <Button variant="outlined" onClick={() => router.push(`/adaptive-courses/${courseId}`)} sx={{ color: "white", borderColor: "rgba(255,255,255,0.3)", textTransform: "none" }}>Back to course</Button>
+            <Button variant="outlined" onClick={() => push(`/adaptive-courses/${courseId}`)} sx={{ color: "white", borderColor: "rgba(255,255,255,0.3)", textTransform: "none" }}>Back to course</Button>
           </Stack>
         </Stack>
       </Box>

--- a/app/adaptive-courses/[courseId]/journey/loading.tsx
+++ b/app/adaptive-courses/[courseId]/journey/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-courses/[courseId]/journey/page.tsx
+++ b/app/adaptive-courses/[courseId]/journey/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { JourneyBoard } from "@/components/adaptive-journey/JourneyBoard";
 
 export default function AdaptiveJourneyPage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
 
@@ -15,7 +16,7 @@ export default function AdaptiveJourneyPage() {
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1500, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
         <ButtonBase
-          onClick={() => router.push(`/adaptive-courses/${courseId}`)}
+          onClick={() => push(`/adaptive-courses/${courseId}`)}
           sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
         >
           <Icon icon="mdi:arrow-left" width={18} />

--- a/app/adaptive-courses/[courseId]/loading.tsx
+++ b/app/adaptive-courses/[courseId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-courses/[courseId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
@@ -14,7 +15,7 @@ import { JourneyBoard } from "@/components/adaptive-journey/JourneyBoard";
 import { JourneyBoardSkeleton } from "@/components/courses/CourseSkeletons";
 
 export default function AdaptiveCourseDetailPage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
   const [course, setCourse] = useState<AdaptiveCourseDetail | null>(null);
@@ -50,7 +51,7 @@ export default function AdaptiveCourseDetailPage() {
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
         <ButtonBase
-          onClick={() => router.push("/adaptive-courses")}
+          onClick={() => push("/adaptive-courses")}
           sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
         >
           <Icon icon="mdi:arrow-left" width={18} />
@@ -75,7 +76,7 @@ export default function AdaptiveCourseDetailPage() {
                 {"Ask your instructor to enroll you, then it'll appear in your Adaptive Courses."}
               </Typography>
               <ButtonBase
-                onClick={() => router.push("/adaptive-courses")}
+                onClick={() => push("/adaptive-courses")}
                 sx={{ mt: 2.5, px: 2.5, py: 1, borderRadius: 999, fontWeight: 800, color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
               >
                 Back to Adaptive Courses

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/loading.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/article/[articleId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Dialog, IconButton, Popover, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -37,7 +38,7 @@ type ExplainState = {
 } | null;
 
 export default function AdaptiveArticleReaderPage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const { showToast } = useToast();
   const courseId = Number(params.courseId);
@@ -203,7 +204,7 @@ export default function AdaptiveArticleReaderPage() {
       </Box>
       <Box sx={{ maxWidth: 1760, mx: "auto", py: { xs: 3, md: 5 } }}>
         <ButtonBase
-          onClick={() => router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}`)}
+          onClick={() => push(`/adaptive-courses/${courseId}/submodule/${submoduleId}`)}
           sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
         >
           <Icon icon="mdi:arrow-left" width={18} />

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/coding/[problemId]/loading.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/coding/[problemId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/coding/[problemId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/coding/[problemId]/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { Suspense } from "react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { CircularProgress, Container, Typography } from "@mui/material";
 
 import { MainLayout } from "@/components/layout/MainLayout";
 import { AdaptiveCodingSolve } from "@/components/coding/AdaptiveCodingSolve";
 
 function SolveInner() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const searchParams = useSearchParams();
 
@@ -31,7 +32,7 @@ function SolveInner() {
     <AdaptiveCodingSolve
       configId={configId}
       problemId={problemId}
-      onBack={() => router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}`)}
+      onBack={() => push(`/adaptive-courses/${courseId}/submodule/${submoduleId}`)}
     />
   );
 }

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/loading.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import { Box, Button, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
@@ -15,6 +15,7 @@ import { MainLayout } from "@/components/layout/MainLayout";
 import { AdditionalPractice } from "@/components/adaptive-journey/AdditionalPractice";
 import { PointsInfo } from "@/components/common/PointsInfo";
 import { AdaptiveSubmoduleSkeleton } from "@/components/courses/CourseSkeletons";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 
 type FlowKind = "video" | "article" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
@@ -27,9 +28,12 @@ interface FlowItem {
   title: string;
   chips: { icon: string; text: string }[];
   onClick: () => void;
+  /** Destination URL — used to prefetch the route on hover for instant open. */
+  href: string;
   completed: boolean;
   /** Where "Review" goes once completed (e.g. past quiz results); falls back to onClick. */
   onReview?: () => void;
+  reviewHref?: string;
 }
 
 // "% correct"-style factor only means something for graded/timed content; articles are flat.
@@ -52,30 +56,34 @@ function buildItems(
   sm: AdaptiveCourseSubModule,
   courseId: number,
   submoduleId: number,
-  router: ReturnType<typeof useRouter>,
+  nav: (href: string) => void,
 ): FlowItem[] {
   const items: FlowItem[] = [];
-  (sm.video_companions ?? []).forEach((vc) =>
+  (sm.video_companions ?? []).forEach((vc) => {
+    const href = `/adaptive-courses/${courseId}/submodule/${submoduleId}/video/${vc.id}`;
     items.push({
       kind: "video", key: `v${vc.id}`, contentKey: `video:${vc.id}`, title: vc.title, completed: !!vc.completed,
       chips: [
         ...(vc.duration_seconds > 0 ? [{ icon: "mdi:clock-outline", text: `~${Math.round(vc.duration_seconds / 60)} min` }] : []),
         ...(vc.check_in_count > 0 ? [{ icon: "mdi:lightning-bolt", text: `${vc.check_in_count} check-ins` }] : []),
       ],
-      onClick: () => router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}/video/${vc.id}`),
-    }),
-  );
-  sm.articles.forEach((a) =>
+      href, onClick: () => nav(href),
+    });
+  });
+  sm.articles.forEach((a) => {
+    const href = `/adaptive-courses/${courseId}/submodule/${submoduleId}/article/${a.article_id}`;
     items.push({
       kind: "article", key: `a${a.article_id}`, contentKey: `article:${a.article_id}`, title: a.title, completed: !!a.completed,
       chips: [
         { icon: "mdi:clock-outline", text: `~${a.reading_time_minutes} min` },
         { icon: "mdi:tune-vertical", text: `${a.default_tier} · adapts` },
       ],
-      onClick: () => router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}/article/${a.article_id}`),
-    }),
-  );
-  sm.quizzes.forEach((q) =>
+      href, onClick: () => nav(href),
+    });
+  });
+  sm.quizzes.forEach((q) => {
+    const href = `/adaptive-quizzes/start?configId=${q.config_id}`;
+    const reviewHref = q.last_session_id ? `/adaptive-quizzes/session/${q.last_session_id}/results` : undefined;
     items.push({
       kind: "quiz", key: `q${q.config_id}`, contentKey: `quiz:${q.config_id}`, title: q.quiz_title, completed: !!q.completed,
       chips: [
@@ -83,30 +91,29 @@ function buildItems(
         { icon: "mdi:arrow-decision-outline", text: `serves ${q.min_questions}–${q.max_questions}` },
         ...q.target_skills.slice(0, 2).map((s) => ({ icon: "mdi:tag-outline", text: s })),
       ],
-      onClick: () => router.push(`/adaptive-quizzes/start?configId=${q.config_id}`),
+      href, onClick: () => nav(href),
       // Completed → open the last attempt's results instead of restarting.
-      onReview: q.last_session_id
-        ? () => router.push(`/adaptive-quizzes/session/${q.last_session_id}/results`)
-        : undefined,
-    }),
-  );
+      reviewHref, onReview: reviewHref ? () => nav(reviewHref) : undefined,
+    });
+  });
   (sm.coding_sets ?? []).forEach((set) =>
-    set.problems.forEach((p) =>
+    set.problems.forEach((p) => {
+      const href = `/adaptive-courses/${courseId}/submodule/${submoduleId}/coding/${p.problem_id}?configId=${set.config_id}`;
       items.push({
         kind: "coding", key: `c${p.problem_id}`, contentKey: `coding:${p.problem_id}`, title: p.title, completed: !!p.completed,
         chips: [
           { icon: "mdi:speedometer", text: p.difficulty_level },
           ...p.target_skills.slice(0, 2).map((s) => ({ icon: "mdi:tag-outline", text: s })),
         ],
-        onClick: () => router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}/coding/${p.problem_id}?configId=${set.config_id}`),
-      }),
-    ),
+        href, onClick: () => nav(href),
+      });
+    }),
   );
   return items;
 }
 
 export default function AdaptiveCourseSubmodulePage() {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
   const submoduleId = Number(params.submoduleId);
@@ -149,8 +156,8 @@ export default function AdaptiveCourseSubmodulePage() {
   );
 
   const items = useMemo(
-    () => (submodule ? buildItems(submodule, courseId, submoduleId, router) : []),
-    [submodule, courseId, submoduleId, router],
+    () => (submodule ? buildItems(submodule, courseId, submoduleId, push) : []),
+    [submodule, courseId, submoduleId, push],
   );
 
   const meta = useMemo(() => {
@@ -204,7 +211,7 @@ export default function AdaptiveCourseSubmodulePage() {
           <>
             {/* Gradient hero — matches the course page */}
             <Box sx={{ borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 2.5, color: "white", position: "relative", overflow: "hidden", background: "linear-gradient(135deg, #7c3aed 0%, #a855f7 55%, #c026d3 100%)", boxShadow: "0 24px 60px -28px rgba(124,58,237,0.6)" }}>
-              <ButtonBase onClick={() => router.push(`/adaptive-courses/${courseId}`)} sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.8)", mb: 1, gap: 0.5 }}>
+              <ButtonBase onMouseEnter={() => prefetch(`/adaptive-courses/${courseId}`)} onClick={() => push(`/adaptive-courses/${courseId}`)} sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.8)", mb: 1, gap: 0.5 }}>
                 <Icon icon="mdi:arrow-left" width={14} /> Back to course
               </ButtonBase>
               <Stack direction="row" spacing={0.75} sx={{ mb: 1 }}>
@@ -274,6 +281,7 @@ export default function AdaptiveCourseSubmodulePage() {
                       last={idx === items.length - 1}
                       status={it.completed ? "done" : idx === firstIncomplete ? "current" : "upcoming"}
                       points={pointsByKey.get(it.contentKey)}
+                      onPrefetch={() => prefetch(it.completed && it.reviewHref ? it.reviewHref : it.href)}
                     />
                   ))}
                 </Box>
@@ -321,7 +329,7 @@ function PointsFactors({ item }: { item: PointsBreakdownItem }) {
   );
 }
 
-function PathRow({ item, step, last, status, points }: { item: FlowItem; step: number; last: boolean; status: StepStatus; points?: PointsBreakdownItem }) {
+function PathRow({ item, step, last, status, points, onPrefetch }: { item: FlowItem; step: number; last: boolean; status: StepStatus; points?: PointsBreakdownItem; onPrefetch?: () => void }) {
   const m = FLOW_META[item.kind];
   const done = status === "done";
   const current = status === "current";
@@ -357,6 +365,7 @@ function PathRow({ item, step, last, status, points }: { item: FlowItem; step: n
       </Box>
 
       <Box
+        onMouseEnter={onPrefetch}
         onClick={cardAction}
         sx={{
           flex: 1, mb: 1.5, p: 2, borderRadius: 3, border: "1px solid",

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/video/[configId]/loading.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/video/[configId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/video/[configId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/video/[configId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { ButtonBase, Container, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 
@@ -9,7 +10,7 @@ import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/Adaptive
 import { VideoCompanion } from "@/components/adaptive-video/VideoCompanion";
 
 export default function AdaptiveVideoCompanionPage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
   const submoduleId = Number(params.submoduleId);
@@ -19,7 +20,7 @@ export default function AdaptiveVideoCompanionPage() {
     <MainLayout>
       <Container maxWidth="xl" sx={{ py: { xs: 2, md: 4 } }}>
         <ButtonBase
-          onClick={() => router.push(`/adaptive-courses/${courseId}/submodule/${submoduleId}`)}
+          onClick={() => push(`/adaptive-courses/${courseId}/submodule/${submoduleId}`)}
           sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
         >
           <Icon icon="mdi:arrow-left" width={18} />

--- a/app/adaptive-courses/loading.tsx
+++ b/app/adaptive-courses/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
 import {
   Box,
   Chip,
@@ -25,10 +24,11 @@ import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/Adaptive
 import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
 import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
 import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { CoursesNavTabs } from "@/components/courses/CoursesNavTabs";
 
 export default function AdaptiveCourseListPage() {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   const featureOn = useIsAdaptiveQuizEnabled();
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<AdaptiveCourseListItem[]>([]);
@@ -228,7 +228,8 @@ export default function AdaptiveCourseListPage() {
                 <Reveal key={course.id} delay={Math.min(idx, 8) * 0.06}>
                   <AdaptiveCourseCard
                     course={course}
-                    onOpen={() => router.push(`/adaptive-courses/${course.id}`)}
+                    onOpen={() => push(`/adaptive-courses/${course.id}`)}
+                    onHover={() => prefetch(`/adaptive-courses/${course.id}`)}
                   />
                 </Reveal>
               ))}

--- a/app/adaptive-quizzes/loading.tsx
+++ b/app/adaptive-quizzes/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/adaptive-quizzes/page.tsx
+++ b/app/adaptive-quizzes/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Container, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
@@ -22,7 +22,7 @@ import { RecentAttemptsRow } from "@/components/adaptive-quiz/RecentAttemptsRow"
 type Filter = "all" | "personal" | "public" | "archived";
 
 export default function AdaptiveQuizListPage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const featureOn = useIsAdaptiveQuizEnabled();
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<AdaptiveQuizCardData[]>([]);
@@ -95,10 +95,10 @@ export default function AdaptiveQuizListPage() {
       <MainLayout>
         <Container sx={{ py: 8, textAlign: "center" }}>
           <Typography variant="h6" sx={{ fontWeight: 700 }}>
-            Adaptive quiz isn't enabled for this organisation.
+            Adaptive quiz isn&apos;t enabled for this organisation.
           </Typography>
           <Typography sx={{ color: "text.secondary", mt: 1 }}>
-            Ask your administrator to switch on the "Adaptive Quiz" feature.
+            Ask your administrator to switch on the &quot;Adaptive Quiz&quot; feature.
           </Typography>
         </Container>
       </MainLayout>
@@ -223,10 +223,10 @@ export default function AdaptiveQuizListPage() {
                         const target = item.is_archived
                           ? `/adaptive-quizzes/session/${item.latest_session_id}/results`
                           : `/adaptive-quizzes/session/${item.latest_session_id}`;
-                        router.push(target);
+                        push(target);
                         return;
                       }
-                      router.push(`/adaptive-quizzes/start?configId=${item.config_id}`);
+                      push(`/adaptive-quizzes/start?configId=${item.config_id}`);
                     }}
                   />
                 </Reveal>
@@ -261,8 +261,8 @@ function EmptyState() {
         No adaptive quizzes yet.
       </Typography>
       <Typography sx={{ color: "text.secondary", mt: 0.75, maxWidth: 520, mx: "auto", lineHeight: 1.5 }}>
-        Your instructor hasn't published an adaptive quiz on this account yet.
-        Check back soon — once one is ready, it'll appear here.
+        Your instructor hasn&apos;t published an adaptive quiz on this account yet.
+        Check back soon — once one is ready, it&apos;ll appear here.
       </Typography>
     </Box>
   );

--- a/app/adaptive-quizzes/start/page.tsx
+++ b/app/adaptive-quizzes/start/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, Container, Typography, ButtonBase } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { adaptiveQuizService } from "@/lib/services/adaptive-quiz.service";
@@ -19,7 +20,7 @@ import { AIPill } from "@/components/adaptive-quiz/shared/AIPill";
  */
 export default function AdaptiveQuizStartPage() {
   const searchParams = useSearchParams();
-  const router = useRouter();
+  const { replace } = useInstantNavigation();
   const featureOn = useAdaptiveFeatureGuard();
 
   const configIdRaw = searchParams.get("configId");
@@ -42,7 +43,7 @@ export default function AdaptiveQuizStartPage() {
     setError(null);
     try {
       const res = await adaptiveQuizService.startSession(configId);
-      router.replace(`/adaptive-quizzes/session/${res.session_id}`);
+      replace(`/adaptive-quizzes/session/${res.session_id}`);
     } catch (e: unknown) {
       const detail = e instanceof Error ? e.message : "Unable to start adaptive session.";
       setError(detail);

--- a/app/admin/adaptive-courses/[courseId]/loading.tsx
+++ b/app/admin/adaptive-courses/[courseId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import {
   Alert,
   AlertTitle,
@@ -62,7 +63,7 @@ const CONTENT_TYPE_LABEL: Record<"quiz" | "article" | "coding" | "video", string
 };
 
 export default function AdminAdaptiveCourseDetailPage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
   const { showToast } = useToast();
@@ -274,7 +275,7 @@ export default function AdminAdaptiveCourseDetailPage() {
               config,
             });
       showToast("AI generation started.", "success");
-      router.push(`/admin/adaptive-courses/jobs/${job.job_id}`);
+      push(`/admin/adaptive-courses/jobs/${job.job_id}`);
     } catch (e) {
       showToast(e instanceof Error ? e.message : "Couldn't start generation.", "error");
       setSubmitting(false);
@@ -289,7 +290,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       setRegenConfirmOpen(false);
       showToast("Filling in the missing content…", "success");
       // Same flow as the generate/add actions: hand off to the live job view.
-      router.push(`/admin/adaptive-courses/jobs/${job.job_id}`);
+      push(`/admin/adaptive-courses/jobs/${job.job_id}`);
     } catch (e) {
       showToast(e instanceof Error ? e.message : "Couldn't start regeneration.", "error");
       setRegenerating(false);
@@ -304,7 +305,7 @@ export default function AdminAdaptiveCourseDetailPage() {
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
         <ButtonBase
-          onClick={() => router.push("/admin/adaptive-courses")}
+          onClick={() => push("/admin/adaptive-courses")}
           sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
         >
           <Icon icon="mdi:arrow-left" width={18} />

--- a/app/admin/adaptive-courses/generate/loading.tsx
+++ b/app/admin/adaptive-courses/generate/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Container, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -30,7 +30,7 @@ import {
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 export default function GenerateAdaptiveCoursePage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const { showToast } = useToast();
 
   const [mode, setMode] = useState<GenerateMode>("describe");
@@ -199,7 +199,7 @@ export default function GenerateAdaptiveCoursePage() {
               config,
             });
       showToast("Generation started.", "success");
-      router.push(`/admin/adaptive-courses/jobs/${job.job_id}`);
+      push(`/admin/adaptive-courses/jobs/${job.job_id}`);
     } catch (e) {
       showToast(getAxiosErrorDetail(e, "Couldn't start generation."), "error");
       setSubmitting(false);
@@ -213,7 +213,7 @@ export default function GenerateAdaptiveCoursePage() {
     <MainLayout>
       <Container maxWidth="xl" sx={{ py: { xs: 3, md: 5 } }}>
         <ButtonBase
-          onClick={() => router.push("/admin/adaptive-courses")}
+          onClick={() => push("/admin/adaptive-courses")}
           sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
         >
           <Icon icon="mdi:arrow-left" width={18} />

--- a/app/admin/adaptive-courses/jobs/[jobId]/loading.tsx
+++ b/app/admin/adaptive-courses/jobs/[jobId]/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="detail" />;
+}

--- a/app/admin/adaptive-courses/jobs/[jobId]/page.tsx
+++ b/app/admin/adaptive-courses/jobs/[jobId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Container, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -28,7 +29,7 @@ const DIFF_COLOR: Record<string, string> = { Easy: "#10b981", Medium: "#f59e0b",
 type LogFilter = "all" | "Easy" | "Medium" | "Hard";
 
 export default function AdaptiveCourseJobPage() {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const params = useParams();
   const jobId = String(params.jobId);
   const [job, setJob] = useState<AdaptiveCourseJobDetail | null>(null);
@@ -100,7 +101,7 @@ export default function AdaptiveCourseJobPage() {
     <MainLayout>
       <Container maxWidth="xl" sx={{ py: { xs: 3, md: 5 } }}>
         <ButtonBase
-          onClick={() => router.push("/admin/adaptive-courses")}
+          onClick={() => push("/admin/adaptive-courses")}
           sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
         >
           <Icon icon="mdi:arrow-left" width={18} />
@@ -125,7 +126,7 @@ export default function AdaptiveCourseJobPage() {
                 rightSlot={
                   job.status === "completed" && job.generated_course_id ? (
                     <ButtonBase
-                      onClick={() => router.push(`/admin/adaptive-courses/${job.generated_course_id}`)}
+                      onClick={() => push(`/admin/adaptive-courses/${job.generated_course_id}`)}
                       sx={{
                         px: 3, py: 1.3, borderRadius: 999, fontWeight: 800, color: "white", gap: 0.6,
                         background: "linear-gradient(135deg, #10b981 0%, #059669 100%)",

--- a/app/admin/adaptive-courses/loading.tsx
+++ b/app/admin/adaptive-courses/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -20,7 +20,7 @@ const POLL_INTERVAL_MS = 10000;
 const ACTIVE_STATUSES = new Set(["pending", "generating_outline", "creating_structure", "generating_content"]);
 
 export default function AdminAdaptiveCoursesPage() {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   const { showToast } = useToast();
   const [courses, setCourses] = useState<AdminAdaptiveCourseListItem[]>([]);
   const [jobs, setJobs] = useState<AdaptiveCourseJob[]>([]);
@@ -108,7 +108,8 @@ export default function AdminAdaptiveCoursesPage() {
             accent="indigo"
             rightSlot={
               <ButtonBase
-                onClick={() => router.push("/admin/adaptive-courses/generate")}
+                onMouseEnter={() => prefetch("/admin/adaptive-courses/generate")}
+                onClick={() => push("/admin/adaptive-courses/generate")}
                 sx={{
                   px: 3,
                   py: 1.4,
@@ -149,7 +150,8 @@ export default function AdminAdaptiveCoursesPage() {
               {activeJobs.map((job) => (
                 <ButtonBase
                   key={job.job_id}
-                  onClick={() => router.push(`/admin/adaptive-courses/jobs/${job.job_id}`)}
+                  onMouseEnter={() => prefetch(`/admin/adaptive-courses/jobs/${job.job_id}`)}
+                  onClick={() => push(`/admin/adaptive-courses/jobs/${job.job_id}`)}
                   sx={{
                     textAlign: "left",
                     display: "block",
@@ -221,7 +223,7 @@ export default function AdminAdaptiveCoursesPage() {
                 <Reveal key={course.id} delay={Math.min(idx, 8) * 0.05}>
                   <CourseCard
                     course={course}
-                    onOpen={() => router.push(`/admin/adaptive-courses/${course.id}`)}
+                    onOpen={() => push(`/admin/adaptive-courses/${course.id}`)}
                     onTogglePublish={() => void handlePublishToggle(course)}
                     onDelete={() => setPendingDelete(course)}
                   />

--- a/components/adaptive-journey/JourneyBoard.tsx
+++ b/components/adaptive-journey/JourneyBoard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Chip, LinearProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
@@ -94,19 +94,22 @@ const NODE_STYLE: Record<string, { color: string; bg: string; icon: string }> = 
 };
 
 function NodeRow({ node, courseId, stepNo, dueAt }: { node: JourneyNodeView; courseId: number; stepNo: number; dueAt?: string | null }) {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   const l = nodeLabel(node);
   const ns = NODE_STYLE[node.type] ?? NODE_STYLE.topic;
   const done = node.status === "done";
   const current = node.status === "current";
   const locked = node.status === "locked";
-  const navigable = !locked && ((node.type === "topic" && !!node.ref.submoduleId) || node.type === "interview");
+  const navHref =
+    node.type === "topic" && node.ref.submoduleId
+      ? `/adaptive-courses/${courseId}/submodule/${node.ref.submoduleId}`
+      : node.type === "interview"
+        ? "/mock-interview/courses"
+        : null;
+  const navigable = !locked && !!navHref;
 
-  const go = () => {
-    if (!navigable) return;
-    if (node.type === "topic" && node.ref.submoduleId) router.push(`/adaptive-courses/${courseId}/submodule/${node.ref.submoduleId}`);
-    else if (node.type === "interview") router.push("/mock-interview/courses");
-  };
+  const go = () => { if (navigable && navHref) push(navHref); };
+  const warm = () => { if (navigable && navHref) prefetch(navHref); };
 
   const circle = done ? (
     <Box sx={{ width: 28, height: 28, borderRadius: "50%", display: "grid", placeItems: "center", bgcolor: "#22c55e", color: "white", flexShrink: 0, zIndex: 1 }}>
@@ -134,6 +137,7 @@ function NodeRow({ node, courseId, stepNo, dueAt }: { node: JourneyNodeView; cou
 
       <Box
         onClick={go}
+        onMouseEnter={warm}
         sx={{
           flex: 1, mb: 1.5, p: 1.75, borderRadius: 3, border: "1px solid",
           borderLeft: "4px solid", borderLeftColor: ns.color,
@@ -274,7 +278,7 @@ function PenaltyCell({ color, bg, head, sub, note }: { color: string; bg: string
 }
 
 function Hero({ board, courseId }: { board: JourneyBoardData; courseId: number }) {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   const c = board.course;
   const [liked, setLiked] = useState(false);
   const subject = c.title.split(/[—-]/)[0].trim() || "Course";
@@ -336,7 +340,8 @@ function Hero({ board, courseId }: { board: JourneyBoardData; courseId: number }
         </Stack>
         <ButtonBase
           disabled={!resumeSub}
-          onClick={() => resumeSub && router.push(`/adaptive-courses/${courseId}/submodule/${resumeSub}`)}
+          onMouseEnter={() => resumeSub && prefetch(`/adaptive-courses/${courseId}/submodule/${resumeSub}`)}
+          onClick={() => resumeSub && push(`/adaptive-courses/${courseId}/submodule/${resumeSub}`)}
           sx={{ flexShrink: 0, px: 2.25, py: 1, borderRadius: 2, fontWeight: 800, fontSize: "0.82rem", color: "#7c3aed", bgcolor: "white", "&.Mui-disabled": { opacity: 0.5 } }}
         >
           Resume learning →

--- a/components/adaptive-journey/JourneyTopCards.tsx
+++ b/components/adaptive-journey/JourneyTopCards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Chip, CircularProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { useToast } from "@/components/common/Toast";
@@ -39,7 +39,7 @@ const CALIB_STATUS_CHIP: Record<string, { label: string; color: string; bg: stri
 };
 
 function CalibrationCard({ calibration, courseId }: { calibration: JourneyBoard["calibration"]; courseId: number }) {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   const card = calibration.card;
   if (!card) return null;
   const status = card.generating ? "generating" : card.status;
@@ -94,7 +94,8 @@ function CalibrationCard({ calibration, courseId }: { calibration: JourneyBoard[
       <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mt: 2 }}>
         <ButtonBase
           disabled={!canStart}
-          onClick={() => canStart && slug && router.push(`/assessments/${slug}/calibration?courseId=${courseId}`)}
+          onMouseEnter={() => canStart && slug && prefetch(`/assessments/${slug}/calibration?courseId=${courseId}`)}
+          onClick={() => canStart && slug && push(`/assessments/${slug}/calibration?courseId=${courseId}`)}
           sx={{
             flex: 1, py: 1.15, borderRadius: 2.5, fontWeight: 800, fontSize: "0.88rem",
             bgcolor: canStart ? "#fff" : "rgba(255,255,255,0.12)",
@@ -125,7 +126,7 @@ const INTERVIEW_CHIPS: { t: string; hot?: boolean }[] = [
 ];
 
 function InterviewerCard({ interview, courseId }: { interview: JourneyBoard["interview"]; courseId: number }) {
-  const router = useRouter();
+  const { push } = useInstantNavigation();
   const { showToast } = useToast();
   const [busy, setBusy] = useState(false);
   const card = interview.card;
@@ -141,7 +142,7 @@ function InterviewerCard({ interview, courseId }: { interview: JourneyBoard["int
       if (card.topic) q.set("topic", card.topic);
       if (card.difficulty) q.set("difficulty", card.difficulty);
       if (card.durationMinutes) q.set("mins", String(card.durationMinutes));
-      router.push(`/adaptive-courses/${courseId}/interview/${created.id}?${q.toString()}`);
+      push(`/adaptive-courses/${courseId}/interview/${created.id}?${q.toString()}`);
     } catch {
       showToast("Couldn't start the interview. Please try again.", "error");
       setBusy(false);

--- a/components/courses/AdaptiveCourseCard.tsx
+++ b/components/courses/AdaptiveCourseCard.tsx
@@ -9,13 +9,17 @@ import type { AdaptiveCourseListItem } from "@/lib/services/adaptive-course.serv
 export function AdaptiveCourseCard({
   course,
   onOpen,
+  onHover,
 }: {
   course: AdaptiveCourseListItem;
   onOpen: () => void;
+  onHover?: () => void;  // warm the destination route on hover/focus for instant open
 }) {
   return (
     <ButtonBase
       onClick={onOpen}
+      onMouseEnter={onHover}
+      onFocus={onHover}
       sx={{
         width: "100%",
         height: "100%",

--- a/components/courses/CoursesNavTabs.tsx
+++ b/components/courses/CoursesNavTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
@@ -20,7 +20,7 @@ interface TabDef {
  * tab only appears when the tenant has the adaptive feature.
  */
 export function CoursesNavTabs({ active }: { active: "courses" | "adaptive" }) {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   const adaptiveOn = useIsAdaptiveQuizEnabled();
 
   const tabs: TabDef[] = [
@@ -66,7 +66,8 @@ export function CoursesNavTabs({ active }: { active: "courses" | "adaptive" }) {
         return (
           <ButtonBase
             key={t.key}
-            onClick={() => !isActive && router.push(t.href)}
+            onMouseEnter={() => !isActive && prefetch(t.href)}
+            onClick={() => !isActive && push(t.href)}
             sx={{
               flex: { xs: 1, sm: "0 0 auto" },
               minWidth: 0,

--- a/components/dashboard/v2/ContinueCoursesRow.tsx
+++ b/components/dashboard/v2/ContinueCoursesRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, LinearProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { Reveal } from "@/components/scorecard/shared";
@@ -15,7 +15,7 @@ const ACCENTS = [
 ];
 
 export function ContinueCoursesRow({ courses }: { courses: DashboardCourse[] }) {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   if (!courses.length) return null;
 
   return (
@@ -76,7 +76,9 @@ export function ContinueCoursesRow({ courses }: { courses: DashboardCourse[] }) 
 
                   <Box sx={{ flex: 1 }} />
                   <ButtonBase
-                    onClick={() => router.push(resume)}
+                    onMouseEnter={() => prefetch(resume)}
+                    onFocus={() => prefetch(resume)}
+                    onClick={() => push(resume)}
                     sx={{ mt: 1.75, py: 1.1, borderRadius: 2.5, fontWeight: 800, fontSize: "0.88rem", color: "white", gap: 0.5, background: accent.btn }}
                   >
                     Continue <Icon icon="mdi:arrow-right" width={16} />

--- a/components/dashboard/v2/UpNextPanel.tsx
+++ b/components/dashboard/v2/UpNextPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import type { CrossCourseUpNext } from "@/lib/types/dashboard";
@@ -14,13 +14,14 @@ const KIND: Record<string, { icon: string; color: string; bg: string }> = {
 };
 
 export function UpNextPanel({ items }: { items: CrossCourseUpNext[] }) {
-  const router = useRouter();
+  const { push, prefetch } = useInstantNavigation();
   if (!items.length) return null;
 
-  const go = (it: CrossCourseUpNext) => {
-    if (it.resumeSubmoduleId) router.push(`/adaptive-courses/${it.courseId}/submodule/${it.resumeSubmoduleId}`);
-    else router.push(`/adaptive-courses/${it.courseId}`);
-  };
+  const hrefOf = (it: CrossCourseUpNext) =>
+    it.resumeSubmoduleId
+      ? `/adaptive-courses/${it.courseId}/submodule/${it.resumeSubmoduleId}`
+      : `/adaptive-courses/${it.courseId}`;
+  const go = (it: CrossCourseUpNext) => push(hrefOf(it));
 
   return (
     <PanelCard>
@@ -35,6 +36,8 @@ export function UpNextPanel({ items }: { items: CrossCourseUpNext[] }) {
           return (
             <ButtonBase
               key={`${it.courseId}-${it.nodeId}`}
+              onMouseEnter={() => prefetch(hrefOf(it))}
+              onFocus={() => prefetch(hrefOf(it))}
               onClick={() => go(it)}
               sx={{ width: "100%", textAlign: "left", justifyContent: "flex-start", p: 1.25, borderRadius: 2.5, border: "1px solid #eef2f7", gap: 1.25, "&:hover": { borderColor: "#cbd5e1" } }}
             >

--- a/lib/hooks/useInstantNavigation.ts
+++ b/lib/hooks/useInstantNavigation.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useTransition } from "react";
+
+/**
+ * Lightning-fast client navigation, reusing the sidebar's recipe:
+ *  - `prefetch(href)` warms the route chunk (call on hover/focus) so the click has nothing to fetch.
+ *  - `push`/`replace` navigate inside a React transition, so the click is acknowledged instantly and
+ *    the route-segment `loading.tsx` shimmer shows immediately while the destination's data loads.
+ *
+ * Usage at a nav site:
+ *   const { push, prefetch } = useInstantNavigation();
+ *   <Box onMouseEnter={() => prefetch(href)} onFocus={() => prefetch(href)} onClick={() => push(href)} />
+ *
+ * Never `await` an API before calling push — navigate first and let the destination fetch + shimmer.
+ */
+export function useInstantNavigation() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const push = useCallback(
+    (href: string) => startTransition(() => router.push(href)),
+    [router],
+  );
+  const replace = useCallback(
+    (href: string) => startTransition(() => router.replace(href)),
+    [router],
+  );
+  // Best-effort warm-up; router.prefetch resolves async and never throws into render.
+  const prefetch = useCallback(
+    (href: string) => {
+      try {
+        router.prefetch(href);
+      } catch {
+        /* prefetch is an optimization — ignore failures */
+      }
+    },
+    [router],
+  );
+
+  return { push, replace, prefetch, isPending };
+}


### PR DESCRIPTION
Makes navigation across **every** adaptive-course route (student + admin) feel instant — clicking transitions immediately and the destination shows a shimmer while its API loads. Reuses the sidebar's recipe.

## What changed
1. **`useInstantNavigation` hook** (`lib/hooks/useInstantNavigation.ts`) — `prefetch(href)` (warm the route on hover/focus) + `push`/`replace` inside a React `useTransition` (click acknowledged instantly). One source for all adaptive nav.
2. **`loading.tsx` on all 13 route segments** (student + admin) — renders `PageShimmerLayout` as the navigation Suspense fallback, so you see a shimmer in ~1ms instead of a blank screen on *every* route. The page's own skeleton then takes over during the API wait.
3. **Prefetch + non-blocking nav wired everywhere**:
   - Student: course list→detail card, journey topic rows / Continue / Resume, submodule path rows + hero CTA (per‑item prefetch on hover), dashboard **Continue** + **Up Next**, courses tabs, quiz start, calibration & interview launchers.
   - Admin: courses list→detail/generate/job.
   - Back buttons routed through the hook too; await-driven buttons (generate / add‑module / regenerate / interview‑start) keep their busy state and run the post‑await push in a transition (their target id only exists after the response, so they can't push‑first — but the destination chunk is warm and the click is acknowledged instantly).

## Why it's fast
prefetch (warm chunk) + `startTransition` push (instant ack) + `loading.tsx` shimmer (fills the transition gap) + the page's in‑component skeleton (covers the API wait) = click → instant shimmer → content.

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)