### PR TITLE
feat(live-sessions): "Create Google Meet" action on the session card

### DIFF
--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -70,9 +70,11 @@ export default function AdminLiveSessionsPage() {
     rowsPerPage,
     watchingRecordingId,
     creatingZoomId,
+    creatingGoogleMeetId,
     loadSessions,
     handleCopyPassword,
     handleCreateZoom,
+    handleCreateGoogleMeet,
     handleWatchRecording,
     formatDateTime,
   } = useAdminLiveSessions();
@@ -304,9 +306,11 @@ export default function AdminLiveSessionsPage() {
                             variant="admin"
                             attendanceCount={uniqueAttendanceCounts[s.id]}
                             creatingZoom={creatingZoomId === s.id}
+                            creatingGoogleMeet={creatingGoogleMeetId === s.id}
                             watchingRecording={watchingRecordingId === s.id}
                             onOpen={openDetail}
                             onCreateZoom={(sess) => handleCreateZoom(sess.id)}
+                            onCreateGoogleMeet={(sess) => handleCreateGoogleMeet(sess.id)}
                             onStart={(sess) => sess.zoom_start_url && window.open(sess.zoom_start_url, "_blank")}
                             onJoin={(sess) => {
                               const url = sess.is_google_meet ? sess.join_link?.trim() : sess.zoom_join_url?.trim();

--- a/components/admin/live-sessions/useAdminLiveSessions.ts
+++ b/components/admin/live-sessions/useAdminLiveSessions.ts
@@ -38,6 +38,7 @@ export function useAdminLiveSessions() {
     number | null
   >(null);
   const [creatingZoomId, setCreatingZoomId] = useState<number | null>(null);
+  const [creatingGoogleMeetId, setCreatingGoogleMeetId] = useState<number | null>(null);
   const [uniqueAttendanceCounts, setUniqueAttendanceCounts] = useState<Record<number, number>>({});
 
   const canAccessAdmin = canAccessAdminArea(user?.role);
@@ -135,6 +136,23 @@ export function useAdminLiveSessions() {
     }
   };
 
+  const handleCreateGoogleMeet = async (liveClassId: number) => {
+    try {
+      setCreatingGoogleMeetId(liveClassId);
+      const result = await adminLiveActivitiesService.createGoogleMeet(liveClassId);
+      if (result.status === "error") {
+        showToast(result.message || "Failed to create Google Meet", "error");
+        return;
+      }
+      showToast("Google Meet created", "success");
+      loadSessions();
+    } catch (error: unknown) {
+      showToast(getLiveSessionErrorMessage(error), "error");
+    } finally {
+      setCreatingGoogleMeetId(null);
+    }
+  };
+
   const handleWatchRecording = async (activity: LiveActivity) => {
     if (activity.zoom_recording_url?.trim()) {
       window.open(activity.zoom_recording_url, "_blank");
@@ -177,6 +195,7 @@ export function useAdminLiveSessions() {
     setRowsPerPage,
     watchingRecordingId,
     creatingZoomId,
+    creatingGoogleMeetId,
     createDialogOpen,
     setCreateDialogOpen,
     detailDrawerOpen,
@@ -186,6 +205,7 @@ export function useAdminLiveSessions() {
     loadSessions,
     handleCopyPassword,
     handleCreateZoom,
+    handleCreateGoogleMeet,
     handleWatchRecording,
     formatDateTime,
     openViewSession: (activity: LiveActivity) => {

--- a/components/live-sessions/ui/LiveSessionCard.tsx
+++ b/components/live-sessions/ui/LiveSessionCard.tsx
@@ -47,10 +47,13 @@ export interface LiveSessionCardProps<T extends LiveSessionCardData = LiveSessio
   /** Overrides session.attendance_count (e.g. de-duplicated unique attendee count). */
   attendanceCount?: number;
   creatingZoom?: boolean;
+  creatingGoogleMeet?: boolean;
   watchingRecording?: boolean;
   /** Admin: open the detail page. When set, the card body is clickable. */
   onOpen?: (session: T) => void;
   onCreateZoom?: (session: T) => void;
+  /** Admin: provision the Google Meet for a session flagged as Meet but not yet created. */
+  onCreateGoogleMeet?: (session: T) => void;
   onStart?: (session: T) => void;
   onJoin?: (session: T) => void;
   onCopyPasscode?: (password: string) => void;
@@ -85,9 +88,11 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
   variant = "admin",
   attendanceCount,
   creatingZoom = false,
+  creatingGoogleMeet = false,
   watchingRecording = false,
   onOpen,
   onCreateZoom,
+  onCreateGoogleMeet,
   onStart,
   onJoin,
   onCopyPasscode,
@@ -127,6 +132,17 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
       }
       if (joinUrl && onJoin) {
         return { label: t("liveSessions.join", "Join"), icon: "mdi:video", onClick: () => onJoin(session) };
+      }
+      // Google Meet flagged but not yet provisioned (no link) — offer to create it, mirroring
+      // the Zoom "Create" affordance. Checked before the Zoom branch since such a session is
+      // already is_google_meet (so hasMeeting is true and the Zoom branch wouldn't fire).
+      if (isAdmin && session.is_google_meet && !joinUrl && onCreateGoogleMeet) {
+        return {
+          label: t("adminLiveSessions.createGoogleMeet", "Create Google Meet"),
+          icon: "mdi:google",
+          onClick: () => onCreateGoogleMeet(session),
+          loading: creatingGoogleMeet,
+        };
       }
       if (isAdmin && !hasMeeting && onCreateZoom) {
         return {


### PR DESCRIPTION
Parity with the Zoom "Create" affordance: the shared LiveSessionCard now offers a "Create Google Meet" primary action for a session flagged as Meet but not yet provisioned (is_google_meet with no join link), wired through useAdminLiveSessions (handleCreateGoogleMeet + creatingGoogleMeetId). Previously such a session could only be provisioned from the detail page.