### PR TITLE
feat(manage-students): quick-enroll a single student without CSV

### DIFF
--- a/app/admin/manage-students/page.tsx
+++ b/app/admin/manage-students/page.tsx
@@ -25,6 +25,7 @@ import { StudentsFilters } from "../../../components/admin/manage-students/Stude
 import { StudentsTable } from "../../../components/admin/manage-students/StudentsTable";
 import { StudentsPagination } from "../../../components/admin/manage-students/StudentsPagination";
 import { BulkEnrollmentDialog } from "../../../components/admin/manage-students/BulkEnrollmentDialog";
+import { QuickEnrollStudentDialog } from "../../../components/admin/manage-students/QuickEnrollStudentDialog";
 import { EnrollmentJobHistory } from "../../../components/admin/manage-students/EnrollmentJobHistory";
 import { BulkActionToolbar } from "../../../components/admin/manage-students/BulkActionToolbar";
 import {
@@ -235,6 +236,7 @@ export default function ManageStudentsPage() {
 
   // Bulk Enrollment
   const [bulkEnrollDialogOpen, setBulkEnrollDialogOpen] = useState(false);
+  const [quickEnrollDialogOpen, setQuickEnrollDialogOpen] = useState(false);
   const enrollmentJobSectionRef = useRef<HTMLDivElement | null>(null);
   const loadStudentsSeqRef = useRef(0);
 
@@ -761,6 +763,10 @@ export default function ManageStudentsPage() {
     });
   };
 
+  const handleQuickEnrollSuccess = () => {
+    loadStudents();
+  };
+
   // ── Row selection for bulk course actions ──────────────────────────────
   const handleToggleSelect = (id: number) => {
     setSelectedIds((prev) => {
@@ -868,6 +874,11 @@ export default function ManageStudentsPage() {
           onBulkEnrollClick={
             showOrgAdminEnrollmentTools
               ? () => setBulkEnrollDialogOpen(true)
+              : undefined
+          }
+          onQuickEnrollClick={
+            showOrgAdminEnrollmentTools
+              ? () => setQuickEnrollDialogOpen(true)
               : undefined
           }
           onDownloadCsv={
@@ -1121,6 +1132,12 @@ export default function ManageStudentsPage() {
           open={bulkEnrollDialogOpen}
           onClose={() => setBulkEnrollDialogOpen(false)}
           onSuccess={handleBulkEnrollSuccess}
+        />
+
+        <QuickEnrollStudentDialog
+          open={quickEnrollDialogOpen}
+          onClose={() => setQuickEnrollDialogOpen(false)}
+          onSuccess={handleQuickEnrollSuccess}
         />
       </Box>
     </MainLayout>

--- a/components/admin/adaptive-course/CourseStudentsPanel.tsx
+++ b/components/admin/adaptive-course/CourseStudentsPanel.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { EnrollAdaptiveStudentsDialog } from "./EnrollAdaptiveStudentsDialog";
 import { BulkEnrollmentDialog } from "@/components/admin/manage-students/BulkEnrollmentDialog";
+import { QuickEnrollStudentDialog } from "@/components/admin/manage-students/QuickEnrollStudentDialog";
 import { GradientBar, StudentAvatar, TYPE_COLOR } from "./studentVisuals";
 
 interface Props {
@@ -71,6 +72,7 @@ export function CourseStudentsPanel({ courseId, courseTitle }: Props) {
   const [loading, setLoading] = useState(true);
   const [enrollOpen, setEnrollOpen] = useState(false);
   const [csvOpen, setCsvOpen] = useState(false);
+  const [quickEnrollOpen, setQuickEnrollOpen] = useState(false);
   const [detailId, setDetailId] = useState<number | null>(null);
   const [busyId, setBusyId] = useState<number | null>(null);
 
@@ -164,6 +166,9 @@ export function CourseStudentsPanel({ courseId, courseTitle }: Props) {
           </Typography>
         </Box>
         <Box sx={{ flex: 1 }} />
+        <Button variant="outlined" startIcon={<Icon icon="mdi:account-plus-outline" width={18} />} onClick={() => setQuickEnrollOpen(true)} sx={outlineBtnSx}>
+          Add new student
+        </Button>
         <Button variant="outlined" startIcon={<Icon icon="mdi:file-upload-outline" width={18} />} onClick={() => setCsvOpen(true)} sx={outlineBtnSx}>
           Upload CSV
         </Button>
@@ -336,6 +341,13 @@ export function CourseStudentsPanel({ courseId, courseTitle }: Props) {
       <BulkEnrollmentDialog
         open={csvOpen}
         onClose={() => setCsvOpen(false)}
+        onSuccess={reload}
+        lockedAdaptiveCourse={{ id: courseId, title: courseTitle }}
+      />
+
+      <QuickEnrollStudentDialog
+        open={quickEnrollOpen}
+        onClose={() => setQuickEnrollOpen(false)}
         onSuccess={reload}
         lockedAdaptiveCourse={{ id: courseId, title: courseTitle }}
       />

--- a/components/admin/manage-students/ManageStudentsHeader.tsx
+++ b/components/admin/manage-students/ManageStudentsHeader.tsx
@@ -7,12 +7,14 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 interface ManageStudentsHeaderProps {
   totalCount: number;
   onBulkEnrollClick?: () => void;
+  onQuickEnrollClick?: () => void;
   onDownloadCsv?: () => void;
 }
 
 export function ManageStudentsHeader({
   totalCount,
   onBulkEnrollClick,
+  onQuickEnrollClick,
   onDownloadCsv,
 }: ManageStudentsHeaderProps) {
   const { t } = useTranslation("common");
@@ -139,6 +141,18 @@ export function ManageStudentsHeader({
               onClick={onDownloadCsv}
             >
               {t("adminManageStudents.downloadCsv")}
+            </Button>
+          )}
+          {onQuickEnrollClick && (
+            <Button
+              variant="outlined"
+              size="medium"
+              fullWidth={false}
+              sx={{ minWidth: { xs: "100%", sm: 160 } }}
+              startIcon={<IconWrapper icon="mdi:account-plus-outline" size={20} />}
+              onClick={onQuickEnrollClick}
+            >
+              {t("adminManageStudents.quickEnroll.addStudent")}
             </Button>
           )}
           {onBulkEnrollClick && (

--- a/components/admin/manage-students/QuickEnrollStudentDialog.tsx
+++ b/components/admin/manage-students/QuickEnrollStudentDialog.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Chip,
+  CircularProgress,
+  IconButton,
+} from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
+import { adminStudentEnrollmentService } from "@/lib/services/admin/admin-student-enrollment.service";
+import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
+import {
+  adminAdaptiveCourseService,
+  type AdminAdaptiveCourseListItem,
+} from "@/lib/services/admin/admin-adaptive-course.service";
+import { Course } from "@/lib/services/courses.service";
+
+interface QuickEnrollStudentDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+  /** When set, enrolls into this one adaptive course (course-builder Students tab) — the course
+   *  pickers are hidden and this is the fixed target. */
+  lockedAdaptiveCourse?: { id: number; title: string };
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function QuickEnrollStudentDialog({
+  open,
+  onClose,
+  onSuccess,
+  lockedAdaptiveCourse,
+}: QuickEnrollStudentDialogProps) {
+  const { showToast } = useToast();
+  const { t } = useTranslation("common");
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [adaptiveCourses, setAdaptiveCourses] = useState<AdminAdaptiveCourseListItem[]>([]);
+  const [selectedCourseIds, setSelectedCourseIds] = useState<number[]>([]);
+  const [selectedAdaptiveCourseIds, setSelectedAdaptiveCourseIds] = useState<number[]>([]);
+  const [loadingCourses, setLoadingCourses] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [nameError, setNameError] = useState("");
+  const [emailError, setEmailError] = useState("");
+
+  useEffect(() => {
+    if (open) {
+      loadCourses();
+    } else {
+      // Reset on close
+      setName("");
+      setEmail("");
+      setPhone("");
+      setSelectedCourseIds([]);
+      setSelectedAdaptiveCourseIds([]);
+      setConfirmOpen(false);
+      setSubmitting(false);
+      setNameError("");
+      setEmailError("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const loadCourses = async () => {
+    if (lockedAdaptiveCourse) return; // fixed target — no pickers needed
+    try {
+      setLoadingCourses(true);
+      const raw = await adminCoursesService.getCourses();
+      const list = Array.isArray(raw)
+        ? raw
+        : Array.isArray((raw as { results?: unknown[] })?.results)
+          ? ((raw as { results: unknown[] }).results as unknown[])
+          : [];
+      setCourses(list as Course[]);
+      try {
+        setAdaptiveCourses(await adminAdaptiveCourseService.listCourses());
+      } catch {
+        setAdaptiveCourses([]);
+      }
+    } catch {
+      showToast(t("adminManageStudents.failedToLoadCourses"), "error");
+    } finally {
+      setLoadingCourses(false);
+    }
+  };
+
+  const validate = (): boolean => {
+    const nErr = name.trim() ? "" : t("adminManageStudents.quickEnroll.nameRequired");
+    const eErr = !email.trim()
+      ? t("adminManageStudents.quickEnroll.emailRequired")
+      : !EMAIL_RE.test(email.trim())
+        ? t("adminManageStudents.quickEnroll.emailInvalid")
+        : "";
+    setNameError(nErr);
+    setEmailError(eErr);
+    return !nErr && !eErr;
+  };
+
+  const handleEnrollClick = () => {
+    if (validate()) setConfirmOpen(true);
+  };
+
+  const doEnroll = async () => {
+    setConfirmOpen(false);
+    try {
+      setSubmitting(true);
+      const adaptiveIds = lockedAdaptiveCourse
+        ? String(lockedAdaptiveCourse.id)
+        : selectedAdaptiveCourseIds.join(",");
+      const res = await adminStudentEnrollmentService.quickEnrollStudent({
+        name: name.trim(),
+        email: email.trim(),
+        phone: phone.trim() || undefined,
+        course_ids: lockedAdaptiveCourse ? "" : selectedCourseIds.join(","),
+        adaptive_course_ids: adaptiveIds,
+      });
+      // Count every selected course the student now belongs to (newly enrolled + already enrolled),
+      // so an idempotent re-enroll doesn't misreport "0 course(s)".
+      const enrolledCount =
+        res.legacy_enrolled.length +
+        res.legacy_already_enrolled.length +
+        res.adaptive_enrolled +
+        res.adaptive_already_enrolled;
+      const msg = res.created_account
+        ? t("adminManageStudents.quickEnroll.successCreated", { name: name.trim(), count: enrolledCount })
+        : t("adminManageStudents.quickEnroll.successExisting", { name: name.trim(), count: enrolledCount });
+      showToast(msg, "success");
+      onSuccess?.();
+      onClose();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : t("adminManageStudents.quickEnroll.failed"), "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const courseCount =
+    (lockedAdaptiveCourse ? 1 : selectedAdaptiveCourseIds.length) + selectedCourseIds.length;
+
+  return (
+    <>
+      <Dialog open={open} onClose={submitting ? undefined : onClose} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          {t("adminManageStudents.quickEnroll.title")}
+          <IconButton onClick={onClose} disabled={submitting} size="small" aria-label="close">
+            <IconWrapper icon="mdi:close" size={20} />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            {t("adminManageStudents.quickEnroll.subtitle")}
+          </Typography>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <TextField
+              label={t("adminManageStudents.quickEnroll.nameLabel")}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              error={!!nameError}
+              helperText={nameError}
+              required
+              fullWidth
+              autoFocus
+            />
+            <TextField
+              label={t("adminManageStudents.quickEnroll.emailLabel")}
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              error={!!emailError}
+              helperText={emailError}
+              required
+              fullWidth
+            />
+            <TextField
+              label={t("adminManageStudents.quickEnroll.phoneLabel")}
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              fullWidth
+            />
+
+            {lockedAdaptiveCourse ? (
+              <Box>
+                <Typography variant="caption" color="text.secondary">
+                  {t("adminManageStudents.quickEnroll.enrollingInto")}
+                </Typography>
+                <Box sx={{ mt: 0.5 }}>
+                  <Chip label={lockedAdaptiveCourse.title} color="primary" variant="outlined" />
+                </Box>
+              </Box>
+            ) : loadingCourses ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <CircularProgress size={18} />
+                <Typography variant="body2" color="text.secondary">
+                  {t("adminManageStudents.quickEnroll.loadingCourses")}
+                </Typography>
+              </Box>
+            ) : (
+              <>
+                <FormControl fullWidth size="small">
+                  <InputLabel>{t("adminManageStudents.quickEnroll.coursesLabel")}</InputLabel>
+                  <Select
+                    multiple
+                    value={selectedCourseIds}
+                    label={t("adminManageStudents.quickEnroll.coursesLabel")}
+                    onChange={(e) => setSelectedCourseIds(e.target.value as number[])}
+                    renderValue={(ids) => (
+                      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                        {(ids as number[]).map((id) => (
+                          <Chip
+                            key={id}
+                            size="small"
+                            label={courses.find((c) => c.id === id)?.title || `Course ${id}`}
+                          />
+                        ))}
+                      </Box>
+                    )}
+                  >
+                    {courses.map((c) => (
+                      <MenuItem key={c.id} value={c.id}>
+                        {c.title}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                {adaptiveCourses.length > 0 && (
+                  <FormControl fullWidth size="small">
+                    <InputLabel>{t("adminManageStudents.quickEnroll.adaptiveCoursesLabel")}</InputLabel>
+                    <Select
+                      multiple
+                      value={selectedAdaptiveCourseIds}
+                      label={t("adminManageStudents.quickEnroll.adaptiveCoursesLabel")}
+                      onChange={(e) => setSelectedAdaptiveCourseIds(e.target.value as number[])}
+                      renderValue={(ids) => (
+                        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                          {(ids as number[]).map((id) => (
+                            <Chip
+                              key={id}
+                              size="small"
+                              label={adaptiveCourses.find((c) => c.id === id)?.title || `Adaptive ${id}`}
+                            />
+                          ))}
+                        </Box>
+                      )}
+                    >
+                      {adaptiveCourses.map((c) => (
+                        <MenuItem key={c.id} value={c.id}>
+                          {c.title}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+                <Typography variant="caption" color="text.secondary">
+                  {t("adminManageStudents.quickEnroll.coursesOptionalHint")}
+                </Typography>
+              </>
+            )}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} disabled={submitting} color="inherit">
+            {t("adminManageStudents.cancel")}
+          </Button>
+          <Button onClick={handleEnrollClick} disabled={submitting} variant="contained">
+            {submitting ? (
+              <CircularProgress size={20} color="inherit" />
+            ) : (
+              t("adminManageStudents.quickEnroll.enrollAction")
+            )}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <ConfirmDialog
+        open={confirmOpen}
+        title={t("adminManageStudents.quickEnroll.confirmTitle")}
+        message={t("adminManageStudents.quickEnroll.confirmMessage", {
+          name: name.trim(),
+          email: email.trim(),
+          count: courseCount,
+        })}
+        confirmText={t("adminManageStudents.quickEnroll.enrollAction")}
+        cancelText={t("adminManageStudents.cancel")}
+        onConfirm={doEnroll}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </>
+  );
+}

--- a/lib/services/admin/admin-student-enrollment.service.ts
+++ b/lib/services/admin/admin-student-enrollment.service.ts
@@ -72,6 +72,28 @@ export interface CreateEnrollmentJobRequest {
   adaptive_course_ids?: string;
 }
 
+/** Quick-enroll ONE student (modal). name + email required; everything else optional (courses
+ *  optional => create the account only). Course ids are comma-separated strings. */
+export interface QuickEnrollRequest {
+  name: string;
+  email: string;
+  phone?: string;
+  course_ids?: string;
+  adaptive_course_ids?: string;
+}
+
+export interface QuickEnrollResult {
+  email: string;
+  user_id: number;
+  profile_id: number;
+  created_account: boolean;
+  created_profile: boolean;
+  legacy_enrolled: number[];
+  legacy_already_enrolled: number[];
+  adaptive_enrolled: number;
+  adaptive_already_enrolled: number;
+}
+
 export const adminStudentEnrollmentService = {
   // Create a new enrollment job
   createEnrollmentJob: async (
@@ -126,6 +148,26 @@ export const adminStudentEnrollmentService = {
         error.response?.data?.message ||
         error.response?.data?.detail ||
         "Failed to fetch enrollment jobs";
+      throw new Error(message);
+    }
+  },
+
+  // Quick-enroll a SINGLE student synchronously — creates the account if missing and (optionally)
+  // enrolls into courses. Non-CSV alternative to createEnrollmentJob; courses are optional.
+  quickEnrollStudent: async (data: QuickEnrollRequest): Promise<QuickEnrollResult> => {
+    try {
+      const response = await apiClient.post<QuickEnrollResult>(
+        `/admin-dashboard/api/clients/${config.clientId}/students/enroll-single/`,
+        data
+      );
+      return response.data;
+    } catch (err) {
+      const error = err as AxiosError<ApiErrorPayload>;
+      const message =
+        error.response?.data?.error ||
+        error.response?.data?.message ||
+        error.response?.data?.detail ||
+        "Failed to enroll student";
       throw new Error(message);
     }
   },

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1772,7 +1772,29 @@
     "csvHeaderMostActiveCourse": "Most Active Course",
     "csvHeaderCompletionPct": "Completion %",
     "csvHeaderAttendancePct": "Attendance %",
-    "csvHeaderSavedResume": "Saved resume"
+    "csvHeaderSavedResume": "Saved resume",
+    "quickEnroll": {
+      "addStudent": "Add Student",
+      "title": "Add a Student",
+      "subtitle": "Create an account (if it doesn't exist) and optionally enroll into courses. Name and email are required.",
+      "nameLabel": "Full name",
+      "emailLabel": "Email",
+      "phoneLabel": "Phone (optional)",
+      "coursesLabel": "Courses (optional)",
+      "adaptiveCoursesLabel": "Adaptive courses (optional)",
+      "coursesOptionalHint": "Leave courses empty to only create the account at the client level.",
+      "enrollingInto": "Enrolling into",
+      "loadingCourses": "Loading courses…",
+      "enrollAction": "Enroll",
+      "confirmTitle": "Confirm enrollment",
+      "confirmMessage": "Add {{name}} ({{email}}) and enroll into {{count}} course(s)?",
+      "successCreated": "Created account for {{name}} and enrolled into {{count}} course(s).",
+      "successExisting": "Enrolled {{name}} into {{count}} course(s).",
+      "failed": "Failed to enroll student",
+      "nameRequired": "Name is required",
+      "emailRequired": "Email is required",
+      "emailInvalid": "Enter a valid email address"
+    }
   },
   "adminCourseBuilder": {
     "title": "Course Builder",


### PR DESCRIPTION
## Summary

Adds a **non-CSV** way to enroll a single student, alongside the existing bulk-CSV enroll. An admin can now open a small form modal, type **name + email** (required) and **phone** (optional), confirm in a second modal, and the platform will:

- **create the account** at the client level if it doesn't exist (username = email, random password — same as the CSV worker, no welcome email), and
- **optionally enroll** into one or more legacy and/or adaptive courses.

Courses are **optional** — leaving them empty just creates the client-level student account. This is the easy path for adding one student when a bulk CSV import is overkill.

Available in two places (both gated on the same org-admin enrollment permission as bulk enroll):
- **Manage Students** → "Add Student" button in the header.
- **Adaptive course → Students panel** → "Add new student" button, with that course locked as the enroll target.

## Changes
- `QuickEnrollStudentDialog.tsx` (new): validated form (name required, email format checked) + `ConfirmDialog`; loads legacy + adaptive course pickers (hidden when a locked adaptive course is supplied). Success toast counts every selected course the student now belongs to (newly enrolled **+** already enrolled) so an idempotent re-enroll never reports "0 course(s)".
- `ManageStudentsHeader.tsx` / `app/admin/manage-students/page.tsx`: wire the "Add Student" button + dialog.
- `components/admin/adaptive-course/CourseStudentsPanel.tsx`: wire the "Add new student" button with the course locked.
- `admin-student-enrollment.service.ts`: `quickEnrollStudent()` → new synchronous `POST /admin-dashboard/api/clients/<id>/students/enroll-single/` endpoint.
- i18n: `adminManageStudents.quickEnroll.*` keys.

## Backend
Pairs with backend PR #310 (new synchronous `StudentSingleEnrollAPIView` + `create_student_and_enroll` helper). The helper mirrors the CSV worker's account creation but for one student, synchronously, with courses optional. Idempotent — existing account / profile / enrollment is reused, never duplicated.

## Testing
- `tsc --noEmit` — passes.
- `eslint` on all changed/added files — clean (2 remaining `no-explicit-any` errors are pre-existing in untouched interface code).
- Backend: `admin_dashboard.tests` — 10/10 pass, including new coverage for the single-enroll helper/endpoint **and** new end-to-end tests for the existing bulk-enroll worker (verifying the shared account-creation path wasn't regressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)