### PR TITLE
Adaptive quiz: live running total + Back/resume with server-anchored timer

### DIFF
--- a/components/adaptive-quiz/AdaptiveQuizLayout.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizLayout.tsx
@@ -100,9 +100,12 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
     ? `${prettySkill(weakest.skill)} is your weakest spot right now — the engine will keep probing here.`
     : undefined;
 
-  const estimatedTotal = Math.round(
-    (session.config.min_questions + session.config.max_questions) / 2,
-  );
+  // Fixed-length quizzes (min == max — now the default) show an exact total ("Q1 / 3"); a true
+  // adaptive range still shows the midpoint estimate ("Q1 / ~3").
+  const fixedLength = session.config.min_questions === session.config.max_questions;
+  const totalQuestions = fixedLength
+    ? session.config.max_questions
+    : Math.round((session.config.min_questions + session.config.max_questions) / 2);
 
   const avgSe = skillRows.length ? skillRows.reduce((a, r) => a + r.se, 0) / skillRows.length : null;
 
@@ -218,7 +221,8 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
             <QuestionCard
               question={q}
               questionNumber={session.question_count + 1}
-              estimatedTotal={estimatedTotal}
+              estimatedTotal={totalQuestions}
+              approxTotal={!fixedLength}
               selectedOption={ctx.selectedOption}
               onSelectOption={ctx.setSelectedOption}
               confidence={ctx.confidence}

--- a/components/adaptive-quiz/AdaptiveQuizLayout.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizLayout.tsx
@@ -108,6 +108,15 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
 
   return (
     <AdaptiveSectionShell>
+      {/* Back leaves WITHOUT ending the session — the per-question clock keeps running server-side
+          and reopening the quiz resumes from here (like the AI coding mentor). */}
+      <Box
+        component="button"
+        onClick={() => router.back()}
+        sx={{ all: "unset", cursor: "pointer", color: "#6366f1", fontWeight: 700, fontSize: "0.85rem", display: "inline-flex", alignItems: "center", gap: 0.5, mb: 1.5 }}
+      >
+        <Icon icon="mdi:arrow-left" width={16} /> Back · your timer keeps running
+      </Box>
       <AdaptiveSectionHero
         chapter="Live · Adaptive Engine"
         title={session.config.quiz_title}
@@ -171,12 +180,14 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
               gap: 1.5,
             }}
           >
-            <LiveTimerRing key={`${q.mcq_id}-${notStarted ? "paused" : "run"}`} resetKey={q.mcq_id} running={!notStarted} />
-            {ctx.sessionPoints > 0 && (
-              <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.25, py: 0.5, borderRadius: 999, bgcolor: "color-mix(in srgb, #7c3aed 10%, transparent)", color: "#6d28d9", fontSize: "0.74rem", fontWeight: 800 }}>
-                <Icon icon="mdi:star-four-points" width={13} /> {ctx.sessionPoints} pts banked
-              </Box>
-            )}
+            <LiveTimerRing key={`${q.mcq_id}-${notStarted ? "paused" : "run"}`} resetKey={q.mcq_id} running={!notStarted} startedAtMs={ctx.questionStartMs} />
+            {/* Running total banked this quiz — always shown, ticks up on every correct answer. */}
+            <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 1.5, py: 0.6, borderRadius: 999, bgcolor: "color-mix(in srgb, #7c3aed 12%, transparent)", color: "#6d28d9", fontSize: "0.82rem", fontWeight: 900 }}>
+              <Icon icon="mdi:star-four-points" width={15} /> {ctx.sessionPoints}
+              <Typography component="span" sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.06em", textTransform: "uppercase", opacity: 0.85 }}>
+                pts this quiz
+              </Typography>
+            </Box>
           </Box>
           {q.points && (
             <LiveQuizPoints
@@ -184,6 +195,7 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
               decay={q.points}
               running={!notStarted}
               hints={ctx.hintRevealed !== null ? 1 : 0}
+              startedAtMs={ctx.questionStartMs}
             />
           )}
           <SkillConfidenceCard

--- a/components/adaptive-quiz/mid/LiveQuizPoints.tsx
+++ b/components/adaptive-quiz/mid/LiveQuizPoints.tsx
@@ -26,15 +26,19 @@ function fmtSecs(s: number): string {
  * Display-only (the scored time is tracked precisely in the session hook); paused until the
  * learner begins, and remounted (key) per question by the caller so it resets to full.
  */
-export function LiveQuizPoints({ decay, running = true, hints = 0 }: { decay: QuestionPointsDecay; running?: boolean; hints?: number }) {
+export function LiveQuizPoints({ decay, running = true, hints = 0, startedAtMs }: { decay: QuestionPointsDecay; running?: boolean; hints?: number; startedAtMs?: number }) {
   const [elapsedMs, setElapsedMs] = useState(0);
 
+  // Measure from the server-anchored start so the live "on offer" matches the server award after a
+  // resume (the clock kept running while away); falls back to mount time.
   useEffect(() => {
     if (!running) return; // paused preview — hold at full points until the learner begins
-    const startedAt = Date.now();
-    const id = window.setInterval(() => setElapsedMs(Date.now() - startedAt), 200);
+    const anchor = startedAtMs ?? Date.now();
+    const tick = () => setElapsedMs(Math.max(0, Date.now() - anchor));
+    tick();
+    const id = window.setInterval(tick, 200);
     return () => window.clearInterval(id);
-  }, [running]);
+  }, [running, startedAtMs]);
 
   const elapsedSec = elapsedMs / 1000;
   // Hint penalty mirrors the engine: each hint shaves decay.hint_penalty off the points.

--- a/components/adaptive-quiz/mid/LiveTimerRing.tsx
+++ b/components/adaptive-quiz/mid/LiveTimerRing.tsx
@@ -12,21 +12,26 @@ interface LiveTimerRingProps {
   /** When false the ring holds at 0:00 (e.g. the pre-"Begin" preview) and only
    *  starts ticking once the learner begins. Defaults to running. */
   running?: boolean;
+  /** Absolute epoch ms (client clock) the question's server clock started. When set, elapsed is
+   *  measured from this anchor — so the timer reflects server time and resumes after leaving. */
+  startedAtMs?: number;
 }
 
 /** Per-question elapsed-time ring. Doesn't enforce a deadline — the engine
  *  uses time-on-question as a signal, not a hard limit. */
-export function LiveTimerRing({ resetKey, expectedSeconds = 60, running = true }: LiveTimerRingProps) {
+export function LiveTimerRing({ resetKey, expectedSeconds = 60, running = true, startedAtMs }: LiveTimerRingProps) {
   const [elapsedMs, setElapsedMs] = useState(0);
 
-  // The caller remounts this (via `key`) on a new question / on begin, so state resets to 0
-  // without a synchronous setState in the effect. While paused we just never start ticking.
+  // Measure from the server-anchored start (so a resumed question shows the time already elapsed);
+  // falls back to mount time. While paused we hold at 0:00 until the learner begins.
   useEffect(() => {
-    if (!running) return; // paused preview — hold at 0:00 until the learner begins
-    const startedAt = Date.now();
-    const id = window.setInterval(() => setElapsedMs(Date.now() - startedAt), 250);
+    if (!running) return;
+    const anchor = startedAtMs ?? Date.now();
+    const tick = () => setElapsedMs(Math.max(0, Date.now() - anchor));
+    tick();
+    const id = window.setInterval(tick, 250);
     return () => window.clearInterval(id);
-  }, [resetKey, running]);
+  }, [resetKey, running, startedAtMs]);
 
   const seconds = Math.floor(elapsedMs / 1000);
   const pct = Math.min(100, (seconds / expectedSeconds) * 100);

--- a/components/adaptive-quiz/mid/QuestionCard.tsx
+++ b/components/adaptive-quiz/mid/QuestionCard.tsx
@@ -11,9 +11,12 @@ import type {
 
 interface QuestionCardProps {
   question: AdaptiveQuestion;
-  /** 1-based — used in the "Q3 / ~6" chip. */
+  /** 1-based — used in the "Q3 / 6" chip. */
   questionNumber: number;
   estimatedTotal: number;
+  /** When the quiz length is a range (min≠max) the total is shown as "~N"; fixed-length quizzes
+   *  (min==max, now the default) show the exact "N". */
+  approxTotal?: boolean;
   selectedOption: string | null;
   onSelectOption: (id: string) => void;
   confidence: ConfidenceLevel | null;
@@ -41,6 +44,7 @@ export function QuestionCard({
   question,
   questionNumber,
   estimatedTotal,
+  approxTotal = true,
   selectedOption,
   onSelectOption,
   confidence,
@@ -77,7 +81,7 @@ export function QuestionCard({
         <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap" }}>
           <Chip
             size="small"
-            label={`Q${questionNumber} / ~${estimatedTotal}`}
+            label={`Q${questionNumber} / ${approxTotal ? "~" : ""}${estimatedTotal}`}
             sx={{ fontWeight: 700, bgcolor: "color-mix(in srgb, #6366f1 12%, transparent)", color: "#6366f1" }}
           />
           <Chip

--- a/hooks/useAdaptiveSession.ts
+++ b/hooks/useAdaptiveSession.ts
@@ -21,6 +21,9 @@ interface UseAdaptiveSessionReturn {
 
   currentQuestion: AdaptiveQuestion | null;
   questionStartedAt: number;
+  /** Absolute epoch ms (client clock) when the current question's server clock started — anchors
+   *  the live timer/points so they reflect server time and survive leave/resume. */
+  questionStartMs: number;
   resetForNextQuestion: () => void;
   selectedOption: string | null;
   setSelectedOption: (id: string | null) => void;
@@ -76,6 +79,10 @@ export function useAdaptiveSession({
 
   const questionStartedAtRef = useRef<number>(Date.now());
   const [questionStartedAt, setQuestionStartedAt] = useState<number>(Date.now());
+  // Client↔server clock offset captured at load (Date.now − server_now), so a question's server
+  // served_at can be expressed on the client clock for the live timer — and the clock keeps running
+  // across leave/resume, matching the server-side decay.
+  const serverClockOffsetRef = useRef<number>(0);
 
   const resetForNextQuestion = useCallback(() => {
     setSelectedOption(null);
@@ -95,6 +102,10 @@ export function useAdaptiveSession({
     try {
       const detail = await adaptiveQuizService.getSession(sessionId);
       setSession(detail);
+      // Seed the running total + clock offset so a resumed session shows the right points and the
+      // per-question timer reflects time already elapsed server-side.
+      setSessionPoints(detail.points_so_far ?? 0);
+      serverClockOffsetRef.current = detail.server_now ? Date.now() - Date.parse(detail.server_now) : 0;
       // Seed thetaHistory from the most-recent response so re-entry shows the right ghost.
       if (detail.responses.length > 1) {
         const prev = detail.responses[detail.responses.length - 2];
@@ -125,6 +136,11 @@ export function useAdaptiveSession({
   const hintsRemaining = session
     ? Math.max(0, session.config.hint_tokens - session.hints_used)
     : 0;
+  // Server-anchored start of the current question on the client clock (falls back to the client
+  // mount time for legacy sessions pinned before served_at existed).
+  const questionStartMs = currentQuestion?.served_at
+    ? Date.parse(currentQuestion.served_at) + serverClockOffsetRef.current
+    : questionStartedAt;
 
   const submit = useCallback(async (): Promise<SubmitAnswerResponse | null> => {
     if (!session || !currentQuestion || !selectedOption) return null;
@@ -214,6 +230,7 @@ export function useAdaptiveSession({
       session,
       currentQuestion,
       questionStartedAt,
+      questionStartMs,
       resetForNextQuestion,
       selectedOption,
       setSelectedOption,
@@ -239,6 +256,7 @@ export function useAdaptiveSession({
       session,
       currentQuestion,
       questionStartedAt,
+      questionStartMs,
       resetForNextQuestion,
       selectedOption,
       confidence,

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -26,6 +26,9 @@ export interface AdaptiveQuestion {
   selector_rationale: string;
   predicted_p_correct: number; // 0..1
   points?: QuestionPointsDecay | null;
+  /** ISO time the server served this question — the per-question clock runs off this (continues
+   *  while away), so the live timer/points resume correctly. */
+  served_at?: string | null;
 }
 
 /** Live completion of a result-page remediation path (GET .../remediation-progress/). */
@@ -178,6 +181,10 @@ export interface AdaptiveSessionDetail {
   ability_state: Record<string, number>;
   se_state: Record<string, number>;
   pending_question: AdaptiveQuestion | null;
+  /** Server clock at response time — anchors the per-question timer to the server. */
+  server_now?: string | null;
+  /** Sum of points earned so far this session — seeds the live running total on load/resume. */
+  points_so_far?: number;
   ai_narration: AdaptiveAINarration | null;
   ai_narration_generated_at: string | null;
   config: {


### PR DESCRIPTION
Pairs with BE ai-linc-backend `feat/adaptive-quiz-points-timer`.

- **Live running total** — seeds `sessionPoints` from `session.points_so_far` on load and shows a persistent **"N pts this quiz"** HUD that ticks up on every correct answer (was only shown when >0, labelled "banked"). Points auto-reflect the new 10/20/30 via `q.points`.
- **Server-anchored timer** — `LiveTimerRing` + `LiveQuizPoints` measure elapsed from the question's server `served_at` (via `session.server_now` → a client/server clock offset), so the live timer and "points on offer" reflect server time and **resume correctly after leaving** (the BE awards off the same `served_at`).
- **Back button** — leaves the quiz **without ending it**; the per-question clock keeps running server-side and reopening the quiz resumes from the same question (`start_session` reuses the active session).

types: `served_at` on `AdaptiveQuestion`; `server_now` + `points_so_far` on `AdaptiveSessionDetail`.

Verified: tsc + eslint clean, full `next build` green (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)