### PR TITLE
fix(requiz) follow-ups: type accuracy + drop dead outcome fetch + passive note steps

### DIFF
--- a/components/adaptive-quiz/results/RemediationPathCard.tsx
+++ b/components/adaptive-quiz/results/RemediationPathCard.tsx
@@ -41,6 +41,10 @@ function prettySkill(s: string): string {
 const isRequiz = (step: RemediationStep) =>
   step.content_type === "requiz" || step.action_kind === "requiz";
 
+// An AI-fallback "note" (standalone quiz, no course content to link) is informational only — it
+// has no deep link and no action, so it renders as a passive note rather than a dead button.
+const isNote = (step: RemediationStep) => step.content_type === "note";
+
 /** Deep-link to the EXACT course item a step maps to, or null when it's the follow-up
  *  re-quiz (spawned via onStartPath). Video/article link straight to the item; only when the
  *  specific id is missing do we fall back to the submodule page. */
@@ -164,6 +168,7 @@ export function RemediationPathCard({ steps, sessionId, onStartPath }: Remediati
         {steps.map((step) => {
           const done = !!doneByStep[step.step];
           const reqStep = isRequiz(step);
+          const noteStep = isNote(step);
           const locked = reqStep && !done && requizLocked;
           return (
             <Box
@@ -172,8 +177,12 @@ export function RemediationPathCard({ steps, sessionId, onStartPath }: Remediati
               variants={fadeRise}
               sx={{
                 display: "flex", alignItems: "flex-start", gap: 1.5, p: 1.5, borderRadius: 3,
-                bgcolor: done ? "color-mix(in srgb, #10b981 9%, white)" : "color-mix(in srgb, white 60%, transparent)",
-                border: `1px solid ${done ? "color-mix(in srgb, #10b981 32%, transparent)" : "color-mix(in srgb, #a855f7 18%, transparent)"}`,
+                bgcolor: noteStep
+                  ? "color-mix(in srgb, #6366f1 6%, white)"
+                  : done ? "color-mix(in srgb, #10b981 9%, white)" : "color-mix(in srgb, white 60%, transparent)",
+                border: `1px solid ${noteStep
+                  ? "color-mix(in srgb, #6366f1 22%, transparent)"
+                  : done ? "color-mix(in srgb, #10b981 32%, transparent)" : "color-mix(in srgb, #a855f7 18%, transparent)"}`,
                 opacity: locked ? 0.65 : 1,
                 transition: "background-color .25s, border-color .25s, opacity .25s",
               }}
@@ -182,14 +191,16 @@ export function RemediationPathCard({ steps, sessionId, onStartPath }: Remediati
                 sx={{
                   width: 36, height: 36, borderRadius: 999, display: "flex", alignItems: "center",
                   justifyContent: "center", color: "white", flexShrink: 0,
-                  background: done
-                    ? "linear-gradient(135deg, #10b981 0%, #22c55e 100%)"
-                    : locked
-                      ? "color-mix(in srgb, #64748b 55%, white)"
-                      : "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
+                  background: noteStep
+                    ? "linear-gradient(135deg, #6366f1 0%, #818cf8 100%)"
+                    : done
+                      ? "linear-gradient(135deg, #10b981 0%, #22c55e 100%)"
+                      : locked
+                        ? "color-mix(in srgb, #64748b 55%, white)"
+                        : "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
                 }}
               >
-                <Icon icon={done ? "mdi:check" : locked ? "mdi:lock-outline" : (ACTION_ICON[step.action_kind] ?? "mdi:book-open-page-variant-outline")} width={18} />
+                <Icon icon={noteStep ? "mdi:information-outline" : done ? "mdi:check" : locked ? "mdi:lock-outline" : (ACTION_ICON[step.action_kind] ?? "mdi:book-open-page-variant-outline")} width={18} />
               </Box>
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography sx={{ fontSize: "0.95rem", fontWeight: 800, color: "text.primary", lineHeight: 1.3 }}>
@@ -201,7 +212,7 @@ export function RemediationPathCard({ steps, sessionId, onStartPath }: Remediati
                 <Box sx={{ display: "flex", gap: 1, mt: 0.75, flexWrap: "wrap" }}>
                   <Chip label={`${step.est_minutes} min`} />
                   <Chip label={prettySkill(step.target_skill)} />
-                  <Chip label={reqStep ? "RE-QUIZ" : step.action_kind.toUpperCase()} accent />
+                  <Chip label={reqStep ? "RE-QUIZ" : noteStep ? "NOTE" : step.action_kind.toUpperCase()} accent />
                 </Box>
                 {locked && (
                   <Typography sx={{ fontSize: "0.72rem", color: "#b45309", fontWeight: 700, mt: 0.75 }}>
@@ -209,21 +220,28 @@ export function RemediationPathCard({ steps, sessionId, onStartPath }: Remediati
                   </Typography>
                 )}
               </Box>
-              <StepButton
-                done={done}
-                locked={locked}
-                reqStep={reqStep}
-                requizActive={requizActive}
-                actionKind={step.action_kind}
-                onClick={() => {
-                  if (locked) return;
-                  if (done && reqStep && requizSessionId) {
-                    router.push(`/adaptive-quizzes/session/${requizSessionId}/results`);
-                    return;
-                  }
-                  openStep(step);
-                }}
-              />
+              {/* A note carries no link + no action — show a passive "Reflect" hint, not a dead button. */}
+              {noteStep ? (
+                <Typography sx={{ alignSelf: "center", flexShrink: 0, px: 1.25, fontSize: "0.72rem", fontWeight: 700, color: "text.secondary" }}>
+                  Reflect &amp; move on
+                </Typography>
+              ) : (
+                <StepButton
+                  done={done}
+                  locked={locked}
+                  reqStep={reqStep}
+                  requizActive={requizActive}
+                  actionKind={step.action_kind}
+                  onClick={() => {
+                    if (locked) return;
+                    if (done && reqStep && requizSessionId) {
+                      router.push(`/adaptive-quizzes/session/${requizSessionId}/results`);
+                      return;
+                    }
+                    openStep(step);
+                  }}
+                />
+              )}
             </Box>
           );
         })}

--- a/lib/services/adaptive-quiz.service.ts
+++ b/lib/services/adaptive-quiz.service.ts
@@ -2,7 +2,6 @@ import apiClient from "./api";
 import type {
   AdaptiveSessionDetail,
   RemediationProgress,
-  RequizOutcome,
   StartSessionResponse,
   SubmitAnswerResponse,
 } from "@/lib/types/adaptive-quiz";
@@ -48,13 +47,6 @@ export const adaptiveQuizService = {
   async getRemediationProgress(sessionId: string): Promise<RemediationProgress> {
     const { data } = await apiClient.get<RemediationProgress>(
       `${BASE}/sessions/${sessionId}/remediation-progress/`,
-    );
-    return data;
-  },
-
-  async getRequizOutcome(sessionId: string): Promise<RequizOutcome> {
-    const { data } = await apiClient.get<RequizOutcome>(
-      `${BASE}/sessions/${sessionId}/requiz-outcome/`,
     );
     return data;
   },

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -38,21 +38,6 @@ export interface RemediationProgress {
   requiz: { done: boolean; session_id: string | null; status: string | null };
 }
 
-/** Re-quiz vs its source attempt on the targeted skill (GET .../requiz-outcome/).
- *  Verdict derives from the same rule as the results-page outcome banner, so the two never
- *  disagree; `first_measure` means the source never measured this skill (no real baseline). */
-export interface RequizOutcome {
-  has_source: boolean;
-  skill?: string;
-  verdict?: "closed" | "narrowed" | "still_weak" | "first_measure";
-  first_measure?: boolean;
-  mastery_pct?: number;
-  delta_pct?: number | null;
-  original?: { accuracy: number; theta: number };
-  requiz?: { accuracy: number; theta: number };
-  accuracy_delta?: number;
-}
-
 export interface AdaptiveSessionMeta {
   min_questions: number;
   max_questions: number;
@@ -139,7 +124,7 @@ export interface AdaptiveAINarration {
   /** Populated only for re-quiz sessions (config targets exactly one skill).
    *  Drives the "Skill mastered" / "Improving" / "Keep practising" banner. */
   target_outcome?: {
-    kind: "mastered" | "improving" | "no_progress";
+    kind: "mastered" | "improving" | "no_progress" | "first_measure";
     target_skill: string;
     mastery_pct: number;
     delta_pct: number | null;


### PR DESCRIPTION
Post-merge follow-ups for the re-quiz FE work (#945, already merged to `stagging`). Surfaced by the adversarial verification pass on the overhaul.

### Changes
- Add the **`first_measure`** kind to `AdaptiveAINarration.target_outcome` (the backend now emits it) so the narration-level type is accurate, not just the banner's local interface.
- **Delete the dead `getRequizOutcome`** service method + `RequizOutcome` type — the results page dropped its `useEffect` when the two outcome banners were consolidated, so nothing consumed them (removes the drift risk the reviewer flagged).
- Render standalone-quiz **"note" remediation steps as passive** (info icon, `NOTE` chip, "Reflect & move on" hint) instead of an enabled Read/Watch button that no-ops — a note has no link and no action.

`tsc --noEmit`, eslint, and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)