### PR TITLE
Fix stagging build: orphaned router ref in submodule page (instant-nav × locked-state merge)

### DIFF
--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -221,7 +221,8 @@ export default function AdaptiveCourseSubmodulePage() {
             <Typography sx={{ fontWeight: 800, fontSize: "1.15rem" }}>This step is locked</Typography>
             <Typography sx={{ color: "text.secondary", mt: 0.75, lineHeight: 1.5 }}>{locked}</Typography>
             <ButtonBase
-              onClick={() => router.push(`/adaptive-courses/${courseId}`)}
+              onMouseEnter={() => prefetch(`/adaptive-courses/${courseId}`)}
+              onClick={() => push(`/adaptive-courses/${courseId}`)}
               sx={{ mt: 2.5, px: 2.5, py: 1, borderRadius: 999, fontWeight: 800, color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
             >
               Go to course


### PR DESCRIPTION
## Why the deploy failed
Netlify's `next build` on stagging failed with:
```
./app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx:224
Type error: Cannot find name 'router'.
```
This is a **merge collision**, not a logic bug:
- **#930** (locked-state) added a `router.push` to the new "Go to course" button.
- **#933** (instant navigation) removed `const router = useRouter()` from the same file (everything routes through the `useInstantNavigation` hook now).

Each PR passed `tsc` in isolation; git text-merged both, leaving a `router.push` with no `router` defined → build break. (`tsc`/eslint locally didn't catch it because neither branch had both changes at once.)

## Fix
Route the locked-state button through the existing hook (`push` + `prefetch`), matching the rest of the page. Verified with a full local `next build` — compiles clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)