### PR TITLE
feat(live-sessions): Google Meet UI — connect, auto-create, manage

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -82,6 +82,10 @@ export default function LiveSessionDetailPage() {
   const [syncingRecording, setSyncingRecording] = useState(false);
   const [playerOpen, setPlayerOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [creatingGoogle, setCreatingGoogle] = useState(false);
+  const [updatingGoogle, setUpdatingGoogle] = useState(false);
+  const [cancellingGoogle, setCancellingGoogle] = useState(false);
+  const [cancelGoogleConfirmOpen, setCancelGoogleConfirmOpen] = useState(false);
 
   const load = useCallback(async () => {
     if (!Number.isFinite(liveClassId)) return;
@@ -186,6 +190,58 @@ export default function LiveSessionDetailPage() {
     }
   };
 
+  const handleCreateGoogleMeet = async () => {
+    try {
+      setCreatingGoogle(true);
+      const result = await adminLiveActivitiesService.createGoogleMeet(liveClassId);
+      if (result.status === "error") {
+        showToast(result.message || t("adminLiveSessions.googleCreateFailed", "Failed to create Google Meet"), "error");
+        return;
+      }
+      showToast(t("adminLiveSessions.googleMeetCreated", "Google Meet created"), "success");
+      await load();
+    } catch (error: unknown) {
+      showToast(getLiveSessionErrorMessage(error), "error");
+    } finally {
+      setCreatingGoogle(false);
+    }
+  };
+
+  const handleUpdateGoogleMeet = async () => {
+    try {
+      setUpdatingGoogle(true);
+      const result = await adminLiveActivitiesService.updateGoogleMeet(liveClassId);
+      if (result.status === "error") {
+        showToast(result.message || t("adminLiveSessions.googleUpdateFailed", "Failed to update Google Meet"), "error");
+        return;
+      }
+      showToast(t("adminLiveSessions.googleMeetUpdated", "Google Meet updated"), "success");
+      await load();
+    } catch (error: unknown) {
+      showToast(getLiveSessionErrorMessage(error), "error");
+    } finally {
+      setUpdatingGoogle(false);
+    }
+  };
+
+  const handleCancelGoogleMeet = async () => {
+    try {
+      setCancellingGoogle(true);
+      const result = await adminLiveActivitiesService.cancelGoogleMeet(liveClassId);
+      if (result.status === "error") {
+        showToast(result.message || t("adminLiveSessions.googleCancelFailed", "Failed to cancel Google Meet"), "error");
+        return;
+      }
+      showToast(t("adminLiveSessions.googleMeetCancelled", "Google Meet cancelled"), "success");
+      setCancelGoogleConfirmOpen(false);
+      await load();
+    } catch (error: unknown) {
+      showToast(getLiveSessionErrorMessage(error), "error");
+    } finally {
+      setCancellingGoogle(false);
+    }
+  };
+
   const copyPasscode = (pwd: string) => {
     navigator.clipboard.writeText(pwd).then(
       () => showToast(t("liveSessions.passwordCopied", "Passcode copied"), "success"),
@@ -196,6 +252,12 @@ export default function LiveSessionDetailPage() {
   const isZoom = Boolean(activity?.is_zoom);
   const isWebinar = isZoom && activity?.zoom_meeting_type === "webinar" && Boolean(activity?.zoom_meeting_id);
   const isCancelled = activity?.zoom_status === "cancelled";
+  // Platform-created Google Meet (vs a manually pasted link) — can be synced/cancelled via the API.
+  const isPlatformGoogle = Boolean(activity?.is_google_meet && activity?.google_source === "platform" && activity?.google_event_id);
+  // A platform Google session whose Calendar event was never minted (e.g. provisioning failed
+  // mid-create) — offer a retry so it's never a dead end.
+  const isGoogleOrphan = Boolean(activity?.is_google_meet && activity?.google_source === "platform" && !activity?.google_event_id && !activity?.is_zoom);
+  const isGoogleCancelled = activity?.google_status === "cancelled";
   const scheduledOrLive = activity?.meeting_status === "scheduled" || activity?.meeting_status === "live";
   const hasRecording = Boolean(activity?.zoom_recording_url?.trim());
 
@@ -288,8 +350,22 @@ export default function LiveSessionDetailPage() {
                   <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
                     <SectionCard title={t("adminLiveSessions.meetingControls", "Meeting controls")} icon="mdi:video-outline">
                       <Box sx={{ display: "flex", gap: 1.25, flexWrap: "wrap", alignItems: "center" }}>
-                        {scheduledOrLive && activity.is_google_meet && activity.join_link?.trim() && (
+                        {isGoogleOrphan && scheduledOrLive && (
+                          <ControlButton icon="mdi:google" label={t("adminLiveSessions.createGoogleMeet", "Create Google Meet")} tone="primary" loading={creatingGoogle} onClick={handleCreateGoogleMeet} />
+                        )}
+                        {scheduledOrLive && activity.is_google_meet && !isGoogleCancelled && activity.join_link?.trim() && (
                           <ControlButton icon="mdi:video" label={t("adminLiveSessions.openGoogleMeet")} tone="success" onClick={() => window.open(activity.join_link!.trim(), "_blank")} />
+                        )}
+                        {isPlatformGoogle && scheduledOrLive && !isGoogleCancelled && (
+                          <ControlButton icon="mdi:calendar-sync" label={t("adminLiveSessions.syncGoogleMeet", "Sync to Google")} tone="outline" loading={updatingGoogle} onClick={handleUpdateGoogleMeet} />
+                        )}
+                        {isPlatformGoogle && scheduledOrLive && !isGoogleCancelled && (
+                          <ControlButton icon="mdi:calendar-remove" label={t("adminLiveSessions.cancelGoogleMeet", "Cancel Meet")} tone="danger" loading={cancellingGoogle} onClick={() => setCancelGoogleConfirmOpen(true)} />
+                        )}
+                        {isPlatformGoogle && isGoogleCancelled && (
+                          <Typography variant="body2" sx={{ color: "var(--font-tertiary)", fontStyle: "italic" }}>
+                            {t("adminLiveSessions.googleMeetCancelledNote", "This Google Meet was cancelled.")}
+                          </Typography>
                         )}
                         {scheduledOrLive && activity.zoom_start_url && (
                           <ControlButton icon="mdi:video" label={t("adminLiveSessions.startMeeting", "Start session")} tone="primary" onClick={() => window.open(activity.zoom_start_url!, "_blank")} />
@@ -396,6 +472,17 @@ export default function LiveSessionDetailPage() {
         confirmColor="error"
         onConfirm={() => void handleDeleteWebinar()}
         onCancel={() => setDeleteConfirmOpen(false)}
+      />
+
+      <ConfirmDialog
+        open={cancelGoogleConfirmOpen}
+        title={t("adminLiveSessions.cancelGoogleConfirmTitle", "Cancel this Google Meet?")}
+        message={t("adminLiveSessions.cancelGoogleConfirmDesc", "This deletes the event from Google Calendar and notifies attendees. The session stays here but is marked cancelled. This can't be undone.")}
+        confirmText={cancellingGoogle ? t("adminLiveSessions.cancelling", "Cancelling…") : t("adminLiveSessions.cancelGoogleMeet", "Cancel Meet")}
+        cancelText={t("adminLiveSessions.keepIt", "Keep it")}
+        confirmColor="error"
+        onConfirm={() => void handleCancelGoogleMeet()}
+        onCancel={() => setCancelGoogleConfirmOpen(false)}
       />
 
       <RecordingPlayerDialog

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -129,7 +129,7 @@ export default function CreateLiveSessionPage() {
     let cancelled = false;
     googleService
       .getGoogleCredentials()
-      .then((creds) => { if (!cancelled) setGoogleConnected(Boolean(creds?.is_connected && creds?.is_active)); })
+      .then((res) => { if (!cancelled) setGoogleConnected(Boolean(res.credentials?.is_connected && res.credentials?.is_active)); })
       .catch(() => { if (!cancelled) setGoogleConnected(false); });
     return () => { cancelled = true; };
   }, []);

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -31,6 +31,7 @@ import {
   MeetingTemplate,
 } from "@/lib/services/admin/admin-live-activities.service";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
+import { googleService } from "@/lib/services/google.service";
 import {
   getLiveSessionErrorMessage,
   getZoomApiErrorMessage,
@@ -85,8 +86,14 @@ export default function CreateLiveSessionPage() {
   const [zoomStartUrl, setZoomStartUrl] = useState<string | null>(null);
   const [zoomPassword, setZoomPassword] = useState<string | null>(null);
 
+  // Google Meet: "auto" creates the meeting + calendar invite via the Google API (default);
+  // "manual" is the legacy paste-your-own-link path (works with no Google connection).
+  const [meetMode, setMeetMode] = useState<"auto" | "manual">("auto");
+  const [googleConnected, setGoogleConnected] = useState<boolean | null>(null);
+
   const isMeet = sessionType === "meet";
   const isWebinar = sessionType === "webinar";
+  const isAutoMeet = isMeet && meetMode === "auto";
 
   // Dynamic step list: Google Meet skips the Zoom-config step.
   const steps = useMemo(
@@ -116,6 +123,21 @@ export default function CreateLiveSessionPage() {
   useEffect(() => {
     if (stepIndex > steps.length - 1) setStepIndex(steps.length - 1);
   }, [steps.length, stepIndex]);
+
+  // Check Google connection once so we can steer the Meet flow (auto vs manual).
+  useEffect(() => {
+    let cancelled = false;
+    googleService
+      .getGoogleCredentials()
+      .then((creds) => { if (!cancelled) setGoogleConnected(Boolean(creds?.is_connected && creds?.is_active)); })
+      .catch(() => { if (!cancelled) setGoogleConnected(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // If Google isn't connected, default the Meet flow to the manual paste-a-link path.
+  useEffect(() => {
+    if (googleConnected === false) setMeetMode("manual");
+  }, [googleConnected]);
 
   // Load courses once.
   useEffect(() => {
@@ -177,9 +199,10 @@ export default function CreateLiveSessionPage() {
     if (Number.isNaN(t0) || t0 < Date.now() - 60 * 1000) return false;
     if (durationMinutes < 1 || durationMinutes > 480) return false;
     if (instructorInvalid) return false;
-    if (isMeet && (!meetLink.trim() || !isValidHttpUrl(meetLink))) return false;
+    // Only the manual paste-a-link mode requires a URL; auto-create generates it.
+    if (isMeet && meetMode === "manual" && (!meetLink.trim() || !isValidHttpUrl(meetLink))) return false;
     return true;
-  }, [topicName, classDatetime, durationMinutes, instructorInvalid, isMeet, meetLink]);
+  }, [topicName, classDatetime, durationMinutes, instructorInvalid, isMeet, meetMode, meetLink]);
 
   const stepValid = stepKey === "details" ? detailsValid : true;
 
@@ -215,20 +238,68 @@ export default function CreateLiveSessionPage() {
           }
           closesIso = cd.toISOString();
         }
-        const session = await liveClassService.createSession({
-          topic_name: trimmedTopic,
-          description: description.trim() || undefined,
-          class_datetime: classDatetime,
-          duration_minutes: duration,
-          instructor_id: getValidInstructorId(),
-          course: courseId ?? undefined,
-          join_link: meetLink.trim(),
-          is_google_meet: true,
-          closes_at: closesIso,
-        });
-        setCreatedSession(session);
-        setZoomStartUrl(session.join_link?.trim() ?? null);
-        showToast(t("adminLiveSessions.meetSessionCreatedToast"), "success");
+
+        // Manual mode: legacy paste-your-own-link — save the session with the link directly.
+        if (meetMode === "manual") {
+          const session = await liveClassService.createSession({
+            topic_name: trimmedTopic,
+            description: description.trim() || undefined,
+            class_datetime: classDatetime,
+            duration_minutes: duration,
+            instructor_id: getValidInstructorId(),
+            course: courseId ?? undefined,
+            join_link: meetLink.trim(),
+            is_google_meet: true,
+            closes_at: closesIso,
+          });
+          setCreatedSession(session);
+          setZoomStartUrl(session.join_link?.trim() ?? null);
+          showToast(t("adminLiveSessions.meetSessionCreatedToast"), "success");
+          goToDone();
+          return;
+        }
+
+        // Auto mode: create the session (marked as a platform Google Meet so a failed
+        // provisioning shows correctly and isn't mistaken for a broken Zoom session), then
+        // mint the Meet + calendar invite via the Google API. Reuse an already-created session
+        // on retry so re-clicking after a transient failure doesn't spawn duplicate rows
+        // (google/create is idempotent server-side).
+        let session = createdSession;
+        if (!session) {
+          session = await liveClassService.createSession({
+            topic_name: trimmedTopic,
+            description: description.trim() || undefined,
+            class_datetime: classDatetime,
+            duration_minutes: duration,
+            instructor_id: getValidInstructorId(),
+            course: courseId ?? undefined,
+            is_google_meet: true,
+            google_source: "platform",
+            closes_at: closesIso,
+          });
+          setCreatedSession(session);
+        }
+
+        const result = await adminLiveActivitiesService.createGoogleMeet(session.id);
+        if (result.status === "error") {
+          const msg = (result.message || "").toLowerCase();
+          if (msg.includes("already exists")) {
+            const detail = await adminLiveActivitiesService.getLiveActivity(session.id);
+            setZoomStartUrl(detail.join_link?.trim() ?? null);
+            showToast(result.message || t("adminLiveSessions.googleMeetExists", "Google Meet already exists"), "info");
+            goToDone();
+          } else {
+            showToast(result.message || getLiveSessionErrorMessage(null, "generic"), "error");
+          }
+          return;
+        }
+
+        const meetUrl =
+          result.data?.join_link ||
+          (await adminLiveActivitiesService.getLiveActivity(session.id)).join_link ||
+          null;
+        setZoomStartUrl(meetUrl?.trim() ?? null);
+        showToast(t("adminLiveSessions.googleMeetCreated", "Google Meet created and invite sent"), "success");
         goToDone();
         return;
       }
@@ -347,8 +418,34 @@ export default function CreateLiveSessionPage() {
                       ? t("adminLiveSessions.zoomTypeHint", "We create the Zoom meeting for you, email enrolled students the link, and auto-sync attendance, recording and transcript after it ends.")
                       : isWebinar
                         ? t("adminLiveSessions.webinarTypeHint", "We create a Zoom webinar (requires the Zoom Webinar add-on on your account), email enrolled students the link, and auto-sync attendance, recording and transcript after it ends.")
-                        : t("adminLiveSessions.meetTypeHint", "Paste your own Google Meet link. Students get the link by email, but attendance, recording and transcript aren't available for Google Meet.")}
+                        : isAutoMeet
+                          ? t("adminLiveSessions.meetAutoTypeHint", "We create the Google Meet for you, add it to the calendar, and email enrolled students an invite (with an .ics). Requires a connected Google account.")
+                          : t("adminLiveSessions.meetTypeHint", "Paste your own Google Meet link. Students get the link by email, but attendance, recording and transcript aren't available for Google Meet.")}
                   </InfoCallout>
+
+                  {isMeet && (
+                    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                      <TextField
+                        select
+                        label={t("adminLiveSessions.meetMode", "Google Meet mode")}
+                        value={meetMode}
+                        onChange={(e) => setMeetMode(e.target.value as "auto" | "manual")}
+                        fullWidth
+                        size="small"
+                      >
+                        <MenuItem value="auto" disabled={googleConnected === false}>
+                          {t("adminLiveSessions.meetModeAuto", "Auto-create (recommended)")}
+                          {googleConnected === false ? ` — ${t("adminLiveSessions.googleNotConnectedShort", "connect Google first")}` : ""}
+                        </MenuItem>
+                        <MenuItem value="manual">{t("adminLiveSessions.meetModeManual", "Paste my own link")}</MenuItem>
+                      </TextField>
+                      {isAutoMeet && googleConnected === false && (
+                        <InfoCallout icon="mdi:alert-outline">
+                          {t("adminLiveSessions.googleNotConnectedHint", "No Google account is connected. Connect one on the Live Sessions page, or switch to \"Paste my own link\".")}
+                        </InfoCallout>
+                      )}
+                    </Box>
+                  )}
                   <TextField
                     label={t("adminLiveSessions.topicName")}
                     value={topicName}
@@ -393,15 +490,17 @@ export default function CreateLiveSessionPage() {
                   </Box>
                   {isMeet && (
                     <>
-                      <TextField
-                        label={t("adminLiveSessions.meetLink")}
-                        value={meetLink}
-                        onChange={(e) => setMeetLink(e.target.value)}
-                        placeholder="https://meet.google.com/..."
-                        fullWidth required size="small"
-                        error={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink)}
-                        helperText={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink) ? t("adminLiveSessions.invalidMeetLink") : t("adminLiveSessions.meetLinkHelper")}
-                      />
+                      {meetMode === "manual" && (
+                        <TextField
+                          label={t("adminLiveSessions.meetLink")}
+                          value={meetLink}
+                          onChange={(e) => setMeetLink(e.target.value)}
+                          placeholder="https://meet.google.com/..."
+                          fullWidth required size="small"
+                          error={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink)}
+                          helperText={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink) ? t("adminLiveSessions.invalidMeetLink") : t("adminLiveSessions.meetLinkHelper")}
+                        />
+                      )}
                       <TextField
                         label={t("adminLiveSessions.closeDateAndTimeOptional")}
                         type="datetime-local"
@@ -513,16 +612,19 @@ export default function CreateLiveSessionPage() {
                       <ReviewRow label={t("adminLiveSessions.classDateAndTime")} value={classDatetime ? new Date(classDatetime).toLocaleString() : "—"} />
                       <ReviewRow label={t("adminLiveSessions.durationMinutes")} value={`${durationMinutes} min`} />
                       {courseId != null && <ReviewRow label={t("adminLiveSessions.course")} value={courses.find((c) => c.id === courseId)?.title ?? String(courseId)} />}
-                      {isMeet && <ReviewRow label={t("adminLiveSessions.meetLink")} value={meetLink.trim() || "—"} />}
+                      {isMeet && <ReviewRow label={t("adminLiveSessions.meetMode", "Google Meet mode")} value={isAutoMeet ? t("adminLiveSessions.meetModeAuto", "Auto-create (recommended)") : t("adminLiveSessions.meetModeManual", "Paste my own link")} />}
+                      {isMeet && meetMode === "manual" && <ReviewRow label={t("adminLiveSessions.meetLink")} value={meetLink.trim() || "—"} />}
                       {!isMeet && selectedTemplateId && <ReviewRow label={t("adminLiveSessions.meetingTemplate", "Template")} value={templates.find((tp) => tp.id === selectedTemplateId)?.name ?? selectedTemplateId} />}
                       {!isMeet && selectedPresetId !== "" && <ReviewRow label={t("adminLiveSessions.meetingPreset", "Preset")} value={presets.find((p) => p.id === selectedPresetId)?.name ?? String(selectedPresetId)} />}
                       {isWebinar && <ReviewRow label={t("adminLiveSessions.requireRegistration", "Registration")} value={registrationRequired ? t("liveSessions.yes", "Yes") : t("liveSessions.no", "No")} />}
                     </Box>
                   </SectionCard>
                   <InfoCallout icon="mdi:information-outline">
-                    {isMeet
-                      ? t("adminLiveSessions.reviewMeetHint", "We'll save the session and email the Google Meet link to enrolled students.")
-                      : t("adminLiveSessions.reviewZoomHint", "We'll create the session, set up Zoom, and email the join link to enrolled students.")}
+                    {isAutoMeet
+                      ? t("adminLiveSessions.reviewMeetAutoHint", "We'll create the Google Meet, add it to the calendar, and email enrolled students an invite.")
+                      : isMeet
+                        ? t("adminLiveSessions.reviewMeetHint", "We'll save the session and email the Google Meet link to enrolled students.")
+                        : t("adminLiveSessions.reviewZoomHint", "We'll create the session, set up Zoom, and email the join link to enrolled students.")}
                   </InfoCallout>
                 </Box>
               )}

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -70,9 +70,11 @@ export default function AdminLiveSessionsPage() {
     rowsPerPage,
     watchingRecordingId,
     creatingZoomId,
+    creatingGoogleMeetId,
     loadSessions,
     handleCopyPassword,
     handleCreateZoom,
+    handleCreateGoogleMeet,
     handleWatchRecording,
     formatDateTime,
   } = useAdminLiveSessions();
@@ -304,9 +306,11 @@ export default function AdminLiveSessionsPage() {
                             variant="admin"
                             attendanceCount={uniqueAttendanceCounts[s.id]}
                             creatingZoom={creatingZoomId === s.id}
+                            creatingGoogleMeet={creatingGoogleMeetId === s.id}
                             watchingRecording={watchingRecordingId === s.id}
                             onOpen={openDetail}
                             onCreateZoom={(sess) => handleCreateZoom(sess.id)}
+                            onCreateGoogleMeet={(sess) => handleCreateGoogleMeet(sess.id)}
                             onStart={(sess) => sess.zoom_start_url && window.open(sess.zoom_start_url, "_blank")}
                             onJoin={(sess) => {
                               const url = sess.is_google_meet ? sess.join_link?.trim() : sess.zoom_join_url?.trim();

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import {
   Container,
@@ -22,6 +22,7 @@ import { AdminLiveSessionsFeatureBlocked } from "@/components/admin/live-session
 import { useAdminLiveSessions } from "@/components/admin/live-sessions/useAdminLiveSessions";
 import { ZoomCredentialsDialog } from "@/components/admin/live-sessions/ZoomCredentialsDialog";
 import { ZoomSetupCard, ZoomSetupStatus } from "@/components/admin/live-sessions/ZoomSetupCard";
+import { GoogleSetupCard } from "@/components/admin/live-sessions/GoogleSetupCard";
 import {
   ImportedMeetingsInbox,
   ImportedMeetingsInboxHandle,
@@ -30,6 +31,7 @@ import { MeetingPresetsDialog } from "@/components/admin/live-sessions/MeetingPr
 import { VirtualBackgroundsDialog } from "@/components/admin/live-sessions/VirtualBackgroundsDialog";
 import { LiveSessionCard } from "@/components/live-sessions/ui/LiveSessionCard";
 import { SessionFilterChips } from "@/components/live-sessions/ui/LiveSessionUI";
+import { useToast } from "@/components/common/Toast";
 import type { LiveActivity } from "@/lib/services/admin/admin-live-activities.service";
 import { zoomService } from "@/lib/services/zoom.service";
 
@@ -38,6 +40,9 @@ const PAST = new Set(["ended", "expired"]);
 export default function AdminLiveSessionsPage() {
   const { t } = useTranslation("common");
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { showToast } = useToast();
+  const googleRedirectHandledRef = useRef(false);
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
   const [backgroundsDialogOpen, setBackgroundsDialogOpen] = useState(false);
@@ -97,6 +102,28 @@ export default function AdminLiveSessionsPage() {
     credsCheckedRef.current = true;
     refreshZoomStatus(true);
   }, [hasAdminLiveSessionsFeature, refreshZoomStatus]);
+
+  // Toast the result of the Google "Connect" OAuth round-trip (?google_connected=1|0), then
+  // strip the param so a refresh doesn't re-toast. GoogleSetupCard re-reads status on this load.
+  useEffect(() => {
+    if (googleRedirectHandledRef.current) return;
+    const flag = searchParams.get("google_connected");
+    if (flag == null) return;
+    googleRedirectHandledRef.current = true;
+    if (flag === "1") {
+      showToast(t("adminLiveSessions.googleConnected", "Google account connected."), "success");
+    } else {
+      const reason = searchParams.get("error");
+      showToast(
+        t("adminLiveSessions.googleConnectError", "Google connection failed{{reason}}.", {
+          reason: reason ? ` (${reason})` : "",
+        }),
+        "error"
+      );
+    }
+    // Strip the query params without leaving the current page.
+    router.replace(window.location.pathname);
+  }, [searchParams, showToast, t, router]);
 
   const counts = useMemo(() => {
     let upcoming = 0;
@@ -230,6 +257,8 @@ export default function AdminLiveSessionsPage() {
 
           <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
             <ZoomSetupCard status={zoomStatus} onConfigure={() => setCredentialsDialogOpen(true)} />
+
+            <GoogleSetupCard />
 
             <ImportedMeetingsInbox
               ref={inboxRef}

--- a/components/admin/live-sessions/GoogleCredentialsDialog.tsx
+++ b/components/admin/live-sessions/GoogleCredentialsDialog.tsx
@@ -24,6 +24,8 @@ import { googleService, GoogleCredentials, GoogleCredentialsInput } from "@/lib/
 interface GoogleCredentialsDialogProps {
   open: boolean;
   creds: GoogleCredentials | null;
+  /** OAuth redirect URI to whitelist in the Google Cloud OAuth client. */
+  redirectUri?: string;
   onClose: () => void;
   onChanged: () => void; // reload status after save/disconnect
   onConnect: () => void; // start / reconnect OAuth
@@ -45,7 +47,7 @@ function getApiErrorMessage(e: unknown): string {
  * calendar id / timezone / active, and an "Advanced" section for a per-tenant Google OAuth app.
  * Most tenants only ever click "Connect Google" on the card and never open this.
  */
-export function GoogleCredentialsDialog({ open, creds, onClose, onChanged, onConnect, connecting }: GoogleCredentialsDialogProps) {
+export function GoogleCredentialsDialog({ open, creds, redirectUri, onClose, onChanged, onConnect, connecting }: GoogleCredentialsDialogProps) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [saving, setSaving] = useState(false);
@@ -165,6 +167,35 @@ export function GoogleCredentialsDialog({ open, creds, onClose, onChanged, onCon
             </Button>
           </Box>
         </Box>
+
+        {redirectUri && (
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="caption" sx={{ color: "var(--font-secondary)", mb: 0.5, display: "block" }}>
+              {t("adminLiveSessions.googleRedirectUriLabel", "Authorized redirect URI (add this in Google Cloud Console → Credentials)")}
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <TextField
+                value={redirectUri}
+                size="small"
+                fullWidth
+                InputProps={{ readOnly: true }}
+                sx={{ "& .MuiInputBase-input": { fontSize: "0.78rem", fontFamily: "monospace" } }}
+              />
+              <IconButton
+                size="small"
+                onClick={() => {
+                  navigator.clipboard.writeText(redirectUri).then(
+                    () => showToast(t("adminLiveSessions.redirectUriCopied", "Redirect URI copied"), "success"),
+                    () => showToast(t("adminLiveSessions.failedToCopy", "Failed to copy"), "error")
+                  );
+                }}
+                aria-label={t("adminLiveSessions.copyRedirectUri", "Copy redirect URI")}
+              >
+                <IconWrapper icon="mdi:content-copy" size={18} />
+              </IconButton>
+            </Box>
+          </Box>
+        )}
 
         <Box sx={{ display: "grid", gridTemplateColumns: "1fr", gap: 2, mb: 1 }}>
           <TextField

--- a/components/admin/live-sessions/GoogleCredentialsDialog.tsx
+++ b/components/admin/live-sessions/GoogleCredentialsDialog.tsx
@@ -20,6 +20,7 @@ import { LoadingButton } from "@/components/common/LoadingButton";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { googleService, GoogleCredentials, GoogleCredentialsInput } from "@/lib/services/google.service";
+import { GoogleSetupGuide } from "./GoogleSetupGuide";
 
 interface GoogleCredentialsDialogProps {
   open: boolean;
@@ -53,6 +54,7 @@ export function GoogleCredentialsDialog({ open, creds, redirectUri, onClose, onC
   const [saving, setSaving] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showGuide, setShowGuide] = useState(false);
   const [form, setForm] = useState<GoogleCredentialsInput>({});
 
   useEffect(() => {
@@ -65,6 +67,7 @@ export function GoogleCredentialsDialog({ open, creds, redirectUri, onClose, onC
       google_client_secret: "",
     });
     setShowAdvanced(false);
+    setShowGuide(false);
   }, [open, creds]);
 
   const connected = Boolean(creds?.is_connected);
@@ -260,6 +263,27 @@ export function GoogleCredentialsDialog({ open, creds, redirectUri, onClose, onC
             />
           </Box>
         </Collapse>
+
+        <Box sx={{ mt: 2 }}>
+          <Button
+            size="small"
+            onClick={() => setShowGuide((v) => !v)}
+            startIcon={<IconWrapper icon="mdi:help-circle-outline" size={18} />}
+            endIcon={<IconWrapper icon={showGuide ? "mdi:chevron-up" : "mdi:chevron-down"} size={18} />}
+            sx={{
+              textTransform: "none",
+              color: "var(--accent-indigo)",
+              "&:hover": { backgroundColor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--surface) 90%)" },
+            }}
+          >
+            {showGuide
+              ? t("adminLiveSessions.hideGoogleGuide", "Hide setup guide")
+              : t("adminLiveSessions.viewGoogleGuide", "First time? View the step-by-step Google setup guide")}
+          </Button>
+          <Collapse in={showGuide}>
+            <GoogleSetupGuide redirectUri={redirectUri} />
+          </Collapse>
+        </Box>
 
         <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}>
           <Button onClick={onClose}>{t("adminLiveSessions.cancel", "Cancel")}</Button>

--- a/components/admin/live-sessions/GoogleCredentialsDialog.tsx
+++ b/components/admin/live-sessions/GoogleCredentialsDialog.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+  Typography,
+  Box,
+  TextField,
+  Button,
+  FormControlLabel,
+  Switch,
+  Chip,
+  Collapse,
+} from "@mui/material";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import { googleService, GoogleCredentials, GoogleCredentialsInput } from "@/lib/services/google.service";
+
+interface GoogleCredentialsDialogProps {
+  open: boolean;
+  creds: GoogleCredentials | null;
+  onClose: () => void;
+  onChanged: () => void; // reload status after save/disconnect
+  onConnect: () => void; // start / reconnect OAuth
+  connecting: boolean;
+}
+
+function getApiErrorMessage(e: unknown): string {
+  if (e && typeof e === "object" && "response" in e) {
+    const data = (e as { response?: { data?: unknown } }).response?.data;
+    if (data && typeof data === "object" && "error" in data && typeof (data as { error: unknown }).error === "string")
+      return (data as { error: string }).error;
+  }
+  if (e && typeof e === "object" && "message" in e) return String((e as { message: unknown }).message);
+  return "Something went wrong. Please try again.";
+}
+
+/**
+ * Optional Google Meet settings: the connection status + Connect/Reconnect/Disconnect, plus
+ * calendar id / timezone / active, and an "Advanced" section for a per-tenant Google OAuth app.
+ * Most tenants only ever click "Connect Google" on the card and never open this.
+ */
+export function GoogleCredentialsDialog({ open, creds, onClose, onChanged, onConnect, connecting }: GoogleCredentialsDialogProps) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [saving, setSaving] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [form, setForm] = useState<GoogleCredentialsInput>({});
+
+  useEffect(() => {
+    if (!open) return;
+    setForm({
+      calendar_id: creds?.calendar_id ?? "primary",
+      timezone: creds?.timezone ?? "",
+      is_active: creds?.is_active ?? true,
+      google_client_id: "",
+      google_client_secret: "",
+    });
+    setShowAdvanced(false);
+  }, [open, creds]);
+
+  const connected = Boolean(creds?.is_connected);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const payload: GoogleCredentialsInput = { is_active: form.is_active };
+      if (form.calendar_id?.trim()) payload.calendar_id = form.calendar_id.trim();
+      if (form.timezone?.trim()) payload.timezone = form.timezone.trim();
+      if (form.google_client_id?.trim()) payload.google_client_id = form.google_client_id.trim();
+      if (form.google_client_secret?.trim()) payload.google_client_secret = form.google_client_secret.trim();
+      await googleService.putGoogleCredentials(payload);
+      showToast(t("adminLiveSessions.googleSettingsSaved", "Google settings saved."), "success");
+      onChanged();
+      onClose();
+    } catch (e: unknown) {
+      showToast(getApiErrorMessage(e), "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await googleService.disconnectGoogle();
+      showToast(t("adminLiveSessions.googleDisconnected", "Google account disconnected."), "success");
+      onChanged();
+      onClose();
+    } catch (e: unknown) {
+      showToast(getApiErrorMessage(e), "error");
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <IconWrapper icon="logos:google-meet" size={22} />
+          <span>{t("adminLiveSessions.googleSettingsTitle", "Google Meet settings")}</span>
+        </Box>
+        <IconButton aria-label={t("adminLiveSessions.close", "Close")} onClick={onClose} size="small">
+          <IconWrapper icon="mdi:close" size={20} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        {/* Connection status + connect/disconnect */}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 1.5,
+            p: 1.5,
+            mb: 2,
+            borderRadius: 2,
+            border: "1px solid var(--border-default)",
+            flexWrap: "wrap",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <Chip
+              label={connected ? t("adminLiveSessions.connected", "Connected") : t("adminLiveSessions.notConnected", "Not connected")}
+              size="small"
+              sx={{
+                bgcolor: connected ? "color-mix(in srgb, var(--success-500) 16%, transparent)" : "color-mix(in srgb, var(--warning-500) 18%, transparent)",
+                color: connected ? "var(--success-500)" : "var(--warning-500)",
+                fontWeight: 600,
+              }}
+            />
+            {connected && creds?.connected_email && (
+              <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+                {creds.connected_email}
+              </Typography>
+            )}
+          </Box>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            {connected && (
+              <LoadingButton
+                variant="text"
+                onClick={handleDisconnect}
+                loading={disconnecting}
+                loadingText={t("adminLiveSessions.disconnecting", "Disconnecting…")}
+                sx={{ textTransform: "none", color: "var(--error-500, #ef4444)" }}
+              >
+                {t("adminLiveSessions.disconnect", "Disconnect")}
+              </LoadingButton>
+            )}
+            <Button
+              variant="outlined"
+              onClick={onConnect}
+              disabled={connecting}
+              startIcon={<IconWrapper icon="mdi:google" size={16} />}
+              sx={{ textTransform: "none" }}
+            >
+              {connected ? t("adminLiveSessions.reconnect", "Reconnect") : t("adminLiveSessions.connectGoogle", "Connect Google")}
+            </Button>
+          </Box>
+        </Box>
+
+        <Box sx={{ display: "grid", gridTemplateColumns: "1fr", gap: 2, mb: 1 }}>
+          <TextField
+            label={t("adminLiveSessions.calendarId", "Calendar ID")}
+            value={form.calendar_id ?? ""}
+            onChange={(e) => setForm((p) => ({ ...p, calendar_id: e.target.value }))}
+            size="small"
+            fullWidth
+            placeholder="primary"
+            helperText={t("adminLiveSessions.calendarIdHelper", "Calendar to create meetings on (default: primary).")}
+          />
+          <TextField
+            label={t("adminLiveSessions.timezoneOptional", "Timezone (optional)")}
+            value={form.timezone ?? ""}
+            onChange={(e) => setForm((p) => ({ ...p, timezone: e.target.value }))}
+            size="small"
+            fullWidth
+            placeholder="Asia/Kolkata"
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={form.is_active ?? true}
+                onChange={(e) => setForm((p) => ({ ...p, is_active: e.target.checked }))}
+                color="primary"
+              />
+            }
+            label={t("adminLiveSessions.active", "Active")}
+          />
+        </Box>
+
+        <Button
+          size="small"
+          onClick={() => setShowAdvanced((v) => !v)}
+          endIcon={<IconWrapper icon={showAdvanced ? "mdi:chevron-up" : "mdi:chevron-down"} size={18} />}
+          sx={{ textTransform: "none", color: "var(--font-secondary)" }}
+        >
+          {t("adminLiveSessions.advancedOwnApp", "Advanced: use your own Google app")}
+        </Button>
+        <Collapse in={showAdvanced}>
+          <Box sx={{ display: "grid", gridTemplateColumns: "1fr", gap: 2, mt: 1, mb: 1 }}>
+            <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+              {t("adminLiveSessions.ownAppHelper", "Optional. Leave blank to use the platform's Google app. If set, reconnect Google afterwards.")}
+            </Typography>
+            <TextField
+              label={t("adminLiveSessions.googleClientId", "Google OAuth client ID")}
+              value={form.google_client_id ?? ""}
+              onChange={(e) => setForm((p) => ({ ...p, google_client_id: e.target.value }))}
+              size="small"
+              fullWidth
+              autoComplete="off"
+            />
+            <TextField
+              label={t("adminLiveSessions.googleClientSecret", "Google OAuth client secret")}
+              type="password"
+              value={form.google_client_secret ?? ""}
+              onChange={(e) => setForm((p) => ({ ...p, google_client_secret: e.target.value }))}
+              size="small"
+              fullWidth
+              autoComplete="off"
+              helperText={t("adminLiveSessions.leaveBlankKeep", "Leave blank to keep the existing secret.")}
+            />
+          </Box>
+        </Collapse>
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}>
+          <Button onClick={onClose}>{t("adminLiveSessions.cancel", "Cancel")}</Button>
+          <LoadingButton
+            variant="contained"
+            onClick={handleSave}
+            loading={saving}
+            loadingText={t("common.saving", "Saving…")}
+            startIcon={<IconWrapper icon="mdi:content-save" size={18} />}
+            sx={{ bgcolor: "var(--accent-indigo)", color: "var(--font-light)", "&:hover": { bgcolor: "var(--accent-indigo-dark)" } }}
+          >
+            {t("adminLiveSessions.save", "Save")}
+          </LoadingButton>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/admin/live-sessions/GoogleSetupCard.tsx
+++ b/components/admin/live-sessions/GoogleSetupCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Box, Paper, Typography, Button, Chip, Skeleton } from "@mui/material";
+import { Box, Paper, Typography, Button, Chip, Skeleton, IconButton, Tooltip } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
@@ -18,19 +18,30 @@ export function GoogleSetupCard() {
   const { showToast } = useToast();
   const [loading, setLoading] = useState(true);
   const [creds, setCreds] = useState<GoogleCredentials | null>(null);
+  const [redirectUri, setRedirectUri] = useState("");
   const [connecting, setConnecting] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      setCreds(await googleService.getGoogleCredentials());
+      const { credentials, redirectUri: uri } = await googleService.getGoogleCredentials();
+      setCreds(credentials);
+      setRedirectUri(uri);
     } catch {
       setCreds(null);
     } finally {
       setLoading(false);
     }
   }, []);
+
+  const copyRedirectUri = () => {
+    if (!redirectUri) return;
+    navigator.clipboard.writeText(redirectUri).then(
+      () => showToast(t("adminLiveSessions.redirectUriCopied", "Redirect URI copied"), "success"),
+      () => showToast(t("adminLiveSessions.failedToCopy", "Failed to copy"), "error")
+    );
+  };
 
   useEffect(() => {
     load();
@@ -103,6 +114,7 @@ export function GoogleSetupCard() {
         <GoogleCredentialsDialog
           open={settingsOpen}
           creds={creds}
+          redirectUri={redirectUri}
           onClose={() => setSettingsOpen(false)}
           onChanged={load}
           onConnect={handleConnect}
@@ -160,6 +172,26 @@ export function GoogleSetupCard() {
                   "Connect a Google account once. After that, scheduling a Google Meet session auto-creates the meeting, adds it to the calendar, and emails enrolled students an invite."
                 )}
               </Typography>
+              {redirectUri && (
+                <Box sx={{ mb: 0.75 }}>
+                  <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 0.25 }}>
+                    {t("adminLiveSessions.googleRedirectUriHint", "First, add this redirect URI to your Google Cloud OAuth client (Authorized redirect URIs):")}
+                  </Typography>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                    <Typography
+                      variant="caption"
+                      sx={{ color: "var(--font-tertiary)", fontFamily: "monospace", fontSize: "0.72rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 360 }}
+                    >
+                      {redirectUri}
+                    </Typography>
+                    <Tooltip title={t("adminLiveSessions.copyRedirectUri", "Copy redirect URI")}>
+                      <IconButton size="small" onClick={copyRedirectUri} aria-label={t("adminLiveSessions.copyRedirectUri", "Copy redirect URI")}>
+                        <IconWrapper icon="mdi:content-copy" size={16} />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                </Box>
+              )}
               {creds?.connected_email && (
                 <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
                   {t("adminLiveSessions.googleLastConnected", "Last connected: {{email}}", { email: creds.connected_email })}

--- a/components/admin/live-sessions/GoogleSetupCard.tsx
+++ b/components/admin/live-sessions/GoogleSetupCard.tsx
@@ -200,11 +200,9 @@ export function GoogleSetupCard() {
             </Box>
           </Box>
           <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-            {connected && (
-              <Button onClick={() => setSettingsOpen(true)} sx={{ textTransform: "none", color: "var(--font-secondary)" }}>
-                {t("adminLiveSessions.settings", "Settings")}
-              </Button>
-            )}
+            <Button onClick={() => setSettingsOpen(true)} sx={{ textTransform: "none", color: "var(--font-secondary)" }}>
+              {connected ? t("adminLiveSessions.settings", "Settings") : t("adminLiveSessions.setupGuide", "Setup guide")}
+            </Button>
             <Button
               variant="contained"
               onClick={handleConnect}

--- a/components/admin/live-sessions/GoogleSetupCard.tsx
+++ b/components/admin/live-sessions/GoogleSetupCard.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Box, Paper, Typography, Button, Chip, Skeleton } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import { googleService, GoogleCredentials } from "@/lib/services/google.service";
+import { GoogleCredentialsDialog } from "./GoogleCredentialsDialog";
+
+/**
+ * Google Meet connection card for the admin live-sessions page. Mirrors ZoomSetupCard, but the
+ * Google flow is a one-click OAuth "Connect Google" (we store a refresh token) rather than pasted
+ * credentials. Self-contained: loads its own status so the page only has to render it.
+ */
+export function GoogleSetupCard() {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [creds, setCreds] = useState<GoogleCredentials | null>(null);
+  const [connecting, setConnecting] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setCreds(await googleService.getGoogleCredentials());
+    } catch {
+      setCreds(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    try {
+      // Bounce back to this page; the backend callback stores the refresh token.
+      const url = await googleService.startConnect("/admin/live-sessions");
+      window.location.href = url;
+    } catch {
+      setConnecting(false);
+      showToast(
+        t("adminLiveSessions.googleConnectFailed", "Couldn't start Google connection. Check that Google is configured."),
+        "error"
+      );
+    }
+  };
+
+  if (loading) {
+    return (
+      <Paper elevation={0} sx={{ p: 2.25, borderRadius: 2, border: "1px solid var(--border-default)" }}>
+        <Skeleton variant="text" width={220} height={28} />
+        <Skeleton variant="text" width="55%" />
+      </Paper>
+    );
+  }
+
+  const connected = Boolean(creds?.is_connected);
+  const active = Boolean(creds?.is_active);
+  const ready = connected && active;
+  const accent = ready ? "var(--success-500)" : "var(--warning-500)";
+
+  // Connected + active — compact confirmation row.
+  if (ready) {
+    return (
+      <>
+        <Paper
+          elevation={0}
+          sx={{
+            p: { xs: 1.5, sm: 2 },
+            borderRadius: 2,
+            border: `1px solid color-mix(in srgb, ${accent} 32%, var(--border-default) 68%)`,
+            bgcolor: `color-mix(in srgb, ${accent} 8%, var(--surface) 92%)`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 1.5,
+            flexWrap: "wrap",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
+            <IconWrapper icon="logos:google-meet" size={22} />
+            <Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
+                {t("adminLiveSessions.googleConnectedTitle", "Google Meet is connected")}
+              </Typography>
+              <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                {creds?.connected_email
+                  ? t("adminLiveSessions.googleConnectedAs", "Meetings are scheduled on {{email}}", { email: creds.connected_email })
+                  : t("adminLiveSessions.googleConnectedDesc", "Scheduling a Google Meet session auto-creates the meeting and calendar invite.")}
+              </Typography>
+            </Box>
+          </Box>
+          <Button size="small" onClick={() => setSettingsOpen(true)} sx={{ textTransform: "none", color: accent }}>
+            {t("adminLiveSessions.manageGoogle", "Manage")}
+          </Button>
+        </Paper>
+        <GoogleCredentialsDialog
+          open={settingsOpen}
+          creds={creds}
+          onClose={() => setSettingsOpen(false)}
+          onChanged={load}
+          onConnect={handleConnect}
+          connecting={connecting}
+        />
+      </>
+    );
+  }
+
+  // Not connected (or inactive) — connect CTA.
+  return (
+    <>
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 2, sm: 2.5 },
+          borderRadius: 2,
+          border: `1px solid color-mix(in srgb, ${accent} 34%, var(--border-default) 66%)`,
+          background: `linear-gradient(135deg, color-mix(in srgb, ${accent} 8%, var(--surface) 92%), color-mix(in srgb, ${accent} 15%, var(--surface) 85%))`,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 2, flexWrap: "wrap" }}>
+          <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5, flex: "1 1 320px" }}>
+            <Box
+              sx={{
+                width: 40,
+                height: 40,
+                borderRadius: "50%",
+                flexShrink: 0,
+                bgcolor: "var(--card-bg)",
+                border: "1px solid var(--border-default)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <IconWrapper icon="logos:google-meet" size={20} />
+            </Box>
+            <Box>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+                  {t("adminLiveSessions.googleConnectTitle", "Connect Google to host Meet sessions")}
+                </Typography>
+                {connected && !active && (
+                  <Chip
+                    label={t("adminLiveSessions.googleInactive", "Inactive")}
+                    size="small"
+                    sx={{ height: 20, fontSize: "0.68rem", fontWeight: 600, bgcolor: "color-mix(in srgb, var(--warning-500) 18%, var(--card-bg) 82%)", color: "var(--warning-500)" }}
+                  />
+                )}
+              </Box>
+              <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.25, mb: 0.5 }}>
+                {t(
+                  "adminLiveSessions.googleSetupHelp",
+                  "Connect a Google account once. After that, scheduling a Google Meet session auto-creates the meeting, adds it to the calendar, and emails enrolled students an invite."
+                )}
+              </Typography>
+              {creds?.connected_email && (
+                <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                  {t("adminLiveSessions.googleLastConnected", "Last connected: {{email}}", { email: creds.connected_email })}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            {connected && (
+              <Button onClick={() => setSettingsOpen(true)} sx={{ textTransform: "none", color: "var(--font-secondary)" }}>
+                {t("adminLiveSessions.settings", "Settings")}
+              </Button>
+            )}
+            <Button
+              variant="contained"
+              onClick={handleConnect}
+              disabled={connecting}
+              startIcon={<IconWrapper icon="mdi:google" size={18} color="#fff" />}
+              sx={{
+                bgcolor: "var(--accent-indigo)",
+                color: "var(--font-light)",
+                whiteSpace: "nowrap",
+                "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+              }}
+            >
+              {connected
+                ? t("adminLiveSessions.reconnectGoogle", "Reconnect Google")
+                : t("adminLiveSessions.connectGoogle", "Connect Google")}
+            </Button>
+          </Box>
+        </Box>
+      </Paper>
+      <GoogleCredentialsDialog
+        open={settingsOpen}
+        creds={creds}
+        onClose={() => setSettingsOpen(false)}
+        onChanged={load}
+        onConnect={handleConnect}
+        connecting={connecting}
+      />
+    </>
+  );
+}

--- a/components/admin/live-sessions/GoogleSetupGuide.tsx
+++ b/components/admin/live-sessions/GoogleSetupGuide.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { Box, Typography, Link } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+/** Inline monospace scope/value token. */
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <Box
+      component="code"
+      sx={{
+        fontFamily: "monospace",
+        fontSize: "0.72rem",
+        bgcolor: "var(--surface)",
+        border: "1px solid var(--border-default)",
+        borderRadius: 0.5,
+        px: 0.5,
+        py: "1px",
+        color: "var(--font-primary)",
+        wordBreak: "break-all",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function StepHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)", mt: 2, mb: 0.75 }}>
+      {children}
+    </Typography>
+  );
+}
+
+const extLink = { color: "var(--accent-indigo)", fontWeight: 600 };
+const liSx = { mb: 0.75, color: "var(--font-secondary)", fontSize: "0.8125rem", lineHeight: 1.55 };
+
+/**
+ * Step-by-step Google Meet / Calendar setup guide shown (collapsed by default) inside the Google
+ * Credentials modal. Mirrors ZoomSetupGuide. `redirectUri` is the exact OAuth redirect URI the
+ * connect flow uses (deterministic from the backend) — the #1 thing to whitelist, since a mismatch
+ * yields the "Access blocked: redirect_uri_mismatch" error.
+ */
+export function GoogleSetupGuide({ redirectUri }: { redirectUri?: string }) {
+  const { t } = useTranslation("common");
+  const uri = redirectUri || "https://<your-backend>/central-auth/oauth/google/calendar/callback";
+
+  return (
+    <Box
+      sx={{
+        mt: 1,
+        p: 2,
+        bgcolor: "var(--surface)",
+        borderRadius: 1.5,
+        border: "1px solid var(--border-default)",
+      }}
+    >
+      {/* Prerequisites */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1,
+          alignItems: "flex-start",
+          p: 1.25,
+          mb: 1,
+          borderRadius: 1,
+          bgcolor: "color-mix(in srgb, var(--warning-500) 10%, var(--surface) 90%)",
+          border: "1px solid color-mix(in srgb, var(--warning-500) 28%, var(--border-default) 72%)",
+        }}
+      >
+        <IconWrapper icon="mdi:shield-key-outline" size={18} color="var(--warning-500)" />
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", lineHeight: 1.5 }}>
+          {t(
+            "adminLiveSessions.googleGuidePrereq",
+            "You need access to the Google Cloud project that owns the platform's OAuth app (or provide your own under Advanced). You'll also need a Google account to host the meetings — its calendar holds the events and its refresh token is stored. A regular Gmail account works; a Google Workspace account is fine too."
+          )}
+        </Typography>
+      </Box>
+
+      {/* Part 1 */}
+      <StepHeading>{t("adminLiveSessions.googleGuidePart1", "Part 1 — Configure the Google Cloud OAuth app")}</StepHeading>
+      <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          Open the{" "}
+          <Link href="https://console.cloud.google.com/apis/dashboard" target="_blank" rel="noopener" sx={extLink}>
+            Google Cloud Console
+          </Link>{" "}
+          and select the project that owns your OAuth client.
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>Enable the Calendar API</strong>:{" "}
+          <Link href="https://console.cloud.google.com/apis/library/calendar-json.googleapis.com" target="_blank" rel="noopener" sx={extLink}>
+            APIs &amp; Services → Library → Google Calendar API → Enable
+          </Link>
+          . Without this, meeting creation fails with a 403.
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>OAuth consent screen</strong> → add the scope <Code>.../auth/calendar.events</Code> (plus{" "}
+          <Code>openid</Code> and <Code>email</Code>, usually already present for login).
+        </Box>
+        <Box component="li" sx={liSx}>
+          If the app is in <strong>Testing</strong> mode, add the Google account you&apos;ll connect under{" "}
+          <strong>Test users</strong> — otherwise Google shows &quot;app isn&apos;t verified&quot; / access_denied.
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>Credentials</strong> → open your <strong>OAuth 2.0 Client ID</strong> →{" "}
+          <strong>Authorized redirect URIs</strong> → <strong>+ Add URI</strong> and paste{" "}
+          <strong>exactly</strong>:
+          <Box sx={{ mt: 0.5 }}>
+            <Code>{uri}</Code>
+          </Box>
+          <Box sx={{ mt: 0.5 }}>
+            Then <strong>Save</strong>. Exact match matters: no trailing slash, <Code>https</Code> not{" "}
+            <Code>http</Code>, exact host. A mismatch is the <Code>redirect_uri_mismatch</Code> error.
+          </Box>
+        </Box>
+      </Box>
+
+      {/* Part 2 */}
+      <StepHeading>{t("adminLiveSessions.googleGuidePart2", "Part 2 — Connect (this screen)")}</StepHeading>
+      <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          Click <strong>Connect Google</strong> and choose the account that will host the meetings.
+        </Box>
+        <Box component="li" sx={liSx}>
+          On the Google consent screen, grant <strong>Calendar</strong> access. You&apos;ll be redirected back and
+          the card will show <strong>&quot;Google Meet is connected&quot;</strong>.
+        </Box>
+        <Box component="li" sx={liSx}>
+          Optional: open <strong>Settings</strong> to set a specific <strong>Calendar ID</strong> or{" "}
+          <strong>timezone</strong> (defaults to the account&apos;s primary calendar).
+        </Box>
+      </Box>
+
+      {/* Part 3 — bring your own app (optional) */}
+      <StepHeading>{t("adminLiveSessions.googleGuidePart3", "Part 3 — Use your own Google app (optional)")}</StepHeading>
+      <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          Under <strong>Advanced</strong> above you can paste your own <strong>OAuth client ID / secret</strong>{" "}
+          instead of the platform&apos;s. If you do, add the same redirect URI to <em>your</em> client and{" "}
+          <strong>Reconnect</strong> afterwards.
+        </Box>
+      </Box>
+
+      {/* Production note */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1,
+          alignItems: "flex-start",
+          mt: 2,
+          p: 1.25,
+          borderRadius: 1,
+          bgcolor: "color-mix(in srgb, var(--accent-indigo) 9%, var(--surface) 91%)",
+          border: "1px solid color-mix(in srgb, var(--accent-indigo) 28%, var(--border-default) 72%)",
+        }}
+      >
+        <IconWrapper icon="mdi:check-decagram-outline" size={18} color="var(--accent-indigo)" />
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", lineHeight: 1.5 }}>
+          {t(
+            "adminLiveSessions.googleGuideVerifyNote",
+            "calendar.events is a sensitive scope. For dev/testing the Test-users allowlist is enough; to open it to everyone, the OAuth app must go through Google's verification review once."
+          )}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/components/admin/live-sessions/useAdminLiveSessions.ts
+++ b/components/admin/live-sessions/useAdminLiveSessions.ts
@@ -38,6 +38,7 @@ export function useAdminLiveSessions() {
     number | null
   >(null);
   const [creatingZoomId, setCreatingZoomId] = useState<number | null>(null);
+  const [creatingGoogleMeetId, setCreatingGoogleMeetId] = useState<number | null>(null);
   const [uniqueAttendanceCounts, setUniqueAttendanceCounts] = useState<Record<number, number>>({});
 
   const canAccessAdmin = canAccessAdminArea(user?.role);
@@ -135,6 +136,23 @@ export function useAdminLiveSessions() {
     }
   };
 
+  const handleCreateGoogleMeet = async (liveClassId: number) => {
+    try {
+      setCreatingGoogleMeetId(liveClassId);
+      const result = await adminLiveActivitiesService.createGoogleMeet(liveClassId);
+      if (result.status === "error") {
+        showToast(result.message || "Failed to create Google Meet", "error");
+        return;
+      }
+      showToast("Google Meet created", "success");
+      loadSessions();
+    } catch (error: unknown) {
+      showToast(getLiveSessionErrorMessage(error), "error");
+    } finally {
+      setCreatingGoogleMeetId(null);
+    }
+  };
+
   const handleWatchRecording = async (activity: LiveActivity) => {
     if (activity.zoom_recording_url?.trim()) {
       window.open(activity.zoom_recording_url, "_blank");
@@ -177,6 +195,7 @@ export function useAdminLiveSessions() {
     setRowsPerPage,
     watchingRecordingId,
     creatingZoomId,
+    creatingGoogleMeetId,
     createDialogOpen,
     setCreateDialogOpen,
     detailDrawerOpen,
@@ -186,6 +205,7 @@ export function useAdminLiveSessions() {
     loadSessions,
     handleCopyPassword,
     handleCreateZoom,
+    handleCreateGoogleMeet,
     handleWatchRecording,
     formatDateTime,
     openViewSession: (activity: LiveActivity) => {

--- a/components/live-sessions/ui/LiveSessionCard.tsx
+++ b/components/live-sessions/ui/LiveSessionCard.tsx
@@ -47,10 +47,13 @@ export interface LiveSessionCardProps<T extends LiveSessionCardData = LiveSessio
   /** Overrides session.attendance_count (e.g. de-duplicated unique attendee count). */
   attendanceCount?: number;
   creatingZoom?: boolean;
+  creatingGoogleMeet?: boolean;
   watchingRecording?: boolean;
   /** Admin: open the detail page. When set, the card body is clickable. */
   onOpen?: (session: T) => void;
   onCreateZoom?: (session: T) => void;
+  /** Admin: provision the Google Meet for a session flagged as Meet but not yet created. */
+  onCreateGoogleMeet?: (session: T) => void;
   onStart?: (session: T) => void;
   onJoin?: (session: T) => void;
   onCopyPasscode?: (password: string) => void;
@@ -85,9 +88,11 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
   variant = "admin",
   attendanceCount,
   creatingZoom = false,
+  creatingGoogleMeet = false,
   watchingRecording = false,
   onOpen,
   onCreateZoom,
+  onCreateGoogleMeet,
   onStart,
   onJoin,
   onCopyPasscode,
@@ -127,6 +132,17 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
       }
       if (joinUrl && onJoin) {
         return { label: t("liveSessions.join", "Join"), icon: "mdi:video", onClick: () => onJoin(session) };
+      }
+      // Google Meet flagged but not yet provisioned (no link) — offer to create it, mirroring
+      // the Zoom "Create" affordance. Checked before the Zoom branch since such a session is
+      // already is_google_meet (so hasMeeting is true and the Zoom branch wouldn't fire).
+      if (isAdmin && session.is_google_meet && !joinUrl && onCreateGoogleMeet) {
+        return {
+          label: t("adminLiveSessions.createGoogleMeet", "Create Google Meet"),
+          icon: "mdi:google",
+          onClick: () => onCreateGoogleMeet(session),
+          loading: creatingGoogleMeet,
+        };
       }
       if (isAdmin && !hasMeeting && onCreateZoom) {
         return {

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -34,6 +34,13 @@ export interface LiveActivity {
   is_google_meet?: boolean;
   zoom_meeting_type?: "meeting" | "webinar" | null;
   closes_at?: string | null;
+  // Google Meet (created via the Google Calendar API)
+  google_source?: "platform" | "manual" | null;
+  google_event_id?: string | null;
+  google_html_link?: string | null;
+  google_status?: "scheduled" | "cancelled" | null;
+  google_cancelled_at?: string | null;
+  google_meet_created_at?: string | null;
   zoom_source?: "platform" | "imported" | null;
   is_unassigned?: boolean;
   zoom_host_id?: string | null;
@@ -107,6 +114,20 @@ export interface ZoomCreateSuccessData {
   zoom_meeting_uuid?: string;
   zoom_join_url?: string;
   zoom_start_url?: string;
+}
+
+/** Google Meet create/cancel envelope data (google/create, google/cancel). */
+export interface GoogleMeetSuccessData {
+  google_event_id?: string;
+  join_link?: string;
+  google_html_link?: string;
+  google_status?: "scheduled" | "cancelled";
+}
+
+/** Optional flags when creating a Google Meet. */
+export interface CreateGoogleMeetOptions {
+  /** Also add enrolled students as native Google Calendar attendees (Google sends invites). */
+  invite_attendees?: boolean;
 }
 
 export interface ZoomStatusResponse {
@@ -304,6 +325,38 @@ export const adminLiveActivitiesService = {
   ): Promise<ZoomApiResponse<unknown>> => {
     const response = await apiClient.post<ZoomApiResponse<unknown>>(
       `${BASE}/live-activities/${liveClassId}/zoom/end-meeting/`
+    );
+    return response.data;
+  },
+
+  /** Create a Google Meet for the session via the Google Calendar API (idempotent). */
+  createGoogleMeet: async (
+    liveClassId: number,
+    options?: CreateGoogleMeetOptions
+  ): Promise<ZoomApiResponse<GoogleMeetSuccessData>> => {
+    const response = await apiClient.post<ZoomApiResponse<GoogleMeetSuccessData>>(
+      `${BASE}/live-activities/${liveClassId}/google/create/`,
+      options ?? {}
+    );
+    return response.data;
+  },
+
+  /** Push topic/time/duration changes to the backing Google Calendar event. */
+  updateGoogleMeet: async (
+    liveClassId: number
+  ): Promise<ZoomApiResponse<GoogleMeetSuccessData>> => {
+    const response = await apiClient.post<ZoomApiResponse<GoogleMeetSuccessData>>(
+      `${BASE}/live-activities/${liveClassId}/google/update/`
+    );
+    return response.data;
+  },
+
+  /** Cancel (delete) the Google Calendar event backing this session. */
+  cancelGoogleMeet: async (
+    liveClassId: number
+  ): Promise<ZoomApiResponse<GoogleMeetSuccessData>> => {
+    const response = await apiClient.post<ZoomApiResponse<GoogleMeetSuccessData>>(
+      `${BASE}/live-activities/${liveClassId}/google/cancel/`
     );
     return response.data;
   },

--- a/lib/services/google.service.ts
+++ b/lib/services/google.service.ts
@@ -1,0 +1,78 @@
+import apiClient from "./api";
+import { config } from "../config";
+
+/**
+ * Per-client Google (Meet/Calendar) config.
+ * GET/PUT/DELETE .../accounts/clients/<id>/google-credentials/
+ * POST .../google-credentials/connect/ starts the "Connect Google" consent flow.
+ * GET never returns google_client_secret or the refresh token.
+ */
+export interface GoogleCredentials {
+  id?: number;
+  is_active?: boolean;
+  /** True once an admin has completed the OAuth consent (we hold a refresh token). */
+  is_connected?: boolean;
+  /** True when the tenant uses its own Google OAuth app instead of the platform default. */
+  has_custom_app?: boolean;
+  connected_email?: string | null;
+  calendar_id?: string | null;
+  timezone?: string | null;
+  connected_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Fields the admin may set via PUT (per-tenant OAuth app is optional). */
+export interface GoogleCredentialsInput {
+  google_client_id?: string;
+  google_client_secret?: string;
+  calendar_id?: string;
+  timezone?: string;
+  is_active?: boolean;
+}
+
+interface GetGoogleCredentialsResponse {
+  google_credentials: GoogleCredentials | null;
+}
+
+interface PutGoogleCredentialsResponse {
+  message?: string;
+  google_credentials: GoogleCredentials;
+}
+
+interface ConnectResponse {
+  authorize_url: string;
+}
+
+const BASE = `/accounts/clients/${config.clientId}/google-credentials`;
+
+export const googleService = {
+  getGoogleCredentials: async (): Promise<GoogleCredentials | null> => {
+    const response = await apiClient.get<GetGoogleCredentialsResponse>(`${BASE}/`);
+    return response.data.google_credentials ?? null;
+  },
+
+  putGoogleCredentials: async (
+    data: GoogleCredentialsInput
+  ): Promise<GoogleCredentials> => {
+    const response = await apiClient.put<PutGoogleCredentialsResponse>(`${BASE}/`, data);
+    return response.data.google_credentials;
+  },
+
+  /** Disconnect the Google account (clears the stored refresh token). */
+  disconnectGoogle: async (): Promise<void> => {
+    await apiClient.delete(`${BASE}/`);
+  },
+
+  /**
+   * Begin the "Connect Google" consent flow. Returns the Google authorize URL — the caller
+   * should redirect the browser to it. `returnTo` is where Google's callback bounces back
+   * (a relative admin path; defaults to /admin/live-sessions).
+   */
+  startConnect: async (returnTo = "/admin/live-sessions"): Promise<string> => {
+    const response = await apiClient.post<ConnectResponse>(`${BASE}/connect/`, {
+      return_to: returnTo,
+    });
+    return response.data.authorize_url;
+  },
+};

--- a/lib/services/google.service.ts
+++ b/lib/services/google.service.ts
@@ -33,6 +33,14 @@ export interface GoogleCredentialsInput {
 
 interface GetGoogleCredentialsResponse {
   google_credentials: GoogleCredentials | null;
+  /** The OAuth redirect URI to whitelist in Google Cloud Console (platform-wide, always present). */
+  redirect_uri?: string;
+}
+
+/** Connection status + the redirect URI the admin must register in Google Cloud Console. */
+export interface GoogleCredentialsStatus {
+  credentials: GoogleCredentials | null;
+  redirectUri: string;
 }
 
 interface PutGoogleCredentialsResponse {
@@ -47,9 +55,12 @@ interface ConnectResponse {
 const BASE = `/accounts/clients/${config.clientId}/google-credentials`;
 
 export const googleService = {
-  getGoogleCredentials: async (): Promise<GoogleCredentials | null> => {
+  getGoogleCredentials: async (): Promise<GoogleCredentialsStatus> => {
     const response = await apiClient.get<GetGoogleCredentialsResponse>(`${BASE}/`);
-    return response.data.google_credentials ?? null;
+    return {
+      credentials: response.data.google_credentials ?? null,
+      redirectUri: response.data.redirect_uri ?? "",
+    };
   },
 
   putGoogleCredentials: async (

--- a/lib/services/live-class.service.ts
+++ b/lib/services/live-class.service.ts
@@ -31,6 +31,7 @@ export interface CreateLiveClassSessionPayload {
   course?: number | null;
   join_link?: string;
   is_google_meet?: boolean;
+  google_source?: "platform" | "manual";
   zoom_meeting_type?: "meeting" | "webinar";
   closes_at?: string | null;
 }


### PR DESCRIPTION
## What
Frontend for the **per-client Google Meet** integration (pairs with the backend PR). Brings the Meet UI to parity with Zoom.

## Frontend changes
- **`google.service.ts`**: credentials GET/PUT/DELETE + one-click **Connect Google** (returns the OAuth authorize URL); `createGoogleMeet`/`updateGoogleMeet`/`cancelGoogleMeet` on the admin live-activities service; `google_*` fields on `LiveActivity`.
- **`GoogleSetupCard` + `GoogleCredentialsDialog`** on the admin live-sessions page: Connect/Reconnect/Disconnect, calendar/timezone settings, optional bring-your-own Google app, and the **exact redirect URI (copyable)** + a collapsible **`GoogleSetupGuide`** (enable Calendar API, add scope/test-users, whitelist redirect URI). Page toasts the `?google_connected` round-trip.
- **Create wizard**: the "Meet" type now offers **Auto-create** (mints the Meet + calendar invite server-side) vs **Paste-a-link**, defaulting to manual when no Google account is connected; auto-create marks the session as platform-Google and reuses the created session on retry (no duplicate rows).
- **Detail page + list card**: Sync / Cancel / Create-retry for API-created Meets, and a **"Create Google Meet"** card action at parity with the Zoom create affordance.

## Verification
`tsc --noEmit` 0 errors, `eslint` clean across all touched files.

## Base branch
Targets **`feat/requiz-outcome-banner`** (this branch was cut from it) so the diff is Google-Meet-only. Retarget to the default branch after that merges if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
