### PR TITLE
fix(interview): cross-browser/platform hardening for voice + camera (iOS/Safari/Firefox/Android)

### DIFF
--- a/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/interview/[interviewId]/page.tsx
@@ -13,7 +13,8 @@ import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service"
 import type { InterviewResult } from "@/lib/types/adaptive-journey";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { useSpeechToText } from "@/lib/hooks/useSpeechToText";
-import { prefetchInterviewerClip } from "@/lib/hooks/useInterviewerVoice";
+import { prefetchInterviewerClip, unlockInterviewerAudio } from "@/lib/hooks/useInterviewerVoice";
+import { useScreenWakeLock } from "@/lib/hooks/useScreenWakeLock";
 import { readSttEngine } from "@/lib/utils/stt-engine";
 import { detectBrowser } from "@/lib/utils/browser-detect";
 import { getAudioConstraints } from "@/lib/utils/audio-constraints";
@@ -114,6 +115,9 @@ function CourseInterviewInner() {
   const retryActionRef = useRef<"send" | "submit">("send");
   // Mic-level analyser (the reliable silence signal, like the platform interview).
   const audioCtxRef = useRef<AudioContext | null>(null);
+  // AudioContext pre-created SYNCHRONOUSLY in the Begin click (WebKit only resumes a context
+  // from inside a real gesture; startMicAnalyser runs after an await, too late on iOS).
+  const preCreatedCtxRef = useRef<AudioContext | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
   // Self-view webcam — a small passive mirror of the candidate (no face detection), so the
   // call feels two-sided. Camera is best-effort; denial never blocks the interview.
@@ -211,7 +215,10 @@ function CourseInterviewInner() {
       // sees matches what the recognizer hears — a raw stream reads systematically louder.
       const stream = await navigator.mediaDevices.getUserMedia({ audio: getAudioConstraints() });
       micStreamRef.current = stream;
-      const ctx = new AudioContext();
+      // Prefer the context pre-created (and resumed) inside the Begin click — a context built
+      // here, after the getUserMedia await, stays suspended on iOS/Safari (silent analyser).
+      const ctx = preCreatedCtxRef.current ?? new AudioContext();
+      preCreatedCtxRef.current = null;
       if (ctx.state === "suspended") void ctx.resume().catch(() => {});
       const analyser = ctx.createAnalyser();
       analyser.fftSize = 256;
@@ -314,6 +321,10 @@ function CourseInterviewInner() {
   useEffect(() => {
     if (stt.needsTypingFallback) setTyping(true);
   }, [stt.needsTypingFallback]);
+
+  // Keep the screen awake during the interview — phones dim/lock mid-answer otherwise, which
+  // suspends timers and (on iOS) can end capture entirely. Best-effort; unsupported = no-op.
+  useScreenWakeLock(started && !submitted);
 
   // timer (elapsed)
   useEffect(() => {
@@ -470,6 +481,20 @@ function CourseInterviewInner() {
 
   const begin = async () => {
     setBusy(true);
+    // SYNCHRONOUS gesture work first — iOS/Safari only honor these inside the click, and any
+    // await below discards the transient activation:
+    // 1) bless the shared TTS <audio> element + prime speechSynthesis (else the interviewer is
+    //    SILENT on every iPhone/iPad browser),
+    // 2) create + resume the analyser AudioContext (created after an await it stays suspended
+    //    on WebKit and the mic level/silence gate reads zero forever).
+    unlockInterviewerAudio();
+    try {
+      const ctx = new AudioContext();
+      if (ctx.state === "suspended") void ctx.resume().catch(() => {});
+      preCreatedCtxRef.current = ctx;
+    } catch {
+      /* startMicAnalyser will create its own as a fallback */
+    }
     try {
       // Fullscreen rides the same click gesture but is NOT awaited — serializing it in front
       // of /start added its animation time to the silence before the interviewer's first word.
@@ -674,8 +699,10 @@ function CourseInterviewInner() {
           {/* Device check BEFORE the interview: permissions are prompted here (not mid-interview,
               where the recognizer used to fire not-allowed while the prompt was still open), the
               candidate sees their mic level, and the speech test pins the exact STT engine that
-              works in this browser. Voice Begin unlocks when the speech check passes. */}
-          <QuickDeviceCheck onStatus={setDeviceCheck} />
+              works in this browser. Voice Begin unlocks when the speech check passes. Unmounted
+              the moment Begin is clicked (busy) so its mic/camera streams are RELEASED before the
+              interview acquires its own — iOS is unforgiving about stacked audio captures. */}
+          {!busy && <QuickDeviceCheck onStatus={setDeviceCheck} />}
 
           <Button variant="contained" disabled={busy || !deviceCheck.speechOk} onClick={begin}
             startIcon={busy ? <CircularProgress size={16} sx={{ color: "white" }} /> : <Icon icon="mdi:microphone" width={20} />}
@@ -702,7 +729,7 @@ function CourseInterviewInner() {
   const finishing = !question && !!closingRemark;
 
   return (
-    <Box sx={{ minHeight: "100vh", bgcolor: "#0b1220", color: "white", display: "flex", flexDirection: "column" }}>
+    <Box sx={{ minHeight: "100vh", "@supports (min-height: 100dvh)": { minHeight: "100dvh" }, bgcolor: "#0b1220", color: "white", display: "flex", flexDirection: "column" }}>
       {/* Header */}
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: { xs: 2, md: 3 }, py: 1.5, borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
         <Box>

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -33,11 +33,15 @@ export async function POST(request: NextRequest) {
   const langRaw = formData.get("language");
   const lang = typeof langRaw === "string" ? langRaw : undefined;
 
+  // OpenAI infers the decoder from the filename extension — it must track the REAL container
+  // (Firefox records ogg/opus; Safari/iOS record mp4/AAC; a mislabel gets a 400).
   const ext = file.type.includes("wav")
     ? "wav"
     : file.type.includes("mp4") || file.type.includes("m4a")
       ? "m4a"
-      : "webm";
+      : file.type.includes("ogg")
+        ? "ogg"
+        : "webm";
   const body = new FormData();
   body.append("file", file, `chunk.${ext}`);
   body.append("model", WHISPER_MODEL);

--- a/app/mock-interview/[id]/take/page.tsx
+++ b/app/mock-interview/[id]/take/page.tsx
@@ -14,6 +14,9 @@ import { useProctoring } from "@/lib/hooks/useProctoring";
 import { useFullscreenMonitor } from "@/lib/hooks/useFullscreenMonitor";
 import { useSpeechToText } from "@/lib/hooks/useSpeechToText";
 import { readSttEngine } from "@/lib/utils/stt-engine";
+import { detectBrowser } from "@/lib/utils/browser-detect";
+import { unlockInterviewerAudio } from "@/lib/hooks/useInterviewerVoice";
+import { useScreenWakeLock } from "@/lib/hooks/useScreenWakeLock";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { stopAllMediaTracks, registerMediaStream } from "@/lib/utils/cameraUtils";
 import { cleanInterviewTitle } from "@/lib/utils/mock-interview-title";
@@ -94,8 +97,12 @@ export default function TakeMockInterviewPage() {
   // Which STT engine the device-check mic test proved works in this browser. Read once on
   // mount (client-side) and forced into useSpeechToText so the interview uses the exact path
   // that passed the test — the fix for "mic works on the test page but fails inside".
-  const [forcedSttEngine] = useState<"browser" | "whisper" | undefined>(() =>
-    readSttEngine(),
+  // Keep the screen awake during the interview (phones dim/lock mid-answer otherwise).
+  useScreenWakeLock(interviewStarted);
+  const [forcedSttEngine] = useState<"browser" | "whisper" | undefined>(
+    // Same Edge default as the adaptive surface: with nothing pinned, Edge's broken native
+    // SpeechRecognition would burn ~10s of retries before Whisper takes over.
+    () => readSttEngine() ?? (detectBrowser() === "edge" ? "whisper" : undefined),
   );
 
   const isInitializingRef = useRef(false);
@@ -259,6 +266,11 @@ export default function TakeMockInterviewPage() {
       if (hasAudio && audioTracks.length > 0) {
         try {
           const audioContext = new AudioContext();
+          // WebKit creates contexts suspended outside a gesture — a suspended analyser reads
+          // all-zero and the silence logic thinks the mic is dead (same guard as line ~631).
+          if (audioContext.state === "suspended") {
+            void audioContext.resume().catch(() => {});
+          }
           audioContextRef.current = audioContext;
           const source = audioContext.createMediaStreamSource(stream);
           const analyser = audioContext.createAnalyser();
@@ -682,8 +694,11 @@ export default function TakeMockInterviewPage() {
   const handleStartInterview = useCallback(async () => {
     if (isInitializingRef.current || !interview) return;
     isInitializingRef.current = true;
-    // Start speech-to-text first (same user gesture as click — required by browser for mic)
+    // Start speech-to-text first (same user gesture as click — required by browser for mic),
+    // and bless the TTS paths (shared <audio> element + speechSynthesis primer) SYNCHRONOUSLY —
+    // iOS/Safari block both for the whole interview if the first play happens after an await.
     startStt();
+    unlockInterviewerAudio();
     setShowStartButton(false);
     setInterviewStarted(true);
 

--- a/components/mock-interview/QuickDeviceCheck.tsx
+++ b/components/mock-interview/QuickDeviceCheck.tsx
@@ -5,6 +5,7 @@ import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material"
 import { Icon } from "@iconify/react";
 import { getAudioConstraints } from "@/lib/utils/audio-constraints";
 import { persistSttEngine } from "@/lib/utils/stt-engine";
+import { detectPlatform } from "@/lib/utils/browser-detect";
 
 /**
  * Lean inline mic + camera + speech check for the adaptive AI-interview Begin screen — the
@@ -231,12 +232,24 @@ export function QuickDeviceCheck({ onStatus }: Props) {
     setHeard("");
     gotSpeechRef.current = false;
 
+    // This click is a real user gesture — use it to resume the level-meter AudioContext.
+    // WebKit creates mount-time contexts suspended (no gesture) and ignores off-gesture
+    // resume(), which left the green level bar dead on iPhone/Safari.
+    try {
+      if (audioCtxRef.current?.state === "suspended") {
+        void audioCtxRef.current.resume().catch(() => {});
+      }
+    } catch {}
+
     const Win = window as Window & {
       SpeechRecognition?: new () => RecognitionLike;
       webkitSpeechRecognition?: new () => RecognitionLike;
     };
     const SpeechRecognition = Win.SpeechRecognition ?? Win.webkitSpeechRecognition;
-    if (!SpeechRecognition) {
+    // iOS WebKit's SpeechRecognition is too unreliable for continuous dictation — a passed
+    // native probe here would pin an engine that then fails inside the interview. Go straight
+    // to the Whisper test (the engine the interview will actually use on iOS).
+    if (!SpeechRecognition || detectPlatform() === "ios") {
       void runWhisperTest();
       return;
     }

--- a/lib/hooks/useInterviewerVoice.ts
+++ b/lib/hooks/useInterviewerVoice.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { pickBestVoice, voicesReady, warmVoices, initializeVoicePreferences } from "@/lib/utils/tts-voice-picker";
+import { isChromiumBased } from "@/lib/utils/browser-detect";
 
 const TTS_RESUME_DELAY_MS = 120;
 const TTS_SAFETY_TIMEOUT_MS = 45000;
@@ -124,6 +125,69 @@ export function prefetchInterviewerClip(text: string | null | undefined): void {
   void fetchAndCacheClip(t).catch(() => {});
 }
 
+// ---------------------------------------------------------------------------
+// iOS/Safari audio unlock.
+//
+// WebKit only allows HTMLMediaElement.play() and the FIRST speechSynthesis.speak() when they
+// happen synchronously inside a user gesture. Every interviewer utterance here plays AFTER
+// awaited fetches (and turns 2+ have no gesture at all — silence auto-advance drives them), so
+// without an unlock the interviewer is SILENT on iPhone/iPad (all iOS browsers are WebKit).
+// The fix is the classic primer: ONE persistent <audio> element, "blessed" by playing a silent
+// WAV inside the Begin/Start click, then reused for every cloud clip by swapping .src — a
+// blessed element may keep playing programmatically; a fresh `new Audio()` per turn may not.
+// ---------------------------------------------------------------------------
+const SILENT_WAV =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=";
+
+let sharedAudioEl: HTMLAudioElement | null = null;
+
+function getSharedAudioEl(): HTMLAudioElement | null {
+  if (typeof window === "undefined") return null;
+  if (!sharedAudioEl) {
+    sharedAudioEl = new Audio();
+    sharedAudioEl.preload = "auto";
+    // iOS: never take over the screen with the native player.
+    (sharedAudioEl as HTMLAudioElement & { playsInline?: boolean }).playsInline = true;
+  }
+  return sharedAudioEl;
+}
+
+/** Call SYNCHRONOUSLY inside a user gesture (Begin/Start click), BEFORE any await. Primes both
+ *  audio paths for WebKit: plays a silent WAV on the shared element (unlocks cloud TTS for the
+ *  whole interview) and fires a zero-volume speechSynthesis utterance (unlocks the browser-voice
+ *  fallback). No-ops harmlessly on browsers that don't need it. */
+export function unlockInterviewerAudio(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const el = getSharedAudioEl();
+    if (el && !el.src) {
+      el.src = SILENT_WAV;
+      el.volume = 0;
+      void el
+        .play()
+        .then(() => {
+          el.pause();
+          el.volume = 1;
+        })
+        .catch(() => {
+          el.volume = 1;
+        });
+    }
+  } catch {
+    /* best-effort */
+  }
+  try {
+    if ("speechSynthesis" in window) {
+      const primer = new SpeechSynthesisUtterance(" ");
+      primer.volume = 0;
+      window.speechSynthesis.speak(primer);
+      window.speechSynthesis.cancel();
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
 export function useInterviewerVoice(
   options: UseInterviewerVoiceOptions
 ): UseInterviewerVoiceReturn {
@@ -186,11 +250,16 @@ export function useInterviewerVoice(
         try {
           audioElRef.current.pause();
         } catch {}
+        // The element is the SHARED unlocked one — detach handlers + source but never destroy
+        // it (its gesture blessing is what keeps iOS playing on gesture-less turns).
+        audioElRef.current.onplaying = null;
+        audioElRef.current.onended = null;
+        audioElRef.current.onerror = null;
         audioElRef.current.src = "";
         audioElRef.current = null;
       }
       if (audioObjectUrlRef.current) {
-        // Don't revoke cached URLs — they're managed by cloudCacheRef.
+        // Don't revoke cached URLs — they're managed by the module clip cache.
         audioObjectUrlRef.current = null;
       }
     };
@@ -342,18 +411,23 @@ export function useInterviewerVoice(
           onSpeakStartRef.current?.();
         }
         setAudioActive(true);
-        keepAliveTimeout = setTimeout(() => {
-          keepAliveInterval = setInterval(() => {
-            try {
-              if (window.speechSynthesis.speaking) {
-                window.speechSynthesis.pause();
-                window.speechSynthesis.resume();
-              } else {
-                clearKeepAlive();
-              }
-            } catch {}
-          }, 10000);
-        }, 13000);
+        // The ~15s silent auto-pause this works around is a CHROMIUM bug. On Firefox/Safari
+        // pause()/resume() itself is the unreliable part (clipped or never-resumed audio on
+        // long questions) — so only arm the keep-alive on Chromium engines.
+        if (isChromiumBased()) {
+          keepAliveTimeout = setTimeout(() => {
+            keepAliveInterval = setInterval(() => {
+              try {
+                if (window.speechSynthesis.speaking) {
+                  window.speechSynthesis.pause();
+                  window.speechSynthesis.resume();
+                } else {
+                  clearKeepAlive();
+                }
+              } catch {}
+            }, 10000);
+          }, 13000);
+        }
       };
       utterance.onend = () => {
         if (firedComplete) return;
@@ -396,9 +470,20 @@ export function useInterviewerVoice(
 
         if (isStale()) return;
 
-        const audio = new Audio(clip.url);
+        // Reuse the ONE shared (gesture-unlocked) element — WebKit lets a blessed element keep
+        // playing programmatically across turns, where a fresh `new Audio()` per utterance
+        // would be blocked on iOS/Safari for every gesture-less turn (2+).
+        const audio = getSharedAudioEl() ?? new Audio();
+        try {
+          audio.pause();
+        } catch {}
+        audio.onplaying = null;
+        audio.onended = null;
+        audio.onerror = null;
+        audio.src = clip.url;
         audio.preload = "auto";
         audio.volume = 1.0;
+        audio.muted = false;
         audio.defaultPlaybackRate = 1;
         audio.playbackRate = 1;
         try {

--- a/lib/hooks/useSpeechToText.ts
+++ b/lib/hooks/useSpeechToText.ts
@@ -6,6 +6,15 @@ import { blobToWav } from "@/lib/utils/audio-to-wav";
 import { detectBrowser, detectPlatform } from "@/lib/utils/browser-detect";
 import { getAudioConstraints } from "@/lib/utils/audio-constraints";
 
+/** Keep the native recognizer running through interviewer TTS? Desktop: yes — restart cost is
+ *  the ~300-800ms cold window that eats the candidate's first words. Android: no — its
+ *  recognizer restarts per-utterance anyway (no cold-start to save), finals arrive SECONDS
+ *  late (the 400ms bleed guard can't catch them), and speakerphone bleed is worst there —
+ *  stopping during TTS is strictly safer on Android. */
+function keepRecognizerWarmThroughTts(): boolean {
+  return detectPlatform() !== "android";
+}
+
 const WHISPER_CHUNK_MS = 2000;
 const TRANSCRIBE_API = "/api/transcribe";
 const MAX_BROWSER_STT_RETRIES = 5;
@@ -91,42 +100,53 @@ function isWhisperHallucination(text: string): boolean {
  * tail of a 2s chunk (the candidate starting to answer mid-rotation) averages out to near-silence
  * over the full chunk and used to fail the VAD gate — silently dropping the opening words of the
  * answer. The windowed peak keeps the gate's anti-hallucination value while passing onset chunks. */
+// Shared decode context for the per-chunk VAD. Creating + closing a LIVE AudioContext for every
+// 2s Whisper chunk churns against WebKit's per-page AudioContext cap (Safari/iOS run Whisper as
+// the PRIMARY engine, so this fires constantly on long interviews). decodeAudioData needs no
+// live/resumed context — a single reusable OfflineAudioContext does the job with zero churn.
+let vadDecodeCtx: OfflineAudioContext | null = null;
+
+function getVadDecodeContext(): OfflineAudioContext | null {
+  if (typeof window === "undefined") return null;
+  if (vadDecodeCtx) return vadDecodeCtx;
+  const Ctor =
+    (window as typeof window & { webkitOfflineAudioContext?: typeof OfflineAudioContext })
+      .OfflineAudioContext ??
+    (window as typeof window & { webkitOfflineAudioContext?: typeof OfflineAudioContext })
+      .webkitOfflineAudioContext;
+  if (!Ctor) return null;
+  try {
+    vadDecodeCtx = new Ctor(1, 1, 44100);
+  } catch {
+    return null;
+  }
+  return vadDecodeCtx;
+}
+
 async function computeAudioEnergy(blob: Blob): Promise<number> {
-  if (typeof window === "undefined") return 1;
-  const AudioCtx =
-    (window as typeof window & { webkitAudioContext?: typeof AudioContext })
-      .AudioContext ??
-    (window as typeof window & { webkitAudioContext?: typeof AudioContext })
-      .webkitAudioContext;
-  if (!AudioCtx) return 1;
+  const ctx = getVadDecodeContext();
+  if (!ctx) return 1;
   try {
     const arrayBuffer = await blob.arrayBuffer();
-    const ctx = new AudioCtx();
-    try {
-      const buf = await ctx.decodeAudioData(arrayBuffer.slice(0));
-      const ch = buf.getChannelData(0);
-      const windowSize = Math.max(1, Math.floor(buf.sampleRate * 0.25));
-      // Sample at most ~4000 evenly spaced points across the whole chunk for speed.
-      const step = Math.max(1, Math.floor(ch.length / 4000));
-      let peak = 0;
-      for (let start = 0; start < ch.length; start += windowSize) {
-        const end = Math.min(start + windowSize, ch.length);
-        let sumSquares = 0;
-        let count = 0;
-        for (let i = start; i < end; i += step) {
-          sumSquares += ch[i] * ch[i];
-          count++;
-        }
-        if (count > 0) peak = Math.max(peak, Math.sqrt(sumSquares / count));
+    const buf = await ctx.decodeAudioData(arrayBuffer.slice(0));
+    const ch = buf.getChannelData(0);
+    const windowSize = Math.max(1, Math.floor(buf.sampleRate * 0.25));
+    // Sample at most ~4000 evenly spaced points across the whole chunk for speed.
+    const step = Math.max(1, Math.floor(ch.length / 4000));
+    let peak = 0;
+    for (let start = 0; start < ch.length; start += windowSize) {
+      const end = Math.min(start + windowSize, ch.length);
+      let sumSquares = 0;
+      let count = 0;
+      for (let i = start; i < end; i += step) {
+        sumSquares += ch[i] * ch[i];
+        count++;
       }
-      return peak;
-    } finally {
-      try {
-        await ctx.close();
-      } catch {}
+      if (count > 0) peak = Math.max(peak, Math.sqrt(sumSquares / count));
     }
+    return peak;
   } catch {
-    // Decoding failed (codec mismatch etc.) — fall through; don't drop the chunk.
+    // Decoding failed (codec mismatch etc.) — fail OPEN; never drop possible speech.
     return 1;
   }
 }
@@ -261,8 +281,11 @@ export function useSpeechToText(
     const energy = await computeAudioEnergy(blob);
     if (energy < WHISPER_MIN_RMS) return;
     let file: Blob = blob;
+    // Filename extension must track the REAL container — OpenAI infers the decoder from it,
+    // and a mislabelled raw upload (when WAV conversion fails below) gets rejected.
     let filename = "chunk.webm";
     if (blob.type.includes("mp4") || blob.type.includes("m4a")) filename = "chunk.m4a";
+    else if (blob.type.includes("ogg")) filename = "chunk.ogg";
     try {
       const wavBlob = await blobToWav(blob);
       if (wavBlob.size > 0) {
@@ -467,12 +490,15 @@ export function useSpeechToText(
       if (errType === "no-speech" || errType === "aborted") {
         // Restart even while paused — the recognizer must stay WARM through the interviewer's
         // TTS so the candidate's first words after the question land in a live engine (results
-        // are suppressed by the pausedRef gate in onresult, so nothing leaks).
+        // are suppressed by the pausedRef gate in onresult, so nothing leaks). Android opts out
+        // (the paused effect stops the recognizer there — no warm restarts while paused).
+        if (pausedRef.current && !keepRecognizerWarmThroughTts()) return;
         if (!retryTimeoutRef.current && wantsListeningRef.current && !browserSttDisabledRef.current) {
           retryTimeoutRef.current = setTimeout(() => {
             retryTimeoutRef.current = null;
             const r = recognitionRef.current;
             if (!r || !wantsListeningRef.current || browserSttDisabledRef.current) return;
+            if (pausedRef.current && !keepRecognizerWarmThroughTts()) return;
             tryStartRecognition(r);
           }, 400);
         }
@@ -523,18 +549,23 @@ export function useSpeechToText(
       recognitionRunningRef.current = false;
       // Restart even while paused (interviewer speaking) — keeping the recognizer warm through
       // TTS is the fix for losing the candidate's opening words to a cold start; transcripts
-      // are suppressed via the pausedRef gate in onresult.
+      // are suppressed via the pausedRef gate in onresult. (On Android the paused effect stops
+      // the recognizer outright instead — see keepRecognizerWarmThroughTts.)
       if (!wantsListeningRef.current || browserSttDisabledRef.current) return;
+      if (pausedRef.current && !keepRecognizerWarmThroughTts()) return;
+      // A restart timer is already pending (e.g. the no-speech 400ms one-shot) — let it do the
+      // restart. Racing it with an immediate start() here caused rapid stop/start churn on
+      // Chromium's silence cycles.
+      if (retryTimeoutRef.current) return;
       // Normal "session ended due to silence" path → restart promptly.
       if (consecutiveErrorsRef.current === 0) {
         tryStartRecognition(rec);
-      } else if (!retryTimeoutRef.current) {
+      } else {
         // Counter is nonzero but no backoff timer is pending (e.g. a no-speech/aborted
         // early-returned after a prior transient error left the counter > 0). Don't strand
         // recognition dead — arm a retry instead of doing nothing.
         scheduleRetry();
       }
-      // else: a scheduleRetry backoff is already pending and will call rec.start().
     };
     recognitionRef.current = rec;
     try {
@@ -590,6 +621,9 @@ export function useSpeechToText(
   const pickWhisperMimeType = useCallback((): string => {
     if (MediaRecorder.isTypeSupported("audio/webm;codecs=opus")) return "audio/webm;codecs=opus";
     if (MediaRecorder.isTypeSupported("audio/webm")) return "audio/webm";
+    // Firefox's native container (older/esr builds without webm audio recording).
+    if (MediaRecorder.isTypeSupported("audio/ogg;codecs=opus")) return "audio/ogg;codecs=opus";
+    // Safari / iOS WebKit records AAC-in-mp4.
     if (MediaRecorder.isTypeSupported("audio/mp4")) return "audio/mp4";
     return "";
   }, []);
@@ -859,6 +893,18 @@ export function useSpeechToText(
       // and the UNPAUSE_FINAL_GUARD drops the interviewer-voice tail after resume.
       // Only the Whisper recorder stops (each chunk costs a transcription call, and its
       // MediaRecorder re-arms instantly on resume — it has no cold-start problem).
+      // ANDROID exception: its recognizer restarts per-utterance anyway (no cold-start win),
+      // finals land seconds late (they'd sail past the bleed guard), and loudspeaker bleed is
+      // the worst case — stop the recognizer outright there, like the pre-keep-warm behavior.
+      if (!keepRecognizerWarmThroughTts()) {
+        clearRetryTimeout();
+        if (recognitionRef.current) {
+          try {
+            recognitionRef.current.stop();
+          } catch {}
+          recognitionRef.current = null;
+        }
+      }
       const recorder = mediaRecorderRef.current;
       if (recorder && recorder.state !== "inactive") {
         try {

--- a/lib/utils/audio-to-wav.ts
+++ b/lib/utils/audio-to-wav.ts
@@ -1,15 +1,27 @@
 type WindowWithAudioContext = Window & {
-  AudioContext?: typeof AudioContext;
-  webkitAudioContext?: typeof AudioContext;
+  OfflineAudioContext?: typeof OfflineAudioContext;
+  webkitOfflineAudioContext?: typeof OfflineAudioContext;
 };
+
+// One shared decode context, reused across calls. This runs for EVERY 2s Whisper chunk during
+// an interview; the old new-AudioContext-per-call + close() churned against WebKit's per-page
+// live-AudioContext cap (Safari/iOS use Whisper as the primary engine) and eventually started
+// throwing. decodeAudioData needs no live/resumed context, so an OfflineAudioContext — exempt
+// from that cap and gesture rules — is the right tool.
+let decodeCtx: OfflineAudioContext | null = null;
+
+function getDecodeContext(): OfflineAudioContext {
+  if (decodeCtx) return decodeCtx;
+  const Win = typeof window !== "undefined" ? (window as WindowWithAudioContext) : null;
+  const Ctor = Win?.OfflineAudioContext ?? Win?.webkitOfflineAudioContext;
+  if (!Ctor) throw new Error("OfflineAudioContext not supported");
+  decodeCtx = new Ctor(1, 1, 44100);
+  return decodeCtx;
+}
 
 export async function blobToWav(blob: Blob): Promise<Blob> {
   const arrayBuffer = await blob.arrayBuffer();
-  const Win = typeof window !== "undefined" ? (window as WindowWithAudioContext) : null;
-  const Ctor = Win?.AudioContext ?? Win?.webkitAudioContext;
-  if (!Ctor) throw new Error("AudioContext not supported");
-  const audioContext = new Ctor();
-  const audioBuffer = await audioContext.decodeAudioData(arrayBuffer.slice(0));
+  const audioBuffer = await getDecodeContext().decodeAudioData(arrayBuffer.slice(0));
 
   const numChannels = audioBuffer.numberOfChannels;
   const sampleRate = audioBuffer.sampleRate;
@@ -44,7 +56,6 @@ export async function blobToWav(blob: Blob): Promise<Blob> {
     }
   }
 
-  await audioContext.close();
   return new Blob([buffer], { type: "audio/wav" });
 }
 

--- a/lib/utils/browser-detect.ts
+++ b/lib/utils/browser-detect.ts
@@ -49,15 +49,23 @@ export function detectPlatform(): PlatformName {
   if (uaDataPlatform.includes("ios") || uaDataPlatform.includes("iphone") || uaDataPlatform.includes("ipad")) return "ios";
   if (uaDataPlatform.includes("linux")) return "linux";
 
-  const platform = (navigator.platform || "").toLowerCase();
-  if (platform.includes("mac")) return "mac";
-  if (platform.includes("win")) return "windows";
-  if (platform.includes("linux")) return "linux";
-  if (platform.includes("iphone") || platform.includes("ipad") || platform.includes("ipod")) return "ios";
-
+  // UA sniff BEFORE navigator.platform: Android reports platform "Linux armv8l" (would
+  // misclassify as linux on browsers without userAgentData, e.g. Firefox for Android), and
+  // iPhones report "iPhone" in the UA.
   const ua = navigator.userAgent.toLowerCase();
   if (ua.includes("android")) return "android";
   if (ua.includes("iphone") || ua.includes("ipad") || ua.includes("ipod")) return "ios";
+
+  const platform = (navigator.platform || "").toLowerCase();
+  if (platform.includes("mac")) {
+    // iPadOS 13+ masquerades as desktop Safari: platform "MacIntel", no iPad UA token. Real
+    // Macs have no multi-touch — touch-capable "Mac" is an iPad (WebKit mobile rules apply).
+    if ((navigator.maxTouchPoints || 0) > 1) return "ios";
+    return "mac";
+  }
+  if (platform.includes("win")) return "windows";
+  if (platform.includes("linux")) return "linux";
+  if (platform.includes("iphone") || platform.includes("ipad") || platform.includes("ipod")) return "ios";
 
   return "other";
 }


### PR DESCRIPTION
## Summary
Follow-up to #958 (merged before this commit landed on the branch). Six-environment compatibility audit of the interview voice + camera stack — **iOS WebKit, macOS Safari, Firefox, Windows Chrome/Edge, Android Chrome, shared utils/server** — with fixes so voice recognition, interviewer TTS, and camera work end-to-end everywhere.

## The blocker: interviewer silent on iOS
WebKit only allows `HTMLMediaElement.play()` / the first `speechSynthesis.speak()` inside a user gesture. Every interviewer utterance played after awaited fetches (and turns 2+ have no gesture at all — silence auto-advance drives them), and each turn built a fresh un-blessed `Audio` → **no interviewer voice on any iPhone/iPad browser** (all are WebKit). Fix: `unlockInterviewerAudio()` — silent-WAV + zero-volume speechSynthesis primer fired synchronously inside the Begin/Start clicks, blessing **one persistent shared `<audio>` element** that every turn reuses via `src` swap.

## Per-environment fixes
- **iOS/Safari:** in-gesture AudioContext creation/resume everywhere (off-gesture contexts stay suspended → dead level meters/silence gates): adaptive Begin pre-creates+resumes the analyser context; QuickDeviceCheck resumes its meter context on the mic-test click; take page proctoring context gets the suspended→resume guard. QuickDeviceCheck runs the **Whisper test directly on iOS** (native WebKit recognition too flaky to pin) and unmounts on Begin so its streams release before the interview grabs the mic. iPadOS's "MacIntel" masquerade now detects as iOS (maxTouchPoints).
- **Firefox:** speechSynthesis pause()/resume() keep-alive is now **Chromium-only** (it works around a Chrome 15s auto-pause; on Firefox/Safari it clips long utterances). `audio/ogg;codecs=opus` supported end-to-end (recorder ladder, raw-fallback filename, `/api/transcribe` extension) — a mislabelled ogg container 400s at OpenAI.
- **Android:** keep-warm-through-TTS is now **desktop-only** — Android's recognizer restarts per-utterance anyway, its finals arrive seconds late (past the 400ms bleed guard), and loudspeaker bleed is worst there; it stops during TTS like before. `detectPlatform()` UA-sniffs before `navigator.platform` (Firefox-Android/WebViews were "linux"). Interview root uses `100dvh` so the soft keyboard doesn't bury the typing-fallback Send button.
- **All engines:** `onend` no longer races a pending retry timer (stop/start churn); `blobToWav` + the Whisper VAD share **one `OfflineAudioContext`** instead of creating+closing a live context per 2s chunk (WebKit caps live contexts; Whisper is the primary engine on Safari/iOS); screen wake lock on both interview pages; Edge Whisper pin extended to the platform take page.

## Compatibility matrix + manual device checklist
See the matrix and 7-step device pass in the [#958 comment](https://github.com/AI-Linc-LMS/lms-platform-frontend/pull/958#issuecomment-4873379066) — top two: iPhone Safari (hear Q1 **and** Q2+), Android speakerphone (no interviewer words leaking into the answer).

## Testing
`tsc --noEmit` clean; eslint zero new issues (delta-checked against base). Audit claims were code-verified; already-handled quirks (no `exact` constraints, iOS-Chrome-as-WebKit classification, rotating-recorder header handling) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)