### PR TITLE
feat(live-sessions): module redesign — sessions-first admin, provider-neutral artifacts, on-platform playback (Phase 2)

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -259,20 +259,32 @@ export default function LiveSessionDetailPage() {
   const isGoogleOrphan = Boolean(activity?.is_google_meet && activity?.google_source === "platform" && !activity?.google_event_id && !activity?.is_zoom);
   const isGoogleCancelled = activity?.google_status === "cancelled";
   const scheduledOrLive = activity?.meeting_status === "scheduled" || activity?.meeting_status === "live";
-  const hasRecording = Boolean(activity?.zoom_recording_url?.trim());
+  const hasRecording = Boolean(
+    activity?.zoom_recording_url?.trim()
+    || (activity as { google_recording_url?: string } | null)?.google_recording_url
+    || (activity as { has_recording?: boolean } | null)?.has_recording
+  );
 
+  const isGoogleMeet = Boolean(activity?.is_google_meet);
   const tabs = useMemo(() => {
-    if (!isZoom) return [{ icon: "mdi:information-outline", label: t("adminLiveSessions.tabOverview", "Overview") }];
+    const overview = { key: "overview", icon: "mdi:information-outline", label: t("adminLiveSessions.tabOverview", "Overview") };
+    const recording = { key: "recording", icon: "mdi:play-circle-outline", label: t("adminLiveSessions.tabRecording", "Recording") };
+    const transcript = { key: "transcript", icon: "mdi:text-box-outline", label: t("adminLiveSessions.tabTranscript", "Transcript") };
+    // Google Meet sessions get the artifact tabs too (recording/transcript come from the
+    // Meet artifact poller); attendance stays Zoom-only (no participant sync for Meet yet).
+    if (isGoogleMeet) return [overview, recording, transcript];
+    if (!isZoom) return [overview];
     const base = [
-      { icon: "mdi:information-outline", label: t("adminLiveSessions.tabOverview", "Overview") },
-      { icon: "mdi:account-group-outline", label: t("adminLiveSessions.tabAttendance", "Attendance") },
-      { icon: "mdi:play-circle-outline", label: t("adminLiveSessions.tabRecording", "Recording") },
-      { icon: "mdi:text-box-outline", label: t("adminLiveSessions.tabTranscript", "Transcript") },
+      overview,
+      { key: "attendance", icon: "mdi:account-group-outline", label: t("adminLiveSessions.tabAttendance", "Attendance") },
+      recording,
+      transcript,
     ];
     return isWebinar
-      ? [...base, { icon: "mdi:email-outline", label: t("adminLiveSessions.tabInvitations", "Invitations") }, { icon: "mdi:email-fast-outline", label: t("adminLiveSessions.tabEmail", "Email") }]
+      ? [...base, { key: "invitations", icon: "mdi:email-outline", label: t("adminLiveSessions.tabInvitations", "Invitations") }, { key: "emails", icon: "mdi:email-fast-outline", label: t("adminLiveSessions.tabEmail", "Email") }]
       : base;
-  }, [isZoom, isWebinar, t]);
+  }, [isZoom, isGoogleMeet, isWebinar, t]);
+  const tabKey = tabs[tab]?.key ?? "overview";
 
   const backButton = (
     <ButtonBase
@@ -404,16 +416,26 @@ export default function LiveSessionDetailPage() {
                       )}
                     </SectionCard>
 
-                    {isZoom && (
+                    {Boolean((activity as { description?: string }).description?.trim()) && (
+                      <SectionCard title={t("adminLiveSessions.description", "Description")} icon="mdi:text-long">
+                        <Typography variant="body2" sx={{ color: "var(--font-secondary)", whiteSpace: "pre-wrap" }}>
+                          {(activity as { description?: string }).description}
+                        </Typography>
+                      </SectionCard>
+                    )}
+
+                    {(isZoom || isGoogleMeet) && (
                       <InfoCallout icon="mdi:lightbulb-on-outline">
-                        {t("adminLiveSessions.overviewHint", "Attendance, recording and transcript appear in their tabs automatically once the meeting ends — or you can sync them manually.")}
+                        {isZoom
+                          ? t("adminLiveSessions.overviewHint", "Attendance, recording and transcript appear in their tabs automatically once the meeting ends — or you can sync them manually.")
+                          : t("adminLiveSessions.overviewHintGoogle", "Recording and transcript appear in their tabs automatically after the meeting ends, when the host recorded it (Google Workspace).")}
                       </InfoCallout>
                     )}
                   </Box>
                 )}
 
                 {/* Attendance */}
-                {isZoom && tab === 1 && (
+                {tabKey === "attendance" && (
                   <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
                     <SectionCard><LiveSessionRosterSection liveClassId={activity.id} /></SectionCard>
                     <SectionCard><ZoomAttendanceSection liveClassId={activity.id} /></SectionCard>
@@ -421,7 +443,7 @@ export default function LiveSessionDetailPage() {
                 )}
 
                 {/* Recording */}
-                {isZoom && tab === 2 && (
+                {tabKey === "recording" && (
                   <SectionCard title={t("adminLiveSessions.recording", "Recording")} icon="mdi:play-circle-outline">
                     <Box sx={{ display: "flex", gap: 1.25, flexWrap: "wrap", alignItems: "center" }}>
                       {hasRecording ? (
@@ -431,21 +453,31 @@ export default function LiveSessionDetailPage() {
                           {t("liveSessions.recordingNotAvailable")}
                         </InfoCallout>
                       )}
-                      <ControlButton icon="mdi:cloud-download" label={t("adminLiveSessions.syncRecording")} tone="outline" loading={syncingRecording} onClick={handleSyncRecording} />
+                      {isZoom && (
+                        <ControlButton icon="mdi:cloud-download" label={t("adminLiveSessions.syncRecording")} tone="outline" loading={syncingRecording} onClick={handleSyncRecording} />
+                      )}
+                      {isGoogleMeet && !hasRecording && (
+                        <Typography variant="caption" sx={{ color: "var(--font-tertiary)", width: "100%" }}>
+                          {t(
+                            "adminLiveSessions.googleRecordingHint",
+                            "Meet recordings appear here automatically after the session ends — the host must press Record in the meeting (requires Google Workspace)."
+                          )}
+                        </Typography>
+                      )}
                     </Box>
                   </SectionCard>
                 )}
 
                 {/* Transcript */}
-                {isZoom && tab === 3 && (
+                {tabKey === "transcript" && (
                   <SectionCard>
-                    <LiveSessionTranscriptSection liveClassId={activity.id} hasSummary={Boolean(activity.zoom_ai_summary?.trim())} />
+                    <LiveSessionTranscriptSection liveClassId={activity.id} hasSummary={Boolean(activity.zoom_ai_summary?.trim() || (activity as { google_ai_summary?: string }).google_ai_summary?.trim())} />
                   </SectionCard>
                 )}
 
                 {/* Webinar management */}
-                {isWebinar && tab === 4 && <WebinarInvitationsSection liveClassId={activity.id} />}
-                {isWebinar && tab === 5 && <WebinarEmailSection liveClassId={activity.id} editable={scheduledOrLive && !isCancelled} />}
+                {tabKey === "invitations" && <WebinarInvitationsSection liveClassId={activity.id} />}
+                {tabKey === "emails" && <WebinarEmailSection liveClassId={activity.id} editable={scheduledOrLive && !isCancelled} />}
               </Box>
             </>
           )}

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  Collapse,
   LinearProgress,
   Pagination,
   Typography,
@@ -23,6 +24,7 @@ import { useAdminLiveSessions } from "@/components/admin/live-sessions/useAdminL
 import { ZoomCredentialsDialog } from "@/components/admin/live-sessions/ZoomCredentialsDialog";
 import { ZoomSetupCard, ZoomSetupStatus } from "@/components/admin/live-sessions/ZoomSetupCard";
 import { GoogleSetupCard } from "@/components/admin/live-sessions/GoogleSetupCard";
+import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import {
   ImportedMeetingsInbox,
   ImportedMeetingsInboxHandle,
@@ -43,6 +45,10 @@ export default function AdminLiveSessionsPage() {
   const searchParams = useSearchParams();
   const { showToast } = useToast();
   const googleRedirectHandledRef = useRef(false);
+  // Integrations strip: expanded when something needs the admin's attention (a failed Google
+  // connect round-trip, or nothing configured yet), else collapsed so the SESSIONS are the
+  // first thing on screen. DERIVED (null = auto) — a manual toggle overrides the automatics.
+  const [integrationsToggled, setIntegrationsToggled] = useState<boolean | null>(null);
   // Error code from a failed Google connect round-trip (?google_connected=0&error=...) —
   // rendered as actionable troubleshooting on the Google card, not just a toast. Initialized
   // lazily from the URL (same value on server + client render) because the effect below
@@ -71,7 +77,8 @@ export default function AdminLiveSessionsPage() {
     hasAdminLiveSessionsFeature,
     loading,
     sessions,
-    uniqueAttendanceCounts,
+    playerSession,
+    setPlayerSession,
     page,
     setPage,
     rowsPerPage,
@@ -130,6 +137,9 @@ export default function AdminLiveSessionsPage() {
     // Strip the query params without leaving the current page.
     router.replace(window.location.pathname);
   }, [searchParams, showToast, t, router]);
+
+  const integrationsOpen =
+    integrationsToggled ?? (Boolean(googleConnectError) || (zoomStatus != null && !zoomStatus.configured));
 
   const counts = useMemo(() => {
     let upcoming = 0;
@@ -226,22 +236,6 @@ export default function AdminLiveSessionsPage() {
             rightSlot={
               <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", justifyContent: "flex-end" }}>
                 <Button
-                  variant="outlined"
-                  startIcon={<IconWrapper icon="mdi:tune-variant" size={18} />}
-                  onClick={() => setPresetsDialogOpen(true)}
-                  sx={{ borderRadius: 999, textTransform: "none", fontWeight: 700, color: "var(--font-secondary)", borderColor: "color-mix(in srgb, var(--border-default) 80%, transparent)" }}
-                >
-                  {t("adminLiveSessions.presets", "Presets")}
-                </Button>
-                <Button
-                  variant="outlined"
-                  startIcon={<IconWrapper icon="mdi:image-outline" size={18} />}
-                  onClick={() => setBackgroundsDialogOpen(true)}
-                  sx={{ borderRadius: 999, textTransform: "none", fontWeight: 700, color: "var(--font-secondary)", borderColor: "color-mix(in srgb, var(--border-default) 80%, transparent)" }}
-                >
-                  {t("adminLiveSessions.backgrounds", "Backgrounds")}
-                </Button>
-                <Button
                   variant="contained"
                   startIcon={<IconWrapper icon="mdi:plus" size={20} color="#fff" />}
                   onClick={() => router.push("/admin/live-sessions/create")}
@@ -262,15 +256,65 @@ export default function AdminLiveSessionsPage() {
           />
 
           <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-            <ZoomSetupCard status={zoomStatus} onConfigure={() => setCredentialsDialogOpen(true)} />
-
-            <GoogleSetupCard connectError={googleConnectError} onDismissError={() => setGoogleConnectError(null)} />
-
-            <ImportedMeetingsInbox
-              ref={inboxRef}
-              formatDateTime={formatDateTime}
-              onAssigned={loadSessions}
-            />
+            {/* Integrations & tools — one slim strip instead of three stacked panels. The full
+                setup cards live inside a Collapse and only demand attention when something
+                actually needs it (nothing configured yet, or a failed Google connect). */}
+            <Box
+              sx={{
+                borderRadius: 2,
+                border: "1px solid var(--border-default)",
+                bgcolor: "var(--card-bg)",
+                overflow: "hidden",
+              }}
+            >
+              <Box
+                role="button"
+                tabIndex={0}
+                onClick={() => setIntegrationsToggled(!integrationsOpen)}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setIntegrationsToggled(!integrationsOpen); }}
+                sx={{
+                  px: 2, py: 1.25, display: "flex", alignItems: "center", gap: 1.25, cursor: "pointer",
+                  flexWrap: "wrap",
+                  "&:hover": { bgcolor: "color-mix(in srgb, var(--accent-indigo) 4%, transparent)" },
+                }}
+              >
+                <IconWrapper icon="mdi:connection" size={18} color="var(--accent-indigo)" />
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+                  {t("adminLiveSessions.integrationsTitle", "Integrations & tools")}
+                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                  <StatusDot ok={Boolean(zoomStatus?.configured && zoomStatus?.active)} label="Zoom" />
+                  <StatusDot ok={googleConnectError == null} warn={Boolean(googleConnectError)} label="Google Meet" />
+                </Box>
+                <Box sx={{ flex: 1 }} />
+                <Button size="small" onClick={(e) => { e.stopPropagation(); setPresetsDialogOpen(true); }}
+                  startIcon={<IconWrapper icon="mdi:tune-variant" size={16} />}
+                  sx={{ textTransform: "none", color: "var(--font-secondary)" }}>
+                  {t("adminLiveSessions.presets", "Presets")}
+                </Button>
+                <Button size="small" onClick={(e) => { e.stopPropagation(); setBackgroundsDialogOpen(true); }}
+                  startIcon={<IconWrapper icon="mdi:image-outline" size={16} />}
+                  sx={{ textTransform: "none", color: "var(--font-secondary)" }}>
+                  {t("adminLiveSessions.backgrounds", "Backgrounds")}
+                </Button>
+                <IconWrapper
+                  icon={integrationsOpen ? "mdi:chevron-up" : "mdi:chevron-down"}
+                  size={20}
+                  color="var(--font-secondary)"
+                />
+              </Box>
+              <Collapse in={integrationsOpen} unmountOnExit={false}>
+                <Box sx={{ px: 2, pb: 2, display: "flex", flexDirection: "column", gap: 2 }}>
+                  <ZoomSetupCard status={zoomStatus} onConfigure={() => setCredentialsDialogOpen(true)} />
+                  <GoogleSetupCard connectError={googleConnectError} onDismissError={() => setGoogleConnectError(null)} />
+                  <ImportedMeetingsInbox
+                    ref={inboxRef}
+                    formatDateTime={formatDateTime}
+                    onAssigned={loadSessions}
+                  />
+                </Box>
+              </Collapse>
+            </Box>
 
             {sessions.length === 0 ? (
               <AdminLiveSessionsEmptyState onCreate={() => router.push("/admin/live-sessions/create")} />
@@ -308,7 +352,6 @@ export default function AdminLiveSessionsPage() {
                           <LiveSessionCard
                             session={s}
                             variant="admin"
-                            attendanceCount={uniqueAttendanceCounts[s.id]}
                             creatingZoom={creatingZoomId === s.id}
                             creatingGoogleMeet={creatingGoogleMeetId === s.id}
                             watchingRecording={watchingRecordingId === s.id}
@@ -363,7 +406,28 @@ export default function AdminLiveSessionsPage() {
           open={backgroundsDialogOpen}
           onClose={() => setBackgroundsDialogOpen(false)}
         />
+
+        {/* In-app recording playback (provider-neutral: Zoom cloud MP4s + Meet Drive files) */}
+        <RecordingPlayerDialog
+          open={Boolean(playerSession)}
+          liveClassId={playerSession?.id ?? null}
+          title={playerSession?.topic_name}
+          onClose={() => setPlayerSession(null)}
+        />
       </Container>
     </MainLayout>
+  );
+}
+
+/** Tiny status dot + label for the integrations strip. */
+function StatusDot({ ok, warn = false, label }: { ok: boolean; warn?: boolean; label: string }) {
+  const color = warn ? "var(--error-500, #ef4444)" : ok ? "var(--success-500)" : "var(--warning-500)";
+  return (
+    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}>
+      <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: color, boxShadow: `0 0 6px ${color}` }} />
+      <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontWeight: 600 }}>
+        {label}
+      </Typography>
+    </Box>
   );
 }

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -44,8 +44,12 @@ export default function AdminLiveSessionsPage() {
   const { showToast } = useToast();
   const googleRedirectHandledRef = useRef(false);
   // Error code from a failed Google connect round-trip (?google_connected=0&error=...) —
-  // rendered as actionable troubleshooting on the Google card, not just a toast.
-  const [googleConnectError, setGoogleConnectError] = useState<string | null>(null);
+  // rendered as actionable troubleshooting on the Google card, not just a toast. Initialized
+  // lazily from the URL (same value on server + client render) because the effect below
+  // strips the query params immediately after toasting.
+  const [googleConnectError, setGoogleConnectError] = useState<string | null>(() =>
+    searchParams.get("google_connected") === "0" ? searchParams.get("error") || "unknown" : null
+  );
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
   const [backgroundsDialogOpen, setBackgroundsDialogOpen] = useState(false);
@@ -119,9 +123,8 @@ export default function AdminLiveSessionsPage() {
       showToast(t("adminLiveSessions.googleConnected", "Google account connected."), "success");
     } else {
       // Keep the toast short — the ACTIONABLE guidance renders as a persistent panel on the
-      // Google card (googleConnectErrors maps each code, incl. Google's "Access blocked").
-      const reason = searchParams.get("error") || "unknown";
-      setGoogleConnectError(reason);
+      // Google card (googleConnectErrors maps each code, incl. Google's "Access blocked");
+      // googleConnectError state was initialized from the URL before this effect stripped it.
       showToast(t("adminLiveSessions.googleConnectError2", "Google connection failed — see the fix steps on the Google Meet card."), "error");
     }
     // Strip the query params without leaving the current page.

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -43,6 +43,9 @@ export default function AdminLiveSessionsPage() {
   const searchParams = useSearchParams();
   const { showToast } = useToast();
   const googleRedirectHandledRef = useRef(false);
+  // Error code from a failed Google connect round-trip (?google_connected=0&error=...) —
+  // rendered as actionable troubleshooting on the Google card, not just a toast.
+  const [googleConnectError, setGoogleConnectError] = useState<string | null>(null);
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
   const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
   const [backgroundsDialogOpen, setBackgroundsDialogOpen] = useState(false);
@@ -115,13 +118,11 @@ export default function AdminLiveSessionsPage() {
     if (flag === "1") {
       showToast(t("adminLiveSessions.googleConnected", "Google account connected."), "success");
     } else {
-      const reason = searchParams.get("error");
-      showToast(
-        t("adminLiveSessions.googleConnectError", "Google connection failed{{reason}}.", {
-          reason: reason ? ` (${reason})` : "",
-        }),
-        "error"
-      );
+      // Keep the toast short — the ACTIONABLE guidance renders as a persistent panel on the
+      // Google card (googleConnectErrors maps each code, incl. Google's "Access blocked").
+      const reason = searchParams.get("error") || "unknown";
+      setGoogleConnectError(reason);
+      showToast(t("adminLiveSessions.googleConnectError2", "Google connection failed — see the fix steps on the Google Meet card."), "error");
     }
     // Strip the query params without leaving the current page.
     router.replace(window.location.pathname);
@@ -260,7 +261,7 @@ export default function AdminLiveSessionsPage() {
           <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
             <ZoomSetupCard status={zoomStatus} onConfigure={() => setCredentialsDialogOpen(true)} />
 
-            <GoogleSetupCard />
+            <GoogleSetupCard connectError={googleConnectError} onDismissError={() => setGoogleConnectError(null)} />
 
             <ImportedMeetingsInbox
               ref={inboxRef}

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -12,6 +12,8 @@ import { LiveSessionsFeatureBlocked } from "@/components/live-sessions/LiveSessi
 import { useLiveSessions } from "@/components/live-sessions/useLiveSessions";
 import { SessionFilterChips } from "@/components/live-sessions/ui/LiveSessionUI";
 import { LiveSessionCard } from "@/components/live-sessions/ui/LiveSessionCard";
+import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
+import { StudentSessionSummaryDialog } from "@/components/live-sessions/StudentSessionSummaryDialog";
 import type { StudentLiveSession } from "@/lib/services/live-sessions";
 
 const PAST = new Set(["ended", "expired"]);
@@ -28,6 +30,10 @@ export default function LiveSessionsPage() {
     setPage,
     rowsPerPage,
     watchingRecordingId,
+    playerSession,
+    setPlayerSession,
+    summarySession,
+    setSummarySession,
     handleCopyPassword,
     handleWatchRecording,
     formatDateTime,
@@ -142,6 +148,7 @@ export default function LiveSessionsPage() {
                           }}
                           onCopyPasscode={handleCopyPassword}
                           onWatchRecording={handleWatchRecording}
+                          onViewSummary={(sess) => setSummarySession(sess)}
                           formatDateTime={formatDateTime}
                         />
                       </Reveal>
@@ -164,6 +171,23 @@ export default function LiveSessionsPage() {
             </Box>
           )}
         </AdaptiveSectionShell>
+
+        {/* Watch ON platform: Zoom cloud MP4s and Google Meet Drive recordings both stream
+            through the backend proxy — no external tabs, gated by course enrollment. */}
+        <RecordingPlayerDialog
+          open={Boolean(playerSession)}
+          liveClassId={playerSession?.id ?? null}
+          title={playerSession?.topic_name}
+          onClose={() => setPlayerSession(null)}
+        />
+        {summarySession && (
+          <StudentSessionSummaryDialog
+            activityId={summarySession.id}
+            topicName={summarySession.topic_name || ""}
+            open
+            onClose={() => setSummarySession(null)}
+          />
+        )}
       </Container>
     </MainLayout>
   );

--- a/components/admin/live-sessions/GoogleSetupCard.tsx
+++ b/components/admin/live-sessions/GoogleSetupCard.tsx
@@ -7,13 +7,21 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { googleService, GoogleCredentials } from "@/lib/services/google.service";
 import { GoogleCredentialsDialog } from "./GoogleCredentialsDialog";
+import { GoogleConnectErrorPanel } from "./googleConnectErrors";
 
 /**
  * Google Meet connection card for the admin live-sessions page. Mirrors ZoomSetupCard, but the
  * Google flow is a one-click OAuth "Connect Google" (we store a refresh token) rather than pasted
  * credentials. Self-contained: loads its own status so the page only has to render it.
  */
-export function GoogleSetupCard() {
+export function GoogleSetupCard({
+  connectError,
+  onDismissError,
+}: {
+  /** Error code from a failed Connect round-trip — rendered as actionable troubleshooting. */
+  connectError?: string | null;
+  onDismissError?: () => void;
+} = {}) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [loading, setLoading] = useState(true);
@@ -76,10 +84,45 @@ export function GoogleSetupCard() {
   const ready = connected && active;
   const accent = ready ? "var(--success-500)" : "var(--warning-500)";
 
+  const needsArtifactsReconnect = connected && creds?.artifacts_scopes_granted === false;
+
+  const errorPanel = connectError ? (
+    <Box sx={{ mb: 1.5 }}>
+      <GoogleConnectErrorPanel code={connectError} onDismiss={() => onDismissError?.()} onRetry={handleConnect} />
+    </Box>
+  ) : null;
+
+  // Amber banner: connected before the recording/transcript scopes existed — one reconnect
+  // unlocks the post-meeting pipeline (recordings, transcript, AI summary) for new meetings.
+  const reconnectBanner = needsArtifactsReconnect ? (
+    <Paper
+      elevation={0}
+      sx={{
+        mb: 1.5, p: 1.5, borderRadius: 2, display: "flex", alignItems: "center", gap: 1.25, flexWrap: "wrap",
+        border: "1px solid color-mix(in srgb, var(--warning-500) 36%, var(--border-default) 64%)",
+        bgcolor: "color-mix(in srgb, var(--warning-500) 9%, var(--surface) 91%)",
+      }}
+    >
+      <IconWrapper icon="mdi:video-plus-outline" size={20} color="var(--warning-500)" />
+      <Typography variant="body2" sx={{ flex: 1, minWidth: 220, color: "var(--font-secondary)" }}>
+        {t(
+          "adminLiveSessions.googleReconnectArtifacts",
+          "Reconnect Google once to enable meeting recordings, transcripts and AI summaries — your account was connected before these permissions existed."
+        )}
+      </Typography>
+      <Button size="small" variant="contained" onClick={handleConnect} disabled={connecting}
+        sx={{ textTransform: "none", fontWeight: 700, bgcolor: "var(--warning-500)", "&:hover": { bgcolor: "var(--warning-600, var(--warning-500))" } }}>
+        {t("adminLiveSessions.reconnectGoogle", "Reconnect Google")}
+      </Button>
+    </Paper>
+  ) : null;
+
   // Connected + active — compact confirmation row.
   if (ready) {
     return (
       <>
+        {errorPanel}
+        {reconnectBanner}
         <Paper
           elevation={0}
           sx={{
@@ -127,6 +170,7 @@ export function GoogleSetupCard() {
   // Not connected (or inactive) — connect CTA.
   return (
     <>
+      {errorPanel}
       <Paper
         elevation={0}
         sx={{

--- a/components/admin/live-sessions/GoogleSetupGuide.tsx
+++ b/components/admin/live-sessions/GoogleSetupGuide.tsx
@@ -97,8 +97,14 @@ export function GoogleSetupGuide({ redirectUri }: { redirectUri?: string }) {
           . Without this, meeting creation fails with a 403.
         </Box>
         <Box component="li" sx={liSx}>
-          <strong>OAuth consent screen</strong> → add the scope <Code>.../auth/calendar.events</Code> (plus{" "}
-          <Code>openid</Code> and <Code>email</Code>, usually already present for login).
+          <strong>OAuth consent screen</strong> → add the scopes <Code>.../auth/calendar.events</Code>,{" "}
+          <Code>.../auth/meetings.space.readonly</Code> and <Code>.../auth/drive.meet.readonly</Code> (plus{" "}
+          <Code>openid</Code> and <Code>email</Code>). The last two power post-meeting{" "}
+          <strong>recordings, transcripts &amp; AI summaries</strong>.
+        </Box>
+        <Box component="li" sx={liSx}>
+          For recordings/transcripts also <strong>enable the Google Meet API and Google Drive API</strong> in{" "}
+          APIs &amp; Services → Library (same as the Calendar API step).
         </Box>
         <Box component="li" sx={liSx}>
           If the app is in <strong>Testing</strong> mode, add the Google account you&apos;ll connect under{" "}
@@ -141,6 +147,39 @@ export function GoogleSetupGuide({ redirectUri }: { redirectUri?: string }) {
           Under <strong>Advanced</strong> above you can paste your own <strong>OAuth client ID / secret</strong>{" "}
           instead of the platform&apos;s. If you do, add the same redirect URI to <em>your</em> client and{" "}
           <strong>Reconnect</strong> afterwards.
+        </Box>
+      </Box>
+
+      {/* Troubleshooting: the two different moments things fail */}
+      <StepHeading>{t("adminLiveSessions.googleGuideTrouble", "Troubleshooting — know WHERE it failed")}</StepHeading>
+      <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          <strong>While connecting (Google shows “Access blocked”)</strong> — this is about WHO may use the
+          OAuth app, in order of likelihood:
+          <Box component="ol" sx={{ m: 0, mt: 0.5, pl: 2.5 }}>
+            <Box component="li" sx={liSx}>
+              App in <strong>Testing</strong> + your account not under <strong>Test users</strong> → add it
+              (OAuth consent screen → Audience/Test users) or click <strong>Publish app</strong>.
+            </Box>
+            <Box component="li" sx={liSx}>
+              Consent screen <strong>User type: Internal</strong> but you used an outside account → use an
+              org account, or switch to <strong>External</strong>.
+            </Box>
+            <Box component="li" sx={liSx}>
+              Your Google <strong>Workspace admin blocks unverified apps</strong> → they must allow it under
+              Admin console → Security → API controls.
+            </Box>
+            <Box component="li" sx={liSx}>
+              “App isn&apos;t verified” warning → <strong>Advanced → Go to app</strong> works for testing;
+              verification removes the warning permanently.
+            </Box>
+          </Box>
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>While creating a meeting (connection is green but create fails)</strong> — that&apos;s the{" "}
+          <strong>Calendar API not enabled</strong> on the Cloud project (step 2 above), or the connected
+          account can&apos;t mint Meet links. Recordings that never appear usually mean the host isn&apos;t on
+          Google Workspace or didn&apos;t press <strong>Record</strong> in the meeting.
         </Box>
       </Box>
 

--- a/components/admin/live-sessions/googleConnectErrors.tsx
+++ b/components/admin/live-sessions/googleConnectErrors.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Box, Paper, Typography, IconButton, Button } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+/**
+ * Plain-language guidance for every way the Google "Connect" round-trip can fail.
+ *
+ * The backend callback now routes ALL consent failures back here with ?google_connected=0&
+ * error=<code> (it used to dead-end on a bare 400 for the "Access blocked" path). This maps
+ * each code to what a NON-TECHNICAL admin should actually do — the #1 case being Google's
+ * "Access blocked" interstitial (error=access_denied), which has four distinct causes that
+ * look identical to the person clicking Connect.
+ */
+
+export interface GoogleConnectErrorInfo {
+  title: string;
+  intro: string;
+  /** Ordered, concrete fixes — each one line, no jargon where avoidable. */
+  fixes: string[];
+}
+
+const ACCESS_BLOCKED: GoogleConnectErrorInfo = {
+  title: "Google showed “Access blocked” (or you cancelled)",
+  intro:
+    "Google refused before asking for permissions. This is a Google-side setting on the OAuth app or your Google account — one of these four, in order of likelihood:",
+  fixes: [
+    "The app is in “Testing” mode and your Google account isn't on its Test users list → in Google Cloud Console open “APIs & Services → OAuth consent screen → Audience/Test users” and add the exact Google account you're connecting, then retry.",
+    "You connected with a personal account but the app is “Internal” → either use an account from the app's Google Workspace organization, or set the consent screen User type to “External”.",
+    "Your Google Workspace organization blocks unverified third-party apps → a Workspace admin must allow this app in “Admin console → Security → API controls → App access control”.",
+    "The app is published but not verified by Google → on the warning screen you can click “Advanced → Go to <app> (unsafe)” to proceed, or complete Google's verification once for a clean screen.",
+  ],
+};
+
+const ERROR_MAP: Record<string, GoogleConnectErrorInfo> = {
+  access_denied: ACCESS_BLOCKED,
+  org_internal: ACCESS_BLOCKED,
+  admin_policy_enforced: {
+    title: "Your Google Workspace blocks this app",
+    intro: "Your organization's Google admin has restricted which apps can access Google data.",
+    fixes: [
+      "Ask your Google Workspace admin to allow this app in “Admin console → Security → API controls → App access control”, then retry Connect.",
+    ],
+  },
+  invalid_state: {
+    title: "The connection attempt expired",
+    intro: "The secure hand-off between this page and Google is only valid for 10 minutes.",
+    fixes: ["Just click “Connect Google” again and complete the Google screens within a few minutes."],
+  },
+  not_configured: {
+    title: "Google isn't configured on the platform yet",
+    intro: "There is no Google OAuth app set up for this environment.",
+    fixes: [
+      "If you manage the platform: set the Google OAuth client ID/secret (or add your own under Advanced in Settings), then retry.",
+      "Otherwise contact your platform administrator.",
+    ],
+  },
+  token_exchange_failed: {
+    title: "Couldn't reach Google to finish connecting",
+    intro: "The final token exchange with Google failed — usually a temporary network problem.",
+    fixes: ["Wait a moment and click “Connect Google” again."],
+  },
+  token_rejected: {
+    title: "Google rejected the connection",
+    intro: "Google refused the final token exchange. This usually means the OAuth client secret is wrong, or the redirect URI isn't whitelisted exactly.",
+    fixes: [
+      "Copy the redirect URI shown on this card and make sure it's listed EXACTLY under “Authorized redirect URIs” on the OAuth client (https, no trailing slash).",
+      "If you use your own Google app (Advanced), re-check the client ID and secret, then Reconnect.",
+    ],
+  },
+  no_refresh_token: {
+    title: "Google didn't grant offline access",
+    intro: "The connection completed but Google didn't return the long-lived token the platform needs.",
+    fixes: [
+      "Retry Connect and approve ALL requested permissions (don't untick anything on the consent screen).",
+      "If it keeps happening, remove the app's access at myaccount.google.com → Security → Third-party access, then Connect again.",
+    ],
+  },
+};
+
+const FALLBACK: GoogleConnectErrorInfo = {
+  title: "Google connection failed",
+  intro: "The connection didn't complete.",
+  fixes: [
+    "Retry “Connect Google”. If it fails again, open the Setup guide below and re-check each step — the redirect URI and the Test users list are the usual culprits.",
+  ],
+};
+
+export function googleConnectErrorInfo(code: string | null | undefined): GoogleConnectErrorInfo {
+  return ERROR_MAP[(code || "").trim()] ?? FALLBACK;
+}
+
+/** Dismissible troubleshooting panel rendered by GoogleSetupCard after a failed connect. */
+export function GoogleConnectErrorPanel({
+  code,
+  onDismiss,
+  onRetry,
+}: {
+  code: string;
+  onDismiss: () => void;
+  onRetry: () => void;
+}) {
+  const info = googleConnectErrorInfo(code);
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 2,
+        borderRadius: 2,
+        border: "1px solid color-mix(in srgb, var(--error-500, #ef4444) 35%, var(--border-default) 65%)",
+        bgcolor: "color-mix(in srgb, var(--error-500, #ef4444) 7%, var(--surface) 93%)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+        <IconWrapper icon="mdi:shield-alert-outline" size={20} color="var(--error-500, #ef4444)" />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+            {info.title}
+          </Typography>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.25 }}>
+            {info.intro}
+          </Typography>
+          <Box component="ol" sx={{ m: 0, mt: 1, pl: 2.5 }}>
+            {info.fixes.map((fix, i) => (
+              <Box key={i} component="li" sx={{ mb: 0.5, color: "var(--font-secondary)", fontSize: "0.8125rem", lineHeight: 1.55 }}>
+                {fix}
+              </Box>
+            ))}
+          </Box>
+          <Button size="small" onClick={onRetry} sx={{ mt: 1, textTransform: "none", fontWeight: 700 }}>
+            Try connecting again
+          </Button>
+        </Box>
+        <IconButton size="small" onClick={onDismiss} aria-label="Dismiss">
+          <IconWrapper icon="mdi:close" size={16} />
+        </IconButton>
+      </Box>
+    </Paper>
+  );
+}

--- a/components/admin/live-sessions/useAdminLiveSessions.ts
+++ b/components/admin/live-sessions/useAdminLiveSessions.ts
@@ -15,7 +15,6 @@ import {
   getZoomApiErrorMessage,
   copyToClipboard,
 } from "@/lib/utils/live-session-errors";
-import { getUniqueAttendanceCount } from "@/lib/utils/attendance-utils";
 import { canAccessAdminArea } from "@/lib/auth/role-utils";
 
 const ADMIN_LIVE_SESSIONS_FEATURE = "admin_live_sessions";
@@ -39,7 +38,8 @@ export function useAdminLiveSessions() {
   >(null);
   const [creatingZoomId, setCreatingZoomId] = useState<number | null>(null);
   const [creatingGoogleMeetId, setCreatingGoogleMeetId] = useState<number | null>(null);
-  const [uniqueAttendanceCounts, setUniqueAttendanceCounts] = useState<Record<number, number>>({});
+  // In-app recording playback (provider-neutral backend proxy: Zoom MP4s + Meet Drive files).
+  const [playerSession, setPlayerSession] = useState<LiveActivity | null>(null);
 
   const canAccessAdmin = canAccessAdminArea(user?.role);
 
@@ -78,36 +78,6 @@ export function useAdminLiveSessions() {
       setLoading(false);
     }
   };
-
-  // Fetch unique attendee count per session (one person = one count, no re-joins)
-  useEffect(() => {
-    const withAttendance = sessions.filter((s) => (s.attendance_count ?? 0) > 0);
-    if (withAttendance.length === 0) {
-      setUniqueAttendanceCounts({});
-      return;
-    }
-    let cancelled = false;
-    Promise.all(
-      withAttendance.map(async (a) => {
-        try {
-          const res = await adminLiveActivitiesService.getZoomAttendance(a.id);
-          return { id: a.id, count: getUniqueAttendanceCount(res.participants ?? []) };
-        } catch {
-          return { id: a.id, count: 0 };
-        }
-      })
-    ).then((results) => {
-      if (cancelled) return;
-      const map: Record<number, number> = {};
-      results.forEach((r) => {
-        map[r.id] = r.count;
-      });
-      setUniqueAttendanceCounts(map);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [sessions]);
 
   const handleCopyPassword = (password: string) => {
     copyToClipboard(password, showToast, "Password copied");
@@ -154,16 +124,20 @@ export function useAdminLiveSessions() {
   };
 
   const handleWatchRecording = async (activity: LiveActivity) => {
-    if (activity.zoom_recording_url?.trim()) {
-      window.open(activity.zoom_recording_url, "_blank");
-      return;
-    }
     try {
       setWatchingRecordingId(activity.id);
-      const data = await studentLiveSessionsService.getRecording(activity.id);
-      if (data.recording_url) {
-        window.open(data.recording_url, "_blank");
+      const info = await studentLiveSessionsService.getRecording(activity.id);
+      if (info.playable_in_app) {
+        // Watch ON platform — the backend proxy streams Zoom MP4s and Meet Drive recordings.
+        setPlayerSession(activity);
+        return;
       }
+      const external = info.recording_link || activity.zoom_recording_url;
+      if (external?.trim()) {
+        window.open(external, "_blank");
+        return;
+      }
+      showToast(getLiveSessionErrorMessage(null, "recording"), "error");
     } catch (error: unknown) {
       showToast(getLiveSessionErrorMessage(error, "recording"), "error");
     } finally {
@@ -188,7 +162,8 @@ export function useAdminLiveSessions() {
     hasAdminLiveSessionsFeature,
     loading,
     sessions,
-    uniqueAttendanceCounts,
+    playerSession,
+    setPlayerSession,
     page,
     setPage,
     rowsPerPage,

--- a/components/live-sessions/RecordingPlayerDialog.tsx
+++ b/components/live-sessions/RecordingPlayerDialog.tsx
@@ -46,7 +46,7 @@ export function RecordingPlayerDialog({ liveClassId, title, open, onClose }: Rec
       setError(null);
       try {
         const res = await apiClient.get<{ token?: string }>(
-          `/live-class/api/clients/${config.clientId}/live-activities/${liveClassId}/zoom/recording/playback/`
+          `/live-class/api/clients/${config.clientId}/live-activities/${liveClassId}/recording/playback/`
         );
         if (cancelled) return;
         const token = res.data?.token;
@@ -55,7 +55,7 @@ export function RecordingPlayerDialog({ liveClassId, title, open, onClose }: Rec
           return;
         }
         setStreamUrl(
-          `${config.apiBaseUrl}/live-class/api/clients/${config.clientId}/live-activities/${liveClassId}/zoom/recording/stream/?t=${encodeURIComponent(token)}`
+          `${config.apiBaseUrl}/live-class/api/clients/${config.clientId}/live-activities/${liveClassId}/recording/stream/?t=${encodeURIComponent(token)}`
         );
       } catch {
         if (!cancelled) setError(t("liveSessions.recordingLoadError", "Could not load the recording."));

--- a/components/live-sessions/StudentSessionSummaryDialog.tsx
+++ b/components/live-sessions/StudentSessionSummaryDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button,
@@ -20,29 +20,54 @@ import type { StudentLiveSessionTranscript } from "@/lib/services/live-sessions/
 interface StudentSessionSummaryDialogProps {
   activityId: number;
   topicName: string;
+  /** Controlled mode: the parent owns visibility (no trigger button is rendered). */
+  open?: boolean;
+  onClose?: () => void;
 }
 
-/** Button + dialog showing the AI summary and searchable transcript for an ended session. Self-contained:
- *  lazily fetches the transcript only when opened, so it adds no cost to the sessions list. */
-export function StudentSessionSummaryDialog({ activityId, topicName }: StudentSessionSummaryDialogProps) {
+/** AI summary + searchable transcript for an ended session (provider-neutral endpoint).
+ *  Two modes: self-contained trigger-button + dialog (default), or CONTROLLED via open/onClose
+ *  so a list can render one instance for whichever card's "View summary" was clicked. Lazily
+ *  fetches the transcript only when opened, so it adds no cost to the sessions list. */
+export function StudentSessionSummaryDialog({ activityId, topicName, open: controlledOpen, onClose }: StudentSessionSummaryDialogProps) {
   const { t } = useTranslation("common");
-  const [open, setOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = isControlled ? Boolean(controlledOpen) : internalOpen;
   const [data, setData] = useState<StudentLiveSessionTranscript | null>(null);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
+  const [loadedFor, setLoadedFor] = useState<number | null>(null);
 
-  const handleOpen = async () => {
-    setOpen(true);
-    if (data) return;
+  const fetchData = async () => {
+    if (loadedFor === activityId && data) return;
     try {
       setLoading(true);
       const res = await studentLiveSessionsService.getTranscript(activityId);
       setData(res);
+      setLoadedFor(activityId);
     } catch {
       setData(null);
+      setLoadedFor(activityId);
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleOpen = async () => {
+    setInternalOpen(true);
+    await fetchData();
+  };
+
+  // Controlled mode: fetch when the parent opens us (or switches the target session).
+  useEffect(() => {
+    if (isControlled && open) void fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isControlled, open, activityId]);
+
+  const handleClose = () => {
+    if (isControlled) onClose?.();
+    else setInternalOpen(false);
   };
 
   const lines = (() => {
@@ -56,6 +81,7 @@ export function StudentSessionSummaryDialog({ activityId, topicName }: StudentSe
 
   return (
     <>
+      {!isControlled && (
       <Button
         variant="text"
         size="small"
@@ -70,8 +96,9 @@ export function StudentSessionSummaryDialog({ activityId, topicName }: StudentSe
       >
         {t("liveSessions.summaryAndTranscript", "Summary & transcript")}
       </Button>
+      )}
 
-      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm" fullWidth>
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
         <DialogTitle sx={{ fontWeight: 600 }}>
           {topicName || t("liveSessions.summaryAndTranscript", "Summary & transcript")}
         </DialogTitle>
@@ -150,7 +177,7 @@ export function StudentSessionSummaryDialog({ activityId, topicName }: StudentSe
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setOpen(false)}>{t("liveSessions.close", "Close")}</Button>
+          <Button onClick={() => handleClose()}>{t("liveSessions.close", "Close")}</Button>
         </DialogActions>
       </Dialog>
     </>

--- a/components/live-sessions/ui/LiveSessionCard.tsx
+++ b/components/live-sessions/ui/LiveSessionCard.tsx
@@ -25,9 +25,16 @@ export interface LiveSessionCardData {
   zoom_password?: string | null;
   zoom_recording_url?: string | null;
   zoom_status?: "scheduled" | "cancelled" | null;
+  google_status?: "scheduled" | "cancelled" | null;
   meeting_status?: "scheduled" | "live" | "ended" | "expired" | null;
   course_detail?: { title?: string } | null;
   attendance_count?: number;
+  /** Provider-neutral artifacts (serializer-computed / Google poller-populated). */
+  has_recording?: boolean;
+  recording_link?: string | null;
+  google_artifacts_status?: string | null;
+  zoom_ai_summary?: string | null;
+  google_ai_summary?: string | null;
 }
 
 /**
@@ -58,6 +65,8 @@ export interface LiveSessionCardProps<T extends LiveSessionCardData = LiveSessio
   onJoin?: (session: T) => void;
   onCopyPasscode?: (password: string) => void;
   onWatchRecording?: (session: T) => void;
+  /** Ended sessions with an AI summary/transcript: open the session summary dialog. */
+  onViewSummary?: (session: T) => void;
   formatDateTime?: (dateString: string) => string;
 }
 
@@ -97,12 +106,15 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
   onJoin,
   onCopyPasscode,
   onWatchRecording,
+  onViewSummary,
   formatDateTime,
 }: LiveSessionCardProps<T>) {
   const { t } = useTranslation("common");
   const isAdmin = variant === "admin";
 
-  const isCancelled = session.zoom_status === "cancelled";
+  // Cancelled is provider-agnostic: a cancelled Google session keeps a dead Meet link and
+  // used to render as joinable because only zoom_status was consulted.
+  const isCancelled = session.zoom_status === "cancelled" || session.google_status === "cancelled";
   const status = isCancelled ? "cancelled" : session.meeting_status ?? "scheduled";
   const accent = STATUS_ACCENT[status] ?? STATUS_ACCENT.scheduled;
   const isUpcomingOrLive = status === "scheduled" || status === "live";
@@ -110,7 +122,23 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
 
   const joinUrl = session.is_google_meet ? session.join_link?.trim() : session.zoom_join_url?.trim();
   const hasMeeting = Boolean(session.is_google_meet || session.zoom_meeting_id || session.zoom_join_url);
-  const hasRecording = Boolean(session.zoom_recording_url?.trim());
+  // Anything watchable, any provider: serializer flag first (covers Google Drive recordings,
+  // which never surface a URL on the card), then legacy per-field fallbacks.
+  const hasRecording = Boolean(
+    session.has_recording || session.zoom_recording_url?.trim() || session.recording_link?.trim()
+  );
+  const hasSummary = Boolean(session.zoom_ai_summary || session.google_ai_summary);
+  // Ended Google session with no recording yet: tell the viewer WHY the card has no CTA
+  // instead of rendering a dead card ("processing" polls for up to ~48h; then unavailable).
+  const artifactsStatus = (session.google_artifacts_status || "").toLowerCase();
+  const recordingHint =
+    isDone && !hasRecording && session.is_google_meet
+      ? artifactsStatus === "pending" || artifactsStatus === "processing"
+        ? t("liveSessions.recordingProcessing", "Recording is processing — check back soon.")
+        : artifactsStatus === "needs_reconnect"
+          ? t("liveSessions.recordingNeedsReconnect", "Recording pending a Google reconnect by your admin.")
+          : t("liveSessions.noRecordingAvailable", "No recording was made for this session.")
+      : null;
 
   // Compute the single most relevant primary action for the current state.
   function primaryAction(): PrimaryAction | null {
@@ -279,6 +307,13 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
           })()}
         </Box>
 
+        {recordingHint && (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+            <IconWrapper icon="mdi:movie-open-off-outline" size={15} color="var(--font-tertiary)" />
+            <Typography sx={{ fontSize: "0.76rem", color: "var(--font-tertiary)" }}>{recordingHint}</Typography>
+          </Box>
+        )}
+
         {/* Actions */}
         <Box sx={{ mt: 1, display: "flex", gap: 1, alignItems: "stretch" }} onClick={(e) => e.stopPropagation()}>
           {primary ? (
@@ -339,6 +374,24 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
                 }}
               >
                 <IconWrapper icon="mdi:key-variant" size={18} />
+              </IconButton>
+            </Tooltip>
+          )}
+
+          {/* Ended sessions with an AI summary: quick access without opening the recording */}
+          {isDone && hasSummary && onViewSummary && (
+            <Tooltip title={t("liveSessions.viewSummary", "View session summary")} placement="top">
+              <IconButton
+                onClick={() => onViewSummary(session)}
+                aria-label={t("liveSessions.viewSummary", "View session summary")}
+                sx={{
+                  color: "var(--accent-indigo)",
+                  border: "1px solid color-mix(in srgb, var(--accent-indigo) 30%, transparent)",
+                  borderRadius: 2.5,
+                  "&:hover": { background: "color-mix(in srgb, var(--accent-indigo) 8%, transparent)" },
+                }}
+              >
+                <IconWrapper icon="mdi:text-box-outline" size={18} />
               </IconButton>
             </Tooltip>
           )}

--- a/components/live-sessions/useLiveSessions.ts
+++ b/components/live-sessions/useLiveSessions.ts
@@ -31,6 +31,10 @@ export function useLiveSessions() {
   const [watchingRecordingId, setWatchingRecordingId] = useState<
     number | null
   >(null);
+  // In-app playback + session summary (provider-neutral: Zoom cloud MP4s and Google Meet
+  // Drive recordings both stream through the backend proxy — "watch ON platform").
+  const [playerSession, setPlayerSession] = useState<StudentLiveSession | null>(null);
+  const [summarySession, setSummarySession] = useState<StudentLiveSession | null>(null);
 
   const enabledFeatureNames = new Set(
     clientInfo?.features?.map((f) => f.name) ?? []
@@ -61,16 +65,22 @@ export function useLiveSessions() {
   };
 
   const handleWatchRecording = async (activity: StudentLiveSession) => {
-    if (activity.zoom_recording_url?.trim()) {
-      window.open(activity.zoom_recording_url, "_blank");
-      return;
-    }
     try {
       setWatchingRecordingId(activity.id);
-      const data = await studentLiveSessionsService.getRecording(activity.id);
-      if (data.recording_url) {
-        window.open(data.recording_url, "_blank");
+      const info = await studentLiveSessionsService.getRecording(activity.id);
+      if (info.playable_in_app) {
+        // Watch ON platform: the backend proxy streams Zoom MP4s and Google Meet Drive
+        // recordings alike — no external tabs, no share links.
+        setPlayerSession(activity);
+        return;
       }
+      // Manually pasted recording link — external is all we have.
+      const external = info.recording_link || activity.recording_link || activity.zoom_recording_url;
+      if (external?.trim()) {
+        window.open(external, "_blank");
+        return;
+      }
+      showToast(getLiveSessionErrorMessage(null, "recording"), "error");
     } catch (error: unknown) {
       showToast(getLiveSessionErrorMessage(error, "recording"), "error");
     } finally {
@@ -119,6 +129,10 @@ export function useLiveSessions() {
     rowsPerPage,
     setRowsPerPage,
     watchingRecordingId,
+    playerSession,
+    setPlayerSession,
+    summarySession,
+    setSummarySession,
     loadSessions,
     handleCopyPassword,
     handleWatchRecording,

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -410,7 +410,7 @@ export const adminLiveActivitiesService = {
     liveClassId: number
   ): Promise<LiveSessionTranscriptResponse> => {
     const response = await apiClient.get<LiveSessionTranscriptResponse>(
-      `${BASE}/live-activities/${liveClassId}/zoom/transcript/`
+      `${BASE}/live-activities/${liveClassId}/transcript/`
     );
     return response.data;
   },

--- a/lib/services/google.service.ts
+++ b/lib/services/google.service.ts
@@ -14,6 +14,9 @@ export interface GoogleCredentials {
   is_connected?: boolean;
   /** True when the tenant uses its own Google OAuth app instead of the platform default. */
   has_custom_app?: boolean;
+  /** False when the account was connected before the recording/transcript scopes existed —
+   *  the admin must Reconnect to enable post-meeting recordings, transcripts & AI summaries. */
+  artifacts_scopes_granted?: boolean;
   connected_email?: string | null;
   calendar_id?: string | null;
   timezone?: string | null;

--- a/lib/services/live-sessions/student-live-sessions.service.ts
+++ b/lib/services/live-sessions/student-live-sessions.service.ts
@@ -55,10 +55,20 @@ function toStudentSession(item: LiveActivityListItem): StudentLiveSession {
     my_attendance: item.my_attendance ?? null,
     zoom_ai_summary: item.zoom_ai_summary ?? null,
     zoom_transcript_synced_at: item.zoom_transcript_synced_at ?? null,
+    google_status: (item.google_status as StudentLiveSession["google_status"]) ?? null,
+    google_artifacts_status: (item.google_artifacts_status as string) ?? null,
+    google_recording_url: (item.google_recording_url as string) ?? null,
+    google_ai_summary: (item.google_ai_summary as string) ?? null,
+    google_transcript_synced_at: (item.google_transcript_synced_at as string) ?? null,
+    recording_link: (item.recording_link as string) ?? null,
+    has_recording: Boolean(item.has_recording),
+    course_detail: (item.course_detail as StudentLiveSession["course_detail"]) ?? null,
   };
 }
 
 function isIncludedLiveSession(item: LiveActivityListItem): boolean {
+  // A cancelled Google session keeps its (dead) Meet link — hide it like cancelled Zoom ones.
+  if (item.google_status === "cancelled") return false;
   if (item.is_zoom === true || Boolean(item.zoom_join_url?.trim())) {
     return true;
   }
@@ -91,7 +101,7 @@ export const studentLiveSessionsService = {
     activityId: number
   ): Promise<StudentLiveSessionTranscript> => {
     const response = await apiClient.get<StudentLiveSessionTranscript>(
-      `${BASE}/live-activities/${activityId}/zoom/transcript/`
+      `${BASE}/live-activities/${activityId}/transcript/`
     );
     return response.data;
   },

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -21,12 +21,29 @@ export interface StudentLiveSession {
   my_attendance?: { attended: boolean; duration_seconds: number } | null;
   zoom_ai_summary?: string | null;
   zoom_transcript_synced_at?: string | null;
+  /** Google Meet lifecycle + post-meeting artifacts (parity with the zoom_* fields). */
+  google_status?: "scheduled" | "cancelled" | null;
+  google_artifacts_status?: string | null;
+  google_recording_url?: string | null;
+  google_ai_summary?: string | null;
+  google_transcript_synced_at?: string | null;
+  /** Manually pasted recording link (provider-independent). */
+  recording_link?: string | null;
+  /** Provider-neutral flag from the serializer: something is watchable for this session. */
+  has_recording?: boolean;
+  course_detail?: { title?: string } | null;
 }
 
+/** GET .../live-activities/<id>/recording/ — provider-neutral availability. */
 export interface LiveSessionRecordingResponse {
-  activity_name: string;
-  recording_url: string;
-  duration_seconds?: number;
+  provider: "zoom" | "google" | "manual";
+  has_recording: boolean;
+  /** True when the in-app player can stream it via .../recording/playback|stream/. */
+  playable_in_app: boolean;
+  recording_link?: string;
+  google_artifacts_status?: string;
+  has_transcript?: boolean;
+  has_summary?: boolean;
 }
 
 export interface StudentLiveSessionTranscript {


### PR DESCRIPTION
## Summary
Phase 2 of the live-sessions Google Meet work: the full **UI/UX redesign** of the module (admin + student), making every artifact surface provider-neutral and giving students **on-platform playback** for both Zoom and Google Meet recordings.

> Stacked on `feat/google-connect-ux` (PR #967) — merge that first; this PR then shows only the redesign diff. Backend counterpart: PR #317 (artifact endpoints/fields).

### Admin page (the "cluttery" complaint)
- The three always-stacked panels (Zoom setup, Google setup, imported-meetings inbox) collapse into **one slim "Integrations & tools" strip** with status dots + Presets/Backgrounds shortcuts. It auto-expands **only when something needs attention** (nothing configured, or a failed Google connect — whose troubleshooting panel lives inside). **Sessions are now the first thing on screen**; the hero has one primary CTA.
- Killed the N+1 attendance fan-out (one request per session per list load).

### Session cards (shared)
- Cancelled detection honors `google_status`; "Watch recording" understands all three sources (Zoom cloud / Meet Drive / pasted link); ended Meet sessions without a recording say **why** (processing / needs reconnect / none made); ended sessions with an AI summary get a summary affordance.

### Students — "watch on platform"
- The watch action now streams through the provider-neutral backend proxy in the in-app player (Zoom MP4s **and** Meet Drive recordings; enrollment-gated server-side). The previously-dead `/recording/` call now works against Phase 1's endpoint.
- Summary & transcript dialog wired from ended cards (it existed but had zero render sites); student payload gains the google_* artifact fields + course mapping; cancelled Meets are filtered out.

### Admin detail page
- Provider-driven tabs: Google sessions get Overview/Recording/Transcript (previously Overview-only); neutral transcript endpoint; Meet-appropriate recording guidance; and the session **description** (captured at create, shown nowhere before) renders in Overview.

`tsc` clean; eslint zero new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)