### PR TITLE
feat(live-sessions): Google Meet participants tab (who joined)

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -439,6 +439,13 @@ export default function LiveSessionDetailPage() {
                       </InfoCallout>
                     )}
 
+                    {/* Instructor was assigned as a real co-host via the API — full host powers. */}
+                    {isGoogleMeet && activity.google_instructor_cohost_state === "done" && (
+                      <InfoCallout icon="mdi:account-key">
+                        {t("adminLiveSessions.instructorCohost", "{{email}} is a co-host — they can admit people from the lobby, mute, remove, and end the meeting. Just make sure they join.", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                      </InfoCallout>
+                    )}
+
                     {/* Same-org instructor: as an invitee they can already admit lobby knockers
                         (Google grants admit to any in-org participant when moderation is off) — no setup. */}
                     {isGoogleMeet && activity.google_instructor_cohost_state === "invitee_can_admit" && (

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -432,6 +432,42 @@ export default function LiveSessionDetailPage() {
                       </SectionCard>
                     )}
 
+                    {/* Admit-control status (Google Meet) */}
+                    {isGoogleMeet && activity.google_admit_control_enabled && (
+                      <InfoCallout icon="mdi:shield-account-outline">
+                        {t("adminLiveSessions.admitOn", "Host-admit is on — people with the link must be let in by a host. Make sure a host or co-host is present to admit them.")}
+                      </InfoCallout>
+                    )}
+
+                    {/* One-time co-host setup: adding the instructor as an attendee does NOT let them
+                        admit people — Google requires a manual "Add co-hosts" in the calendar event. */}
+                    {isGoogleMeet && activity.google_instructor_cohost_state === "manual_pending" && (
+                      <SectionCard title={t("adminLiveSessions.finishCohostTitle", "Finish setup: let the instructor admit people")} icon="mdi:account-key-outline">
+                        <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 1 }}>
+                          {t("adminLiveSessions.finishCohostBody", "{{email}} is invited, but to let them admit participants they must be a Meet co-host. Google can only set this in the calendar event:", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                        </Typography>
+                        <Box component="ol" sx={{ m: 0, pl: 2.5, mb: 1.5 }}>
+                          <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mb: 0.5 }}>
+                            {t("adminLiveSessions.finishCohostStep1", "Open the calendar event (button below).")}
+                          </Box>
+                          <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mb: 0.5 }}>
+                            {t("adminLiveSessions.finishCohostStep2", "Click the settings gear → “Meet” → turn on “Host management”, then “Add co-hosts”.")}
+                          </Box>
+                          <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem" }}>
+                            {t("adminLiveSessions.finishCohostStep3", "Add the instructor and Save. For a recurring series this sticks — you only do it once.")}
+                          </Box>
+                        </Box>
+                        {activity.google_html_link && (
+                          <ControlButton
+                            icon="mdi:open-in-new"
+                            label={t("adminLiveSessions.openCalendarEvent", "Open calendar event")}
+                            tone="outline"
+                            onClick={() => window.open(activity.google_html_link!, "_blank", "noopener")}
+                          />
+                        )}
+                      </SectionCard>
+                    )}
+
                     {(isZoom || isGoogleMeet) && (
                       <InfoCallout icon="mdi:lightbulb-on-outline">
                         {isZoom

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/live-sessions/ui/LiveSessionUI";
 import { LiveSessionRosterSection } from "@/components/admin/live-sessions/LiveSessionRosterSection";
 import { ZoomAttendanceSection } from "@/components/admin/live-sessions/ZoomAttendanceSection";
+import { GoogleMeetParticipantsSection } from "@/components/admin/live-sessions/GoogleMeetParticipantsSection";
 import { LiveSessionTranscriptSection } from "@/components/admin/live-sessions/LiveSessionTranscriptSection";
 import { WebinarInvitationsSection } from "@/components/admin/live-sessions/WebinarInvitationsSection";
 import { WebinarEmailSection } from "@/components/admin/live-sessions/WebinarEmailSection";
@@ -270,9 +271,16 @@ export default function LiveSessionDetailPage() {
     const overview = { key: "overview", icon: "mdi:information-outline", label: t("adminLiveSessions.tabOverview", "Overview") };
     const recording = { key: "recording", icon: "mdi:play-circle-outline", label: t("adminLiveSessions.tabRecording", "Recording") };
     const transcript = { key: "transcript", icon: "mdi:text-box-outline", label: t("adminLiveSessions.tabTranscript", "Transcript") };
-    // Google Meet sessions get the artifact tabs too (recording/transcript come from the
-    // Meet artifact poller); attendance stays Zoom-only (no participant sync for Meet yet).
-    if (isGoogleMeet) return [overview, recording, transcript];
+    // Google Meet sessions get the artifact tabs too (recording/transcript come from the Meet
+    // artifact poller), plus a Participants tab — the roster is synced post-meeting from the Meet
+    // REST API (conferenceRecords.participants), so no manual-sync affordance like Zoom's.
+    if (isGoogleMeet)
+      return [
+        overview,
+        { key: "participants", icon: "mdi:account-group-outline", label: t("adminLiveSessions.tabParticipants", "Participants") },
+        recording,
+        transcript,
+      ];
     if (!isZoom) return [overview];
     const base = [
       overview,
@@ -434,12 +442,17 @@ export default function LiveSessionDetailPage() {
                   </Box>
                 )}
 
-                {/* Attendance */}
+                {/* Attendance (Zoom) */}
                 {tabKey === "attendance" && (
                   <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
                     <SectionCard><LiveSessionRosterSection liveClassId={activity.id} /></SectionCard>
                     <SectionCard><ZoomAttendanceSection liveClassId={activity.id} /></SectionCard>
                   </Box>
+                )}
+
+                {/* Participants (Google Meet) — synced post-meeting from the Meet REST API */}
+                {tabKey === "participants" && (
+                  <SectionCard><GoogleMeetParticipantsSection liveClassId={activity.id} /></SectionCard>
                 )}
 
                 {/* Recording */}

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -439,13 +439,6 @@ export default function LiveSessionDetailPage() {
                       </InfoCallout>
                     )}
 
-                    {/* Instructor was assigned as a real co-host via the API — full host powers. */}
-                    {isGoogleMeet && activity.google_instructor_cohost_state === "done" && (
-                      <InfoCallout icon="mdi:account-key">
-                        {t("adminLiveSessions.instructorCohost", "{{email}} is a co-host — they can admit people from the lobby, mute, remove, and end the meeting. Just make sure they join.", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
-                      </InfoCallout>
-                    )}
-
                     {/* Same-org instructor: as an invitee they can already admit lobby knockers
                         (Google grants admit to any in-org participant when moderation is off) — no setup. */}
                     {isGoogleMeet && activity.google_instructor_cohost_state === "invitee_can_admit" && (

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -439,12 +439,20 @@ export default function LiveSessionDetailPage() {
                       </InfoCallout>
                     )}
 
-                    {/* One-time co-host setup: adding the instructor as an attendee does NOT let them
-                        admit people — Google requires a manual "Add co-hosts" in the calendar event. */}
+                    {/* Same-org instructor: as an invitee they can already admit lobby knockers
+                        (Google grants admit to any in-org participant when moderation is off) — no setup. */}
+                    {isGoogleMeet && activity.google_instructor_cohost_state === "invitee_can_admit" && (
+                      <InfoCallout icon="mdi:account-check-outline">
+                        {t("adminLiveSessions.instructorCanAdmit", "{{email}} is in your organization, so they can let people in from the lobby directly — no extra setup. Just make sure they join the meeting.", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                      </InfoCallout>
+                    )}
+
+                    {/* External/out-of-org instructor: being invited does NOT let them admit — Google
+                        requires a manual "Add co-hosts" in the calendar event (or an in-org instructor). */}
                     {isGoogleMeet && activity.google_instructor_cohost_state === "manual_pending" && (
                       <SectionCard title={t("adminLiveSessions.finishCohostTitle", "Finish setup: let the instructor admit people")} icon="mdi:account-key-outline">
                         <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 1 }}>
-                          {t("adminLiveSessions.finishCohostBody", "{{email}} is invited, but to let them admit participants they must be a Meet co-host. Google can only set this in the calendar event:", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                          {t("adminLiveSessions.finishCohostBody", "{{email}} is invited, but they're outside your Google Workspace, so being invited doesn't let them admit people. Make them a Meet co-host in the calendar event (or use an instructor in your organization, who can admit without this step):", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
                         </Typography>
                         <Box component="ol" sx={{ m: 0, pl: 2.5, mb: 1.5 }}>
                           <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mb: 0.5 }}>

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -540,7 +540,7 @@ export default function CreateLiveSessionPage() {
                             onChange={(e) => setInstructorEmail(e.target.value)}
                             type="email" size="small" fullWidth
                             placeholder="teacher@school.edu"
-                            helperText={t("adminLiveSessions.instructorEmailHelp", "Optional. They're invited to the meeting. To let them admit people, add them as a co-host once in the calendar event — we'll show you where after creating.")}
+                            helperText={t("adminLiveSessions.instructorEmailHelp", "Optional. They're invited and skip the lobby. If they're in your Google Workspace organization, they can also admit others straight away — otherwise you'll add them as a co-host (we'll show you where).")}
                           />
                         </Box>
                       )}

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -90,6 +90,10 @@ export default function CreateLiveSessionPage() {
   // "manual" is the legacy paste-your-own-link path (works with no Google connection).
   const [meetMode, setMeetMode] = useState<"auto" | "manual">("auto");
   const [googleConnected, setGoogleConnected] = useState<boolean | null>(null);
+  // Admit-control (Phase 2). admitAvailable = Workspace host + admit scopes granted (null = unknown).
+  const [admitAvailable, setAdmitAvailable] = useState<boolean | null>(null);
+  const [requireAdmit, setRequireAdmit] = useState(false);
+  const [instructorEmail, setInstructorEmail] = useState("");
 
   const isMeet = sessionType === "meet";
   const isWebinar = sessionType === "webinar";
@@ -124,13 +128,18 @@ export default function CreateLiveSessionPage() {
     if (stepIndex > steps.length - 1) setStepIndex(steps.length - 1);
   }, [steps.length, stepIndex]);
 
-  // Check Google connection once so we can steer the Meet flow (auto vs manual).
+  // Check Google connection once so we can steer the Meet flow (auto vs manual), and learn whether
+  // this tenant's connected account can gate joins (Workspace-only) to enable/disable the toggle.
   useEffect(() => {
     let cancelled = false;
     googleService
       .getGoogleCredentials()
-      .then((res) => { if (!cancelled) setGoogleConnected(Boolean(res.credentials?.is_connected && res.credentials?.is_active)); })
-      .catch(() => { if (!cancelled) setGoogleConnected(false); });
+      .then((res) => {
+        if (cancelled) return;
+        setGoogleConnected(Boolean(res.credentials?.is_connected && res.credentials?.is_active));
+        setAdmitAvailable(Boolean(res.credentials?.admit_control_available));
+      })
+      .catch(() => { if (!cancelled) { setGoogleConnected(false); setAdmitAvailable(false); } });
     return () => { cancelled = true; };
   }, []);
 
@@ -280,7 +289,10 @@ export default function CreateLiveSessionPage() {
           setCreatedSession(session);
         }
 
-        const result = await adminLiveActivitiesService.createGoogleMeet(session.id);
+        const result = await adminLiveActivitiesService.createGoogleMeet(session.id, {
+          require_admit: requireAdmit && admitAvailable === true,
+          instructor_email: instructorEmail.trim() || undefined,
+        });
         if (result.status === "error") {
           const msg = (result.message || "").toLowerCase();
           if (msg.includes("already exists")) {
@@ -300,6 +312,9 @@ export default function CreateLiveSessionPage() {
           null;
         setZoomStartUrl(meetUrl?.trim() ?? null);
         showToast(t("adminLiveSessions.googleMeetCreated", "Google Meet created and invite sent"), "success");
+        // Admit-control couldn't be applied (e.g. personal-Gmail host) — the meeting was still
+        // created, so warn rather than fail.
+        if (result.data?.warning) showToast(result.data.warning, "warning");
         goToDone();
         return;
       }
@@ -500,6 +515,34 @@ export default function CreateLiveSessionPage() {
                           error={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink)}
                           helperText={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink) ? t("adminLiveSessions.invalidMeetLink") : t("adminLiveSessions.meetLinkHelper")}
                         />
+                      )}
+                      {isAutoMeet && (
+                        <Box sx={{ display: "flex", flexDirection: "column", gap: 1, p: 1.5, borderRadius: 1.5, border: "1px solid var(--border-default)", bgcolor: "var(--surface)" }}>
+                          <FormControlLabel
+                            sx={{ m: 0 }}
+                            control={
+                              <Switch
+                                checked={requireAdmit && admitAvailable === true}
+                                disabled={admitAvailable !== true}
+                                onChange={(e) => setRequireAdmit(e.target.checked)}
+                              />
+                            }
+                            label={t("adminLiveSessions.requireAdmit", "Require a host to admit participants")}
+                          />
+                          <Typography variant="caption" sx={{ color: "var(--font-tertiary)", mt: -0.5, ml: 0.5 }}>
+                            {admitAvailable === true
+                              ? t("adminLiveSessions.requireAdmitHelp", "Link-holders can't just walk in — they wait on an “asking to join” screen until a host lets them in. A host or co-host must be present to admit them.")
+                              : t("adminLiveSessions.requireAdmitUnavailable", "Available only with a connected Google Workspace account. Reconnect Google if you just upgraded — personal Gmail can't gate joins.")}
+                          </Typography>
+                          <TextField
+                            label={t("adminLiveSessions.instructorEmail", "Instructor email (host who can admit)")}
+                            value={instructorEmail}
+                            onChange={(e) => setInstructorEmail(e.target.value)}
+                            type="email" size="small" fullWidth
+                            placeholder="teacher@school.edu"
+                            helperText={t("adminLiveSessions.instructorEmailHelp", "Optional. They're invited to the meeting. To let them admit people, add them as a co-host once in the calendar event — we'll show you where after creating.")}
+                          />
+                        </Box>
                       )}
                       <TextField
                         label={t("adminLiveSessions.closeDateAndTimeOptional")}

--- a/components/admin/live-sessions/GoogleMeetParticipantsSection.tsx
+++ b/components/admin/live-sessions/GoogleMeetParticipantsSection.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Box,
+  Typography,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  CircularProgress,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  adminLiveActivitiesService,
+  GoogleParticipantsResponse,
+  GoogleParticipantIdentity,
+} from "@/lib/services/admin/admin-live-activities.service";
+import { formatDurationSeconds } from "@/lib/utils/date-utils";
+
+interface Props {
+  liveClassId: number;
+}
+
+const IDENTITY_META: Record<
+  GoogleParticipantIdentity,
+  { label: string; icon: string; color: string }
+> = {
+  signed_in: { label: "Google user", icon: "mdi:account-check-outline", color: "var(--success-500)" },
+  anonymous: { label: "Guest", icon: "mdi:account-question-outline", color: "var(--warning-500)" },
+  phone: { label: "Dial-in", icon: "mdi:phone-outline", color: "var(--font-tertiary)" },
+};
+
+/**
+ * Google Meet attendance roster (admin/instructor). Unlike Zoom there is NO manual sync — the
+ * backend poller fills the roster shortly after the meeting ends. IMPORTANT: the Meet API gives
+ * no participant email, so the name is "as it appeared in the meeting" and the enrolled-student
+ * link (shown as a chip) is a best-effort NAME match only, absent for guests and dial-ins.
+ */
+export function GoogleMeetParticipantsSection({ liveClassId }: Props) {
+  const { t } = useTranslation("common");
+  const [data, setData] = useState<GoogleParticipantsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchRoster = useCallback(async () => {
+    try {
+      setLoading(true);
+      setData(await adminLiveActivitiesService.getGoogleParticipants(liveClassId));
+    } catch {
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [liveClassId]);
+
+  useEffect(() => {
+    fetchRoster();
+  }, [fetchRoster]);
+
+  const formatDateTimeShort = (s: string | null | undefined) =>
+    !s ? "—" : new Date(s).toLocaleString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+  const formatTimeOnly = (s: string | null | undefined) =>
+    !s ? "—" : new Date(s).toLocaleString("en-US", { hour: "numeric", minute: "2-digit" });
+
+  if (loading) {
+    return (
+      <Box sx={{ py: 2, display: "flex", justifyContent: "center" }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  const participants = data?.participants ?? [];
+  const count = participants.length;
+  const syncState = data?.sync_state ?? "pending";
+  const syncedAt = data?.synced_at;
+
+  const cellSx = { fontSize: "0.75rem", verticalAlign: "middle" } as const;
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
+          {t("adminLiveSessions.participantsSection", "Participants ({{count}})", { count })}
+        </Typography>
+      </Box>
+
+      <Typography variant="caption" sx={{ color: "var(--font-tertiary)", mb: 1.5, display: "block" }}>
+        {syncedAt
+          ? t("adminLiveSessions.lastSynced", { date: formatDateTimeShort(syncedAt) })
+          : t("adminLiveSessions.googleRosterAuto", "Fills in automatically a few minutes after the meeting ends.")}
+      </Typography>
+
+      {/* State messaging when the table is empty */}
+      {count === 0 && syncState === "pending" && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, py: 1 }}>
+          <CircularProgress size={14} />
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+            {t("adminLiveSessions.googleRosterPending", "Waiting for Google to finalize the attendee list after the meeting…")}
+          </Typography>
+        </Box>
+      )}
+      {count === 0 && syncState === "synced" && (
+        <Typography variant="body2" sx={{ color: "var(--font-secondary)", py: 1 }}>
+          {t("adminLiveSessions.googleRosterEmpty", "No participants were recorded for this meeting.")}
+        </Typography>
+      )}
+      {count === 0 && syncState === "unavailable" && (
+        <Typography variant="body2" sx={{ color: "var(--font-secondary)", py: 1 }}>
+          {t("adminLiveSessions.googleRosterUnavailable", "No attendance is available — the meeting doesn't appear to have taken place.")}
+        </Typography>
+      )}
+
+      {count > 0 && (
+        <>
+          <Typography variant="caption" sx={{ color: "var(--font-secondary)", mb: 1.5, display: "block", fontStyle: "italic" }}>
+            {t("adminLiveSessions.googleRosterHint", "Names are shown as they appeared in Meet. Google doesn't share attendee emails, so the enrolled-student link is a best-effort name match.")}
+          </Typography>
+          <TableContainer component={Paper} variant="outlined" sx={{ overflow: "hidden" }}>
+            <Table size="small" sx={{ tableLayout: "fixed", width: "100%" }}>
+              <TableHead>
+                <TableRow sx={{ bgcolor: "var(--surface)" }}>
+                  <TableCell sx={{ fontWeight: 600, ...cellSx, width: "28%" }}>{t("adminLiveSessions.name", "Name")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...cellSx, width: "18%" }}>{t("adminLiveSessions.type", "Type")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...cellSx, width: "14%" }}>{t("adminLiveSessions.join", "Join")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...cellSx, width: "14%" }}>{t("adminLiveSessions.leave", "Leave")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...cellSx, width: "13%" }}>{t("adminLiveSessions.duration", "Duration")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...cellSx, width: "13%" }}>{t("adminLiveSessions.student", "Student")}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {participants.map((p) => {
+                  const meta = IDENTITY_META[p.identity_type] ?? IDENTITY_META.signed_in;
+                  return (
+                    <TableRow key={p.id}>
+                      <TableCell
+                        sx={{ ...cellSx, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                        title={p.display_name || undefined}
+                      >
+                        {p.display_name || "—"}
+                      </TableCell>
+                      <TableCell sx={cellSx}>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                          <IconWrapper icon={meta.icon} size={14} color={meta.color} />
+                          <span style={{ color: "var(--font-secondary)" }}>{meta.label}</span>
+                        </Box>
+                      </TableCell>
+                      <TableCell sx={cellSx} title={formatDateTimeShort(p.earliest_start_time)}>
+                        {formatTimeOnly(p.earliest_start_time)}
+                      </TableCell>
+                      <TableCell sx={cellSx} title={formatDateTimeShort(p.latest_end_time)}>
+                        {formatTimeOnly(p.latest_end_time)}
+                      </TableCell>
+                      <TableCell sx={cellSx}>{formatDurationSeconds(p.duration_seconds ?? 0)}</TableCell>
+                      <TableCell sx={cellSx}>
+                        {p.matched_student ? (
+                          <Chip
+                            size="small"
+                            label={p.matched_student.name}
+                            title={p.matched_student.email}
+                            sx={{ height: 20, fontSize: "0.68rem", bgcolor: "color-mix(in srgb, var(--success-500) 14%, transparent)", color: "var(--success-500)" }}
+                          />
+                        ) : (
+                          <span style={{ color: "var(--font-tertiary)" }}>—</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -165,6 +165,29 @@ export interface ZoomAttendanceResponse {
   sync_available: boolean;
 }
 
+export type GoogleParticipantIdentity = "signed_in" | "anonymous" | "phone";
+
+export interface GoogleMeetParticipant {
+  id: number;
+  display_name: string;
+  identity_type: GoogleParticipantIdentity;
+  earliest_start_time: string | null;
+  latest_end_time: string | null;
+  duration_seconds: number | null;
+  user_profile: number | null;
+  // Meet exposes no email, so this is a best-effort NAME match only; null for guests/dial-ins.
+  matched_student: { id: number; email: string; name: string } | null;
+}
+
+export interface GoogleParticipantsResponse {
+  provider: "google";
+  count: number;
+  participants: GoogleMeetParticipant[];
+  synced_at: string | null;
+  // pending = ended, still polling the roster; synced = have it; unavailable = no record (never held).
+  sync_state: "pending" | "synced" | "unavailable";
+}
+
 export interface SyncAttendanceData {
   synced: boolean;
   total_participants: number;
@@ -393,6 +416,17 @@ export const adminLiveActivitiesService = {
   ): Promise<SyncAttendanceResponse> => {
     const response = await apiClient.post<SyncAttendanceResponse>(
       `${BASE}/live-activities/${liveClassId}/zoom/sync-attendance/`
+    );
+    return response.data;
+  },
+
+  // Google Meet attendance roster — synced automatically post-meeting (no manual sync button;
+  // Google has no sync-on-demand, the backend poller fills it in).
+  getGoogleParticipants: async (
+    liveClassId: number
+  ): Promise<GoogleParticipantsResponse> => {
+    const response = await apiClient.get<GoogleParticipantsResponse>(
+      `${BASE}/live-activities/${liveClassId}/google/participants/`
     );
     return response.data;
   },

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -45,7 +45,7 @@ export interface LiveActivity {
   google_admit_control_enabled?: boolean;
   google_access_type?: string | null;
   instructor_email?: string | null;
-  google_instructor_cohost_state?: "none" | "manual_pending" | "done" | null;
+  google_instructor_cohost_state?: "none" | "manual_pending" | "invitee_can_admit" | "done" | null;
   zoom_source?: "platform" | "imported" | null;
   is_unassigned?: boolean;
   zoom_host_id?: string | null;
@@ -130,7 +130,7 @@ export interface GoogleMeetSuccessData {
   google_admit_control_enabled?: boolean;
   google_access_type?: string;
   instructor_email?: string;
-  google_instructor_cohost_state?: "none" | "manual_pending" | "done";
+  google_instructor_cohost_state?: "none" | "manual_pending" | "invitee_can_admit" | "done";
   /** Set when admit-control was requested but couldn't be applied (personal Gmail / missing scope). */
   warning?: string;
 }

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -41,6 +41,11 @@ export interface LiveActivity {
   google_status?: "scheduled" | "cancelled" | null;
   google_cancelled_at?: string | null;
   google_meet_created_at?: string | null;
+  // Admit-control + instructor co-host (Phase 2)
+  google_admit_control_enabled?: boolean;
+  google_access_type?: string | null;
+  instructor_email?: string | null;
+  google_instructor_cohost_state?: "none" | "manual_pending" | "done" | null;
   zoom_source?: "platform" | "imported" | null;
   is_unassigned?: boolean;
   zoom_host_id?: string | null;
@@ -122,12 +127,22 @@ export interface GoogleMeetSuccessData {
   join_link?: string;
   google_html_link?: string;
   google_status?: "scheduled" | "cancelled";
+  google_admit_control_enabled?: boolean;
+  google_access_type?: string;
+  instructor_email?: string;
+  google_instructor_cohost_state?: "none" | "manual_pending" | "done";
+  /** Set when admit-control was requested but couldn't be applied (personal Gmail / missing scope). */
+  warning?: string;
 }
 
 /** Optional flags when creating a Google Meet. */
 export interface CreateGoogleMeetOptions {
   /** Also add enrolled students as native Google Calendar attendees (Google sends invites). */
   invite_attendees?: boolean;
+  /** Require a host to admit participants (RESTRICTED). Workspace hosts only; degrades with a warning. */
+  require_admit?: boolean;
+  /** Instructor to invite + make a co-host (they finish a one-time "Add co-hosts" in Calendar). */
+  instructor_email?: string;
 }
 
 export interface ZoomStatusResponse {

--- a/lib/services/google.service.ts
+++ b/lib/services/google.service.ts
@@ -17,6 +17,10 @@ export interface GoogleCredentials {
   /** False when the account was connected before the recording/transcript scopes existed —
    *  the admin must Reconnect to enable post-meeting recordings, transcripts & AI summaries. */
   artifacts_scopes_granted?: boolean;
+  /** True if the connected host is a Google Workspace account (has an 'hd' claim). */
+  is_workspace_host?: boolean;
+  /** True only when host-admit control is actually usable (Workspace + admit scopes granted). */
+  admit_control_available?: boolean;
   connected_email?: string | null;
   calendar_id?: string | null;
   timezone?: string | null;


### PR DESCRIPTION
Frontend for the Meet participant roster (your ask #4 — "see who joined after the meeting"). Pairs with backend **#320**.

Adds a **Participants** tab to the admin session detail page for Google Meet sessions, showing the roster the backend syncs post-meeting from the Meet REST API.

### What you see
Name (as it appeared in Meet), an identity badge (**Google user / Guest / Dial-in**), join, leave, duration, and a best-effort **matched-student** chip.

- **No manual sync button** — unlike Zoom, Google has no sync-on-demand; the roster fills in automatically a few minutes after the meeting, and the tab reflects that.
- **Distinct empty states**: *pending* (ended, still polling), *synced-but-empty* (no one recorded), and *unavailable* (meeting never took place / no conference record).
- **Honest hint**: Google doesn't share attendee emails, so the enrolled-student link is a **name match only** and is absent for guests and dial-ins.

### Notes
- Stacked on `feat/live-sessions-redesign` (#968), which owns the provider-keyed detail tabs — targets that branch for a clean diff.
- ESLint + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)