### PR TITLE
feat(live-sessions): guided Google connect for non-technical admins + access-blocked recovery (Phase 3 FE)

### DIFF
--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -44,8 +44,12 @@ export default function AdminLiveSessionsPage() {
   const { showToast } = useToast();
   const googleRedirectHandledRef = useRef(false);
   // Error code from a failed Google connect round-trip (?google_connected=0&error=...) —
-  // rendered as actionable troubleshooting on the Google card, not just a toast.
-  const [googleConnectError, setGoogleConnectError] = useState<string | null>(null);
+  // rendered as actionable troubleshooting on the Google card, not just a toast. Initialized
+  // lazily from the URL (same value on server + client render) because the effect below
+  // strips the query params immediately after toasting.
+  const [googleConnectError, setGoogleConnectError] = useState<string | null>(() =>
+    searchParams.get("google_connected") === "0" ? searchParams.get("error") || "unknown" : null
+  );
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
   const [backgroundsDialogOpen, setBackgroundsDialogOpen] = useState(false);
@@ -119,9 +123,8 @@ export default function AdminLiveSessionsPage() {
       showToast(t("adminLiveSessions.googleConnected", "Google account connected."), "success");
     } else {
       // Keep the toast short — the ACTIONABLE guidance renders as a persistent panel on the
-      // Google card (googleConnectErrors maps each code, incl. Google's "Access blocked").
-      const reason = searchParams.get("error") || "unknown";
-      setGoogleConnectError(reason);
+      // Google card (googleConnectErrors maps each code, incl. Google's "Access blocked");
+      // googleConnectError state was initialized from the URL before this effect stripped it.
       showToast(t("adminLiveSessions.googleConnectError2", "Google connection failed — see the fix steps on the Google Meet card."), "error");
     }
     // Strip the query params without leaving the current page.

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -43,6 +43,9 @@ export default function AdminLiveSessionsPage() {
   const searchParams = useSearchParams();
   const { showToast } = useToast();
   const googleRedirectHandledRef = useRef(false);
+  // Error code from a failed Google connect round-trip (?google_connected=0&error=...) —
+  // rendered as actionable troubleshooting on the Google card, not just a toast.
+  const [googleConnectError, setGoogleConnectError] = useState<string | null>(null);
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
   const [backgroundsDialogOpen, setBackgroundsDialogOpen] = useState(false);
@@ -115,13 +118,11 @@ export default function AdminLiveSessionsPage() {
     if (flag === "1") {
       showToast(t("adminLiveSessions.googleConnected", "Google account connected."), "success");
     } else {
-      const reason = searchParams.get("error");
-      showToast(
-        t("adminLiveSessions.googleConnectError", "Google connection failed{{reason}}.", {
-          reason: reason ? ` (${reason})` : "",
-        }),
-        "error"
-      );
+      // Keep the toast short — the ACTIONABLE guidance renders as a persistent panel on the
+      // Google card (googleConnectErrors maps each code, incl. Google's "Access blocked").
+      const reason = searchParams.get("error") || "unknown";
+      setGoogleConnectError(reason);
+      showToast(t("adminLiveSessions.googleConnectError2", "Google connection failed — see the fix steps on the Google Meet card."), "error");
     }
     // Strip the query params without leaving the current page.
     router.replace(window.location.pathname);
@@ -260,7 +261,7 @@ export default function AdminLiveSessionsPage() {
           <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
             <ZoomSetupCard status={zoomStatus} onConfigure={() => setCredentialsDialogOpen(true)} />
 
-            <GoogleSetupCard />
+            <GoogleSetupCard connectError={googleConnectError} onDismissError={() => setGoogleConnectError(null)} />
 
             <ImportedMeetingsInbox
               ref={inboxRef}

--- a/components/admin/live-sessions/GoogleSetupCard.tsx
+++ b/components/admin/live-sessions/GoogleSetupCard.tsx
@@ -7,13 +7,21 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { googleService, GoogleCredentials } from "@/lib/services/google.service";
 import { GoogleCredentialsDialog } from "./GoogleCredentialsDialog";
+import { GoogleConnectErrorPanel } from "./googleConnectErrors";
 
 /**
  * Google Meet connection card for the admin live-sessions page. Mirrors ZoomSetupCard, but the
  * Google flow is a one-click OAuth "Connect Google" (we store a refresh token) rather than pasted
  * credentials. Self-contained: loads its own status so the page only has to render it.
  */
-export function GoogleSetupCard() {
+export function GoogleSetupCard({
+  connectError,
+  onDismissError,
+}: {
+  /** Error code from a failed Connect round-trip — rendered as actionable troubleshooting. */
+  connectError?: string | null;
+  onDismissError?: () => void;
+} = {}) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [loading, setLoading] = useState(true);
@@ -76,10 +84,45 @@ export function GoogleSetupCard() {
   const ready = connected && active;
   const accent = ready ? "var(--success-500)" : "var(--warning-500)";
 
+  const needsArtifactsReconnect = connected && creds?.artifacts_scopes_granted === false;
+
+  const errorPanel = connectError ? (
+    <Box sx={{ mb: 1.5 }}>
+      <GoogleConnectErrorPanel code={connectError} onDismiss={() => onDismissError?.()} onRetry={handleConnect} />
+    </Box>
+  ) : null;
+
+  // Amber banner: connected before the recording/transcript scopes existed — one reconnect
+  // unlocks the post-meeting pipeline (recordings, transcript, AI summary) for new meetings.
+  const reconnectBanner = needsArtifactsReconnect ? (
+    <Paper
+      elevation={0}
+      sx={{
+        mb: 1.5, p: 1.5, borderRadius: 2, display: "flex", alignItems: "center", gap: 1.25, flexWrap: "wrap",
+        border: "1px solid color-mix(in srgb, var(--warning-500) 36%, var(--border-default) 64%)",
+        bgcolor: "color-mix(in srgb, var(--warning-500) 9%, var(--surface) 91%)",
+      }}
+    >
+      <IconWrapper icon="mdi:video-plus-outline" size={20} color="var(--warning-500)" />
+      <Typography variant="body2" sx={{ flex: 1, minWidth: 220, color: "var(--font-secondary)" }}>
+        {t(
+          "adminLiveSessions.googleReconnectArtifacts",
+          "Reconnect Google once to enable meeting recordings, transcripts and AI summaries — your account was connected before these permissions existed."
+        )}
+      </Typography>
+      <Button size="small" variant="contained" onClick={handleConnect} disabled={connecting}
+        sx={{ textTransform: "none", fontWeight: 700, bgcolor: "var(--warning-500)", "&:hover": { bgcolor: "var(--warning-600, var(--warning-500))" } }}>
+        {t("adminLiveSessions.reconnectGoogle", "Reconnect Google")}
+      </Button>
+    </Paper>
+  ) : null;
+
   // Connected + active — compact confirmation row.
   if (ready) {
     return (
       <>
+        {errorPanel}
+        {reconnectBanner}
         <Paper
           elevation={0}
           sx={{
@@ -127,6 +170,7 @@ export function GoogleSetupCard() {
   // Not connected (or inactive) — connect CTA.
   return (
     <>
+      {errorPanel}
       <Paper
         elevation={0}
         sx={{

--- a/components/admin/live-sessions/GoogleSetupGuide.tsx
+++ b/components/admin/live-sessions/GoogleSetupGuide.tsx
@@ -97,8 +97,14 @@ export function GoogleSetupGuide({ redirectUri }: { redirectUri?: string }) {
           . Without this, meeting creation fails with a 403.
         </Box>
         <Box component="li" sx={liSx}>
-          <strong>OAuth consent screen</strong> → add the scope <Code>.../auth/calendar.events</Code> (plus{" "}
-          <Code>openid</Code> and <Code>email</Code>, usually already present for login).
+          <strong>OAuth consent screen</strong> → add the scopes <Code>.../auth/calendar.events</Code>,{" "}
+          <Code>.../auth/meetings.space.readonly</Code> and <Code>.../auth/drive.meet.readonly</Code> (plus{" "}
+          <Code>openid</Code> and <Code>email</Code>). The last two power post-meeting{" "}
+          <strong>recordings, transcripts &amp; AI summaries</strong>.
+        </Box>
+        <Box component="li" sx={liSx}>
+          For recordings/transcripts also <strong>enable the Google Meet API and Google Drive API</strong> in{" "}
+          APIs &amp; Services → Library (same as the Calendar API step).
         </Box>
         <Box component="li" sx={liSx}>
           If the app is in <strong>Testing</strong> mode, add the Google account you&apos;ll connect under{" "}
@@ -141,6 +147,39 @@ export function GoogleSetupGuide({ redirectUri }: { redirectUri?: string }) {
           Under <strong>Advanced</strong> above you can paste your own <strong>OAuth client ID / secret</strong>{" "}
           instead of the platform&apos;s. If you do, add the same redirect URI to <em>your</em> client and{" "}
           <strong>Reconnect</strong> afterwards.
+        </Box>
+      </Box>
+
+      {/* Troubleshooting: the two different moments things fail */}
+      <StepHeading>{t("adminLiveSessions.googleGuideTrouble", "Troubleshooting — know WHERE it failed")}</StepHeading>
+      <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          <strong>While connecting (Google shows “Access blocked”)</strong> — this is about WHO may use the
+          OAuth app, in order of likelihood:
+          <Box component="ol" sx={{ m: 0, mt: 0.5, pl: 2.5 }}>
+            <Box component="li" sx={liSx}>
+              App in <strong>Testing</strong> + your account not under <strong>Test users</strong> → add it
+              (OAuth consent screen → Audience/Test users) or click <strong>Publish app</strong>.
+            </Box>
+            <Box component="li" sx={liSx}>
+              Consent screen <strong>User type: Internal</strong> but you used an outside account → use an
+              org account, or switch to <strong>External</strong>.
+            </Box>
+            <Box component="li" sx={liSx}>
+              Your Google <strong>Workspace admin blocks unverified apps</strong> → they must allow it under
+              Admin console → Security → API controls.
+            </Box>
+            <Box component="li" sx={liSx}>
+              “App isn&apos;t verified” warning → <strong>Advanced → Go to app</strong> works for testing;
+              verification removes the warning permanently.
+            </Box>
+          </Box>
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>While creating a meeting (connection is green but create fails)</strong> — that&apos;s the{" "}
+          <strong>Calendar API not enabled</strong> on the Cloud project (step 2 above), or the connected
+          account can&apos;t mint Meet links. Recordings that never appear usually mean the host isn&apos;t on
+          Google Workspace or didn&apos;t press <strong>Record</strong> in the meeting.
         </Box>
       </Box>
 

--- a/components/admin/live-sessions/googleConnectErrors.tsx
+++ b/components/admin/live-sessions/googleConnectErrors.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Box, Paper, Typography, IconButton, Button } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+/**
+ * Plain-language guidance for every way the Google "Connect" round-trip can fail.
+ *
+ * The backend callback now routes ALL consent failures back here with ?google_connected=0&
+ * error=<code> (it used to dead-end on a bare 400 for the "Access blocked" path). This maps
+ * each code to what a NON-TECHNICAL admin should actually do — the #1 case being Google's
+ * "Access blocked" interstitial (error=access_denied), which has four distinct causes that
+ * look identical to the person clicking Connect.
+ */
+
+export interface GoogleConnectErrorInfo {
+  title: string;
+  intro: string;
+  /** Ordered, concrete fixes — each one line, no jargon where avoidable. */
+  fixes: string[];
+}
+
+const ACCESS_BLOCKED: GoogleConnectErrorInfo = {
+  title: "Google showed “Access blocked” (or you cancelled)",
+  intro:
+    "Google refused before asking for permissions. This is a Google-side setting on the OAuth app or your Google account — one of these four, in order of likelihood:",
+  fixes: [
+    "The app is in “Testing” mode and your Google account isn't on its Test users list → in Google Cloud Console open “APIs & Services → OAuth consent screen → Audience/Test users” and add the exact Google account you're connecting, then retry.",
+    "You connected with a personal account but the app is “Internal” → either use an account from the app's Google Workspace organization, or set the consent screen User type to “External”.",
+    "Your Google Workspace organization blocks unverified third-party apps → a Workspace admin must allow this app in “Admin console → Security → API controls → App access control”.",
+    "The app is published but not verified by Google → on the warning screen you can click “Advanced → Go to <app> (unsafe)” to proceed, or complete Google's verification once for a clean screen.",
+  ],
+};
+
+const ERROR_MAP: Record<string, GoogleConnectErrorInfo> = {
+  access_denied: ACCESS_BLOCKED,
+  org_internal: ACCESS_BLOCKED,
+  admin_policy_enforced: {
+    title: "Your Google Workspace blocks this app",
+    intro: "Your organization's Google admin has restricted which apps can access Google data.",
+    fixes: [
+      "Ask your Google Workspace admin to allow this app in “Admin console → Security → API controls → App access control”, then retry Connect.",
+    ],
+  },
+  invalid_state: {
+    title: "The connection attempt expired",
+    intro: "The secure hand-off between this page and Google is only valid for 10 minutes.",
+    fixes: ["Just click “Connect Google” again and complete the Google screens within a few minutes."],
+  },
+  not_configured: {
+    title: "Google isn't configured on the platform yet",
+    intro: "There is no Google OAuth app set up for this environment.",
+    fixes: [
+      "If you manage the platform: set the Google OAuth client ID/secret (or add your own under Advanced in Settings), then retry.",
+      "Otherwise contact your platform administrator.",
+    ],
+  },
+  token_exchange_failed: {
+    title: "Couldn't reach Google to finish connecting",
+    intro: "The final token exchange with Google failed — usually a temporary network problem.",
+    fixes: ["Wait a moment and click “Connect Google” again."],
+  },
+  token_rejected: {
+    title: "Google rejected the connection",
+    intro: "Google refused the final token exchange. This usually means the OAuth client secret is wrong, or the redirect URI isn't whitelisted exactly.",
+    fixes: [
+      "Copy the redirect URI shown on this card and make sure it's listed EXACTLY under “Authorized redirect URIs” on the OAuth client (https, no trailing slash).",
+      "If you use your own Google app (Advanced), re-check the client ID and secret, then Reconnect.",
+    ],
+  },
+  no_refresh_token: {
+    title: "Google didn't grant offline access",
+    intro: "The connection completed but Google didn't return the long-lived token the platform needs.",
+    fixes: [
+      "Retry Connect and approve ALL requested permissions (don't untick anything on the consent screen).",
+      "If it keeps happening, remove the app's access at myaccount.google.com → Security → Third-party access, then Connect again.",
+    ],
+  },
+};
+
+const FALLBACK: GoogleConnectErrorInfo = {
+  title: "Google connection failed",
+  intro: "The connection didn't complete.",
+  fixes: [
+    "Retry “Connect Google”. If it fails again, open the Setup guide below and re-check each step — the redirect URI and the Test users list are the usual culprits.",
+  ],
+};
+
+export function googleConnectErrorInfo(code: string | null | undefined): GoogleConnectErrorInfo {
+  return ERROR_MAP[(code || "").trim()] ?? FALLBACK;
+}
+
+/** Dismissible troubleshooting panel rendered by GoogleSetupCard after a failed connect. */
+export function GoogleConnectErrorPanel({
+  code,
+  onDismiss,
+  onRetry,
+}: {
+  code: string;
+  onDismiss: () => void;
+  onRetry: () => void;
+}) {
+  const info = googleConnectErrorInfo(code);
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 2,
+        borderRadius: 2,
+        border: "1px solid color-mix(in srgb, var(--error-500, #ef4444) 35%, var(--border-default) 65%)",
+        bgcolor: "color-mix(in srgb, var(--error-500, #ef4444) 7%, var(--surface) 93%)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+        <IconWrapper icon="mdi:shield-alert-outline" size={20} color="var(--error-500, #ef4444)" />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+            {info.title}
+          </Typography>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.25 }}>
+            {info.intro}
+          </Typography>
+          <Box component="ol" sx={{ m: 0, mt: 1, pl: 2.5 }}>
+            {info.fixes.map((fix, i) => (
+              <Box key={i} component="li" sx={{ mb: 0.5, color: "var(--font-secondary)", fontSize: "0.8125rem", lineHeight: 1.55 }}>
+                {fix}
+              </Box>
+            ))}
+          </Box>
+          <Button size="small" onClick={onRetry} sx={{ mt: 1, textTransform: "none", fontWeight: 700 }}>
+            Try connecting again
+          </Button>
+        </Box>
+        <IconButton size="small" onClick={onDismiss} aria-label="Dismiss">
+          <IconWrapper icon="mdi:close" size={16} />
+        </IconButton>
+      </Box>
+    </Paper>
+  );
+}

--- a/lib/services/google.service.ts
+++ b/lib/services/google.service.ts
@@ -14,6 +14,9 @@ export interface GoogleCredentials {
   is_connected?: boolean;
   /** True when the tenant uses its own Google OAuth app instead of the platform default. */
   has_custom_app?: boolean;
+  /** False when the account was connected before the recording/transcript scopes existed —
+   *  the admin must Reconnect to enable post-meeting recordings, transcripts & AI summaries. */
+  artifacts_scopes_granted?: boolean;
   connected_email?: string | null;
   calendar_id?: string | null;
   timezone?: string | null;


### PR DESCRIPTION
## Summary
Frontend half of the "Access blocked" fix + the non-techy connect experience (Phase 3 of the live-sessions Google Meet work). Pairs with backend PR #318 (callback now returns every consent failure to the tenant with an error code instead of dead-ending on a bare 400).

- **Actionable failure panel**: every `?google_connected=0&error=<code>` return renders a persistent, dismissible troubleshooting panel on the Google Meet card with ordered plain-language fixes + a Retry button. `access_denied` (Google's **"Access blocked"** interstitial) documents its four real causes in likelihood order — Testing-mode app without the admin in Test users, Internal-only app + outside account, Workspace admin policy, unverified-app warning — each with the exact Google Console path.
- **Reconnect-for-artifacts banner**: accounts connected before the recording/transcript scopes (from Phase 1, PR #317) get a one-click amber "Reconnect Google" prompt explaining it unlocks recordings, transcripts & AI summaries.
- **Setup guide** now lists the Meet/Drive artifact scopes + APIs, and splits troubleshooting by *where* it failed: connect-time (who may use the OAuth app) vs create-time (Calendar API disabled; recordings need Workspace + pressing Record).

`tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)