### PR TITLE
fix(interview): recover from mic-permission races + device check on t…

### DIFF
--- a/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
@@ -21,6 +21,7 @@ import { registerMediaStream } from "@/lib/utils/media-stream-registry";
 import { AIAvatar } from "@/components/mock-interview/AIAvatar";
 import { MicWaveform } from "@/components/mock-interview/MicWaveform";
 import { PauseProgressBar } from "@/components/mock-interview/PauseProgressBar";
+import { QuickDeviceCheck, type QuickDeviceCheckStatus } from "@/components/mock-interview/QuickDeviceCheck";
 
 // Strip STT hallucinations (YouTube/caption boilerplate Whisper emits on near-silent audio)
 // from a final chunk before it lands in the answer — the same second-pass filter the
@@ -142,15 +143,18 @@ function CourseInterviewInner() {
   const noiseFloorRef = useRef(0);
   const voicePeakRef = useRef(0);
 
-  // Honour the STT engine the user's device-check pinned (if they did one). The adaptive flow
-  // has no device-check step, so most users arrive with nothing pinned — on Edge that used to
-  // mean the broken native SpeechRecognition path and its ~10s retry ladder ate the entire
-  // first answer ("doesn't recognize my voice"). Pin Whisper on Edge outright, exactly what
-  // the platform's device-check concludes there. Elsewhere undefined → auto-decide.
-  const forcedEngine = useMemo(
+  // Which STT engine to force. Priority: the engine the Begin-screen device check just PROVED
+  // works in this browser > a previously pinned engine (platform device-check) > the Edge pin
+  // (its native SpeechRecognition is broken; Whisper is what a device-check concludes there)
+  // > auto-decide.
+  const [deviceCheck, setDeviceCheck] = useState<QuickDeviceCheckStatus>({
+    camera: null, mic: null, speechOk: false, engine: null,
+  });
+  const pinnedEngine = useMemo(
     () => readSttEngine() ?? (detectBrowser() === "edge" ? ("whisper" as const) : undefined),
     []
   );
+  const forcedEngine = deviceCheck.engine ?? pinnedEngine;
 
   // Warm the interviewer's OPENING clip while the candidate is still reading the Begin screen.
   // The journey card stashes the opening question text at claim time (sessionStorage), because
@@ -666,11 +670,27 @@ function CourseInterviewInner() {
               </Stack>
             ))}
           </Stack>
-          <Button variant="contained" disabled={busy} onClick={begin}
+
+          {/* Device check BEFORE the interview: permissions are prompted here (not mid-interview,
+              where the recognizer used to fire not-allowed while the prompt was still open), the
+              candidate sees their mic level, and the speech test pins the exact STT engine that
+              works in this browser. Voice Begin unlocks when the speech check passes. */}
+          <QuickDeviceCheck onStatus={setDeviceCheck} />
+
+          <Button variant="contained" disabled={busy || !deviceCheck.speechOk} onClick={begin}
             startIcon={busy ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:microphone" width={20} />}
-            sx={{ mt: 1, textTransform: "none", fontWeight: 800, borderRadius: 2, px: 4, py: 1.2, background: "linear-gradient(135deg, #7c3aed, #db2777)" }}>
-            {busy ? "Connecting…" : "Begin interview"}
+            sx={{ mt: 1, textTransform: "none", fontWeight: 800, borderRadius: 2, px: 4, py: 1.2,
+              background: "linear-gradient(135deg, #7c3aed, #db2777)",
+              "&.Mui-disabled": { background: "rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.45)" } }}>
+            {busy ? "Connecting…" : deviceCheck.speechOk ? "Begin interview" : "Pass the mic check to begin"}
           </Button>
+          {!deviceCheck.speechOk && (
+            <Button disabled={busy} onClick={() => { setTyping(true); void begin(); }}
+              startIcon={<Icon icon="mdi:keyboard-outline" width={16} />}
+              sx={{ textTransform: "none", color: "rgba(255,255,255,0.55)", fontSize: "0.8rem" }}>
+              Can&apos;t use a mic? Start and type your answers instead
+            </Button>
+          )}
         </Stack>
       </Box>
     );

--- a/components/mock-interview/QuickDeviceCheck.tsx
+++ b/components/mock-interview/QuickDeviceCheck.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { getAudioConstraints } from "@/lib/utils/audio-constraints";
+import { persistSttEngine } from "@/lib/utils/stt-engine";
+
+/**
+ * Lean inline mic + camera + speech check for the adaptive AI-interview Begin screen — the
+ * compact cousin of the platform's full device-check page. It:
+ *   - requests camera+mic UP FRONT (so the permission prompt happens here, not mid-interview,
+ *     which is how the recognizer used to fire `not-allowed` while the prompt was still open),
+ *   - shows a live self-preview + mic level so the candidate SEES they're being picked up,
+ *   - runs the same speech self-test as the platform device-check (native SpeechRecognition,
+ *     Whisper /api/transcribe fallback) and PINS the working engine via persistSttEngine so
+ *     the interview uses the exact path that just passed.
+ * Camera is optional (the adaptive interview has no proctoring); the mic/speech check gates
+ * the Begin button in the parent (with a type-instead escape hatch).
+ */
+
+export interface QuickDeviceCheckStatus {
+  camera: boolean | null; // null = still checking
+  mic: boolean | null;
+  speechOk: boolean;
+  engine: "browser" | "whisper" | null;
+}
+
+interface Props {
+  onStatus: (status: QuickDeviceCheckStatus) => void;
+}
+
+interface RecognitionLike {
+  start: () => void;
+  stop: () => void;
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((event: { results: ArrayLike<ArrayLike<{ transcript: string }>> }) => void) | null;
+  onerror: (() => void) | null;
+  onend: (() => void) | null;
+}
+
+const SPEECH_TEST_WINDOW_MS = 4000;
+const WHISPER_TEST_RECORD_MS = 3500;
+
+export function QuickDeviceCheck({ onStatus }: Props) {
+  const [status, setStatus] = useState<QuickDeviceCheckStatus>({
+    camera: null,
+    mic: null,
+    speechOk: false,
+    engine: null,
+  });
+  const [testing, setTesting] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [heard, setHeard] = useState("");
+  const [testFailed, setTestFailed] = useState(false);
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const rafRef = useRef(0);
+  const levelRef = useRef<HTMLDivElement | null>(null);
+  const recognitionRef = useRef<RecognitionLike | null>(null);
+  const testTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const gotSpeechRef = useRef(false);
+  const onStatusRef = useRef(onStatus);
+
+  useEffect(() => {
+    onStatusRef.current = onStatus;
+  });
+
+  const update = useCallback((patch: Partial<QuickDeviceCheckStatus>) => {
+    setStatus((prev) => {
+      const next = { ...prev, ...patch };
+      onStatusRef.current(next);
+      return next;
+    });
+  }, []);
+
+  // Acquire devices on mount: camera+mic together first, mic-only as fallback.
+  useEffect(() => {
+    let cancelled = false;
+
+    const attachLevelMeter = (stream: MediaStream) => {
+      try {
+        const ctx = new AudioContext();
+        if (ctx.state === "suspended") void ctx.resume().catch(() => {});
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = 256;
+        ctx.createMediaStreamSource(stream).connect(analyser);
+        audioCtxRef.current = ctx;
+        const data = new Uint8Array(analyser.frequencyBinCount);
+        const loop = () => {
+          if (!audioCtxRef.current) return;
+          analyser.getByteFrequencyData(data);
+          const avg = data.reduce((a, b) => a + b, 0) / data.length / 255;
+          if (levelRef.current) {
+            levelRef.current.style.width = `${Math.min(100, Math.round(avg * 260))}%`;
+          }
+          rafRef.current = requestAnimationFrame(loop);
+        };
+        loop();
+      } catch {
+        /* level meter is a nicety — the speech test is the real check */
+      }
+    };
+
+    (async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { width: { ideal: 640 }, height: { ideal: 480 }, facingMode: "user" },
+          audio: getAudioConstraints(),
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          void videoRef.current.play().catch(() => {});
+        }
+        attachLevelMeter(stream);
+        update({ camera: true, mic: true });
+      } catch {
+        // Camera refused/absent — mic alone still runs the interview (self-view is optional).
+        try {
+          const audioOnly = await navigator.mediaDevices.getUserMedia({
+            audio: getAudioConstraints(),
+          });
+          if (cancelled) {
+            audioOnly.getTracks().forEach((t) => t.stop());
+            return;
+          }
+          streamRef.current = audioOnly;
+          attachLevelMeter(audioOnly);
+          update({ camera: false, mic: true });
+        } catch {
+          if (!cancelled) update({ camera: false, mic: false });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      try {
+        void audioCtxRef.current?.close();
+      } catch {}
+      audioCtxRef.current = null;
+      try {
+        recognitionRef.current?.stop();
+      } catch {}
+      if (testTimerRef.current) clearTimeout(testTimerRef.current);
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    };
+  }, [update]);
+
+  /** Whisper path of the self-test: record a short clip and transcribe server-side. Mirrors
+   *  the platform device-check fallback; passing pins engine="whisper" for the interview. */
+  const runWhisperTest = useCallback(async () => {
+    const stream = streamRef.current;
+    if (!stream) {
+      setTesting(false);
+      setTestFailed(true);
+      return;
+    }
+    setTranscribing(false);
+    const mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
+      ? "audio/webm;codecs=opus"
+      : MediaRecorder.isTypeSupported("audio/webm")
+        ? "audio/webm"
+        : MediaRecorder.isTypeSupported("audio/mp4")
+          ? "audio/mp4"
+          : "";
+    try {
+      const chunks: BlobPart[] = [];
+      const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+      recorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) chunks.push(e.data);
+      };
+      recorder.onstop = async () => {
+        setTesting(false);
+        setTranscribing(true);
+        try {
+          const blob = new Blob(chunks, { type: mimeType || "audio/webm" });
+          if (blob.size < 1000) {
+            setTestFailed(true);
+            return;
+          }
+          const form = new FormData();
+          form.append("file", blob, "speech.webm");
+          form.append("language", "en");
+          const res = await fetch("/api/transcribe", { method: "POST", body: form });
+          const data = (await res.json().catch(() => ({}))) as { text?: string };
+          const text = typeof data?.text === "string" ? data.text.trim() : "";
+          if (res.ok && text) {
+            persistSttEngine("whisper");
+            setHeard(text);
+            setTestFailed(false);
+            update({ speechOk: true, engine: "whisper" });
+          } else {
+            setTestFailed(true);
+          }
+        } catch {
+          setTestFailed(true);
+        } finally {
+          setTranscribing(false);
+        }
+      };
+      recorder.start();
+      setTimeout(() => {
+        try {
+          if (recorder.state !== "inactive") recorder.stop();
+        } catch {}
+      }, WHISPER_TEST_RECORD_MS);
+    } catch {
+      setTesting(false);
+      setTestFailed(true);
+    }
+  }, [update]);
+
+  /** The speech self-test: native SpeechRecognition first; anything heard passes and pins
+   *  engine="browser". No result / error within the window → Whisper fallback. */
+  const runSpeechTest = useCallback(() => {
+    if (testing || transcribing) return;
+    setTesting(true);
+    setTestFailed(false);
+    setHeard("");
+    gotSpeechRef.current = false;
+
+    const Win = window as Window & {
+      SpeechRecognition?: new () => RecognitionLike;
+      webkitSpeechRecognition?: new () => RecognitionLike;
+    };
+    const SpeechRecognition = Win.SpeechRecognition ?? Win.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      void runWhisperTest();
+      return;
+    }
+
+    const rec = new SpeechRecognition();
+    recognitionRef.current = rec;
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.lang = "en-US";
+    rec.onresult = (event) => {
+      const last = event.results[event.results.length - 1];
+      const text = (last?.[0]?.transcript || "").trim();
+      if (text.replace(/[\W_]/g, "").length >= 2) {
+        gotSpeechRef.current = true;
+        setHeard(text);
+        persistSttEngine("browser");
+        update({ speechOk: true, engine: "browser" });
+        if (testTimerRef.current) clearTimeout(testTimerRef.current);
+        setTesting(false);
+        try {
+          rec.stop();
+        } catch {}
+      }
+    };
+    rec.onerror = () => {
+      if (gotSpeechRef.current) return;
+      if (testTimerRef.current) clearTimeout(testTimerRef.current);
+      // Native path broken (Edge network quirk, blocked service…) — try Whisper instead.
+      void runWhisperTest();
+    };
+    rec.onend = () => {
+      if (gotSpeechRef.current) return;
+      // Ended without hearing anything and without erroring — let the window timer decide.
+    };
+    try {
+      rec.start();
+    } catch {
+      void runWhisperTest();
+      return;
+    }
+    testTimerRef.current = setTimeout(() => {
+      if (gotSpeechRef.current) return;
+      try {
+        rec.stop();
+      } catch {}
+      void runWhisperTest();
+    }, SPEECH_TEST_WINDOW_MS);
+  }, [testing, transcribing, runWhisperTest, update]);
+
+  const chip = (ok: boolean | null, label: string) => (
+    <Stack direction="row" spacing={0.6} alignItems="center">
+      {ok === null ? (
+        <CircularProgress size={12} sx={{ color: "rgba(255,255,255,0.5)" }} />
+      ) : (
+        <Icon
+          icon={ok ? "mdi:check-circle" : "mdi:close-circle"}
+          width={15}
+          color={ok ? "#4ade80" : "#f87171"}
+        />
+      )}
+      <Typography sx={{ fontSize: "0.74rem", color: "rgba(255,255,255,0.75)" }}>{label}</Typography>
+    </Stack>
+  );
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        p: 2,
+        borderRadius: 3,
+        bgcolor: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.1)",
+        textAlign: "left",
+      }}
+    >
+      <Stack direction="row" spacing={2} alignItems="flex-start">
+        {/* Camera preview (optional) */}
+        <Box
+          sx={{
+            width: 120,
+            aspectRatio: "4 / 3",
+            borderRadius: 2,
+            overflow: "hidden",
+            flexShrink: 0,
+            bgcolor: "#020617",
+            border: "1px solid rgba(255,255,255,0.12)",
+            display: "grid",
+            placeItems: "center",
+          }}
+        >
+          {status.camera === false ? (
+            <Icon icon="mdi:camera-off-outline" width={24} color="rgba(255,255,255,0.35)" />
+          ) : (
+            <video
+              ref={videoRef}
+              autoPlay
+              muted
+              playsInline
+              style={{ width: "100%", height: "100%", objectFit: "cover", transform: "scaleX(-1)" }}
+            />
+          )}
+        </Box>
+
+        <Stack spacing={1} sx={{ flex: 1, minWidth: 0 }}>
+          <Stack direction="row" spacing={1.5} flexWrap="wrap" useFlexGap>
+            {chip(status.mic, "Microphone")}
+            {chip(status.camera, "Camera (optional)")}
+            {chip(status.speechOk ? true : testing || transcribing ? null : testFailed ? false : null, "Speech check")}
+          </Stack>
+
+          {/* Live mic level — visible proof the mic is picking you up */}
+          <Box sx={{ height: 6, borderRadius: 999, bgcolor: "rgba(255,255,255,0.08)", overflow: "hidden" }}>
+            <Box
+              ref={levelRef}
+              sx={{ height: "100%", width: 0, borderRadius: 999, bgcolor: "#22c55e", transition: "width 80ms linear" }}
+            />
+          </Box>
+
+          {status.speechOk ? (
+            <Typography sx={{ fontSize: "0.76rem", color: "#86efac" }}>
+              Heard you loud and clear{heard ? `: “${heard}”` : ""} — you&apos;re all set.
+            </Typography>
+          ) : status.mic === false ? (
+            <Typography sx={{ fontSize: "0.76rem", color: "#fca5a5" }}>
+              Microphone unavailable. Allow mic access in your browser (padlock icon in the address bar), then reload —
+              or start the interview and type your answers.
+            </Typography>
+          ) : (
+            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={testing || transcribing || status.mic !== true}
+                onClick={runSpeechTest}
+                startIcon={
+                  testing || transcribing ? (
+                    <CircularProgress size={12} sx={{ color: "inherit" }} />
+                  ) : (
+                    <Icon icon="mdi:microphone-message" width={15} />
+                  )
+                }
+                sx={{
+                  textTransform: "none",
+                  fontWeight: 700,
+                  fontSize: "0.74rem",
+                  color: "#c4b5fd",
+                  borderColor: "rgba(196,181,253,0.5)",
+                  "&:hover": { borderColor: "#c4b5fd" },
+                }}
+              >
+                {testing ? "Listening — say anything…" : transcribing ? "Checking…" : testFailed ? "Try the mic test again" : "Test my mic — say anything"}
+              </Button>
+              {testFailed && (
+                <Typography sx={{ fontSize: "0.72rem", color: "#fca5a5" }}>
+                  Didn&apos;t catch anything — check your input device and try again.
+                </Typography>
+              )}
+            </Stack>
+          )}
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/lib/hooks/useSpeechToText.ts
+++ b/lib/hooks/useSpeechToText.ts
@@ -214,6 +214,12 @@ export function useSpeechToText(
   const recognitionRunningRef = useRef(false);
   // When we last flipped paused -> unpaused; drives the TTS-bleed final guard in onresult.
   const unpausedAtRef = useRef(0);
+  // The native recognizer reported a mic-permission denial (it fires not-allowed even while
+  // the browser's permission PROMPT is still open). Drives the permission-specific message
+  // and the Permissions-API recovery below.
+  const permissionDeniedRef = useRef(false);
+  // Live PermissionStatus we subscribed to (cleared on unmount).
+  const permissionWatchRef = useRef<PermissionStatus | null>(null);
 
   useEffect(() => {
     onFinalRef.current = onFinal;
@@ -237,7 +243,11 @@ export function useSpeechToText(
       setIsListening(false);
       setMode("unavailable");
       setNeedsTypingFallback(true);
-      setError("Voice transcription is unavailable — please type your answer.");
+      setError(
+        permissionDeniedRef.current
+          ? "Microphone access is blocked. Allow the mic in your browser and speech will resume automatically — or type your answer."
+          : "Voice transcription is unavailable — please type your answer."
+      );
     }
   }, []);
 
@@ -287,6 +297,10 @@ export function useSpeechToText(
       whisperConsecutiveFailuresRef.current = 0;
       // Reject empty results and known Whisper silent-audio hallucinations.
       if (!text || isWhisperHallucination(text)) return;
+      // Real speech made it through — clear any stale error (e.g. the permission scare from
+      // a not-allowed fired while the browser's permission prompt was still open).
+      setError(null);
+      setIsListening(true);
       setTranscript((prev) => (prev ? `${prev} ${text}` : text));
       onFinalRef.current?.(text);
     } catch {
@@ -418,13 +432,30 @@ export function useSpeechToText(
     };
     rec.onerror = (e: SpeechRecognitionErrorEvent) => {
       const errType = e.error;
-      // Permission errors are non-recoverable — user must act.
+      // Permission errors: the native recognizer fires not-allowed even while the browser's
+      // permission PROMPT is still open (first visit), so this must NOT be treated as a
+      // terminal "denied forever". Three-part handling:
+      //  1. cascade to Whisper — its getUserMedia is the REAL permission test: if the user
+      //     granted (or grants a second later), capture starts and the interview just works;
+      //  2. watch the Permissions API — the moment mic permission flips to granted, browser
+      //     STT is restored automatically and any error clears (the old code left a sticky
+      //     "Microphone access denied" on screen even after the user clicked Allow);
+      //  3. only if Whisper's own mic acquisition fails too (a genuine hard denial) does
+      //     markWhisperDead surface the typing fallback with a permission-specific message.
       if (errType === "not-allowed" || errType === "service-not-allowed") {
-        wantsListeningRef.current = false;
+        permissionDeniedRef.current = true;
         browserSttDisabledRef.current = true;
+        armPermissionRecovery();
+        if (preferWhisper && !whisperFailedRef.current) {
+          whisperActiveRef.current = true;
+          setMode("whisper-only");
+          void startWhisperRecording();
+          return;
+        }
         setIsListening(false);
+        setNeedsTypingFallback(true);
+        setMode("unavailable");
         setError("Microphone access denied. Please allow microphone permission and try again.");
-        setMode(preferWhisper ? "whisper-only" : "unavailable");
         return;
       }
       // Silent / transient — Web Speech auto-stops on silence and fires these constantly.
@@ -514,7 +545,47 @@ export function useSpeechToText(
       wantsListeningRef.current = false;
       setError("Could not start microphone. Allow microphone permission and try again.");
     }
+    // `armPermissionRecovery`/`startWhisperRecording` are referenced in onerror above but
+    // defined LATER in this scope; closures resolve at call time (established pattern here).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [continuous, lang, preferWhisper, scheduleRetry, tryStartRecognition, error, tip]);
+
+  /** Subscribe (once) to the mic PermissionStatus so a user who grants permission AFTER the
+   *  recognizer already fired `not-allowed` (the prompt was still open, or they fixed it via
+   *  the address bar) gets speech back automatically — no reload, no stale "access denied". */
+  const armPermissionRecovery = useCallback(() => {
+    if (permissionWatchRef.current || typeof navigator === "undefined") return;
+    try {
+      navigator.permissions
+        ?.query({ name: "microphone" as PermissionName })
+        .then((status) => {
+          permissionWatchRef.current = status;
+          status.onchange = () => {
+            if (status.state !== "granted" || !startedRef.current) return;
+            permissionDeniedRef.current = false;
+            // Browser STT is the primary engine again — demote the denial-cascade Whisper
+            // so the two never emit duplicate finals for the same speech.
+            whisperActiveRef.current = false;
+            const recorder = mediaRecorderRef.current;
+            if (recorder && recorder.state !== "inactive") {
+              try {
+                recorder.stop();
+              } catch {}
+              mediaRecorderRef.current = null;
+            }
+            browserSttDisabledRef.current = false;
+            consecutiveErrorsRef.current = 0;
+            setNeedsTypingFallback(false);
+            setError(null);
+            setMode("browser");
+            startBrowserStt();
+          };
+        })
+        .catch(() => {});
+    } catch {
+      // Permissions API unavailable (older Safari) — the Whisper cascade still covers recovery.
+    }
+  }, [startBrowserStt]);
 
   const pickWhisperMimeType = useCallback((): string => {
     if (MediaRecorder.isTypeSupported("audio/webm;codecs=opus")) return "audio/webm;codecs=opus";
@@ -719,6 +790,7 @@ export function useSpeechToText(
     whisperFailedRef.current = false;
     whisperConsecutiveFailuresRef.current = 0;
     whisperActiveRef.current = false;
+    permissionDeniedRef.current = false;
     if (pausedRef.current) return;
 
     // Honor the engine the device-check page proved works in THIS browser, so the interview
@@ -863,6 +935,10 @@ export function useSpeechToText(
   useEffect(() => {
     return () => {
       clearRetryTimeout();
+      if (permissionWatchRef.current) {
+        permissionWatchRef.current.onchange = null;
+        permissionWatchRef.current = null;
+      }
       if (recognitionRef.current) {
         try {
           recognitionRef.current.stop();


### PR DESCRIPTION
…he adaptive Begin screen

"Microphone access denied" stayed on screen even after the user clicked Allow: the native recognizer fires `not-allowed` while the browser's permission prompt is STILL OPEN (first visit), and that branch was terminal — it disabled browser STT forever, set the sticky error, claimed whisper-only mode but never actually started Whisper (whisperActiveRef stayed false), and had no recovery when permission was granted a second later. The session sat deaf behind a lit "Listening…" UI.

useSpeechToText:
- not-allowed now CASCADES to Whisper for real (start the recorder — its getUserMedia is the true permission test; if the user granted, capture just works) instead of a half-configured dead mode.
- Permissions API watcher: the moment mic permission flips to granted, browser STT is restored, the denial-cascade Whisper is demoted (no duplicate finals), and the error clears — no reload needed.
- Only a genuine hard denial (Whisper's mic acquisition fails too) surfaces the typing fallback, with a permission-specific message.
- A successful Whisper transcript clears any stale error.

Adaptive Begin screen — device check (parity with the platform module):
- New QuickDeviceCheck: camera+mic requested UP FRONT (permission prompt happens on the Begin screen, not mid-interview — eliminating the not-allowed race), live self-preview + mic level meter, and the same speech self-test as the platform device-check (native SpeechRecognition, Whisper /api/transcribe fallback) which PINS the proven engine via persistSttEngine.
- Voice "Begin interview" unlocks when the speech check passes; a "start and type your answers instead" escape keeps mic-less candidates unblocked.
- The checked engine takes priority over the pinned/Edge-default engine.