### PR TITLE
Dashboard: v2 for all students + legacy-upgrade banner + reliable Readiness/Skill cards

### DIFF
--- a/components/courses/AdaptiveCourseIntroModal.tsx
+++ b/components/courses/AdaptiveCourseIntroModal.tsx
@@ -16,7 +16,7 @@ const STEPS: { icon: string; accent: string; title: string; body: string }[] = [
     icon: "mdi:auto-awesome",
     accent: "#6366f1",
     title: "Meet Adaptive Courses",
-    body: "A brand-new way to learn — find it under Courses → Adaptive Course. The course adjusts itself to you instead of one-size-fits-all.",
+    body: "A brand-new way to learn — find it under Courses → Adaptive Course. The course adjusts itself to you instead of one-size-fits-all. It's a fresh start: your progress begins at 0 and earlier (non-adaptive) course progress doesn't transfer.",
   },
   {
     icon: "mdi:target-account",

--- a/components/courses/AdaptiveCoursePromoBanner.tsx
+++ b/components/courses/AdaptiveCoursePromoBanner.tsx
@@ -41,10 +41,11 @@ export function AdaptiveCoursePromoBanner({ course, onExplore, onDismiss }: Prop
       </Box>
       <Box sx={{ flex: 1, minWidth: 220 }}>
         <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.2 }}>
-          New: Adaptive Courses are here ✨
+          Your learning experience just got an upgrade ✨
         </Typography>
         <Typography sx={{ fontSize: "0.85rem", opacity: 0.95, mt: 0.25 }}>
-          Your learning now adapts to you in real time — questions, difficulty and pacing meet you at your level.
+          We&apos;ve moved to Adaptive Courses that adjust to your skill level as you go. Heads up: your progress
+          starts fresh at 0 — your earlier course history doesn&apos;t carry over.
         </Typography>
       </Box>
       <Button

--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Stack, Typography } from "@mui/material";
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import {
   useHideLeaderboardView,
   useIsCourseEnabled,
-  useIsScorecardEnabled,
 } from "@/lib/contexts/ClientInfoContext";
 import { DashboardContent } from "@/components/dashboard/DashboardContent";
 import { useDashboardData } from "@/hooks/useDashboardData";
@@ -21,18 +22,43 @@ import { LeaderboardPanel } from "./LeaderboardPanel";
 import { ContinueCoursesRow } from "./ContinueCoursesRow";
 import { DashboardSkeleton } from "./DashboardSkeleton";
 
-/** Degraded view for learners with no adaptive courses — the existing dashboard
- *  (regular-course grid + streak + leaderboard). Mounts useDashboardData only here. */
-function DegradedDashboard() {
+/** Legacy fallback — ONLY for tenants WITHOUT the adaptive feature (the dashboard endpoint 403s) or
+ *  an unrecoverable load failure. Every adaptive-enabled tenant gets DashboardV2 (the full layout or
+ *  the empty state below), so this old grid is no longer the default for normal students. */
+function LegacyFallback() {
   const { loading, courses } = useDashboardData();
-  // streak props are deprecated on DashboardContent (StreakTable fetches the real streak
-  // from the API); don't pass placeholder values.
+  // streak props are deprecated on DashboardContent (StreakTable fetches the real streak); don't pass them.
   return <DashboardContent courses={courses} loading={loading} />;
+}
+
+/** v2 empty state for students on an adaptive-enabled tenant who aren't in any adaptive course yet
+ *  (including legacy-only students — the AdaptivePromo banner mounted above this nudges them to
+ *  start). Keeps the v2 chrome instead of dropping back to the old dashboard. */
+function EmptyAdaptiveDashboard({ data, hideLeaderboard }: { data: LearnerDashboard | null; hideLeaderboard: boolean }) {
+  const { push } = useInstantNavigation();
+  return (
+    <Stack spacing={2.5}>
+      {data && <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />}
+      <Box sx={{ p: { xs: 3, md: 5 }, borderRadius: 4, textAlign: "center", border: "1px solid #eef2f7", bgcolor: "#faf9ff" }}>
+        <Box sx={{ width: 56, height: 56, mx: "auto", mb: 2, borderRadius: "50%", display: "grid", placeItems: "center", background: "linear-gradient(135deg,#7c3aed,#a855f7)" }}>
+          <Icon icon="mdi:rocket-launch-outline" width={28} color="#fff" />
+        </Box>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.15rem", color: "#0f172a" }}>Start your adaptive journey</Typography>
+        <Typography sx={{ color: "#64748b", mt: 1, mb: 2.5, maxWidth: 460, mx: "auto" }}>
+          You&apos;re not in an adaptive course yet. Adaptive courses adjust to your skill level as you learn — pick one to begin.
+        </Typography>
+        <Button onClick={() => push("/adaptive-courses")} variant="contained" endIcon={<Icon icon="mdi:arrow-right" width={18} />}
+          sx={{ textTransform: "none", fontWeight: 800, borderRadius: 2, px: 3, py: 1.1, background: "linear-gradient(135deg,#7c3aed,#db2777)" }}>
+          Browse adaptive courses
+        </Button>
+      </Box>
+      {!hideLeaderboard && data?.leaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
+    </Stack>
+  );
 }
 
 export function DashboardV2() {
   const hideLeaderboard = useHideLeaderboardView();
-  const scorecardEnabled = useIsScorecardEnabled();
   const courseEnabled = useIsCourseEnabled();
 
   const [data, setData] = useState<LearnerDashboard | null>(null);
@@ -48,10 +74,11 @@ export function DashboardV2() {
       .then((d) => { if (!cancelled) setData(d); })
       .catch((e) => {
         if (cancelled) return;
-        // Tenants without the adaptive feature 403 here — that's not an error, just fall
-        // back to the regular-course dashboard. Reserve the error banner for real failures.
+        // Feature-off tenants 403/404; a transient 5xx or a network error (no status) shouldn't blank
+        // the page with a scary banner — degrade to the legacy grid instead. Reserve the error text
+        // for explicit client errors we genuinely can't recover from.
         const status = (e as { response?: { status?: number } })?.response?.status;
-        if (status === 403 || status === 404) setDegraded(true);
+        if (status === 403 || status === 404 || !status || status >= 500) setDegraded(true);
         else setError(e instanceof Error ? e.message : "Failed to load your dashboard.");
       })
       .finally(() => { if (!cancelled) setLoading(false); });
@@ -60,40 +87,37 @@ export function DashboardV2() {
 
   if (loading) return <DashboardSkeleton hideLeaderboard={hideLeaderboard} />;
   if (error) return <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center", fontWeight: 600 }}>{error}</Typography>;
-  if (degraded || !data || data.courses.length === 0) return <DegradedDashboard />;
+  // Only tenants without the adaptive feature (403/404) or a hard failure see the old dashboard.
+  if (degraded) return <LegacyFallback />;
+  // Everyone else gets v2 — even with zero adaptive courses (legacy-only / brand-new students).
+  if (!data || data.courses.length === 0) return <EmptyAdaptiveDashboard data={data} hideLeaderboard={hideLeaderboard} />;
 
   const activeCourse = data.courses.find((c) => c.id === activeCourseId) ?? data.courses[0];
-  const showSidebar =
-    (scorecardEnabled) || activeCourse?.certificate.enabled || courseEnabled || !hideLeaderboard;
 
   return (
-    // Two columns like the mockup: AI briefing + stats + readiness + continue on the
-    // left; skill profile + certificate + up-next + leaderboard on the right.
-    <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: showSidebar ? "minmax(0,1fr) 390px" : "1fr" }, gap: 2.5, alignItems: "start" }}>
+    // Two columns like the mockup: AI briefing + stats + readiness + continue on the left;
+    // skill profile + certificate + up-next + leaderboard on the right. Course Readiness and Skill
+    // Profile are core to the adaptive dashboard, so they render whenever there's an active course
+    // (no separate feature flag — that mismatch was what made them intermittently disappear).
+    <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5, alignItems: "start" }}>
       <Box sx={{ minWidth: 0 }}>
         {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
         <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
-        {scorecardEnabled && (
-          <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
-        )}
+        <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
         {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
       </Box>
 
-      {showSidebar && (
-        <Stack spacing={2}>
-          {scorecardEnabled && (
-            <SkillProfilePanel
-              courses={data.courses}
-              activeCourseId={activeCourse?.id ?? null}
-              onSelect={setActiveCourseId}
-              crossCourseMastery={data.aggregate.overallMasteryAvg}
-            />
-          )}
-          {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
-          {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
-          {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
-        </Stack>
-      )}
+      <Stack spacing={2}>
+        <SkillProfilePanel
+          courses={data.courses}
+          activeCourseId={activeCourse?.id ?? null}
+          onSelect={setActiveCourseId}
+          crossCourseMastery={data.aggregate.overallMasteryAvg}
+        />
+        {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
+        {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
+        {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
+      </Stack>
     </Box>
   );
 }

--- a/components/dashboard/v2/SkillProfilePanel.tsx
+++ b/components/dashboard/v2/SkillProfilePanel.tsx
@@ -122,7 +122,7 @@ export function SkillProfilePanel({
           })}
         </Stack>
       ) : (
-        <Typography sx={{ fontSize: "0.8rem", color: "#94a3b8", py: 1 }}>Take the calibration to map your skills here.</Typography>
+        <Typography sx={{ fontSize: "0.8rem", color: "#94a3b8", py: 1 }}>Complete course quizzes to map your skills here.</Typography>
       )}
 
       <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "#f5f3ff" }}>


### PR DESCRIPTION
**v2 for everyone + retire the old dashboard.** Students with no adaptive courses (legacy-only / brand-new) now get a v2 empty state ("Start your adaptive journey") instead of the old dashboard. The old dashboard remains only as a fallback for tenants without the adaptive feature (the endpoint 403s) or a hard failure.

**Reliable Course Readiness + Skill Profile (RCA fix).** They "sometimes" didn't appear because they were gated on a separate FE `scorecard` feature flag that newer wizard-provisioned tenants never received, while the backend serves the data on a different flag — so a fully-populated payload rendered neither card. They now render whenever there's course data. A transient 5xx / network error degrades gracefully instead of a full-page red banner. (Pairs with the backend per-course resilience PR.)

**Legacy-course upgrade banner.** The existing AdaptivePromo banner + intro modal (already mounted, already detects legacy-only students) now explain the move to adaptive courses and that **progress starts fresh at 0**.

tsc + next build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)