### PR TITLE
fix(interview): hot mic through TTS + instant first question on both interview surfaces

### DIFF
--- a/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
@@ -13,7 +13,10 @@ import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service"
 import type { InterviewResult } from "@/lib/types/adaptive-journey";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { useSpeechToText } from "@/lib/hooks/useSpeechToText";
+import { prefetchInterviewerClip } from "@/lib/hooks/useInterviewerVoice";
 import { readSttEngine } from "@/lib/utils/stt-engine";
+import { detectBrowser } from "@/lib/utils/browser-detect";
+import { getAudioConstraints } from "@/lib/utils/audio-constraints";
 import { registerMediaStream } from "@/lib/utils/media-stream-registry";
 import { AIAvatar } from "@/components/mock-interview/AIAvatar";
 import { MicWaveform } from "@/components/mock-interview/MicWaveform";
@@ -102,6 +105,12 @@ function CourseInterviewInner() {
   // can't stop the silence timer and a manual click from both firing in the same tick.
   const sendingRef = useRef(false);
   const submittingRef = useRef(false);
+  // Mirror of `typing` for the STT callbacks: while the candidate types, ambient voice
+  // fragments must not interleave into the typed answer.
+  const typingRef = useRef(false);
+  // Which action the in-interview error banner's Retry re-runs (a failed follow-up fetch
+  // restores the answer so sendAnswer can re-send the SAME turn; a failed submit re-submits).
+  const retryActionRef = useRef<"send" | "submit">("send");
   // Mic-level analyser (the reliable silence signal, like the platform interview).
   const audioCtxRef = useRef<AudioContext | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
@@ -133,9 +142,29 @@ function CourseInterviewInner() {
   const noiseFloorRef = useRef(0);
   const voicePeakRef = useRef(0);
 
-  // Honour the STT engine the user's device-check pinned (if they did one) — avoids the
-  // Edge "first answer dropped" / wrong-engine gibberish. Undefined → auto-decide.
-  const forcedEngine = useMemo(() => readSttEngine(), []);
+  // Honour the STT engine the user's device-check pinned (if they did one). The adaptive flow
+  // has no device-check step, so most users arrive with nothing pinned — on Edge that used to
+  // mean the broken native SpeechRecognition path and its ~10s retry ladder ate the entire
+  // first answer ("doesn't recognize my voice"). Pin Whisper on Edge outright, exactly what
+  // the platform's device-check concludes there. Elsewhere undefined → auto-decide.
+  const forcedEngine = useMemo(
+    () => readSttEngine() ?? (detectBrowser() === "edge" ? ("whisper" as const) : undefined),
+    []
+  );
+
+  // Warm the interviewer's OPENING clip while the candidate is still reading the Begin screen.
+  // The journey card stashes the opening question text at claim time (sessionStorage), because
+  // the detail API only serves completed interviews. Cache is keyed by exact text, so if the
+  // tailored plan swaps the opening between claim and start, this is simply an unused warm-up.
+  useEffect(() => {
+    if (!interviewId) return;
+    try {
+      const stashed = sessionStorage.getItem(`adaptiveInterviewOpening_${interviewId}`);
+      if (stashed) prefetchInterviewerClip(stashed);
+    } catch {
+      /* sessionStorage unavailable — the Begin-click prefetch still covers most of the win */
+    }
+  }, [interviewId]);
 
   useEffect(() => {
     answerRef.current = answer;
@@ -144,6 +173,10 @@ function CourseInterviewInner() {
   useEffect(() => {
     aiSpeakingRef.current = aiSpeaking;
   }, [aiSpeaking]);
+
+  useEffect(() => {
+    typingRef.current = typing;
+  }, [typing]);
 
   const bumpSpeech = () => {
     lastSpeechRef.current = performance.now();
@@ -170,7 +203,9 @@ function CourseInterviewInner() {
   const startMicAnalyser = useCallback(async () => {
     if (audioCtxRef.current) return;
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Same constraints as the STT capture (echoCancellation etc.) so the level the gate
+      // sees matches what the recognizer hears — a raw stream reads systematically louder.
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: getAudioConstraints() });
       micStreamRef.current = stream;
       const ctx = new AudioContext();
       if (ctx.state === "suspended") void ctx.resume().catch(() => {});
@@ -227,6 +262,16 @@ function CourseInterviewInner() {
 
   useEffect(() => () => { stopMicAnalyser(); stopSelfView(); }, [stopMicAnalyser, stopSelfView]);
 
+  // Returning to a backgrounded tab: the rAF-driven analyser was throttled, so lastSpeechRef
+  // is stale — re-prime it so the silence auto-advance can't fire the instant the tab wakes.
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") bumpSpeech();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, []);
+
   // ---- voice: student answers continuously (browser STT + Whisper fallback). STT is
   //      PAUSED while the AI speaks, so it never fights the interviewer's voice. ----
   const stt = useSpeechToText({
@@ -236,16 +281,35 @@ function CourseInterviewInner() {
     lang: "en-US",
     forcedEngine,
     onInterim: (t) => {
+      // While typing, ambient voice must not pollute the typed answer; while the follow-up
+      // fetch is in flight the visible buffer belongs to the NEXT turn — suppress both.
+      if (typingRef.current || sendingRef.current) return;
       setInterim(t);
       bumpSpeech();
     },
     onFinal: (t) => {
+      if (typingRef.current) return;
       const cleaned = sanitizeSttFragment(t);
       setInterim("");
-      if (cleaned) setAnswer((a) => (a ? `${a} ${cleaned}` : cleaned).replace(/\s+/g, " "));
+      if (!cleaned) return;
+      if (sendingRef.current && respRef.current.length > 0) {
+        // The candidate kept talking while the next question was being fetched — those words
+        // belong to the answer JUST sent, not the (empty) buffer of the upcoming turn.
+        const prev = respRef.current[respRef.current.length - 1];
+        prev.answer = `${prev.answer} ${cleaned}`.replace(/\s+/g, " ").trim();
+        return;
+      }
+      setAnswer((a) => (a ? `${a} ${cleaned}` : cleaned).replace(/\s+/g, " "));
       bumpSpeech();
     },
   });
+
+  // If speech recognition dies for good (mic denied, engines exhausted), don't leave the
+  // candidate talking at a lit-but-deaf mic — flip to typing mode with the hook's message
+  // visible below the controls.
+  useEffect(() => {
+    if (stt.needsTypingFallback) setTyping(true);
+  }, [stt.needsTypingFallback]);
 
   // timer (elapsed)
   useEffect(() => {
@@ -310,6 +374,7 @@ function CourseInterviewInner() {
       }
       setResultLoading(false);
     } catch {
+      retryActionRef.current = "submit";
       setError("Couldn't submit your interview. Please try again.");
     } finally {
       setBusy(false);
@@ -339,6 +404,7 @@ function CourseInterviewInner() {
           previous_question_id: question.id,
           candidate_answer: text,
         });
+        setError(null);
         if (next.is_closing_remark || next.interview_complete || !next.question) {
           const remark = next.closing_remark || "Thanks — that's the end of the interview.";
           setClosingRemark(remark);
@@ -358,7 +424,17 @@ function CourseInterviewInner() {
           askQuestion(next.question);
         }
       } catch {
-        setError("The interviewer didn't respond. Please try again.");
+        // Roll back the optimistic commit: keep the candidate's words in the answer box and
+        // off respRef, so Retry re-sends the SAME turn (no duplicate server-side response)
+        // and nothing is lost. Without this, a transient failure was a silent dead-end —
+        // the error state only rendered on the pre-start screen. Restore from the popped
+        // entry (not the snapshot): continuation speech during the fetch was routed into it.
+        const popped = respRef.current[respRef.current.length - 1];
+        respRef.current = respRef.current.slice(0, -1);
+        setTranscript((tr) => tr.slice(0, -1));
+        setAnswer(popped?.answer ?? text);
+        retryActionRef.current = "send";
+        setError("The interviewer didn't respond. Your answer is saved — tap Retry.");
       } finally {
         setBusy(false);
       }
@@ -391,12 +467,18 @@ function CourseInterviewInner() {
   const begin = async () => {
     setBusy(true);
     try {
+      // Fullscreen rides the same click gesture but is NOT awaited — serializing it in front
+      // of /start added its animation time to the silence before the interviewer's first word.
       try {
-        await document.documentElement.requestFullscreen?.();
+        void document.documentElement.requestFullscreen?.()?.catch?.(() => {});
       } catch {
         /* optional */
       }
       const d = await mockInterviewService.startInterview(interviewId);
+      // Warm the opening question's TTS clip NOW — before React even renders the avatar — so
+      // the interviewer's first word plays from cache instead of paying a cold /api/tts
+      // round-trip (the main "it takes a while for the interviewer to ask" latency).
+      prefetchInterviewerClip(qText(d.current_question ?? null));
       if (d.resume_window_expired || ["completed", "finalized"].includes(String(d.status))) {
         setSubmitted(true);
         return;
@@ -404,6 +486,17 @@ function CourseInterviewInner() {
       if (d.is_resume && Array.isArray(d.conversation_history)) {
         respRef.current = d.conversation_history.map((h) => ({ question_id: h.question_id, question_text: h.question_text, answer: h.answer }));
         setTranscript(d.conversation_history.flatMap((h) => [{ role: "ai" as const, text: h.question_text }, { role: "student" as const, text: h.answer }]));
+      }
+      if (d.is_resume) {
+        // Restore what a reload loses: the wrap-up flag (or an answered final question would be
+        // re-asked as a normal turn) and the visible clock (server started_at, not zero).
+        if (typeof d.turn_number === "number" && typeof d.max_turns === "number" && d.max_turns > 0) {
+          setCurrentIsFinal(d.turn_number >= d.max_turns);
+        }
+        if (d.started_at) {
+          const secs = Math.floor((Date.now() - new Date(d.started_at).getTime()) / 1000);
+          if (Number.isFinite(secs) && secs > 0) setElapsed(secs);
+        }
       }
       startedAtRef.current = performance.now();
       bumpSpeech();
@@ -689,6 +782,26 @@ function CourseInterviewInner() {
               <Button onClick={() => setTyping(true)} sx={{ textTransform: "none", color: "rgba(255,255,255,0.55)", fontSize: "0.82rem" }}
                 startIcon={<Icon icon="mdi:keyboard-outline" width={16} />}>
                 Type instead
+              </Button>
+            </Stack>
+          )}
+          {/* In-interview failures used to be invisible (the error screen only rendered
+              pre-start), leaving the interview looking frozen. Surface them inline with a
+              Retry that re-runs exactly what failed — the answer was restored by the
+              rollback, so retrying can't duplicate a turn. */}
+          {error && (
+            <Stack direction="row" spacing={1} alignItems="center"
+              sx={{ mt: 1.5, p: 1.25, borderRadius: 2, bgcolor: "rgba(239,68,68,0.12)", border: "1px solid rgba(239,68,68,0.35)" }}>
+              <Icon icon="mdi:alert-circle-outline" width={18} color="#fca5a5" style={{ flexShrink: 0 }} />
+              <Typography sx={{ flex: 1, fontSize: "0.78rem", color: "#fecaca" }}>{error}</Typography>
+              <Button size="small" disabled={busy}
+                onClick={() => {
+                  setError(null);
+                  if (retryActionRef.current === "submit") void doSubmit();
+                  else void sendAnswer();
+                }}
+                sx={{ textTransform: "none", fontWeight: 800, color: "#fecaca", bgcolor: "rgba(239,68,68,0.2)", "&:hover": { bgcolor: "rgba(239,68,68,0.3)" } }}>
+                Retry
               </Button>
             </Stack>
           )}

--- a/app/mock-interview/[id]/device-check/page.tsx
+++ b/app/mock-interview/[id]/device-check/page.tsx
@@ -19,6 +19,7 @@ import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import mockInterviewService from "@/lib/services/mock-interview.service";
 import { persistSttEngine } from "@/lib/utils/stt-engine";
+import { prefetchInterviewerClip } from "@/lib/hooks/useInterviewerVoice";
 import { useProctoring } from "@/lib/hooks/useProctoring";
 import {
   detectBrowser,
@@ -657,6 +658,16 @@ export default function MockInterviewDeviceCheckPage() {
       const startedInterview = await mockInterviewService.startInterview(
         Number(params.id)
       );
+
+      // Prewarm the interviewer's opening TTS clip while the router transitions to the take
+      // page — the module-level clip cache survives client-side navigation, so the first
+      // question speaks instantly instead of paying a cold /api/tts round-trip on top of
+      // camera/proctoring init.
+      const opening =
+        startedInterview.current_question ??
+        (startedInterview.questions_for_interview || [])[0] ??
+        null;
+      prefetchInterviewerClip(opening?.question_text || opening?.question || "");
 
       if (typeof window !== "undefined") {
         sessionStorage.setItem(

--- a/app/mock-interview/[id]/take/page.tsx
+++ b/app/mock-interview/[id]/take/page.tsx
@@ -688,6 +688,21 @@ export default function TakeMockInterviewPage() {
     setInterviewStarted(true);
 
     try {
+      // Auto-read first question — kicked off FIRST, so the interviewer's voice is not gated
+      // behind camera/face-model init (startProctoring below can take 1-3s; the TTS fetch and
+      // proctoring warm up concurrently now). For dynamic interviews
+      // `questions_for_interview` is intentionally empty (so the candidate can't see future
+      // questions); the opening question lives on `interview.current_question` and is
+      // mirrored into `dynamicCurrentQuestion`.
+      const hasOpeningQuestion = isDynamicInterview
+        ? !!dynamicCurrentQuestion
+        : !!(
+            (interview.questions_for_interview || interview.questions)?.length
+          );
+      if (hasOpeningQuestion) {
+        setIsSpeaking(true);
+      }
+
       // Resume any suspended AudioContext on THIS user gesture. Browsers (Edge/Safari, and
       // Chrome under strict-autoplay) create AudioContexts in "suspended" state until a user
       // gesture resumes them. While suspended the analyser reports ~0 level, which the
@@ -720,8 +735,9 @@ export default function TakeMockInterviewPage() {
         showToast("Failed to enter fullscreen mode", "warning");
       });
 
-      // Start proctoring immediately. Reset the warmup window so the camera
-      // re-attach doesn't surface a stale "no face" toast (see onViolation suppression).
+      // Start proctoring. Reset the warmup window so the camera re-attach doesn't surface a
+      // stale "no face" toast (see onViolation suppression). Runs while the avatar is
+      // already speaking the opening question.
       proctoringStartedAtRef.current = Date.now();
       await startProctoring().catch((error) => {
         showToast(
@@ -729,22 +745,9 @@ export default function TakeMockInterviewPage() {
           "error"
         );
       });
-
-      // Auto-read first question. For dynamic interviews `questions_for_interview` is
-      // intentionally empty (so the candidate can't see future questions); the opening
-      // question lives on `interview.current_question` and is mirrored into
-      // `dynamicCurrentQuestion`. Check `currentQuestion` (which resolves to either source
-      // via the useMemo) so the avatar speaks in both modes.
-      const hasOpeningQuestion = isDynamicInterview
-        ? !!dynamicCurrentQuestion
-        : !!(
-            (interview.questions_for_interview || interview.questions)?.length
-          );
-      if (hasOpeningQuestion) {
-        setIsSpeaking(true);
-      }
     } catch (error: any) {
       showToast(error.message || "Failed to start interview", "error");
+      setIsSpeaking(false);
       setShowStartButton(true);
       setInterviewStarted(false);
       isInitializingRef.current = false;

--- a/components/adaptive-journey/JourneyTopCards.tsx
+++ b/components/adaptive-journey/JourneyTopCards.tsx
@@ -6,6 +6,7 @@ import { Box, ButtonBase, Chip, CircularProgress, Stack, Typography } from "@mui
 import { Icon } from "@iconify/react";
 import { useToast } from "@/components/common/Toast";
 import mockInterviewService from "@/lib/services/mock-interview.service";
+import { prefetchInterviewerClip } from "@/lib/hooks/useInterviewerVoice";
 import type { JourneyBoard } from "@/lib/types/adaptive-journey";
 
 // Subtle diagonal "lining" texture for the dark calibration card.
@@ -144,6 +145,17 @@ function InterviewerCard({ interview, courseId }: { interview: JourneyBoard["int
     setBusy(true);
     try {
       const created = await mockInterviewService.startTemplateInterview(card.templateId);
+      // Warm the interviewer's opening TTS clip while the candidate reads the Begin screen,
+      // and stash the text so the interview page can re-warm after a reload (its detail API
+      // only serves completed interviews). Kills the first-question dead air.
+      if (created.opening_question_text) {
+        prefetchInterviewerClip(created.opening_question_text);
+        try {
+          sessionStorage.setItem(`adaptiveInterviewOpening_${created.id}`, created.opening_question_text);
+        } catch {
+          /* best-effort */
+        }
+      }
       const q = new URLSearchParams();
       if (card.topic) q.set("topic", card.topic);
       if (card.difficulty) q.set("difficulty", card.difficulty);

--- a/lib/hooks/useInterviewerVoice.ts
+++ b/lib/hooks/useInterviewerVoice.ts
@@ -32,6 +32,98 @@ interface CachedClip {
   blob: Blob;
 }
 
+// ---------------------------------------------------------------------------
+// Module-level cloud-TTS clip cache (shared across hook instances and pages).
+//
+// Hoisted out of the hook so the OPENING question's clip can be prefetched BEFORE the avatar
+// starts speaking — e.g. on interview-page mount or during device-check — killing the 1-3s of
+// dead air between "Begin interview" and the interviewer's first word. Keyed by exact utterance
+// text; a prefetch for text that later changes (tailored-plan swap) is simply never read, and
+// playback falls back to today's on-demand fetch.
+// ---------------------------------------------------------------------------
+const CLIP_CACHE_MAX = 24;
+const clipCache = new Map<string, CachedClip>();
+const inflightClipFetches = new Map<string, Promise<CachedClip | null>>();
+let cloudBlockedUntil = 0;
+
+function cacheClip(text: string, clip: CachedClip) {
+  if (clipCache.size >= CLIP_CACHE_MAX) {
+    // Evict the oldest entry (Map preserves insertion order) and release its object URL.
+    const oldest = clipCache.keys().next().value;
+    if (oldest !== undefined) {
+      const evicted = clipCache.get(oldest);
+      clipCache.delete(oldest);
+      try {
+        if (evicted) URL.revokeObjectURL(evicted.url);
+      } catch {}
+    }
+  }
+  clipCache.set(text, clip);
+}
+
+/** Fetch a cloud-TTS clip for `text` into the module cache. Single-flight per text so a
+ *  prefetch and a playback request never double-fetch the same utterance. */
+async function fetchAndCacheClip(text: string): Promise<CachedClip | null> {
+  const cached = clipCache.get(text);
+  if (cached) return cached;
+  const inflight = inflightClipFetches.get(text);
+  if (inflight) return inflight;
+
+  const doFetch = (async (): Promise<CachedClip | null> => {
+    for (let i = 0; i < CLOUD_TTS_RETRY_DELAYS_MS.length; i++) {
+      const delay = CLOUD_TTS_RETRY_DELAYS_MS[i];
+      if (delay > 0) await new Promise<void>((r) => setTimeout(r, delay));
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), CLOUD_TTS_FETCH_TIMEOUT_MS);
+      try {
+        const res = await fetch(TTS_API, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text }),
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          if (res.status === 503) {
+            cloudBlockedUntil = Date.now() + CLOUD_503_COOLDOWN_MS;
+            return null;
+          }
+          continue;
+        }
+        const blob = await res.blob();
+        if (!blob.size) continue;
+        const contentType = (blob.type || "").toLowerCase();
+        if (contentType && !contentType.includes("audio")) continue;
+        const clip: CachedClip = { url: URL.createObjectURL(blob), blob };
+        cacheClip(text, clip);
+        return clip;
+      } catch {
+        // Transient — continue retries.
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    }
+    return null;
+  })();
+
+  inflightClipFetches.set(text, doFetch);
+  try {
+    return await doFetch;
+  } finally {
+    inflightClipFetches.delete(text);
+  }
+}
+
+/** Warm the cloud-TTS cache for an utterance the interviewer is ABOUT to say (fire-and-forget).
+ *  Call as early as the text is known — page mount, device-check proceed, /start resolve — so
+ *  the avatar's first word plays from cache instead of paying a cold /api/tts round-trip. */
+export function prefetchInterviewerClip(text: string | null | undefined): void {
+  const t = (text || "").trim();
+  if (!t || typeof window === "undefined") return;
+  if (Date.now() < cloudBlockedUntil) return;
+  void fetchAndCacheClip(t).catch(() => {});
+}
+
 export function useInterviewerVoice(
   options: UseInterviewerVoiceOptions
 ): UseInterviewerVoiceReturn {
@@ -43,10 +135,8 @@ export function useInterviewerVoice(
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
   const audioElRef = useRef<HTMLAudioElement | null>(null);
   const audioObjectUrlRef = useRef<string | null>(null);
-  const cloudCacheRef = useRef<Map<string, CachedClip>>(new Map());
   const safetyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const sessionIdRef = useRef(0);
-  const cloudBlockedUntilRef = useRef(0);
   const onSpeakStartRef = useRef(onSpeakStart);
   const onSpeakCompleteRef = useRef(onSpeakComplete);
 
@@ -59,18 +149,8 @@ export function useInterviewerVoice(
     warmVoices();
     initializeVoicePreferences();
   }, []);
-
-  useEffect(() => {
-    const cache = cloudCacheRef.current;
-    return () => {
-      cache.forEach((clip) => {
-        try {
-          URL.revokeObjectURL(clip.url);
-        } catch {}
-      });
-      cache.clear();
-    };
-  }, []);
+  // Clips live in the module-level cache (shared + prefetchable); its LRU eviction owns
+  // object-URL revocation, so there is no per-mount cleanup to do here.
 
   useEffect(() => {
     if (!isSpeaking) return;
@@ -178,52 +258,14 @@ export function useInterviewerVoice(
     };
 
     const fetchCloudClip = async (): Promise<CachedClip | null> => {
-      let cached = cloudCacheRef.current.get(question);
-      if (cached) return cached;
-
-      for (let i = 0; i < CLOUD_TTS_RETRY_DELAYS_MS.length; i++) {
-        if (isStale()) return null;
-        const delay = CLOUD_TTS_RETRY_DELAYS_MS[i];
-        if (delay > 0) await wait(delay);
-
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), CLOUD_TTS_FETCH_TIMEOUT_MS);
-
-        try {
-          const res = await fetch(TTS_API, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ text: question }),
-            signal: controller.signal,
-          });
-
-          if (isStale()) return null;
-
-          if (!res.ok) {
-            if (res.status === 503) {
-              cloudBlockedUntilRef.current = Date.now() + CLOUD_503_COOLDOWN_MS;
-              return null;
-            }
-            continue;
-          }
-
-          const blob = await res.blob();
-          if (!blob.size) continue;
-          const contentType = (blob.type || "").toLowerCase();
-          if (contentType && !contentType.includes("audio")) continue;
-
-          const url = URL.createObjectURL(blob);
-          cached = { url, blob };
-          cloudCacheRef.current.set(question, cached);
-          return cached;
-        } catch {
-          // Continue retries for transient failures.
-        } finally {
-          clearTimeout(timeoutId);
-        }
-      }
-
-      return null;
+      // Module cache first — a prefetched opening question plays instantly from here. The
+      // single-flight map inside fetchAndCacheClip also means an in-progress prefetch is
+      // awaited rather than duplicated. The fetch itself intentionally has no isStale()
+      // checks (a completed download is cached for future turns either way); staleness is
+      // re-checked by the caller after the await.
+      const clip = clipCache.get(question) ?? (await fetchAndCacheClip(question));
+      if (isStale()) return null;
+      return clip;
     };
 
     const playBrowser = async (isFallback: boolean) => {
@@ -340,7 +382,7 @@ export function useInterviewerVoice(
     const playCloud = async () => {
       if (isStale()) return;
 
-      if (Date.now() < cloudBlockedUntilRef.current) {
+      if (Date.now() < cloudBlockedUntil) {
         await playBrowser(true);
         return;
       }

--- a/lib/hooks/useSpeechToText.ts
+++ b/lib/hooks/useSpeechToText.ts
@@ -23,6 +23,12 @@ const WHISPER_FATAL_STATUSES = new Set<number>([401, 403]);
 // sending it to Whisper. Whisper otherwise hallucinates phrases like
 // "Thanks for watching" / "subscribe" / "mic testing" on quiet audio.
 const WHISPER_MIN_RMS = 0.012;
+// TTS-bleed guard: a FINAL transcript that completes within this window after unpausing
+// (interviewer just stopped speaking) can only be the tail of the interviewer's own voice —
+// a human answer can't be spoken AND finalized that fast. The recognizer is now kept ALIVE
+// through the interviewer's turn (see the paused effect), so this is what keeps the last
+// TTS words from leaking into the candidate's answer.
+const UNPAUSE_FINAL_GUARD_MS = 400;
 // Lower-cased patterns that match Whisper's silent-audio hallucinations. These
 // regularly appear when the speaker pauses; we drop chunks that match.
 const WHISPER_HALLUCINATION_PATTERNS: RegExp[] = [
@@ -79,7 +85,12 @@ function isWhisperHallucination(text: string): boolean {
   return WHISPER_HALLUCINATION_PATTERNS.some((re) => re.test(trimmed));
 }
 
-/** Compute peak RMS energy (0-1) of an audio blob via WebAudio decoding. */
+/** Peak WINDOWED RMS energy (0-1) of an audio blob via WebAudio decoding.
+ *
+ * Deliberately the max RMS over ~250ms windows, NOT the whole-chunk mean: a single word in the
+ * tail of a 2s chunk (the candidate starting to answer mid-rotation) averages out to near-silence
+ * over the full chunk and used to fail the VAD gate — silently dropping the opening words of the
+ * answer. The windowed peak keeps the gate's anti-hallucination value while passing onset chunks. */
 async function computeAudioEnergy(blob: Blob): Promise<number> {
   if (typeof window === "undefined") return 1;
   const AudioCtx =
@@ -94,15 +105,21 @@ async function computeAudioEnergy(blob: Blob): Promise<number> {
     try {
       const buf = await ctx.decodeAudioData(arrayBuffer.slice(0));
       const ch = buf.getChannelData(0);
-      let sumSquares = 0;
-      // Sample at most 4000 evenly spaced points for speed
+      const windowSize = Math.max(1, Math.floor(buf.sampleRate * 0.25));
+      // Sample at most ~4000 evenly spaced points across the whole chunk for speed.
       const step = Math.max(1, Math.floor(ch.length / 4000));
-      let count = 0;
-      for (let i = 0; i < ch.length; i += step) {
-        sumSquares += ch[i] * ch[i];
-        count++;
+      let peak = 0;
+      for (let start = 0; start < ch.length; start += windowSize) {
+        const end = Math.min(start + windowSize, ch.length);
+        let sumSquares = 0;
+        let count = 0;
+        for (let i = start; i < end; i += step) {
+          sumSquares += ch[i] * ch[i];
+          count++;
+        }
+        if (count > 0) peak = Math.max(peak, Math.sqrt(sumSquares / count));
       }
-      return count > 0 ? Math.sqrt(sumSquares / count) : 0;
+      return peak;
     } finally {
       try {
         await ctx.close();
@@ -195,6 +212,8 @@ export function useSpeechToText(
   // SpeechRecognition has no real `.state`, so this — plus result-freshness — is how the
   // watchdog tells a live recognizer from one that has silently died/wedged.
   const recognitionRunningRef = useRef(false);
+  // When we last flipped paused -> unpaused; drives the TTS-bleed final guard in onresult.
+  const unpausedAtRef = useRef(0);
 
   useEffect(() => {
     onFinalRef.current = onFinal;
@@ -209,8 +228,25 @@ export function useSpeechToText(
     }
   }, []);
 
-  const sendChunkToWhisper = useCallback(async (blob: Blob) => {
-    if (pausedRef.current || whisperFailedRef.current || blob.size < 1000) return;
+  /** Whisper is permanently gone for this session. If it was the ACTIVE transcriber (browser
+   *  STT already disabled), the mic affordance must not stay lit with nobody transcribing —
+   *  surface the typing fallback so the candidate isn't stuck talking to a dead pipeline. */
+  const markWhisperDead = useCallback(() => {
+    whisperFailedRef.current = true;
+    if (whisperActiveRef.current && browserSttDisabledRef.current) {
+      setIsListening(false);
+      setMode("unavailable");
+      setNeedsTypingFallback(true);
+      setError("Voice transcription is unavailable — please type your answer.");
+    }
+  }, []);
+
+  const sendChunkToWhisper = useCallback(async (blob: Blob, recordedWhilePaused: boolean) => {
+    // Gate on whether the chunk STARTED while paused (interviewer speaking), not on the pause
+    // state at send time: a chunk that began while the candidate was answering and got cut off
+    // by the interviewer starting to speak still carries the END of their answer — dropping it
+    // at send time (the old behavior) lost those last words.
+    if (recordedWhilePaused || whisperFailedRef.current || blob.size < 1000) return;
     // Voice-activity gate: skip silent/quiet chunks so Whisper doesn't hallucinate.
     const energy = await computeAudioEnergy(blob);
     if (energy < WHISPER_MIN_RMS) return;
@@ -233,7 +269,7 @@ export function useSpeechToText(
       if (!res.ok) {
         // 401 / 403 → auth or config error — permanent.
         if (WHISPER_FATAL_STATUSES.has(res.status)) {
-          whisperFailedRef.current = true;
+          markWhisperDead();
           return;
         }
         // Everything else (400 bad chunk, 429 rate limit, 502/503 upstream
@@ -241,7 +277,7 @@ export function useSpeechToText(
         // consecutive failures so brief outages don't kill the whole session.
         whisperConsecutiveFailuresRef.current += 1;
         if (whisperConsecutiveFailuresRef.current >= WHISPER_MAX_CONSECUTIVE_FAILURES) {
-          whisperFailedRef.current = true;
+          markWhisperDead();
         }
         return;
       }
@@ -257,10 +293,10 @@ export function useSpeechToText(
       // Network error or aborted — count as transient.
       whisperConsecutiveFailuresRef.current += 1;
       if (whisperConsecutiveFailuresRef.current >= WHISPER_MAX_CONSECUTIVE_FAILURES) {
-        whisperFailedRef.current = true;
+        markWhisperDead();
       }
     }
-  }, [lang]);
+  }, [lang, markWhisperDead]);
 
   const tryStartRecognition = useCallback((rec: SpeechRecognitionInstance) => {
     try {
@@ -305,7 +341,9 @@ export function useSpeechToText(
     clearRetryTimeout();
     retryTimeoutRef.current = setTimeout(() => {
       const rec = recognitionRef.current;
-      if (!rec || !wantsListeningRef.current || pausedRef.current) return;
+      // No paused gate: restarts run even during interviewer TTS so the engine stays warm
+      // (results are suppressed in onresult while paused).
+      if (!rec || !wantsListeningRef.current) return;
       tryStartRecognition(rec);
     }, delay);
     // `startWhisperRecording` is referenced in the body above but defined LATER in this
@@ -332,8 +370,10 @@ export function useSpeechToText(
       }
       return;
     }
+    // NOTE: whisperFailedRef is deliberately NOT reset here — only start() resets it. This
+    // used to re-enable a fatally-failed Whisper endpoint on every per-turn resume, hiding
+    // real outages behind an endless retry loop.
     wantsListeningRef.current = true;
-    whisperFailedRef.current = false;
     const rec = new SpeechRecognition();
     rec.continuous = continuous;
     rec.interimResults = true;
@@ -343,11 +383,18 @@ export function useSpeechToText(
       lastSuccessfulResultAtRef.current = Date.now();
     };
     rec.onresult = (event: SpeechRecognitionResultEvent) => {
-      if (pausedRef.current) return;
-      // Got a result → recognition is healthy. Reset error counters.
+      // Got a result → the ENGINE is healthy, whatever the pause state (during interviewer TTS
+      // the recognizer stays alive and hears the interviewer). Stamp liveness BEFORE the paused
+      // gate so the watchdog doesn't judge a warm-but-suppressed recognizer "deaf" and churn it.
       consecutiveErrorsRef.current = 0;
       lastErrorTypeRef.current = null;
       lastSuccessfulResultAtRef.current = Date.now();
+      // Suppress transcripts while the interviewer speaks — the recognizer is kept warm purely
+      // so the candidate's first words after the question aren't lost to a cold start.
+      if (pausedRef.current) return;
+      // TTS-bleed guard: a final that completes this soon after unpausing is the tail of the
+      // interviewer's own voice still in the recognizer's buffer, not the candidate.
+      if (Date.now() - unpausedAtRef.current < UNPAUSE_FINAL_GUARD_MS) return;
       if (error) setError(null);
       if (tip) setTip(null);
       let interim = "";
@@ -387,11 +434,14 @@ export function useSpeechToText(
       // delay (NOT scheduleRetry), so silence never consumes the retry budget or wrongly
       // promotes to Whisper/typing.
       if (errType === "no-speech" || errType === "aborted") {
-        if (!retryTimeoutRef.current && !pausedRef.current && wantsListeningRef.current && !browserSttDisabledRef.current) {
+        // Restart even while paused — the recognizer must stay WARM through the interviewer's
+        // TTS so the candidate's first words after the question land in a live engine (results
+        // are suppressed by the pausedRef gate in onresult, so nothing leaks).
+        if (!retryTimeoutRef.current && wantsListeningRef.current && !browserSttDisabledRef.current) {
           retryTimeoutRef.current = setTimeout(() => {
             retryTimeoutRef.current = null;
             const r = recognitionRef.current;
-            if (!r || !wantsListeningRef.current || pausedRef.current || browserSttDisabledRef.current) return;
+            if (!r || !wantsListeningRef.current || browserSttDisabledRef.current) return;
             tryStartRecognition(r);
           }, 400);
         }
@@ -440,7 +490,10 @@ export function useSpeechToText(
     };
     rec.onend = () => {
       recognitionRunningRef.current = false;
-      if (!wantsListeningRef.current || pausedRef.current || browserSttDisabledRef.current) return;
+      // Restart even while paused (interviewer speaking) — keeping the recognizer warm through
+      // TTS is the fix for losing the candidate's opening words to a cold start; transcripts
+      // are suppressed via the pausedRef gate in onresult.
+      if (!wantsListeningRef.current || browserSttDisabledRef.current) return;
       // Normal "session ended due to silence" path → restart promptly.
       if (consecutiveErrorsRef.current === 0) {
         tryStartRecognition(rec);
@@ -490,6 +543,9 @@ export function useSpeechToText(
       const mimeType = pickWhisperMimeType();
       const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : {});
       mediaRecorderRef.current = recorder;
+      // Pause state when THIS recording began — decides whether the assembled chunk is
+      // candidate speech (send) or interviewer-TTS-era audio (drop). See sendChunkToWhisper.
+      const recordedWhilePaused = pausedRef.current;
       // Buffer the (typically single) data event for this recording session.
       const buffered: Blob[] = [];
       let rotationTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -513,7 +569,7 @@ export function useSpeechToText(
           const type = recorder.mimeType || mimeType || "audio/webm";
           const completeBlob = new Blob(buffered, { type });
           buffered.length = 0;
-          void sendChunkToWhisper(completeBlob);
+          void sendChunkToWhisper(completeBlob, recordedWhilePaused);
         }
         // Start the next rotation if we still want recording.
         if (!startedRef.current || pausedRef.current) return;
@@ -607,8 +663,9 @@ export function useSpeechToText(
           streamRef.current = stream;
           registerMediaStream(stream);
         } catch {
-          // Can't get mic — give up on Whisper (browser STT may still work).
-          whisperFailedRef.current = true;
+          // Can't get mic — give up on Whisper (browser STT may still work). If Whisper was
+          // the only transcriber, this also surfaces the typing fallback.
+          markWhisperDead();
           return;
         }
       }
@@ -619,7 +676,7 @@ export function useSpeechToText(
     } finally {
       whisperStartingRef.current = false;
     }
-  }, [preferWhisper, streamIsAlive, attachRecorder]);
+  }, [preferWhisper, streamIsAlive, attachRecorder, markWhisperDead]);
 
   // Public start hook for Whisper. Idempotent.
   const startWhisperRecording = useCallback(async () => {
@@ -723,13 +780,13 @@ export function useSpeechToText(
     pausedRef.current = paused;
     if (!startedRef.current) return;
     if (paused) {
-      clearRetryTimeout();
-      if (recognitionRef.current) {
-        try {
-          recognitionRef.current.stop();
-        } catch {}
-        recognitionRef.current = null;
-      }
+      // Keep the browser recognizer ALIVE through the interviewer's TTS. Tearing it down here
+      // and cold-starting on resume (the old behavior) opened a ~300-800ms dead window at the
+      // exact moment candidates start answering — the "it doesn't recognize my voice as soon
+      // as I start speaking" bug. Transcripts are suppressed by the pausedRef gate in onresult,
+      // and the UNPAUSE_FINAL_GUARD drops the interviewer-voice tail after resume.
+      // Only the Whisper recorder stops (each chunk costs a transcription call, and its
+      // MediaRecorder re-arms instantly on resume — it has no cold-start problem).
       const recorder = mediaRecorderRef.current;
       if (recorder && recorder.state !== "inactive") {
         try {
@@ -739,11 +796,19 @@ export function useSpeechToText(
       }
       return;
     }
-    // Resume — defer to avoid running setState within the effect body.
+    // Resume — the interviewer stopped speaking, the candidate may start instantly.
+    unpausedAtRef.current = Date.now();
+    // Defer to avoid running setState within the effect body.
     let cancelled = false;
     const timer = setTimeout(() => {
       if (cancelled || pausedRef.current) return;
-      if (!browserSttDisabledRef.current) startBrowserStt();
+      // The recognizer usually survived the pause (kept warm above) — only build a new one if
+      // it's genuinely not running (e.g. the browser killed it and every restart path missed).
+      if (!browserSttDisabledRef.current && !recognitionRunningRef.current) {
+        const rec = recognitionRef.current;
+        if (rec) tryStartRecognition(rec);
+        else startBrowserStt();
+      }
       // Whisper only resumes when it's the active fallback. If browser STT is still
       // healthy, Whisper stays idle and the avatar's TTS-driven pause doesn't trigger
       // an unnecessary Whisper start.
@@ -755,7 +820,7 @@ export function useSpeechToText(
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [paused, preferWhisper, startBrowserStt, ensureWhisperRunning, clearRetryTimeout]);
+  }, [paused, preferWhisper, startBrowserStt, ensureWhisperRunning, clearRetryTimeout, tryStartRecognition]);
 
   // Watchdog: if continuous mode and recognition silently dies, restart it.
   // Also keeps Whisper alive — MediaRecorder can be killed by the browser
@@ -764,7 +829,9 @@ export function useSpeechToText(
   useEffect(() => {
     if (!continuous || !startedRef.current) return;
     const id = setInterval(() => {
-      if (pausedRef.current) return;
+      // Runs even while paused: the recognizer is deliberately kept warm through interviewer
+      // TTS, so the watchdog must keep maintaining it there too. (Whisper stays pause-gated —
+      // ensureWhisperRunning itself refuses to start while paused.)
       // Browser STT — the hand-rolled SpeechRecognition has no real `.state`, so detect a
       // dead-or-deaf recognizer from our onstart/onend liveness flag + result-freshness.
       // Skip while a scheduleRetry backoff is pending so the watchdog never fights it.

--- a/lib/services/mock-interview.service.ts
+++ b/lib/services/mock-interview.service.ts
@@ -16,6 +16,9 @@ export interface MockInterview {
   interview_type?: string; // Legacy field
   score?: number;
   feedback?: string;
+  /** Opening question text, returned by the template-start (claim) endpoint so the client can
+   *  prewarm the interviewer's first TTS clip before the candidate clicks Begin. */
+  opening_question_text?: string;
 }
 
 export interface MockInterviewDetail extends MockInterview {


### PR DESCRIPTION
## Summary
End-to-end fix for the two reported mock-interview bugs — **voice not recognized as soon as the candidate starts speaking** and **long silence before the interviewer asks the first question** — plus robustness parity between the adaptive-course AI mock interview and the platform mock interview. Based on a 7-agent end-to-end RCA of both surfaces (FE voice stack + BE start/next-question paths).

## Bug A — start-of-speech loss (both surfaces, worst on adaptive)
- **`useSpeechToText`: the recognizer now stays ALIVE while the interviewer speaks.** Previously `paused` tore it down and cold-started a new `SpeechRecognition` after TTS ended — a ~300-800ms dead window at exactly the moment candidates begin answering. Transcripts remain suppressed while paused; a **400ms post-unpause final guard** drops interviewer-voice bleed; all restart paths (onend / no-speech / retry / watchdog) now run during pause so the engine is warm when TTS ends.
- **Whisper VAD gate is onset-safe:** chunks are scored by *peak windowed RMS* (250ms windows) instead of the whole-chunk mean, so a word in the tail of a 2s chunk no longer averages out to "silence" and gets dropped.
- **Whisper boundary chunk preserved:** chunks are gated on the pause state when recording *started*, so the candidate's last words before the interviewer speaks aren't discarded at send time.
- **Adaptive page pins `engine=whisper` on Edge** (it has no device-check to pin one) — skips Edge's broken native path and its ~10s retry ladder that ate the first answer.
- Dead-Whisper sessions now surface the typing fallback instead of a lit-but-deaf mic.

## Bug B — first-question latency
- **`useInterviewerVoice`: module-level TTS clip cache** (LRU 24, single-flight) + exported `prefetchInterviewerClip()`.
- **Adaptive:** the journey card prefetches the opening clip at claim time (+ sessionStorage stash for reloads, paired with backend `opening_question_text`); `begin()` no longer awaits fullscreen; the clip is prefetched the instant `/start` resolves.
- **Platform:** device-check prefetches the opening clip right after `/start`; the take page starts TTS *before* the awaited camera/proctoring init (they warm up concurrently) instead of after it.

## Adaptive-page robustness (parity with the platform surface)
- Failed next-question is no longer a silent dead-end: optimistic commit **rolls back** (answer restored, no duplicate turn) with an inline **Retry** banner; failed submits retry too.
- Speech continuing during the follow-up fetch is appended to the answer just sent, not leaked into the next turn.
- `needsTypingFallback` auto-switches to typing mode; voice fragments no longer interleave into typed answers.
- Resume after reload restores the wrap-up flag (final question isn't re-asked) and seeds the clock from the server's `started_at`.
- Mic analyser uses the same audio constraints as STT; returning from a backgrounded tab re-primes the silence timer.

## Pairs with
Backend PR (ai-linc-backend `fix/interview-latency-loopholes`): conversational turn-2 pregeneration + `opening_question_text` + finalize race guard.

## Testing
- `tsc --noEmit` passes; eslint has **zero new** issues (verified by diffing lint output against base).
- Manual pass recommended on Chrome/Edge/Safari with open speakers to confirm the 400ms bleed guard (headphones are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)