### PR TITLE
fix(interview): level-gauge result page redirects to the course's level insight

### DIFF
--- a/app/mock-interview/[id]/result/page.tsx
+++ b/app/mock-interview/[id]/result/page.tsx
@@ -165,6 +165,14 @@ export default function InterviewResultPage() {
       try {
         const data = await mockInterviewService.getInterviewDetail(interviewId);
         if (cancelled) return;
+        // Level-gauge (adaptive calibration) attempts are "no marks, no right or wrong" — the
+        // backend hands back a redirect instead of scores; send the student to their course's
+        // level insight rather than rendering a scored result page.
+        const gaugeShape = data as { is_level_gauge?: boolean; redirect_url?: string };
+        if (gaugeShape?.is_level_gauge) {
+          router.replace(gaugeShape.redirect_url || "/adaptive-courses");
+          return;
+        }
         const gatedShape = data as {
           result_visible_to_student?: boolean;
           title?: string;


### PR DESCRIPTION
## Summary
Frontend half of the level-gauge "no marks" fix (backend PR: `fix/level-gauge-no-marks`). The adaptive calibration interview promises *no marks, no right or wrong* — but opening its result (via the old notification or a direct URL) rendered the platform's scored result page.

The backend now returns `{is_level_gauge: true, redirect_url}` instead of scores for gauge attempts; the result page honors it and **redirects to the adaptive course's level insight** instead of rendering marks. One guard clause in the existing fetch path; normal and gated interviews unchanged.

`tsc` clean; the 3 eslint errors in this file are pre-existing on base (verified by diffing against `stagging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)