### PR TITLE
feat(adaptive): presentation deck viewer + AI-voiceover video UI (Phases 1–3)

### DIFF
--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -17,7 +17,7 @@ import { PointsInfo } from "@/components/common/PointsInfo";
 import { AdaptiveSubmoduleSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 
-type FlowKind = "video" | "article" | "quiz" | "coding";
+type FlowKind = "video" | "article" | "presentation" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
 
 interface FlowItem {
@@ -41,13 +41,14 @@ const KIND_CORRECTNESS: Partial<Record<PointsKind, string>> = {
   quiz: "correct", coding: "tests passed", video: "watched",
 };
 
-const VERB: Record<FlowKind, string> = { video: "watch", article: "read", quiz: "quiz", coding: "practice" };
-const KIND_ORDER: FlowKind[] = ["video", "article", "quiz", "coding"];
+const VERB: Record<FlowKind, string> = { video: "watch", article: "read", presentation: "view", quiz: "quiz", coding: "practice" };
+const KIND_ORDER: FlowKind[] = ["video", "article", "presentation", "quiz", "coding"];
 
 /** Per-content-type identity — same palette family as the course timeline nodes. */
 const FLOW_META: Record<FlowKind, { label: string; icon: string; action: string; actionIcon: string; color: string; bg: string }> = {
   video: { label: "WATCH", icon: "mdi:play-circle", action: "Watch", actionIcon: "mdi:play", color: "#0ea5e9", bg: "#e0f2fe" },
   article: { label: "READ", icon: "mdi:book-open-page-variant", action: "Read", actionIcon: "mdi:book-open-page-variant-outline", color: "#a855f7", bg: "#f5f3ff" },
+  presentation: { label: "SLIDES", icon: "mdi:presentation", action: "View", actionIcon: "mdi:presentation-play", color: "#0d9488", bg: "#ccfbf1" },
   quiz: { label: "QUIZ", icon: "mdi:tune-vertical", action: "Start", actionIcon: "mdi:play", color: "#6366f1", bg: "#eef2ff" },
   coding: { label: "PRACTICE", icon: "mdi:code-tags", action: "Solve", actionIcon: "mdi:code-tags", color: "#ec4899", bg: "#fdf2f8" },
 };
@@ -78,6 +79,15 @@ function buildItems(
         { icon: "mdi:clock-outline", text: `~${a.reading_time_minutes} min` },
         { icon: "mdi:tune-vertical", text: `${a.default_tier} · adapts` },
       ],
+      href, onClick: () => nav(href),
+    });
+  });
+  (sm.presentations ?? []).forEach((p) => {
+    const href = `/adaptive-courses/${courseId}/submodule/${submoduleId}/presentation/${p.presentation_id}`;
+    items.push({
+      kind: "presentation", key: `p${p.presentation_id}`, contentKey: `presentation:${p.presentation_id}`,
+      title: p.title, completed: false,
+      chips: [{ icon: "mdi:card-multiple-outline", text: `${p.slide_count} slide${p.slide_count === 1 ? "" : "s"}` }],
       href, onClick: () => nav(href),
     });
   });
@@ -169,7 +179,7 @@ export default function AdaptiveCourseSubmodulePage() {
 
   const meta = useMemo(() => {
     if (!submodule) return { counts: {} as Record<FlowKind, number>, estMin: 0 };
-    const counts: Record<FlowKind, number> = { video: 0, article: 0, quiz: 0, coding: 0 };
+    const counts: Record<FlowKind, number> = { video: 0, article: 0, presentation: 0, quiz: 0, coding: 0 };
     items.forEach((i) => { counts[i.kind] += 1; });
     let estMin = 0;
     (submodule.video_companions ?? []).forEach((v) => { estMin += Math.round((v.duration_seconds || 0) / 60); });
@@ -191,6 +201,7 @@ export default function AdaptiveCourseSubmodulePage() {
         ...(doneCount ? [{ icon: "mdi:check-circle-outline", label: `${doneCount}/${items.length} done` }] : []),
         ...(meta.counts.video ? [{ icon: "mdi:play-circle-outline", label: `${meta.counts.video} video${meta.counts.video > 1 ? "s" : ""}` }] : []),
         ...(meta.counts.article ? [{ icon: "mdi:book-open-variant", label: `${meta.counts.article} article${meta.counts.article > 1 ? "s" : ""}` }] : []),
+        ...(meta.counts.presentation ? [{ icon: "mdi:presentation", label: `${meta.counts.presentation} deck${meta.counts.presentation > 1 ? "s" : ""}` }] : []),
         ...(meta.counts.quiz ? [{ icon: "mdi:tune-variant", label: `${meta.counts.quiz} quiz${meta.counts.quiz > 1 ? "zes" : ""}` }] : []),
         ...(meta.counts.coding ? [{ icon: "mdi:code-tags", label: `${meta.counts.coding} coding` }] : []),
         ...(meta.estMin ? [{ icon: "mdi:clock-outline", label: `~${meta.estMin} min` }] : []),

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -17,7 +17,7 @@ import { PointsInfo } from "@/components/common/PointsInfo";
 import { AdaptiveSubmoduleSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 
-type FlowKind = "video" | "article" | "presentation" | "quiz" | "coding";
+type FlowKind = "video" | "article" | "presentation" | "video_lesson" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
 
 interface FlowItem {
@@ -41,14 +41,15 @@ const KIND_CORRECTNESS: Partial<Record<PointsKind, string>> = {
   quiz: "correct", coding: "tests passed", video: "watched",
 };
 
-const VERB: Record<FlowKind, string> = { video: "watch", article: "read", presentation: "view", quiz: "quiz", coding: "practice" };
-const KIND_ORDER: FlowKind[] = ["video", "article", "presentation", "quiz", "coding"];
+const VERB: Record<FlowKind, string> = { video: "watch", article: "read", presentation: "view", video_lesson: "watch", quiz: "quiz", coding: "practice" };
+const KIND_ORDER: FlowKind[] = ["video", "article", "presentation", "video_lesson", "quiz", "coding"];
 
 /** Per-content-type identity — same palette family as the course timeline nodes. */
 const FLOW_META: Record<FlowKind, { label: string; icon: string; action: string; actionIcon: string; color: string; bg: string }> = {
   video: { label: "WATCH", icon: "mdi:play-circle", action: "Watch", actionIcon: "mdi:play", color: "#0ea5e9", bg: "#e0f2fe" },
   article: { label: "READ", icon: "mdi:book-open-page-variant", action: "Read", actionIcon: "mdi:book-open-page-variant-outline", color: "#a855f7", bg: "#f5f3ff" },
   presentation: { label: "SLIDES", icon: "mdi:presentation", action: "View", actionIcon: "mdi:presentation-play", color: "#0d9488", bg: "#ccfbf1" },
+  video_lesson: { label: "VIDEO", icon: "mdi:movie-open-play", action: "Watch", actionIcon: "mdi:play", color: "#0891b2", bg: "#cffafe" },
   quiz: { label: "QUIZ", icon: "mdi:tune-vertical", action: "Start", actionIcon: "mdi:play", color: "#6366f1", bg: "#eef2ff" },
   coding: { label: "PRACTICE", icon: "mdi:code-tags", action: "Solve", actionIcon: "mdi:code-tags", color: "#ec4899", bg: "#fdf2f8" },
 };
@@ -88,6 +89,17 @@ function buildItems(
       kind: "presentation", key: `p${p.presentation_id}`, contentKey: `presentation:${p.presentation_id}`,
       title: p.title, completed: false,
       chips: [{ icon: "mdi:card-multiple-outline", text: `${p.slide_count} slide${p.slide_count === 1 ? "" : "s"}` }],
+      href, onClick: () => nav(href),
+    });
+  });
+  (sm.video_lessons ?? []).forEach((v) => {
+    const href = `/adaptive-courses/${courseId}/submodule/${submoduleId}/video-lesson/${v.video_lesson_id}`;
+    items.push({
+      kind: "video_lesson", key: `vl${v.video_lesson_id}`, contentKey: `video_lesson:${v.video_lesson_id}`,
+      title: v.title, completed: false,
+      chips: v.duration_seconds > 0
+        ? [{ icon: "mdi:clock-outline", text: `~${Math.max(1, Math.round(v.duration_seconds / 60))} min` }]
+        : [],
       href, onClick: () => nav(href),
     });
   });
@@ -179,7 +191,7 @@ export default function AdaptiveCourseSubmodulePage() {
 
   const meta = useMemo(() => {
     if (!submodule) return { counts: {} as Record<FlowKind, number>, estMin: 0 };
-    const counts: Record<FlowKind, number> = { video: 0, article: 0, presentation: 0, quiz: 0, coding: 0 };
+    const counts: Record<FlowKind, number> = { video: 0, article: 0, presentation: 0, video_lesson: 0, quiz: 0, coding: 0 };
     items.forEach((i) => { counts[i.kind] += 1; });
     let estMin = 0;
     (submodule.video_companions ?? []).forEach((v) => { estMin += Math.round((v.duration_seconds || 0) / 60); });
@@ -202,6 +214,7 @@ export default function AdaptiveCourseSubmodulePage() {
         ...(meta.counts.video ? [{ icon: "mdi:play-circle-outline", label: `${meta.counts.video} video${meta.counts.video > 1 ? "s" : ""}` }] : []),
         ...(meta.counts.article ? [{ icon: "mdi:book-open-variant", label: `${meta.counts.article} article${meta.counts.article > 1 ? "s" : ""}` }] : []),
         ...(meta.counts.presentation ? [{ icon: "mdi:presentation", label: `${meta.counts.presentation} deck${meta.counts.presentation > 1 ? "s" : ""}` }] : []),
+        ...(meta.counts.video_lesson ? [{ icon: "mdi:movie-open-play", label: `${meta.counts.video_lesson} AI video${meta.counts.video_lesson > 1 ? "s" : ""}` }] : []),
         ...(meta.counts.quiz ? [{ icon: "mdi:tune-variant", label: `${meta.counts.quiz} quiz${meta.counts.quiz > 1 ? "zes" : ""}` }] : []),
         ...(meta.counts.coding ? [{ icon: "mdi:code-tags", label: `${meta.counts.coding} coding` }] : []),
         ...(meta.estMin ? [{ icon: "mdi:clock-outline", label: `~${meta.estMin} min` }] : []),

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/presentation/[presentationId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/presentation/[presentationId]/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Box, ButtonBase, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import {
+  adaptiveCourseService,
+  type AdaptivePresentationDetail,
+} from "@/lib/services/adaptive-course.service";
+import { PresentationViewer } from "@/components/adaptive-quiz/presentation/PresentationViewer";
+
+export default function AdaptivePresentationPage() {
+  const { push, prefetch } = useInstantNavigation();
+  const params = useParams();
+  const courseId = Number(params.courseId);
+  const submoduleId = Number(params.submoduleId);
+  const presentationId = Number(params.presentationId);
+
+  const [detail, setDetail] = useState<AdaptivePresentationDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!Number.isFinite(presentationId)) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await adaptiveCourseService.getPresentation(presentationId);
+        if (!cancelled) setDetail(data);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load presentation.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [presentationId]);
+
+  const backHref = `/adaptive-courses/${courseId}/submodule/${submoduleId}`;
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1280, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 4 } }}>
+        <ButtonBase
+          onMouseEnter={() => prefetch(backHref)}
+          onClick={() => push(backHref)}
+          sx={{ mb: 2, color: "#0d9488", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
+        >
+          <Icon icon="mdi:arrow-left" width={18} />
+          Back to topic
+        </ButtonBase>
+
+        {loading && (
+          <Box sx={{ aspectRatio: "16 / 9", borderRadius: 4, bgcolor: "color-mix(in srgb, var(--card-bg, #f1f5f9) 70%, transparent)", display: "grid", placeItems: "center" }}>
+            <Icon icon="mdi:loading" width={32} className="spin" style={{ opacity: 0.5 }} />
+          </Box>
+        )}
+
+        {error && (
+          <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 6 }}>{error}</Typography>
+        )}
+
+        {detail && (
+          <>
+            <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.3rem", md: "1.6rem" }, mb: 0.5, color: "#0f172a" }}>
+              {detail.title}
+            </Typography>
+            <Typography sx={{ fontSize: "0.82rem", color: "#64748b", mb: 2 }}>
+              {detail.slide_count} slide{detail.slide_count === 1 ? "" : "s"} · use ← / → to navigate
+            </Typography>
+            <PresentationViewer document={detail.document} />
+          </>
+        )}
+      </Box>
+    </MainLayout>
+  );
+}

--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/video-lesson/[videoLessonId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/video-lesson/[videoLessonId]/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Box, ButtonBase, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import {
+  adaptiveCourseService,
+  type AdaptiveCourseVideoLessonSummary,
+} from "@/lib/services/adaptive-course.service";
+import { VideoLessonPlayer } from "@/components/adaptive-quiz/presentation/VideoLessonPlayer";
+
+export default function AdaptiveVideoLessonPage() {
+  const { push, prefetch } = useInstantNavigation();
+  const params = useParams();
+  const courseId = Number(params.courseId);
+  const submoduleId = Number(params.submoduleId);
+  const videoLessonId = Number(params.videoLessonId);
+
+  const [lesson, setLesson] = useState<AdaptiveCourseVideoLessonSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!Number.isFinite(courseId) || !Number.isFinite(submoduleId)) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        // The learner submodule payload carries ready video lessons (with resolved
+        // URLs) — find ours there rather than adding a separate detail endpoint.
+        const sm = await adaptiveCourseService.getSubmodule(courseId, submoduleId);
+        const found = (sm.video_lessons ?? []).find((v) => v.video_lesson_id === videoLessonId) ?? null;
+        if (!cancelled) {
+          setLesson(found);
+          if (!found) setError("This video isn't available yet — it may still be rendering.");
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load this video.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId, submoduleId, videoLessonId]);
+
+  const backHref = `/adaptive-courses/${courseId}/submodule/${submoduleId}`;
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1100, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 4 } }}>
+        <ButtonBase
+          onMouseEnter={() => prefetch(backHref)}
+          onClick={() => push(backHref)}
+          sx={{ mb: 2, color: "#0891b2", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
+        >
+          <Icon icon="mdi:arrow-left" width={18} />
+          Back to topic
+        </ButtonBase>
+
+        {loading && (
+          <Box sx={{ aspectRatio: "16 / 9", borderRadius: 4, bgcolor: "#0b1220", display: "grid", placeItems: "center" }}>
+            <Icon icon="mdi:loading" width={32} className="spin" style={{ color: "#64748b" }} />
+          </Box>
+        )}
+        {!loading && error && (
+          <Typography sx={{ color: "text.secondary", textAlign: "center", py: 6 }}>{error}</Typography>
+        )}
+        {lesson && (
+          <>
+            <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.3rem", md: "1.6rem" }, mb: 1.5, color: "#0f172a" }}>
+              {lesson.title}
+            </Typography>
+            <VideoLessonPlayer lesson={lesson} />
+          </>
+        )}
+      </Box>
+    </MainLayout>
+  );
+}

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -34,6 +34,8 @@ import {
 import { CourseQuizEditor } from "@/components/admin/adaptive-course/CourseQuizEditor";
 import { AdminArticleViewer } from "@/components/admin/adaptive-course/AdminArticleViewer";
 import { AdminCodingViewer } from "@/components/admin/adaptive-course/AdminCodingViewer";
+import { AdminPresentationViewer } from "@/components/admin/adaptive-course/AdminPresentationViewer";
+import { AdminVideoLessonViewer } from "@/components/admin/adaptive-course/AdminVideoLessonViewer";
 import { MatchedVideoReview } from "@/components/adaptive-video/admin/MatchedVideoReview";
 import { CourseStudentsPanel } from "@/components/admin/adaptive-course/CourseStudentsPanel";
 import { CourseCoverArtPanel } from "@/components/admin/adaptive-course/CourseCoverArtPanel";
@@ -78,6 +80,7 @@ export default function AdminAdaptiveCourseDetailPage() {
   const [expandedQuiz, setExpandedQuiz] = useState<number | null>(null);
   const [expandedArticle, setExpandedArticle] = useState<number | null>(null);
   const [expandedCoding, setExpandedCoding] = useState<number | null>(null);
+  const [expandedPresentation, setExpandedPresentation] = useState<number | null>(null);
   const [tab, setTab] = useState<
     "content" | "calibration" | "mock" | "certificate" | "students" | "cover"
   >("content");
@@ -181,6 +184,19 @@ export default function AdminAdaptiveCourseDetailPage() {
     if (!Number.isFinite(courseId)) return;
     void load();
   }, [courseId, load]);
+
+  // Render-status poll: a video render finishes AFTER the generation job completes,
+  // so refresh while any video lesson is still pending/rendering.
+  const hasRenderingVideo = !!course?.modules?.some((m) =>
+    m.submodules.some((s) =>
+      (s.video_lessons ?? []).some((v) => v.render_status === "pending" || v.render_status === "rendering"),
+    ),
+  );
+  useEffect(() => {
+    if (!hasRenderingVideo) return;
+    const id = setInterval(() => void load(), 15000);
+    return () => clearInterval(id);
+  }, [hasRenderingVideo, load]);
 
   function handleCoverChange(target: CourseImageTarget, patch: { url?: string | null; hidden?: boolean }) {
     setCourse((prev) => {
@@ -572,6 +588,43 @@ export default function AdminAdaptiveCourseDetailPage() {
                                   </Box>
                                 );
                               })}
+                              {(sub.presentations ?? []).map((p) => {
+                                const open = expandedPresentation === p.presentation_id;
+                                return (
+                                  <Box
+                                    key={`pres-${p.presentation_id}`}
+                                    sx={{
+                                      borderRadius: 2.5,
+                                      border: "1px solid color-mix(in srgb, var(--border-default) 65%, transparent)",
+                                      bgcolor: open ? "color-mix(in srgb, #0d9488 6%, transparent)" : "transparent",
+                                      overflow: "hidden",
+                                    }}
+                                  >
+                                    <ButtonBase
+                                      onClick={() => setExpandedPresentation(open ? null : p.presentation_id)}
+                                      sx={{ width: "100%", textAlign: "left", display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap", p: 1.25 }}
+                                    >
+                                      <Icon icon="mdi:presentation" width={15} style={{ color: "#0d9488" }} />
+                                      <Typography sx={{ fontWeight: 700, fontSize: "0.85rem" }}>{p.title}</Typography>
+                                      <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
+                                        presentation · {p.slide_count} slide{p.slide_count === 1 ? "" : "s"}
+                                        {p.is_active ? "" : " · inactive"}
+                                      </Typography>
+                                      <Box sx={{ flex: 1 }} />
+                                      <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.4, color: "#0d9488", fontSize: "0.75rem", fontWeight: 800 }}>
+                                        <Icon icon="mdi:presentation-play" width={14} />
+                                        {open ? "Hide deck" : "View deck"}
+                                        <Icon icon={open ? "mdi:chevron-up" : "mdi:chevron-down"} width={16} />
+                                      </Box>
+                                    </ButtonBase>
+                                    {open && (
+                                      <Box sx={{ px: 1.25, pb: 1.5 }}>
+                                        <AdminPresentationViewer courseId={course.id} presentationId={p.presentation_id} />
+                                      </Box>
+                                    )}
+                                  </Box>
+                                );
+                              })}
                               {sub.quizzes.map((q) => {
                                 const open = expandedQuiz === q.config_id;
                                 return (
@@ -701,8 +754,18 @@ export default function AdminAdaptiveCourseDetailPage() {
                               {(sub.video_companions ?? []).map((vc) => (
                                 <MatchedVideoReview key={vc.id} companion={vc} onChanged={() => void load()} />
                               ))}
+                              {(sub.video_lessons ?? []).map((vl) => (
+                                <AdminVideoLessonViewer
+                                  key={`vl-${vl.video_lesson_id}`}
+                                  courseId={course.id}
+                                  lesson={vl}
+                                  onChanged={() => void load()}
+                                />
+                              ))}
                               {sub.quizzes.length === 0 &&
                                 sub.articles.length === 0 &&
+                                (sub.presentations?.length ?? 0) === 0 &&
+                                (sub.video_lessons?.length ?? 0) === 0 &&
                                 (sub.coding_sets?.length ?? 0) === 0 &&
                                 (sub.video_companions?.length ?? 0) === 0 && (
                                   <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>

--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -53,6 +53,7 @@ export default function GenerateAdaptiveCoursePage() {
   const [questionsPerCell, setQuestionsPerCell] = useState(3);
   const [articlesPerSubmodule, setArticlesPerSubmodule] = useState(1);
   const [presentationSlideCount, setPresentationSlideCount] = useState(12);
+  const [generateCharts, setGenerateCharts] = useState(false);
   const [videoVoice, setVideoVoice] = useState("");
   const [videoStorage, setVideoStorage] = useState<"s3" | "vimeo">("s3");
   // Default to a fixed 15-question quiz (min === max): every quiz asks 15, difficulty adapts.
@@ -154,7 +155,7 @@ export default function GenerateAdaptiveCoursePage() {
       confidence_prompt_enabled: confidence,
       content_types: contentTypes,
       ...(contentTypes.includes("presentation")
-        ? { presentation_slide_count: presentationSlideCount }
+        ? { presentation_slide_count: presentationSlideCount, generate_charts: generateCharts }
         : {}),
       ...(contentTypes.includes("video_lesson")
         ? { video_voice: videoVoice, video_storage: videoStorage }
@@ -294,6 +295,8 @@ export default function GenerateAdaptiveCoursePage() {
                 onArticlesPerSubmoduleChange={setArticlesPerSubmodule}
                 presentationSlideCount={presentationSlideCount}
                 onPresentationSlideCountChange={setPresentationSlideCount}
+                generateCharts={generateCharts}
+                onGenerateChartsChange={setGenerateCharts}
                 videoVoice={videoVoice}
                 onVideoVoiceChange={setVideoVoice}
                 videoStorage={videoStorage}

--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -52,6 +52,7 @@ export default function GenerateAdaptiveCoursePage() {
   const [difficulties, setDifficulties] = useState<Difficulty[]>(["Easy", "Medium", "Hard"]);
   const [questionsPerCell, setQuestionsPerCell] = useState(3);
   const [articlesPerSubmodule, setArticlesPerSubmodule] = useState(1);
+  const [presentationSlideCount, setPresentationSlideCount] = useState(12);
   // Default to a fixed 15-question quiz (min === max): every quiz asks 15, difficulty adapts.
   const [minQuestions, setMinQuestions] = useState(15);
   const [maxQuestions, setMaxQuestions] = useState(15);
@@ -150,6 +151,9 @@ export default function GenerateAdaptiveCoursePage() {
       max_questions: maxQuestions,
       confidence_prompt_enabled: confidence,
       content_types: contentTypes,
+      ...(contentTypes.includes("presentation")
+        ? { presentation_slide_count: presentationSlideCount }
+        : {}),
       ...(contentTypes.includes("coding")
         ? { coding_problems_per_submodule: 2, coding_language: "Python", coding_allow_clipboard: codingClipboard }
         : {}),
@@ -283,6 +287,8 @@ export default function GenerateAdaptiveCoursePage() {
                 onQuestionsPerCellChange={setQuestionsPerCell}
                 articlesPerSubmodule={articlesPerSubmodule}
                 onArticlesPerSubmoduleChange={setArticlesPerSubmodule}
+                presentationSlideCount={presentationSlideCount}
+                onPresentationSlideCountChange={setPresentationSlideCount}
                 minQuestions={minQuestions}
                 onMinQuestionsChange={setMinQuestions}
                 maxQuestions={maxQuestions}

--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -53,6 +53,8 @@ export default function GenerateAdaptiveCoursePage() {
   const [questionsPerCell, setQuestionsPerCell] = useState(3);
   const [articlesPerSubmodule, setArticlesPerSubmodule] = useState(1);
   const [presentationSlideCount, setPresentationSlideCount] = useState(12);
+  const [videoVoice, setVideoVoice] = useState("");
+  const [videoStorage, setVideoStorage] = useState<"s3" | "vimeo">("s3");
   // Default to a fixed 15-question quiz (min === max): every quiz asks 15, difficulty adapts.
   const [minQuestions, setMinQuestions] = useState(15);
   const [maxQuestions, setMaxQuestions] = useState(15);
@@ -153,6 +155,9 @@ export default function GenerateAdaptiveCoursePage() {
       content_types: contentTypes,
       ...(contentTypes.includes("presentation")
         ? { presentation_slide_count: presentationSlideCount }
+        : {}),
+      ...(contentTypes.includes("video_lesson")
+        ? { video_voice: videoVoice, video_storage: videoStorage }
         : {}),
       ...(contentTypes.includes("coding")
         ? { coding_problems_per_submodule: 2, coding_language: "Python", coding_allow_clipboard: codingClipboard }
@@ -289,6 +294,10 @@ export default function GenerateAdaptiveCoursePage() {
                 onArticlesPerSubmoduleChange={setArticlesPerSubmodule}
                 presentationSlideCount={presentationSlideCount}
                 onPresentationSlideCountChange={setPresentationSlideCount}
+                videoVoice={videoVoice}
+                onVideoVoiceChange={setVideoVoice}
+                videoStorage={videoStorage}
+                onVideoStorageChange={setVideoStorage}
                 minQuestions={minQuestions}
                 onMinQuestionsChange={setMinQuestions}
                 maxQuestions={maxQuestions}

--- a/components/adaptive-quiz/generate/EditableCsvPlanPreview.tsx
+++ b/components/adaptive-quiz/generate/EditableCsvPlanPreview.tsx
@@ -15,6 +15,7 @@ const CONTENT_ICON: Record<ContentType, { icon: string; label: string }> = {
   presentation: { icon: "mdi:presentation", label: "Presentation" },
   coding: { icon: "mdi:robot-happy-outline", label: "Coding" },
   video: { icon: "mdi:play-circle-outline", label: "Video" },
+  video_lesson: { icon: "mdi:movie-open-play-outline", label: "Video lesson" },
 };
 
 const ROLE_LABEL: Record<string, string> = {

--- a/components/adaptive-quiz/generate/EditableCsvPlanPreview.tsx
+++ b/components/adaptive-quiz/generate/EditableCsvPlanPreview.tsx
@@ -12,6 +12,7 @@ import { makeRowUid, type ContentType } from "./types";
 const CONTENT_ICON: Record<ContentType, { icon: string; label: string }> = {
   article: { icon: "mdi:book-open-variant", label: "Article" },
   quiz: { icon: "mdi:tune-vertical", label: "Quiz" },
+  presentation: { icon: "mdi:presentation", label: "Presentation" },
   coding: { icon: "mdi:robot-happy-outline", label: "Coding" },
   video: { icon: "mdi:play-circle-outline", label: "Video" },
 };

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -34,6 +34,8 @@ export function SharedGenerationConfig({
   onArticlesPerSubmoduleChange,
   presentationSlideCount,
   onPresentationSlideCountChange,
+  generateCharts,
+  onGenerateChartsChange,
   videoVoice,
   onVideoVoiceChange,
   videoStorage,
@@ -58,6 +60,8 @@ export function SharedGenerationConfig({
   onArticlesPerSubmoduleChange: (v: number) => void;
   presentationSlideCount: number;
   onPresentationSlideCountChange: (v: number) => void;
+  generateCharts: boolean;
+  onGenerateChartsChange: (v: boolean) => void;
   videoVoice: string;
   onVideoVoiceChange: (v: string) => void;
   videoStorage: "s3" | "vimeo";
@@ -180,6 +184,13 @@ export function SharedGenerationConfig({
               sx={{ width: 240 }}
             />
           </Box>
+
+          {hasPresentation && (
+            <FormControlLabel
+              control={<Switch checked={generateCharts} onChange={(e) => onGenerateChartsChange(e.target.checked)} />}
+              label="Render real charts in presentations (Claude code execution — extra cost; off = clean placeholders)"
+            />
+          )}
 
           <FormControlLabel
             control={<Switch checked={confidence} onChange={(e) => onConfidenceChange(e.target.checked)} />}

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -11,6 +11,7 @@ const CONTENT_META: Record<ContentType, { label: string; icon: string }> = {
   presentation: { label: "Presentation", icon: "mdi:presentation" },
   coding: { label: "AI Coding Mentor", icon: "mdi:robot-happy-outline" },
   video: { label: "Video Companion", icon: "mdi:play-circle-outline" },
+  video_lesson: { label: "Video lesson", icon: "mdi:movie-open-play-outline" },
 };
 
 /**
@@ -33,6 +34,10 @@ export function SharedGenerationConfig({
   onArticlesPerSubmoduleChange,
   presentationSlideCount,
   onPresentationSlideCountChange,
+  videoVoice,
+  onVideoVoiceChange,
+  videoStorage,
+  onVideoStorageChange,
   // minQuestions intentionally not read — the single "Questions per quiz" field drives both
   // min and max (fixed-length quizzes) via the change handlers below.
   onMinQuestionsChange,
@@ -53,6 +58,10 @@ export function SharedGenerationConfig({
   onArticlesPerSubmoduleChange: (v: number) => void;
   presentationSlideCount: number;
   onPresentationSlideCountChange: (v: number) => void;
+  videoVoice: string;
+  onVideoVoiceChange: (v: string) => void;
+  videoStorage: "s3" | "vimeo";
+  onVideoStorageChange: (v: "s3" | "vimeo") => void;
   minQuestions: number;
   onMinQuestionsChange: (v: number) => void;
   maxQuestions: number;
@@ -66,6 +75,7 @@ export function SharedGenerationConfig({
   const hasCoding = contentTypes.includes("coding");
   const hasVideo = contentTypes.includes("video");
   const hasPresentation = contentTypes.includes("presentation");
+  const hasVideoLesson = contentTypes.includes("video_lesson");
 
   return (
     <Box>
@@ -205,6 +215,30 @@ export function SharedGenerationConfig({
               We AI-match a transcribed Vimeo video per submodule from your catalog (review &amp; swap after). Sync
               the catalog first if it&apos;s empty.
             </Typography>
+          )}
+
+          {hasVideoLesson && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+              <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>
+                Video lesson (slides + AI voice-over)
+              </Typography>
+              <TextField
+                label="Voice (Amazon Polly id)"
+                value={videoVoice}
+                onChange={(e) => onVideoVoiceChange(e.target.value)}
+                helperText="Blank = default 'Kajal' (Indian-English / Hindi)"
+                sx={{ width: 280 }}
+              />
+              <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+                <Typography sx={{ fontSize: "0.82rem", fontWeight: 700, color: "text.secondary" }}>Storage</Typography>
+                <Pill active={videoStorage === "s3"} onClick={() => onVideoStorageChange("s3")}>S3</Pill>
+                <Pill active={videoStorage === "vimeo"} onClick={() => onVideoStorageChange("vimeo")}>Vimeo</Pill>
+              </Box>
+              <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", display: "flex", gap: 0.5, alignItems: "center" }}>
+                <Icon icon="mdi:information-outline" width={16} />
+                Each video renders in the background after generation finishes (a few minutes each) and appears once ready.
+              </Typography>
+            </Box>
           )}
         </Box>
       </Collapse>

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -8,6 +8,7 @@ import { ALL_CONTENT_TYPES, ALL_DIFFICULTIES, type ContentType, type Difficulty 
 const CONTENT_META: Record<ContentType, { label: string; icon: string }> = {
   article: { label: "Adaptive Article", icon: "mdi:book-open-variant" },
   quiz: { label: "Adaptive Quiz", icon: "mdi:tune-vertical" },
+  presentation: { label: "Presentation", icon: "mdi:presentation" },
   coding: { label: "AI Coding Mentor", icon: "mdi:robot-happy-outline" },
   video: { label: "Video Companion", icon: "mdi:play-circle-outline" },
 };
@@ -30,6 +31,8 @@ export function SharedGenerationConfig({
   onQuestionsPerCellChange,
   articlesPerSubmodule,
   onArticlesPerSubmoduleChange,
+  presentationSlideCount,
+  onPresentationSlideCountChange,
   // minQuestions intentionally not read — the single "Questions per quiz" field drives both
   // min and max (fixed-length quizzes) via the change handlers below.
   onMinQuestionsChange,
@@ -48,6 +51,8 @@ export function SharedGenerationConfig({
   onQuestionsPerCellChange: (v: number) => void;
   articlesPerSubmodule: number;
   onArticlesPerSubmoduleChange: (v: number) => void;
+  presentationSlideCount: number;
+  onPresentationSlideCountChange: (v: number) => void;
   minQuestions: number;
   onMinQuestionsChange: (v: number) => void;
   maxQuestions: number;
@@ -60,6 +65,7 @@ export function SharedGenerationConfig({
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const hasCoding = contentTypes.includes("coding");
   const hasVideo = contentTypes.includes("video");
+  const hasPresentation = contentTypes.includes("presentation");
 
   return (
     <Box>
@@ -136,6 +142,16 @@ export function SharedGenerationConfig({
               helperText="Default 1 · up to 5"
               sx={{ width: 220 }}
             />
+            {hasPresentation && (
+              <TextField
+                label="Slides per presentation"
+                type="number"
+                value={presentationSlideCount}
+                onChange={(e) => onPresentationSlideCountChange(clamp(Number(e.target.value), 4, 24))}
+                helperText="Default 12 · 4–24 · Claude-generated deck"
+                sx={{ width: 240 }}
+              />
+            )}
           </Box>
 
           <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>

--- a/components/adaptive-quiz/generate/types.ts
+++ b/components/adaptive-quiz/generate/types.ts
@@ -5,11 +5,11 @@
 import type { CsvCoursePlan } from "@/lib/services/admin/admin-adaptive-course.service";
 
 export type Difficulty = "Easy" | "Medium" | "Hard";
-export type ContentType = "quiz" | "article" | "presentation" | "coding" | "video";
+export type ContentType = "quiz" | "article" | "presentation" | "coding" | "video" | "video_lesson";
 
 export const ALL_DIFFICULTIES: Difficulty[] = ["Easy", "Medium", "Hard"];
-// Canonical generation order shared with the backend (quiz → article → presentation → coding → video).
-export const ALL_CONTENT_TYPES: ContentType[] = ["quiz", "article", "presentation", "coding", "video"];
+// Canonical generation order shared with the backend (quiz → article → presentation → coding → video → video_lesson).
+export const ALL_CONTENT_TYPES: ContentType[] = ["quiz", "article", "presentation", "coding", "video", "video_lesson"];
 
 export type GenerateMode = "describe" | "csv";
 

--- a/components/adaptive-quiz/generate/types.ts
+++ b/components/adaptive-quiz/generate/types.ts
@@ -5,11 +5,11 @@
 import type { CsvCoursePlan } from "@/lib/services/admin/admin-adaptive-course.service";
 
 export type Difficulty = "Easy" | "Medium" | "Hard";
-export type ContentType = "quiz" | "article" | "coding" | "video";
+export type ContentType = "quiz" | "article" | "presentation" | "coding" | "video";
 
 export const ALL_DIFFICULTIES: Difficulty[] = ["Easy", "Medium", "Hard"];
-// Canonical generation order shared with the backend (quiz → article → coding → video).
-export const ALL_CONTENT_TYPES: ContentType[] = ["quiz", "article", "coding", "video"];
+// Canonical generation order shared with the backend (quiz → article → presentation → coding → video).
+export const ALL_CONTENT_TYPES: ContentType[] = ["quiz", "article", "presentation", "coding", "video"];
 
 export type GenerateMode = "describe" | "csv";
 

--- a/components/adaptive-quiz/presentation/PresentationViewer.tsx
+++ b/components/adaptive-quiz/presentation/PresentationViewer.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { AnimatePresence, motion } from "framer-motion";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type {
+  PresentationDocument,
+  PresentationSlide,
+} from "@/lib/services/adaptive-course.service";
+
+/**
+ * Self-contained slide-deck viewer (no slide library needed). Renders the
+ * canonical slide-JSON one slide at a time on a dark stage, keyed off each
+ * slide's `layout`. Keyboard ← / → / Home / End navigate; a transcript toggle
+ * shows the per-slide narration. This is the in-app deck; the same document
+ * drives the rendered video in Phase 2.
+ */
+export function PresentationViewer({ document: deck }: { document: PresentationDocument }) {
+  const slides = deck.slides ?? [];
+  const accent = deck.theme?.accent_hex || "#3B82F6";
+  const [index, setIndex] = useState(0);
+  const [showTranscript, setShowTranscript] = useState(false);
+  const count = slides.length;
+
+  const go = useCallback(
+    (next: number) => setIndex((i) => Math.max(0, Math.min(count - 1, next ?? i))),
+    [count],
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "ArrowRight" || e.key === " ") go(index + 1);
+      else if (e.key === "ArrowLeft") go(index - 1);
+      else if (e.key === "Home") go(0);
+      else if (e.key === "End") go(count - 1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [index, count, go]);
+
+  if (count === 0) {
+    return (
+      <Box sx={{ p: 5, textAlign: "center", color: "text.secondary" }}>
+        This presentation has no slides yet.
+      </Box>
+    );
+  }
+
+  const slide = slides[index];
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      {/* Stage */}
+      <Box
+        sx={{
+          position: "relative",
+          width: "100%",
+          aspectRatio: "16 / 9",
+          maxHeight: "calc(100vh - 240px)",
+          borderRadius: 4,
+          overflow: "hidden",
+          color: "#f8fafc",
+          background:
+            "radial-gradient(1200px 600px at 15% -10%, #1e293b 0%, #0f172a 55%, #020617 100%)",
+          boxShadow: "0 30px 80px -40px rgba(2,6,23,0.8)",
+          border: "1px solid rgba(148,163,184,0.18)",
+        }}
+      >
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={slide.id ?? index}
+            initial={{ opacity: 0, x: 24 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -24 }}
+            transition={{ duration: 0.28, ease: "easeOut" }}
+            style={{ position: "absolute", inset: 0 }}
+          >
+            <SlideStage slide={slide} accent={accent} />
+          </motion.div>
+        </AnimatePresence>
+
+        {/* Accent rail */}
+        <Box sx={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 6, background: accent }} />
+
+        {/* Prev / Next */}
+        {index > 0 && <NavButton side="left" onClick={() => go(index - 1)} />}
+        {index < count - 1 && <NavButton side="right" onClick={() => go(index + 1)} />}
+
+        {/* Slide counter */}
+        <Box
+          sx={{
+            position: "absolute", bottom: 12, right: 16, px: 1.25, py: 0.4, borderRadius: 999,
+            fontSize: "0.75rem", fontWeight: 700, color: "#e2e8f0", bgcolor: "rgba(15,23,42,0.6)",
+            border: "1px solid rgba(148,163,184,0.25)",
+          }}
+        >
+          {index + 1} / {count}
+        </Box>
+      </Box>
+
+      {/* Progress dots */}
+      <Stack direction="row" justifyContent="center" flexWrap="wrap" sx={{ gap: 0.75, mt: 1.75 }}>
+        {slides.map((s, i) => (
+          <ButtonBase
+            key={s.id ?? i}
+            onClick={() => go(i)}
+            aria-label={`Go to slide ${i + 1}`}
+            sx={{
+              width: i === index ? 26 : 9, height: 9, borderRadius: 999,
+              transition: "width .2s, background .2s",
+              bgcolor: i === index ? accent : "color-mix(in srgb, var(--border-default, #cbd5e1) 90%, transparent)",
+            }}
+          />
+        ))}
+      </Stack>
+
+      {/* Transcript (per-slide narration) */}
+      {(slide.narration_script || "").trim() && (
+        <Box sx={{ mt: 2 }}>
+          <ButtonBase
+            onClick={() => setShowTranscript((v) => !v)}
+            sx={{ gap: 0.5, fontWeight: 700, fontSize: "0.82rem", color: "text.secondary" }}
+          >
+            <Icon icon={showTranscript ? "mdi:chevron-down" : "mdi:chevron-right"} width={18} />
+            <Icon icon="mdi:text-to-speech" width={16} />
+            {showTranscript ? "Hide narration" : "Show narration"}
+          </ButtonBase>
+          {showTranscript && (
+            <Typography
+              sx={{
+                mt: 0.75, p: 1.75, borderRadius: 2, fontSize: "0.9rem", lineHeight: 1.6,
+                color: "text.primary", bgcolor: "color-mix(in srgb, var(--card-bg, #f8fafc) 70%, transparent)",
+                border: "1px solid color-mix(in srgb, var(--border-default, #e2e8f0) 70%, transparent)",
+              }}
+            >
+              {slide.narration_script}
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function NavButton({ side, onClick }: { side: "left" | "right"; onClick: () => void }) {
+  return (
+    <ButtonBase
+      onClick={onClick}
+      aria-label={side === "left" ? "Previous slide" : "Next slide"}
+      sx={{
+        position: "absolute", top: "50%", transform: "translateY(-50%)",
+        [side]: 12, width: 40, height: 40, borderRadius: "50%",
+        color: "#e2e8f0", bgcolor: "rgba(15,23,42,0.55)",
+        border: "1px solid rgba(148,163,184,0.3)",
+        "&:hover": { bgcolor: "rgba(15,23,42,0.8)" },
+      }}
+    >
+      <Icon icon={side === "left" ? "mdi:chevron-left" : "mdi:chevron-right"} width={26} />
+    </ButtonBase>
+  );
+}
+
+const CENTERED_LAYOUTS = new Set(["title", "section", "closing", "quote"]);
+
+function SlideStage({ slide, accent }: { slide: PresentationSlide; accent: string }) {
+  const centered = CENTERED_LAYOUTS.has(slide.layout);
+  const mediaUrl = slide.media?.url || null;
+  const mediaSide = slide.media?.position === "left" ? "left" : "right";
+  const hasMedia = !!mediaUrl || slide.media?.kind === "chart" || slide.media?.kind === "diagram";
+  const showMediaColumn = hasMedia && !centered && slide.media?.position !== "background";
+
+  if (centered) {
+    return (
+      <Box sx={{ height: "100%", display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", textAlign: "center", p: { xs: 4, md: 8 } }}>
+        {slide.layout === "section" && (
+          <Typography sx={{ fontSize: "0.8rem", fontWeight: 800, letterSpacing: 2, color: accent, mb: 1.5 }}>
+            SECTION
+          </Typography>
+        )}
+        <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.8rem", md: "2.8rem" }, lineHeight: 1.1, fontStyle: slide.layout === "quote" ? "italic" : "normal" }}>
+          {slide.title}
+        </Typography>
+        {slide.subtitle && (
+          <Typography sx={{ mt: 2, fontSize: { xs: "1rem", md: "1.25rem" }, color: "#cbd5e1", maxWidth: 800 }}>
+            {slide.subtitle}
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ height: "100%", display: "flex", flexDirection: "column", p: { xs: 3, md: 6 } }}>
+      <Box sx={{ mb: 2 }}>
+        <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.4rem", md: "2rem" }, lineHeight: 1.15 }}>
+          {slide.title}
+        </Typography>
+        {slide.subtitle && (
+          <Typography sx={{ mt: 0.5, fontSize: { xs: "0.95rem", md: "1.1rem" }, color: "#94a3b8" }}>
+            {slide.subtitle}
+          </Typography>
+        )}
+        <Box sx={{ width: 56, height: 4, borderRadius: 999, background: accent, mt: 1.5 }} />
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1, minHeight: 0, display: "grid", gap: { xs: 2, md: 4 }, alignItems: "center",
+          gridTemplateColumns: showMediaColumn ? { xs: "1fr", md: mediaSide === "left" ? "1fr 1.2fr" : "1.2fr 1fr" } : "1fr",
+          overflow: "hidden",
+        }}
+      >
+        {showMediaColumn && mediaSide === "left" && <MediaArea slide={slide} accent={accent} url={mediaUrl} />}
+
+        <Box sx={{ minWidth: 0, overflow: "auto", maxHeight: "100%" }}>
+          {slide.bullets?.length > 0 && (
+            <Stack spacing={1.25}>
+              {slide.bullets.map((b, i) => (
+                <Stack key={i} direction="row" spacing={1.25} alignItems="flex-start" sx={{ pl: (b.level || 0) * 2.5 }}>
+                  <Box sx={{ mt: "9px", flexShrink: 0, width: b.level ? 6 : 8, height: b.level ? 6 : 8, borderRadius: "50%", background: accent, opacity: b.level ? 0.6 : 1 }} />
+                  <Typography sx={{ fontSize: { xs: "0.95rem", md: b.level ? "1rem" : "1.15rem" }, lineHeight: 1.45, color: b.level ? "#cbd5e1" : "#f1f5f9" }}>
+                    {b.text}
+                  </Typography>
+                </Stack>
+              ))}
+            </Stack>
+          )}
+
+          {slide.body_markdown && (
+            <Box sx={{ mt: slide.bullets?.length ? 2 : 0, fontSize: "1rem", lineHeight: 1.6, color: "#e2e8f0", "& a": { color: accent }, "& code": { background: "rgba(148,163,184,0.18)", px: 0.5, borderRadius: 1 } }}>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{slide.body_markdown}</ReactMarkdown>
+            </Box>
+          )}
+
+          {slide.code?.source && <CodeBlock language={slide.code.language} source={slide.code.source} accent={accent} />}
+        </Box>
+
+        {showMediaColumn && mediaSide !== "left" && <MediaArea slide={slide} accent={accent} url={mediaUrl} />}
+      </Box>
+    </Box>
+  );
+}
+
+function MediaArea({ slide, accent, url }: { slide: PresentationSlide; accent: string; url: string | null }) {
+  if (url) {
+    return (
+      <Box sx={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center", minHeight: 0 }}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={url}
+          alt={slide.media?.alt || ""}
+          style={{ maxWidth: "100%", maxHeight: "100%", borderRadius: 12, objectFit: "contain", boxShadow: "0 18px 40px -20px rgba(0,0,0,0.6)" }}
+        />
+      </Box>
+    );
+  }
+  // Phase 1: chart/diagram media has no raster yet — show a tasteful placeholder
+  // from the brief (real, accurate charts arrive with the Phase 2 renderer).
+  return (
+    <Box
+      sx={{
+        height: "100%", minHeight: 140, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+        gap: 1, p: 3, textAlign: "center", borderRadius: 3,
+        border: `1px dashed color-mix(in srgb, ${accent} 50%, transparent)`,
+        bgcolor: "rgba(148,163,184,0.08)",
+      }}
+    >
+      <Icon icon={slide.media?.kind === "diagram" ? "mdi:sitemap-outline" : "mdi:chart-line"} width={34} style={{ color: accent }} />
+      <Typography sx={{ fontSize: "0.85rem", color: "#cbd5e1", maxWidth: 320 }}>
+        {slide.media?.alt || slide.media?.image_brief || "Visual"}
+      </Typography>
+    </Box>
+  );
+}
+
+function CodeBlock({ language, source, accent }: { language: string; source: string; accent: string }) {
+  return (
+    <Box sx={{ mt: 2, borderRadius: 2, overflow: "hidden", border: "1px solid rgba(148,163,184,0.25)" }}>
+      <Box sx={{ px: 1.5, py: 0.5, fontSize: "0.7rem", fontWeight: 700, letterSpacing: 1, color: accent, bgcolor: "rgba(2,6,23,0.6)", textTransform: "uppercase" }}>
+        {language || "code"}
+      </Box>
+      <Box
+        component="pre"
+        sx={{
+          m: 0, p: 1.75, overflow: "auto", maxHeight: 280, fontSize: "0.85rem", lineHeight: 1.5,
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace", color: "#e2e8f0", bgcolor: "rgba(2,6,23,0.75)",
+        }}
+      >
+        <code>{source}</code>
+      </Box>
+    </Box>
+  );
+}

--- a/components/adaptive-quiz/presentation/VideoLessonPlayer.tsx
+++ b/components/adaptive-quiz/presentation/VideoLessonPlayer.tsx
@@ -36,6 +36,10 @@ export function VideoLessonPlayer({ lesson }: { lesson: AdaptiveCourseVideoLesso
     <Box sx={{ borderRadius: 4, overflow: "hidden", bgcolor: "#000", boxShadow: "0 30px 80px -40px rgba(2,6,23,0.8)" }}>
       <video
         controls
+        // crossOrigin is required for the cross-origin caption <track> to load
+        // (text tracks are CORS-gated). Needs S3/CloudFront CORS to allow this
+        // origin — see the deploy runbook.
+        crossOrigin="anonymous"
         poster={lesson.poster_url || undefined}
         style={{ width: "100%", display: "block", aspectRatio: "16 / 9", background: "#000" }}
       >

--- a/components/adaptive-quiz/presentation/VideoLessonPlayer.tsx
+++ b/components/adaptive-quiz/presentation/VideoLessonPlayer.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import type { AdaptiveCourseVideoLessonSummary } from "@/lib/services/adaptive-course.service";
+
+/**
+ * Plays a rendered adaptive video lesson. S3-stored videos use a native HTML5
+ * <video> (with a WebVTT caption track); Vimeo-stored videos use the Vimeo
+ * iframe player. The MP4 URL is presigned + resolved server-side per request.
+ */
+export function VideoLessonPlayer({ lesson }: { lesson: AdaptiveCourseVideoLessonSummary }) {
+  if (lesson.storage === "vimeo" && (lesson.vimeo_id || lesson.video_url)) {
+    const src = lesson.video_url || `https://player.vimeo.com/video/${lesson.vimeo_id}`;
+    return (
+      <Box sx={{ position: "relative", width: "100%", aspectRatio: "16 / 9", borderRadius: 4, overflow: "hidden", bgcolor: "#000" }}>
+        <iframe
+          src={src}
+          title={lesson.title}
+          allow="autoplay; fullscreen; picture-in-picture"
+          allowFullScreen
+          style={{ position: "absolute", inset: 0, width: "100%", height: "100%", border: 0 }}
+        />
+      </Box>
+    );
+  }
+
+  if (!lesson.video_url) {
+    return (
+      <Typography sx={{ color: "text.secondary", textAlign: "center", py: 6 }}>
+        This video isn&apos;t available yet.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box sx={{ borderRadius: 4, overflow: "hidden", bgcolor: "#000", boxShadow: "0 30px 80px -40px rgba(2,6,23,0.8)" }}>
+      <video
+        controls
+        poster={lesson.poster_url || undefined}
+        style={{ width: "100%", display: "block", aspectRatio: "16 / 9", background: "#000" }}
+      >
+        <source src={lesson.video_url} type="video/mp4" />
+        {lesson.captions_url && (
+          <track kind="captions" src={lesson.captions_url} srcLang="en-IN" label="English" default />
+        )}
+      </video>
+    </Box>
+  );
+}

--- a/components/admin/adaptive-course/AdminPresentationViewer.tsx
+++ b/components/admin/adaptive-course/AdminPresentationViewer.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, ButtonBase, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
+import type { PresentationDocument } from "@/lib/services/adaptive-course.service";
+import { PresentationViewer } from "@/components/adaptive-quiz/presentation/PresentationViewer";
+
+/** Admin deck preview: fetches the full document and renders the shared viewer,
+ *  plus an opt-in "Download .pptx" export (Anthropic pptx skill). */
+export function AdminPresentationViewer({ courseId, presentationId }: { courseId: number; presentationId: number }) {
+  const [doc, setDoc] = useState<PresentationDocument | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const d = await adminAdaptiveCourseService.getCoursePresentation(courseId, presentationId);
+        if (!cancelled) setDoc(d.document);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load presentation.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId, presentationId]);
+
+  async function downloadPptx() {
+    if (exporting) return;
+    setExporting(true);
+    setError(null);
+    try {
+      const { pptx_url } = await adminAdaptiveCourseService.exportPresentationPptx(courseId, presentationId);
+      if (pptx_url) window.open(pptx_url, "_blank", "noopener");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't export .pptx — please retry.");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  if (loading) return <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", py: 2 }}>Loading deck…</Typography>;
+  if (error && !doc) return <Typography sx={{ fontSize: "0.82rem", color: "#ef4444", py: 2 }}>{error}</Typography>;
+  if (!doc) return null;
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 1.5, mb: 1 }}>
+        {error && <Typography sx={{ fontSize: "0.74rem", color: "#ef4444" }}>{error}</Typography>}
+        <ButtonBase
+          onClick={downloadPptx}
+          disabled={exporting}
+          sx={{
+            gap: 0.5, px: 1.5, py: 0.6, borderRadius: 999, fontWeight: 800, fontSize: "0.78rem",
+            color: "#0d9488", border: "1px solid color-mix(in srgb, #0d9488 40%, transparent)",
+            opacity: exporting ? 0.6 : 1,
+          }}
+        >
+          <Icon icon={exporting ? "mdi:loading" : "mdi:file-powerpoint-box"} width={16} className={exporting ? "spin" : ""} />
+          {exporting ? "Exporting…" : "Download .pptx"}
+        </ButtonBase>
+      </Box>
+      <PresentationViewer document={doc} />
+    </Box>
+  );
+}

--- a/components/admin/adaptive-course/AdminVideoLessonViewer.tsx
+++ b/components/admin/adaptive-course/AdminVideoLessonViewer.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import {
+  adminAdaptiveCourseService,
+  type AdminAdaptiveCourseVideoLesson,
+} from "@/lib/services/admin/admin-adaptive-course.service";
+import { VideoLessonPlayer } from "@/components/adaptive-quiz/presentation/VideoLessonPlayer";
+
+const STATUS_META: Record<string, { label: string; color: string; icon: string }> = {
+  pending: { label: "Queued", color: "#f59e0b", icon: "mdi:clock-outline" },
+  rendering: { label: "Rendering…", color: "#0891b2", icon: "mdi:loading" },
+  ready: { label: "Ready", color: "#10b981", icon: "mdi:check-circle" },
+  failed: { label: "Failed", color: "#ef4444", icon: "mdi:alert-circle" },
+};
+
+/** Admin row for a rendered video lesson: status badge, inline preview when ready,
+ *  re-render action, and the render error when failed. */
+export function AdminVideoLessonViewer({
+  courseId,
+  lesson,
+  onChanged,
+}: {
+  courseId: number;
+  lesson: AdminAdaptiveCourseVideoLesson;
+  onChanged?: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [open, setOpen] = useState(false);
+  const s = STATUS_META[lesson.render_status] ?? STATUS_META.pending;
+  const rendering = lesson.render_status === "rendering";
+
+  async function reRender() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await adminAdaptiveCourseService.rerenderVideoLesson(courseId, lesson.video_lesson_id);
+      onChanged?.();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Box sx={{ borderRadius: 2.5, border: "1px solid color-mix(in srgb, var(--border-default) 65%, transparent)", overflow: "hidden" }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap", p: 1.25 }}>
+        <Icon icon="mdi:movie-open-play" width={15} style={{ color: "#0891b2" }} />
+        <Typography sx={{ fontWeight: 700, fontSize: "0.85rem" }}>{lesson.title}</Typography>
+        <Stack
+          direction="row"
+          spacing={0.4}
+          alignItems="center"
+          sx={{ px: 0.75, py: 0.2, borderRadius: 999, bgcolor: `color-mix(in srgb, ${s.color} 12%, transparent)` }}
+        >
+          <Icon icon={s.icon} width={12} color={s.color} className={rendering ? "spin" : ""} />
+          <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, color: s.color }}>{s.label}</Typography>
+        </Stack>
+        {lesson.duration_seconds > 0 && (
+          <Typography sx={{ fontSize: "0.74rem", color: "text.secondary" }}>
+            ~{Math.max(1, Math.round(lesson.duration_seconds / 60))} min
+          </Typography>
+        )}
+        <Box sx={{ flex: 1 }} />
+        {lesson.render_status === "ready" && (
+          <ButtonBase onClick={() => setOpen((o) => !o)} sx={{ gap: 0.4, color: "#0891b2", fontSize: "0.75rem", fontWeight: 800 }}>
+            <Icon icon={open ? "mdi:chevron-up" : "mdi:play-circle-outline"} width={14} />
+            {open ? "Hide" : "Preview"}
+          </ButtonBase>
+        )}
+        <ButtonBase
+          onClick={reRender}
+          disabled={busy || rendering}
+          sx={{ gap: 0.4, color: "#64748b", fontSize: "0.75rem", fontWeight: 800, opacity: busy || rendering ? 0.5 : 1 }}
+        >
+          <Icon icon="mdi:refresh" width={14} className={busy ? "spin" : ""} />
+          Re-render
+        </ButtonBase>
+      </Box>
+      {lesson.render_status === "failed" && lesson.render_error && (
+        <Typography sx={{ px: 1.25, pb: 1, fontSize: "0.74rem", color: "#ef4444" }}>{lesson.render_error}</Typography>
+      )}
+      {open && lesson.render_status === "ready" && (
+        <Box sx={{ px: 1.25, pb: 1.5 }}>
+          <VideoLessonPlayer
+            lesson={{
+              video_lesson_id: lesson.video_lesson_id,
+              title: lesson.title,
+              duration_seconds: lesson.duration_seconds,
+              storage: lesson.storage ?? "s3",
+              video_url: lesson.video_url,
+              poster_url: lesson.poster_url,
+              captions_url: lesson.captions_url,
+              vimeo_id: lesson.vimeo_id,
+            }}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -154,6 +154,17 @@ export interface AdaptivePresentationDetail {
   document: PresentationDocument;
 }
 
+export interface AdaptiveCourseVideoLessonSummary {
+  video_lesson_id: number;
+  title: string;
+  duration_seconds: number;
+  storage: "s3" | "vimeo";
+  video_url?: string | null;
+  poster_url?: string | null;
+  captions_url?: string | null;
+  vimeo_id?: string | null;
+}
+
 export interface AdaptiveCourseSubModule {
   id: number;
   order: number;
@@ -161,6 +172,8 @@ export interface AdaptiveCourseSubModule {
   description: string;
   articles: AdaptiveCourseArticleSummary[];
   presentations?: AdaptiveCoursePresentationSummary[];
+  /** Only ``ready`` renders are returned to learners (render finishes after generation). */
+  video_lessons?: AdaptiveCourseVideoLessonSummary[];
   quizzes: AdaptiveCourseQuizSummary[];
   coding_sets?: AdaptiveCourseCodingSet[];
   video_companions?: AdaptiveCourseVideoCompanionSummary[];
@@ -186,6 +199,7 @@ export interface AdaptiveCourseListItem {
   quiz_count: number;
   article_count: number;
   presentation_count?: number;
+  video_lesson_count?: number;
   coding_count?: number;
   video_count?: number;
   /** AI/admin card thumbnail; null when absent or hidden by the admin. */

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -103,12 +103,64 @@ export interface AdaptiveCourseVideoCompanionSummary {
   completed?: boolean;
 }
 
+export interface AdaptiveCoursePresentationSummary {
+  presentation_id: number;
+  title: string;
+  slide_count: number;
+}
+
+// --- Presentation deck document (canonical slide-JSON, served with media URLs resolved) ---
+export interface PresentationSlideMedia {
+  kind: "none" | "chart" | "ai_image" | "stock" | "diagram";
+  image_brief?: string | null;
+  alt?: string | null;
+  position: "full" | "left" | "right" | "background";
+  s3_key?: string | null;
+  /** Resolved at serve time from s3_key (or a pass-through stock URL). */
+  url?: string | null;
+}
+
+export interface PresentationSlide {
+  id: string;
+  index: number;
+  layout: string;
+  title: string;
+  subtitle?: string | null;
+  bullets: Array<{ text: string; level: number }>;
+  body_markdown?: string | null;
+  code?: { language: string; source: string } | null;
+  media: PresentationSlideMedia;
+  speaker_notes?: string;
+  narration_script?: string;
+  narration_duration_sec?: number | null;
+  estimated_duration_sec?: number;
+}
+
+export interface PresentationDocument {
+  schema_version: string;
+  title: string;
+  subtitle?: string | null;
+  theme: { preset: string; accent_hex: string; font_family: string };
+  aspect_ratio: string;
+  estimated_duration_sec: number;
+  slides: PresentationSlide[];
+  render?: Record<string, unknown>;
+}
+
+export interface AdaptivePresentationDetail {
+  id: number;
+  title: string;
+  slide_count: number;
+  document: PresentationDocument;
+}
+
 export interface AdaptiveCourseSubModule {
   id: number;
   order: number;
   title: string;
   description: string;
   articles: AdaptiveCourseArticleSummary[];
+  presentations?: AdaptiveCoursePresentationSummary[];
   quizzes: AdaptiveCourseQuizSummary[];
   coding_sets?: AdaptiveCourseCodingSet[];
   video_companions?: AdaptiveCourseVideoCompanionSummary[];
@@ -133,6 +185,7 @@ export interface AdaptiveCourseListItem {
   submodule_count: number;
   quiz_count: number;
   article_count: number;
+  presentation_count?: number;
   coding_count?: number;
   video_count?: number;
   /** AI/admin card thumbnail; null when absent or hidden by the admin. */
@@ -261,6 +314,14 @@ export const adaptiveCourseService = {
     const { data } = await apiClient.get<AdaptiveArticleDetail>(
       `${BASE}/articles/${articleId}/`,
       { params: tier ? { tier } : {} },
+    );
+    return data;
+  },
+
+  /** Full slide-deck document for a presentation (media URLs already resolved). */
+  async getPresentation(presentationId: number): Promise<AdaptivePresentationDetail> {
+    const { data } = await apiClient.get<AdaptivePresentationDetail>(
+      `${BASE}/presentations/${presentationId}/`,
     );
     return data;
   },

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -20,9 +20,12 @@ export interface AdaptiveCourseGenConfig {
   se_threshold?: number;
   hint_tokens?: number;
   confidence_prompt_enabled?: boolean;
-  content_types?: Array<"quiz" | "article" | "presentation" | "coding" | "video">;
+  content_types?: Array<"quiz" | "article" | "presentation" | "coding" | "video" | "video_lesson">;
   /** Target slides per presentation — only used when content_types includes "presentation". */
   presentation_slide_count?: number;
+  /** Video lesson (slides+voiceover) knobs — only used when content_types includes "video_lesson". */
+  video_voice?: string;
+  video_storage?: "s3" | "vimeo";
   /** AI Coding Mentor knobs — only used when content_types includes "coding". */
   coding_problems_per_submodule?: number;
   coding_language?: string;
@@ -118,12 +121,14 @@ export interface AdaptiveCourseJobTreeSubmodule {
   quiz_ready: boolean;
   article_ready?: boolean;
   presentation_ready?: boolean;
+  video_lesson_ready?: boolean;
   coding_ready?: boolean;
   video_ready?: boolean;
   question_count: number;
   coding_problem_count?: number;
   video_count?: number;
   presentation_count?: number;
+  video_lesson_count?: number;
 }
 
 export interface AdaptiveCourseJobTreeModule {
@@ -270,6 +275,23 @@ export interface AdminAdaptiveCoursePresentation {
   is_active: boolean;
 }
 
+export type VideoRenderStatus = "pending" | "rendering" | "ready" | "failed";
+
+export interface AdminAdaptiveCourseVideoLesson {
+  video_lesson_id: number;
+  title: string;
+  render_status: VideoRenderStatus;
+  render_error?: string;
+  duration_seconds: number;
+  is_active: boolean;
+  // Present only when render_status === "ready":
+  storage?: "s3" | "vimeo";
+  video_url?: string | null;
+  poster_url?: string | null;
+  captions_url?: string | null;
+  vimeo_id?: string | null;
+}
+
 export interface AdminAdaptiveCourseSubModule {
   id: number;
   order: number;
@@ -277,6 +299,7 @@ export interface AdminAdaptiveCourseSubModule {
   description: string;
   articles: AdminAdaptiveCourseArticle[];
   presentations?: AdminAdaptiveCoursePresentation[];
+  video_lessons?: AdminAdaptiveCourseVideoLesson[];
   quizzes: AdminAdaptiveCourseQuiz[];
   coding_sets?: AdminAdaptiveCourseCodingSet[];
   video_companions?: AdminAdaptiveCourseVideoCompanion[];
@@ -303,6 +326,7 @@ export interface AdminAdaptiveCourseListItem {
   quiz_count: number;
   article_count: number;
   presentation_count?: number;
+  video_lesson_count?: number;
   coding_count?: number;
   video_count?: number;
   // Cover art — admins always get the URLs (even when hidden) to preview/manage;
@@ -326,7 +350,7 @@ export interface AdminAdaptiveCourseContentHealth {
   submodules_total: number;
   /** e.g. ["quiz"] or ["quiz","article"] — the content types this course expects. */
   expected_content_types: string[];
-  missing: { quiz?: number; article?: number; presentation?: number; coding?: number; video?: number };
+  missing: { quiz?: number; article?: number; presentation?: number; video_lesson?: number; coding?: number; video?: number };
   total_missing: number;
   /** True when NON-video content is missing (i.e. LLM regeneration would help). */
   needs_regeneration: boolean;
@@ -495,6 +519,18 @@ export const adminAdaptiveCourseService = {
   ): Promise<AdaptivePresentationDetail> {
     const { data } = await apiClient.get<AdaptivePresentationDetail>(
       `${BASE}/courses/${courseId}/presentations/${presentationId}/`,
+    );
+    return data;
+  },
+
+  /** Re-queue a video render (recovery for a failed render, or to pick up an edited deck). */
+  async rerenderVideoLesson(
+    courseId: number,
+    videoLessonId: number,
+  ): Promise<{ video_lesson_id: number; render_status: VideoRenderStatus }> {
+    const { data } = await apiClient.post<{ video_lesson_id: number; render_status: VideoRenderStatus }>(
+      `${BASE}/courses/${courseId}/video-lessons/${videoLessonId}/re-render/`,
+      {},
     );
     return data;
   },

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -525,6 +525,18 @@ export const adminAdaptiveCourseService = {
     return data;
   },
 
+  /** Export a deck to .pptx via the Anthropic pptx skill; returns a download URL. */
+  async exportPresentationPptx(
+    courseId: number,
+    presentationId: number,
+  ): Promise<{ presentation_id: number; pptx_url: string }> {
+    const { data } = await apiClient.post<{ presentation_id: number; pptx_url: string }>(
+      `${BASE}/courses/${courseId}/presentations/${presentationId}/export-pptx/`,
+      {},
+    );
+    return data;
+  },
+
   /** Re-queue a video render (recovery for a failed render, or to pick up an edited deck). */
   async rerenderVideoLesson(
     courseId: number,

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -23,6 +23,8 @@ export interface AdaptiveCourseGenConfig {
   content_types?: Array<"quiz" | "article" | "presentation" | "coding" | "video" | "video_lesson">;
   /** Target slides per presentation — only used when content_types includes "presentation". */
   presentation_slide_count?: number;
+  /** Render real charts/diagrams via Claude code execution (vs placeholders); ZDR-gated server-side. */
+  generate_charts?: boolean;
   /** Video lesson (slides+voiceover) knobs — only used when content_types includes "video_lesson". */
   video_voice?: string;
   video_storage?: "s3" | "vimeo";

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -1,6 +1,7 @@
 import apiClient from "@/lib/services/api";
 import type {
   AdaptiveArticleDetail,
+  AdaptivePresentationDetail,
   ArticleTierResult,
   ReadingTier,
 } from "@/lib/services/adaptive-course.service";
@@ -19,7 +20,9 @@ export interface AdaptiveCourseGenConfig {
   se_threshold?: number;
   hint_tokens?: number;
   confidence_prompt_enabled?: boolean;
-  content_types?: Array<"quiz" | "article" | "coding" | "video">;
+  content_types?: Array<"quiz" | "article" | "presentation" | "coding" | "video">;
+  /** Target slides per presentation — only used when content_types includes "presentation". */
+  presentation_slide_count?: number;
   /** AI Coding Mentor knobs — only used when content_types includes "coding". */
   coding_problems_per_submodule?: number;
   coding_language?: string;
@@ -114,11 +117,13 @@ export interface AdaptiveCourseJobTreeSubmodule {
   title: string;
   quiz_ready: boolean;
   article_ready?: boolean;
+  presentation_ready?: boolean;
   coding_ready?: boolean;
   video_ready?: boolean;
   question_count: number;
   coding_problem_count?: number;
   video_count?: number;
+  presentation_count?: number;
 }
 
 export interface AdaptiveCourseJobTreeModule {
@@ -130,7 +135,7 @@ export interface AdaptiveCourseJobTreeModule {
 
 export interface AdaptiveCourseJobLogEntry {
   key: string;
-  kind: "quiz" | "article" | "coding" | "video";
+  kind: "quiz" | "article" | "presentation" | "coding" | "video";
   id: number;
   skill: string;
   difficulty: string;
@@ -144,6 +149,7 @@ export interface AdaptiveCourseJobStats {
   questions_planned: number;
   questions_generated: number;
   articles_generated: number;
+  presentations_generated?: number;
   coding_generated?: number;
   videos_generated?: number;
   by_difficulty: Record<string, number>;
@@ -257,12 +263,20 @@ export interface AdminAdaptiveCourseVideoCompanion {
   is_active: boolean;
 }
 
+export interface AdminAdaptiveCoursePresentation {
+  presentation_id: number;
+  title: string;
+  slide_count: number;
+  is_active: boolean;
+}
+
 export interface AdminAdaptiveCourseSubModule {
   id: number;
   order: number;
   title: string;
   description: string;
   articles: AdminAdaptiveCourseArticle[];
+  presentations?: AdminAdaptiveCoursePresentation[];
   quizzes: AdminAdaptiveCourseQuiz[];
   coding_sets?: AdminAdaptiveCourseCodingSet[];
   video_companions?: AdminAdaptiveCourseVideoCompanion[];
@@ -288,6 +302,7 @@ export interface AdminAdaptiveCourseListItem {
   submodule_count: number;
   quiz_count: number;
   article_count: number;
+  presentation_count?: number;
   coding_count?: number;
   video_count?: number;
   // Cover art — admins always get the URLs (even when hidden) to preview/manage;
@@ -311,7 +326,7 @@ export interface AdminAdaptiveCourseContentHealth {
   submodules_total: number;
   /** e.g. ["quiz"] or ["quiz","article"] — the content types this course expects. */
   expected_content_types: string[];
-  missing: { quiz?: number; article?: number; coding?: number; video?: number };
+  missing: { quiz?: number; article?: number; presentation?: number; coding?: number; video?: number };
   total_missing: number;
   /** True when NON-video content is missing (i.e. LLM regeneration would help). */
   needs_regeneration: boolean;
@@ -470,6 +485,16 @@ export const adminAdaptiveCourseService = {
     const { data } = await apiClient.get<AdaptiveArticleDetail>(
       `${BASE}/courses/${courseId}/articles/${articleId}/`,
       { params: tier ? { tier } : {} },
+    );
+    return data;
+  },
+
+  async getCoursePresentation(
+    courseId: number,
+    presentationId: number,
+  ): Promise<AdaptivePresentationDetail> {
+    const { data } = await apiClient.get<AdaptivePresentationDetail>(
+      `${BASE}/courses/${courseId}/presentations/${presentationId}/`,
     );
     return data;
   },


### PR DESCRIPTION
Front-end for the adaptive-course **presentations** + **AI-voiceover videos** feature. Pairs with `AI-Linc-LMS/ai-linc-backend#289`.

## What's in here
- **Generate UI:** new `Presentation` and `Video lesson` content-type pills, with slides-per-deck, voice, storage (S3/Vimeo), and "render real charts" controls.
- **Learner:** a dependency-free `PresentationViewer` (keyboard nav, progress, narration transcript) + deck route; a `VideoLessonPlayer` (HTML5 `<video>`+captions for S3, Vimeo iframe) + route; both surfaced as steps in the submodule learning path.
- **Admin (course detail):** expandable **deck preview** + **Download .pptx**, **video preview** with render-status badge + **re-render**, and a **render-status poll** that refreshes while a video is pending/rendering (renders finish after the generation job).
- **Services/types:** presentation + video-lesson types, deck-document shape, `getPresentation` / `getCoursePresentation` / `exportPresentationPptx` / `rerenderVideoLesson`.

No new dependencies (uses framer-motion / react-markdown already present).

## Verification
`tsc --noEmit` 0 errors · eslint clean on touched files.

> Note: this branch builds on the instant-nav build-fix commit (`d03e54de`), which isn't yet on `main`, so it's included here — rebase/squash as preferred when merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)