### PR TITLE
Mock interview: self-view webcam + reliable speech capture

### DIFF
--- a/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
@@ -14,6 +14,7 @@ import type { InterviewResult } from "@/lib/types/adaptive-journey";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { useSpeechToText } from "@/lib/hooks/useSpeechToText";
 import { readSttEngine } from "@/lib/utils/stt-engine";
+import { registerMediaStream } from "@/lib/utils/media-stream-registry";
 import { AIAvatar } from "@/components/mock-interview/AIAvatar";
 import { MicWaveform } from "@/components/mock-interview/MicWaveform";
 import { PauseProgressBar } from "@/components/mock-interview/PauseProgressBar";
@@ -89,6 +90,7 @@ function CourseInterviewInner() {
   const [interim, setInterim] = useState("");
   const [typing, setTyping] = useState(false);
   const [elapsed, setElapsed] = useState(0);
+  const [selfViewOn, setSelfViewOn] = useState(false);
 
   const respRef = useRef<InterviewResponse[]>([]);
   const startedAtRef = useRef<number>(0);
@@ -103,6 +105,25 @@ function CourseInterviewInner() {
   // Mic-level analyser (the reliable silence signal, like the platform interview).
   const audioCtxRef = useRef<AudioContext | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
+  // Self-view webcam — a small passive mirror of the candidate (no face detection), so the
+  // call feels two-sided. Camera is best-effort; denial never blocks the interview.
+  const selfViewRef = useRef<HTMLVideoElement | null>(null);
+  const selfViewStreamRef = useRef<MediaStream | null>(null);
+  // Callback ref: the <video> only mounts once selfViewOn flips true (after the stream is
+  // acquired), so attach the stream the moment the element exists.
+  const attachSelfView = useCallback((el: HTMLVideoElement | null) => {
+    selfViewRef.current = el;
+    if (el && selfViewStreamRef.current) {
+      el.srcObject = selfViewStreamRef.current;
+      void el.play().catch(() => {});
+    }
+  }, []);
+  const stopSelfView = useCallback(() => {
+    selfViewStreamRef.current?.getTracks().forEach((t) => t.stop());
+    selfViewStreamRef.current = null;
+    if (selfViewRef.current) selfViewRef.current.srcObject = null;
+    setSelfViewOn(false);
+  }, []);
   const micRafRef = useRef<number>(0);
   const micLevelRef = useRef(0);        // 0..1 loudness → MicWaveform
   const pauseProgressRef = useRef(0);   // 0..1 toward auto-advance → PauseProgressBar
@@ -204,7 +225,7 @@ function CourseInterviewInner() {
     }
   }, []);
 
-  useEffect(() => () => stopMicAnalyser(), [stopMicAnalyser]);
+  useEffect(() => () => { stopMicAnalyser(); stopSelfView(); }, [stopMicAnalyser, stopSelfView]);
 
   // ---- voice: student answers continuously (browser STT + Whisper fallback). STT is
   //      PAUSED while the AI speaks, so it never fights the interviewer's voice. ----
@@ -255,6 +276,7 @@ function CourseInterviewInner() {
       window.speechSynthesis?.cancel();
       stt.stop();
       stopMicAnalyser();
+      stopSelfView();
       await mockInterviewService.submitInterview(interviewId, {
         transcript: {
           responses: respRef.current,
@@ -294,7 +316,7 @@ function CourseInterviewInner() {
       setEvaluating(false);
       submittingRef.current = false;
     }
-  }, [busy, courseId, interviewId, stt, stopMicAnalyser]);
+  }, [busy, courseId, interviewId, stt, stopMicAnalyser, stopSelfView]);
 
   const sendAnswer = useCallback(async () => {
     if (sendingRef.current || busy || !question) return;
@@ -393,6 +415,22 @@ function CourseInterviewInner() {
       // permission + audio unlock, so the AudioContext isn't created suspended).
       stt.start();
       void startMicAnalyser();
+      // Best-effort self-view (a small mirror of the candidate, like a real video call).
+      // Acquired in the same Begin gesture so the camera prompt rides the click. Failure or
+      // denial must NEVER block the interview — it's purely a presence cue.
+      void (async () => {
+        try {
+          const cam = await navigator.mediaDevices.getUserMedia({
+            video: { width: { ideal: 640 }, height: { ideal: 480 }, facingMode: "user" },
+            audio: false,
+          });
+          selfViewStreamRef.current = cam;
+          registerMediaStream(cam);
+          setSelfViewOn(true); // renders the tile → the callback ref attaches the stream
+        } catch {
+          /* no camera / denied — interview continues without the self-view */
+        }
+      })();
       askQuestion(d.current_question ?? null);
     } catch (e) {
       const code = (e as { response?: { status?: number } })?.response?.status;
@@ -591,6 +629,15 @@ function CourseInterviewInner() {
             <Chip size="small" icon={<Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: phaseColor }} />} label={phase}
               sx={{ color: phaseColor, bgcolor: "rgba(255,255,255,0.06)", fontWeight: 800, fontSize: "0.72rem" }} />
           </Stack>
+
+          {/* Self-view — a small mirror of the candidate under the interviewer, like a real call.
+              Only shown once the camera is granted; denial leaves the layout unchanged. */}
+          {selfViewOn && (
+            <Box sx={{ mt: 1.5, alignSelf: "flex-end", width: { xs: 120, md: 160 }, aspectRatio: "4 / 3", borderRadius: 2, overflow: "hidden", border: "1px solid rgba(255,255,255,0.15)", position: "relative", bgcolor: "#020617", boxShadow: "0 8px 24px -16px rgba(0,0,0,0.8)" }}>
+              <video ref={attachSelfView} autoPlay muted playsInline style={{ width: "100%", height: "100%", objectFit: "cover", transform: "scaleX(-1)" }} />
+              <Box sx={{ position: "absolute", bottom: 4, left: 6, px: 0.75, py: 0.15, borderRadius: 1, bgcolor: "rgba(2,6,23,0.72)", fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.3, color: "rgba(255,255,255,0.85)" }}>You</Box>
+            </Box>
+          )}
 
           <Box sx={{ flex: 1 }} />
 

--- a/lib/hooks/useCameraRouteGuard.ts
+++ b/lib/hooks/useCameraRouteGuard.ts
@@ -12,6 +12,7 @@ const ALLOWED_CAMERA_ROUTES = [
   "/assessments/[slug]/device-check",
   "/mock-interview/[id]/take",
   "/mock-interview/[id]/device-check",
+  "/adaptive-courses/[courseId]/interview/[interviewId]",
 ];
 
 /**
@@ -29,6 +30,7 @@ function isCameraAllowedRoute(pathname: string): boolean {
     /^\/assessments\/[^/]+\/device-check$/,
     /^\/mock-interview\/[^/]+\/take$/,
     /^\/mock-interview\/[^/]+\/device-check$/,
+    /^\/adaptive-courses\/[^/]+\/interview\/[^/]+$/,
   ];
 
   return patterns.some((pattern) => pattern.test(pathname));

--- a/lib/hooks/useSpeechToText.ts
+++ b/lib/hooks/useSpeechToText.ts
@@ -45,7 +45,6 @@ const WHISPER_HALLUCINATION_PATTERNS: RegExp[] = [
 interface SpeechRecognitionInstance {
   start: () => void;
   stop: () => void;
-  state: string;
   continuous: boolean;
   interimResults: boolean;
   lang: string;
@@ -192,6 +191,10 @@ export function useSpeechToText(
   // Guard so a watchdog tick and a natural rotation don't both spin up a
   // second MediaRecorder while ensureWhisperRunning is mid-acquisition.
   const whisperStartingRef = useRef(false);
+  // Liveness of the native recognizer, maintained in onstart/onend. The hand-rolled
+  // SpeechRecognition has no real `.state`, so this — plus result-freshness — is how the
+  // watchdog tells a live recognizer from one that has silently died/wedged.
+  const recognitionRunningRef = useRef(false);
 
   useEffect(() => {
     onFinalRef.current = onFinal;
@@ -280,6 +283,7 @@ export function useSpeechToText(
       if (preferWhisper && !whisperFailedRef.current) {
         whisperActiveRef.current = true;
         setMode("whisper-only");
+        setIsListening(true); // Whisper is the active transcriber now — keep the "Listening" affordance lit.
         // Kick Whisper on in the background. The recorder will start producing chunks
         // every WHISPER_CHUNK_MS and pipe transcripts through the same onFinal callback.
         void startWhisperRecording();
@@ -335,6 +339,7 @@ export function useSpeechToText(
     rec.interimResults = true;
     rec.lang = lang;
     rec.onstart = () => {
+      recognitionRunningRef.current = true;
       lastSuccessfulResultAtRef.current = Date.now();
     };
     rec.onresult = (event: SpeechRecognitionResultEvent) => {
@@ -375,8 +380,21 @@ export function useSpeechToText(
         setMode(preferWhisper ? "whisper-only" : "unavailable");
         return;
       }
-      // Silent / transient — let onend reschedule, don't surface anything.
+      // Silent / transient — Web Speech auto-stops on silence and fires these constantly.
+      // Don't bump the error counter (these aren't real failures) but DO ensure we come back:
+      // onend normally restarts us, but if a browser fires onerror WITHOUT a following onend
+      // (or onend refuses), a short one-shot restart keeps us listening. Uses a fixed 400ms
+      // delay (NOT scheduleRetry), so silence never consumes the retry budget or wrongly
+      // promotes to Whisper/typing.
       if (errType === "no-speech" || errType === "aborted") {
+        if (!retryTimeoutRef.current && !pausedRef.current && wantsListeningRef.current && !browserSttDisabledRef.current) {
+          retryTimeoutRef.current = setTimeout(() => {
+            retryTimeoutRef.current = null;
+            const r = recognitionRef.current;
+            if (!r || !wantsListeningRef.current || pausedRef.current || browserSttDisabledRef.current) return;
+            tryStartRecognition(r);
+          }, 400);
+        }
         return;
       }
       // network / audio-capture / language-not-supported / generic →
@@ -421,14 +439,18 @@ export function useSpeechToText(
       scheduleRetry();
     };
     rec.onend = () => {
+      recognitionRunningRef.current = false;
       if (!wantsListeningRef.current || pausedRef.current || browserSttDisabledRef.current) return;
-      // If we ended without an error or are between attempts, restart promptly.
-      // The retry scheduler handles backoff for error cases; here, we cover the
-      // normal "session ended due to silence" path.
+      // Normal "session ended due to silence" path → restart promptly.
       if (consecutiveErrorsRef.current === 0) {
         tryStartRecognition(rec);
+      } else if (!retryTimeoutRef.current) {
+        // Counter is nonzero but no backoff timer is pending (e.g. a no-speech/aborted
+        // early-returned after a prior transient error left the counter > 0). Don't strand
+        // recognition dead — arm a retry instead of doing nothing.
+        scheduleRetry();
       }
-      // else: scheduleRetry will call rec.start() at the right time
+      // else: a scheduleRetry backoff is already pending and will call rec.start().
     };
     recognitionRef.current = rec;
     try {
@@ -651,6 +673,7 @@ export function useSpeechToText(
       browserSttDisabledRef.current = true;
       whisperActiveRef.current = true;
       setMode("whisper-only");
+      setIsListening(true); // Whisper-only mode — light the "Listening" affordance so it's truthful.
       startWhisperRecording();
       return;
     }
@@ -679,6 +702,7 @@ export function useSpeechToText(
       browserSttDisabledRef.current = true;
       whisperActiveRef.current = true;
       setMode("whisper-only");
+      setIsListening(true); // Whisper-only mode — light the "Listening" affordance so it's truthful.
       startWhisperRecording();
       return;
     }
@@ -741,14 +765,20 @@ export function useSpeechToText(
     if (!continuous || !startedRef.current) return;
     const id = setInterval(() => {
       if (pausedRef.current) return;
-      // Browser STT
-      if (!browserSttDisabledRef.current && recognitionRef.current) {
-        try {
-          const state = recognitionRef.current.state;
-          if (state === "stopped" || state === "inactive") {
-            tryStartRecognition(recognitionRef.current);
-          }
-        } catch {}
+      // Browser STT — the hand-rolled SpeechRecognition has no real `.state`, so detect a
+      // dead-or-deaf recognizer from our onstart/onend liveness flag + result-freshness.
+      // Skip while a scheduleRetry backoff is pending so the watchdog never fights it.
+      if (!browserSttDisabledRef.current && recognitionRef.current && wantsListeningRef.current && !retryTimeoutRef.current) {
+        const stale = Date.now() - lastSuccessfulResultAtRef.current > 8000; // running but deaf >8s
+        if (recognitionRunningRef.current && stale) {
+          // Running but silently deaf — stop() forces a clean onend → restart cycle.
+          try { recognitionRef.current.stop(); } catch {}
+        } else if (!recognitionRunningRef.current) {
+          // Not running and nothing scheduled to restart it — the watchdog IS the recovery,
+          // so clear the error counter and restart directly.
+          consecutiveErrorsRef.current = 0;
+          tryStartRecognition(recognitionRef.current);
+        }
       }
       // Whisper — only if it's been PROMOTED to active fallback. Whisper stays on hold
       // when browser STT is healthy, so the watchdog doesn't spin it up speculatively.


### PR DESCRIPTION
**Self-view webcam.** A small mirrored picture-in-picture of the candidate now sits under the interviewer video so the call feels two-sided. Camera is acquired on Begin (best-effort — denial never blocks the interview) and released on submit/unmount. The adaptive interview route is allowlisted in the camera route guard so the global guard doesn't kill the stream.

**Reliable speech capture (RCA + fix).** "Listening" was shown but speech often wasn't captured. Adversarially-verified causes: the Web Speech API watchdog probed a non-existent `.state` property (dead code), and `no-speech`/`aborted` errors early-returned without rescheduling — so a silently-dead or silence-auto-stopped recognizer was never restarted.
- Real onstart/onend liveness + result-freshness watchdog that force-cycles a dead/deaf recognizer.
- `no-speech`/`aborted` schedule a short restart (without burning the retry budget); `onend` self-heals even with a nonzero error counter.
- The "Listening" indicator lights up in Whisper-only mode too.

tsc + next build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)