### PR TITLE
feat(promo): soften adaptive banner/intro copy for brand-new users

### DIFF
--- a/components/courses/AdaptiveCourseIntroModal.tsx
+++ b/components/courses/AdaptiveCourseIntroModal.tsx
@@ -8,15 +8,22 @@ import { useRouter } from "next/navigation";
 
 interface Props {
   course: { id: number; title: string; route: string };
+  /** When true (has prior/legacy courses), the first step warns progress doesn't transfer; when
+   *  false (brand-new user), it shows a plain welcome instead. Defaults to true. */
+  hasPriorCourses?: boolean;
   onClose: () => void;   // called on X / Skip / final CTA — persists "seen forever"
 }
 
-const STEPS: { icon: string; accent: string; title: string; body: string }[] = [
+type Step = { icon: string; accent: string; title: string; body: string };
+
+const buildSteps = (hasPriorCourses: boolean): Step[] => [
   {
     icon: "mdi:auto-awesome",
     accent: "#6366f1",
     title: "Meet Adaptive Courses",
-    body: "A brand-new way to learn — find it under Courses → Adaptive Course. The course adjusts itself to you instead of one-size-fits-all. It's a fresh start: your progress begins at 0 and earlier (non-adaptive) course progress doesn't transfer.",
+    body: hasPriorCourses
+      ? "A brand-new way to learn — find it under Courses → Adaptive Course. The course adjusts itself to you instead of one-size-fits-all. It's a fresh start: your adaptive progress begins at 0 and earlier (non-adaptive) course progress doesn't transfer."
+      : "A brand-new way to learn — find it under Courses → Adaptive Course. The course adjusts itself to you instead of one-size-fits-all, meeting you at your level and growing as you learn.",
   },
   {
     icon: "mdi:target-account",
@@ -38,12 +45,13 @@ const STEPS: { icon: string; accent: string; title: string; body: string }[] = [
   },
 ];
 
-export function AdaptiveCourseIntroModal({ course, onClose }: Props) {
+export function AdaptiveCourseIntroModal({ course, hasPriorCourses = true, onClose }: Props) {
   const router = useRouter();
   const [step, setStep] = useState(0);
   const [dir, setDir] = useState(1);
-  const isLast = step === STEPS.length - 1;
-  const s = STEPS[step];
+  const steps = buildSteps(hasPriorCourses);
+  const isLast = step === steps.length - 1;
+  const s = steps[step];
 
   const go = (next: number) => { setDir(next > step ? 1 : -1); setStep(next); };
   const finish = () => { onClose(); router.push(course.route); };
@@ -109,7 +117,7 @@ export function AdaptiveCourseIntroModal({ course, onClose }: Props) {
 
       {/* Dots + nav */}
       <Stack direction="row" spacing={0.75} justifyContent="center" sx={{ mt: 1 }}>
-        {STEPS.map((_, i) => (
+        {steps.map((_, i) => (
           <Box key={i} onClick={() => go(i)} sx={{ cursor: "pointer", height: 7, borderRadius: 999,
             width: i === step ? 22 : 7, transition: "all 0.3s ease",
             bgcolor: i === step ? s.accent : "color-mix(in srgb, var(--border-default,#cbd5e1) 90%, transparent)" }} />

--- a/components/courses/AdaptiveCoursePromoBanner.tsx
+++ b/components/courses/AdaptiveCoursePromoBanner.tsx
@@ -7,15 +7,19 @@ import { useRouter } from "next/navigation";
 
 interface Props {
   course: { id: number; title: string; route: string };
+  /** When true, the user has prior (legacy) courses, so warn that progress doesn't carry over.
+   *  When false (brand-new user with no history), show a plain welcome instead. Defaults to true. */
+  hasPriorCourses?: boolean;
   onExplore?: () => void;   // optional: open the intro modal instead of routing
   onDismiss: () => void;
 }
 
 /**
- * Dismissible top banner announcing Adaptive Courses to students still on legacy courses. Routes to
- * the promoted course (or opens the intro guide via onExplore). Dismissal persists server-side.
+ * Dismissible top banner announcing Adaptive Courses. Routes to the promoted course (or opens the
+ * intro guide via onExplore). Copy adapts to whether the user is migrating from legacy courses or is
+ * brand new. Dismissal persists server-side.
  */
-export function AdaptiveCoursePromoBanner({ course, onExplore, onDismiss }: Props) {
+export function AdaptiveCoursePromoBanner({ course, hasPriorCourses = true, onExplore, onDismiss }: Props) {
   const router = useRouter();
   return (
     <Box
@@ -44,8 +48,17 @@ export function AdaptiveCoursePromoBanner({ course, onExplore, onDismiss }: Prop
           Your learning experience just got an upgrade ✨
         </Typography>
         <Typography sx={{ fontSize: "0.85rem", opacity: 0.95, mt: 0.25 }}>
-          We&apos;ve moved to Adaptive Courses that adjust to your skill level as you go. Heads up: your progress
-          starts fresh at 0 — your earlier course history doesn&apos;t carry over.
+          {hasPriorCourses ? (
+            <>
+              We&apos;ve moved to Adaptive Courses that adjust to your skill level as you go. Heads up: your
+              adaptive progress starts fresh at 0 — your earlier course history doesn&apos;t carry over.
+            </>
+          ) : (
+            <>
+              We&apos;ve added Adaptive Courses that adjust to your skill level as you learn — pick one and the
+              engine meets you right where you are.
+            </>
+          )}
         </Typography>
       </Box>
       <Button

--- a/components/courses/AdaptivePromo.tsx
+++ b/components/courses/AdaptivePromo.tsx
@@ -6,23 +6,30 @@ import { AdaptiveCoursePromoBanner } from "./AdaptiveCoursePromoBanner";
 import { AdaptiveCourseIntroModal } from "./AdaptiveCourseIntroModal";
 
 /**
- * Mounts the adaptive-course promotion surfaces for legacy-only students: a dismissible top banner
- * and a first-time animated intro modal. Renders nothing for ineligible students / tenants without
- * the feature (the hook skips the fetch). Mount ONCE near the top of the dashboard.
+ * Mounts the adaptive-course promotion surfaces: a dismissible top banner and a first-time animated
+ * intro modal, shown to any eligible user once a course is published. Renders nothing for ineligible
+ * users / tenants without the feature (the hook skips the fetch). Mount ONCE near the top of the
+ * dashboard. Copy adapts via `has_prior_courses` (migration warning vs plain welcome).
  */
 export function AdaptivePromo() {
   const { promotion, dismissBanner, dismissIntro } = useAdaptivePromotion();
   if (!promotion?.eligible || !promotion.adaptive_course) return null;
   const course = promotion.adaptive_course;
+  const hasPriorCourses = promotion.has_prior_courses ?? true;
   return (
     <>
       <AnimatePresence>
         {promotion.show_banner && (
-          <AdaptiveCoursePromoBanner key="adaptive-promo-banner" course={course} onDismiss={dismissBanner} />
+          <AdaptiveCoursePromoBanner
+            key="adaptive-promo-banner"
+            course={course}
+            hasPriorCourses={hasPriorCourses}
+            onDismiss={dismissBanner}
+          />
         )}
       </AnimatePresence>
       {promotion.show_intro_modal && (
-        <AdaptiveCourseIntroModal course={course} onClose={dismissIntro} />
+        <AdaptiveCourseIntroModal course={course} hasPriorCourses={hasPriorCourses} onClose={dismissIntro} />
       )}
     </>
   );

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -2,10 +2,13 @@ import apiClient from "./api";
 
 const BASE = "/adaptive-quiz/api";
 
-/** Promotion payload for nudging legacy-only students toward Adaptive Courses. */
+/** Promotion payload for nudging users toward Adaptive Courses. */
 export interface AdaptivePromotion {
   eligible: boolean;
   adaptive_course?: { id: number; title: string; route: string };
+  /** True when the user has >=1 prior (legacy) course — drives migration-worded copy vs a plain
+   *  welcome for brand-new users with no course history. */
+  has_prior_courses?: boolean;
   show_banner?: boolean;
   show_intro_modal?: boolean;
 }


### PR DESCRIPTION
## Summary
Now that the adaptive-upgrade promo shows to **every** eligible user once a course is published (not just legacy-course users — see backend PR #311), the banner and intro-modal copy needed to adapt. Previously both told everyone *"your earlier course history doesn't carry over"* — meaningless and slightly alarming for a brand-new user with no prior courses.

Uses the backend's new `has_prior_courses` flag to pick copy:
- **Migrating users** (have ≥1 legacy course) keep the *"adaptive progress starts fresh at 0 — your earlier course history doesn't carry over"* heads-up.
- **Brand-new users** (no enrollments) get a plain welcome: *"We've added Adaptive Courses that adjust to your skill level as you learn — pick one and the engine meets you right where you are."*

Falls back to the migration wording when the flag is absent, so it's safe if the backend field isn't deployed yet.

## Changes
- `lib/services/adaptive-course.service.ts`: add `has_prior_courses?: boolean` to `AdaptivePromotion`.
- `components/courses/AdaptivePromo.tsx`: thread the flag into the banner + intro modal.
- `components/courses/AdaptiveCoursePromoBanner.tsx`: conditional banner subtitle.
- `components/courses/AdaptiveCourseIntroModal.tsx`: conditional first-step body (`buildSteps(hasPriorCourses)`).

## Pairs with
Backend PR #311 (`feat/adaptive-promo-all-published` → master), which drops the legacy-course requirement and adds the `has_prior_courses` field.

## Testing
- `tsc --noEmit` — passes.
- `eslint` on all four changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)