### PR TITLE
Quiz results: redesign Skill mastery so few skills don't leave empty space

### DIFF
--- a/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
+++ b/app/adaptive-quizzes/session/[sessionId]/results/page.tsx
@@ -297,7 +297,12 @@ export default function AdaptiveQuizResultsPage() {
                   <Box
                     sx={{
                       display: "grid",
-                      gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 1.4fr) minmax(0, 1fr)" },
+                      // Few skills → stack full-width (skill mastery strip over the path) so a short
+                      // skill list never leaves a tall empty column beside the remediation path.
+                      gridTemplateColumns:
+                        skillMasteryReady && (narration.skill_mastery?.length ?? 0) <= 3
+                          ? "1fr"
+                          : { xs: "1fr", lg: "minmax(0, 1.4fr) minmax(0, 1fr)" },
                       gap: 2.5,
                       alignItems: "flex-start",
                     }}

--- a/components/adaptive-quiz/results/SkillMasteryHeatmap.tsx
+++ b/components/adaptive-quiz/results/SkillMasteryHeatmap.tsx
@@ -73,7 +73,9 @@ export function SkillMasteryHeatmap({ skills }: SkillMasteryHeatmapProps) {
         </Stack>
       </Stack>
 
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+      {/* Responsive auto-fit grid: many skills pack into 2–3 columns (compact, no tall single
+          column); 1–2 skills stretch to fill the width instead of leaving a lonely short card. */}
+      <Box sx={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 1.25 }}>
         {skills.map((row) => {
           const color = BAND_COLOR[row.band] ?? "#6366f1";
           const hasBaseline = row.delta_pct !== null && row.delta_pct !== undefined;


### PR DESCRIPTION
## Problem
On the quiz results page, **Skill mastery** was a fixed `1.4fr` column beside the remediation path. With only 1–2 skills it became a short card next to the (much taller) "Your next 15 minutes" path → a big empty column (see the 1-skill case).

## Fix
- **`SkillMasteryHeatmap`** now lays skills out in a **responsive auto-fit grid** (`repeat(auto-fit, minmax(280px, 1fr))`): many skills pack into 2–3 compact columns (no more single tall stack), and a lone skill stretches to fill the width instead of sitting as a short card.
- **Results page** stacks **full-width** (skill-mastery strip over the path) when there are **≤3 skills**, so there's no empty column; it keeps the side-by-side two-column layout only when there are enough skills to fill it.

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)