### PR TITLE
feat(live-sessions): Google Meet admit-control + instructor co-host UI (Phase 2)

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -439,6 +439,13 @@ export default function LiveSessionDetailPage() {
                       </InfoCallout>
                     )}
 
+                    {/* Instructor was assigned as a real co-host via the API — full host powers. */}
+                    {isGoogleMeet && activity.google_instructor_cohost_state === "done" && (
+                      <InfoCallout icon="mdi:account-key">
+                        {t("adminLiveSessions.instructorCohost", "{{email}} is a co-host — they can admit people from the lobby, mute, remove, and end the meeting. Just make sure they join.", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                      </InfoCallout>
+                    )}
+
                     {/* Same-org instructor: as an invitee they can already admit lobby knockers
                         (Google grants admit to any in-org participant when moderation is off) — no setup. */}
                     {isGoogleMeet && activity.google_instructor_cohost_state === "invitee_can_admit" && (

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -432,6 +432,42 @@ export default function LiveSessionDetailPage() {
                       </SectionCard>
                     )}
 
+                    {/* Admit-control status (Google Meet) */}
+                    {isGoogleMeet && activity.google_admit_control_enabled && (
+                      <InfoCallout icon="mdi:shield-account-outline">
+                        {t("adminLiveSessions.admitOn", "Host-admit is on — people with the link must be let in by a host. Make sure a host or co-host is present to admit them.")}
+                      </InfoCallout>
+                    )}
+
+                    {/* One-time co-host setup: adding the instructor as an attendee does NOT let them
+                        admit people — Google requires a manual "Add co-hosts" in the calendar event. */}
+                    {isGoogleMeet && activity.google_instructor_cohost_state === "manual_pending" && (
+                      <SectionCard title={t("adminLiveSessions.finishCohostTitle", "Finish setup: let the instructor admit people")} icon="mdi:account-key-outline">
+                        <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 1 }}>
+                          {t("adminLiveSessions.finishCohostBody", "{{email}} is invited, but to let them admit participants they must be a Meet co-host. Google can only set this in the calendar event:", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                        </Typography>
+                        <Box component="ol" sx={{ m: 0, pl: 2.5, mb: 1.5 }}>
+                          <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mb: 0.5 }}>
+                            {t("adminLiveSessions.finishCohostStep1", "Open the calendar event (button below).")}
+                          </Box>
+                          <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mb: 0.5 }}>
+                            {t("adminLiveSessions.finishCohostStep2", "Click the settings gear → “Meet” → turn on “Host management”, then “Add co-hosts”.")}
+                          </Box>
+                          <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem" }}>
+                            {t("adminLiveSessions.finishCohostStep3", "Add the instructor and Save. For a recurring series this sticks — you only do it once.")}
+                          </Box>
+                        </Box>
+                        {activity.google_html_link && (
+                          <ControlButton
+                            icon="mdi:open-in-new"
+                            label={t("adminLiveSessions.openCalendarEvent", "Open calendar event")}
+                            tone="outline"
+                            onClick={() => window.open(activity.google_html_link!, "_blank", "noopener")}
+                          />
+                        )}
+                      </SectionCard>
+                    )}
+
                     {(isZoom || isGoogleMeet) && (
                       <InfoCallout icon="mdi:lightbulb-on-outline">
                         {isZoom

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -439,13 +439,6 @@ export default function LiveSessionDetailPage() {
                       </InfoCallout>
                     )}
 
-                    {/* Instructor was assigned as a real co-host via the API — full host powers. */}
-                    {isGoogleMeet && activity.google_instructor_cohost_state === "done" && (
-                      <InfoCallout icon="mdi:account-key">
-                        {t("adminLiveSessions.instructorCohost", "{{email}} is a co-host — they can admit people from the lobby, mute, remove, and end the meeting. Just make sure they join.", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
-                      </InfoCallout>
-                    )}
-
                     {/* Same-org instructor: as an invitee they can already admit lobby knockers
                         (Google grants admit to any in-org participant when moderation is off) — no setup. */}
                     {isGoogleMeet && activity.google_instructor_cohost_state === "invitee_can_admit" && (

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -439,12 +439,20 @@ export default function LiveSessionDetailPage() {
                       </InfoCallout>
                     )}
 
-                    {/* One-time co-host setup: adding the instructor as an attendee does NOT let them
-                        admit people — Google requires a manual "Add co-hosts" in the calendar event. */}
+                    {/* Same-org instructor: as an invitee they can already admit lobby knockers
+                        (Google grants admit to any in-org participant when moderation is off) — no setup. */}
+                    {isGoogleMeet && activity.google_instructor_cohost_state === "invitee_can_admit" && (
+                      <InfoCallout icon="mdi:account-check-outline">
+                        {t("adminLiveSessions.instructorCanAdmit", "{{email}} is in your organization, so they can let people in from the lobby directly — no extra setup. Just make sure they join the meeting.", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                      </InfoCallout>
+                    )}
+
+                    {/* External/out-of-org instructor: being invited does NOT let them admit — Google
+                        requires a manual "Add co-hosts" in the calendar event (or an in-org instructor). */}
                     {isGoogleMeet && activity.google_instructor_cohost_state === "manual_pending" && (
                       <SectionCard title={t("adminLiveSessions.finishCohostTitle", "Finish setup: let the instructor admit people")} icon="mdi:account-key-outline">
                         <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 1 }}>
-                          {t("adminLiveSessions.finishCohostBody", "{{email}} is invited, but to let them admit participants they must be a Meet co-host. Google can only set this in the calendar event:", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
+                          {t("adminLiveSessions.finishCohostBody", "{{email}} is invited, but they're outside your Google Workspace, so being invited doesn't let them admit people. Make them a Meet co-host in the calendar event (or use an instructor in your organization, who can admit without this step):", { email: activity.instructor_email || t("adminLiveSessions.theInstructor", "the instructor") })}
                         </Typography>
                         <Box component="ol" sx={{ m: 0, pl: 2.5, mb: 1.5 }}>
                           <Box component="li" sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mb: 0.5 }}>

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -540,7 +540,7 @@ export default function CreateLiveSessionPage() {
                             onChange={(e) => setInstructorEmail(e.target.value)}
                             type="email" size="small" fullWidth
                             placeholder="teacher@school.edu"
-                            helperText={t("adminLiveSessions.instructorEmailHelp", "Optional. They're invited to the meeting. To let them admit people, add them as a co-host once in the calendar event — we'll show you where after creating.")}
+                            helperText={t("adminLiveSessions.instructorEmailHelp", "Optional. They're invited and skip the lobby. If they're in your Google Workspace organization, they can also admit others straight away — otherwise you'll add them as a co-host (we'll show you where).")}
                           />
                         </Box>
                       )}

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -90,6 +90,10 @@ export default function CreateLiveSessionPage() {
   // "manual" is the legacy paste-your-own-link path (works with no Google connection).
   const [meetMode, setMeetMode] = useState<"auto" | "manual">("auto");
   const [googleConnected, setGoogleConnected] = useState<boolean | null>(null);
+  // Admit-control (Phase 2). admitAvailable = Workspace host + admit scopes granted (null = unknown).
+  const [admitAvailable, setAdmitAvailable] = useState<boolean | null>(null);
+  const [requireAdmit, setRequireAdmit] = useState(false);
+  const [instructorEmail, setInstructorEmail] = useState("");
 
   const isMeet = sessionType === "meet";
   const isWebinar = sessionType === "webinar";
@@ -124,13 +128,18 @@ export default function CreateLiveSessionPage() {
     if (stepIndex > steps.length - 1) setStepIndex(steps.length - 1);
   }, [steps.length, stepIndex]);
 
-  // Check Google connection once so we can steer the Meet flow (auto vs manual).
+  // Check Google connection once so we can steer the Meet flow (auto vs manual), and learn whether
+  // this tenant's connected account can gate joins (Workspace-only) to enable/disable the toggle.
   useEffect(() => {
     let cancelled = false;
     googleService
       .getGoogleCredentials()
-      .then((res) => { if (!cancelled) setGoogleConnected(Boolean(res.credentials?.is_connected && res.credentials?.is_active)); })
-      .catch(() => { if (!cancelled) setGoogleConnected(false); });
+      .then((res) => {
+        if (cancelled) return;
+        setGoogleConnected(Boolean(res.credentials?.is_connected && res.credentials?.is_active));
+        setAdmitAvailable(Boolean(res.credentials?.admit_control_available));
+      })
+      .catch(() => { if (!cancelled) { setGoogleConnected(false); setAdmitAvailable(false); } });
     return () => { cancelled = true; };
   }, []);
 
@@ -280,7 +289,10 @@ export default function CreateLiveSessionPage() {
           setCreatedSession(session);
         }
 
-        const result = await adminLiveActivitiesService.createGoogleMeet(session.id);
+        const result = await adminLiveActivitiesService.createGoogleMeet(session.id, {
+          require_admit: requireAdmit && admitAvailable === true,
+          instructor_email: instructorEmail.trim() || undefined,
+        });
         if (result.status === "error") {
           const msg = (result.message || "").toLowerCase();
           if (msg.includes("already exists")) {
@@ -300,6 +312,9 @@ export default function CreateLiveSessionPage() {
           null;
         setZoomStartUrl(meetUrl?.trim() ?? null);
         showToast(t("adminLiveSessions.googleMeetCreated", "Google Meet created and invite sent"), "success");
+        // Admit-control couldn't be applied (e.g. personal-Gmail host) — the meeting was still
+        // created, so warn rather than fail.
+        if (result.data?.warning) showToast(result.data.warning, "warning");
         goToDone();
         return;
       }
@@ -500,6 +515,34 @@ export default function CreateLiveSessionPage() {
                           error={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink)}
                           helperText={meetLink.trim().length > 0 && !isValidHttpUrl(meetLink) ? t("adminLiveSessions.invalidMeetLink") : t("adminLiveSessions.meetLinkHelper")}
                         />
+                      )}
+                      {isAutoMeet && (
+                        <Box sx={{ display: "flex", flexDirection: "column", gap: 1, p: 1.5, borderRadius: 1.5, border: "1px solid var(--border-default)", bgcolor: "var(--surface)" }}>
+                          <FormControlLabel
+                            sx={{ m: 0 }}
+                            control={
+                              <Switch
+                                checked={requireAdmit && admitAvailable === true}
+                                disabled={admitAvailable !== true}
+                                onChange={(e) => setRequireAdmit(e.target.checked)}
+                              />
+                            }
+                            label={t("adminLiveSessions.requireAdmit", "Require a host to admit participants")}
+                          />
+                          <Typography variant="caption" sx={{ color: "var(--font-tertiary)", mt: -0.5, ml: 0.5 }}>
+                            {admitAvailable === true
+                              ? t("adminLiveSessions.requireAdmitHelp", "Link-holders can't just walk in — they wait on an “asking to join” screen until a host lets them in. A host or co-host must be present to admit them.")
+                              : t("adminLiveSessions.requireAdmitUnavailable", "Available only with a connected Google Workspace account. Reconnect Google if you just upgraded — personal Gmail can't gate joins.")}
+                          </Typography>
+                          <TextField
+                            label={t("adminLiveSessions.instructorEmail", "Instructor email (host who can admit)")}
+                            value={instructorEmail}
+                            onChange={(e) => setInstructorEmail(e.target.value)}
+                            type="email" size="small" fullWidth
+                            placeholder="teacher@school.edu"
+                            helperText={t("adminLiveSessions.instructorEmailHelp", "Optional. They're invited to the meeting. To let them admit people, add them as a co-host once in the calendar event — we'll show you where after creating.")}
+                          />
+                        </Box>
                       )}
                       <TextField
                         label={t("adminLiveSessions.closeDateAndTimeOptional")}

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -45,7 +45,7 @@ export interface LiveActivity {
   google_admit_control_enabled?: boolean;
   google_access_type?: string | null;
   instructor_email?: string | null;
-  google_instructor_cohost_state?: "none" | "manual_pending" | "done" | null;
+  google_instructor_cohost_state?: "none" | "manual_pending" | "invitee_can_admit" | "done" | null;
   zoom_source?: "platform" | "imported" | null;
   is_unassigned?: boolean;
   zoom_host_id?: string | null;
@@ -130,7 +130,7 @@ export interface GoogleMeetSuccessData {
   google_admit_control_enabled?: boolean;
   google_access_type?: string;
   instructor_email?: string;
-  google_instructor_cohost_state?: "none" | "manual_pending" | "done";
+  google_instructor_cohost_state?: "none" | "manual_pending" | "invitee_can_admit" | "done";
   /** Set when admit-control was requested but couldn't be applied (personal Gmail / missing scope). */
   warning?: string;
 }

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -41,6 +41,11 @@ export interface LiveActivity {
   google_status?: "scheduled" | "cancelled" | null;
   google_cancelled_at?: string | null;
   google_meet_created_at?: string | null;
+  // Admit-control + instructor co-host (Phase 2)
+  google_admit_control_enabled?: boolean;
+  google_access_type?: string | null;
+  instructor_email?: string | null;
+  google_instructor_cohost_state?: "none" | "manual_pending" | "done" | null;
   zoom_source?: "platform" | "imported" | null;
   is_unassigned?: boolean;
   zoom_host_id?: string | null;
@@ -122,12 +127,22 @@ export interface GoogleMeetSuccessData {
   join_link?: string;
   google_html_link?: string;
   google_status?: "scheduled" | "cancelled";
+  google_admit_control_enabled?: boolean;
+  google_access_type?: string;
+  instructor_email?: string;
+  google_instructor_cohost_state?: "none" | "manual_pending" | "done";
+  /** Set when admit-control was requested but couldn't be applied (personal Gmail / missing scope). */
+  warning?: string;
 }
 
 /** Optional flags when creating a Google Meet. */
 export interface CreateGoogleMeetOptions {
   /** Also add enrolled students as native Google Calendar attendees (Google sends invites). */
   invite_attendees?: boolean;
+  /** Require a host to admit participants (RESTRICTED). Workspace hosts only; degrades with a warning. */
+  require_admit?: boolean;
+  /** Instructor to invite + make a co-host (they finish a one-time "Add co-hosts" in Calendar). */
+  instructor_email?: string;
 }
 
 export interface ZoomStatusResponse {

--- a/lib/services/google.service.ts
+++ b/lib/services/google.service.ts
@@ -17,6 +17,10 @@ export interface GoogleCredentials {
   /** False when the account was connected before the recording/transcript scopes existed —
    *  the admin must Reconnect to enable post-meeting recordings, transcripts & AI summaries. */
   artifacts_scopes_granted?: boolean;
+  /** True if the connected host is a Google Workspace account (has an 'hd' claim). */
+  is_workspace_host?: boolean;
+  /** True only when host-admit control is actually usable (Workspace + admit scopes granted). */
+  admit_control_available?: boolean;
   connected_email?: string | null;
   calendar_id?: string | null;
   timezone?: string | null;


### PR DESCRIPTION
Frontend for **host-must-admit** (#2) and **instructor admit rights** (#3). Pairs with backend **#321**. (Final state — the co-host "done" callout tied to the removed Developer-Preview automation has been dropped.)

## Create wizard (Google Meet, auto-create)
- **"Require a host to admit participants" toggle** — **disabled** with a plain explainer when the connected account isn't Google Workspace (reads `admit_control_available`), so an admin can't enable something Google would silently ignore.
- **"Instructor email (host who can admit)"** field. Both go to `google/create`; the backend `warning` (e.g. personal-Gmail host, or an out-of-org instructor) surfaces as a toast — the meeting is still created.

## Session detail (Overview)
- **"Host-admit is on"** callout when enabled.
- **Same-org instructor** → a green "**{instructor} is in your organization, so they can let people in from the lobby directly — no extra setup, just make sure they join**" callout.
- **External instructor** → the one-time **"Finish setup: Add co-hosts"** card, worded to explain *why* (they're outside your Workspace, so invited ≠ admit power), with an **Open calendar event** deep link.

## Honest UX
The toggle and cards make the Workspace-only and same-org-vs-external constraints visible instead of letting them fail silently.

## Types + stacking
`admit_control_available`/`is_workspace_host` on `GoogleCredentials`; `require_admit`/`instructor_email` on `CreateGoogleMeetOptions`; admit + cohost fields on `GoogleMeetSuccessData` + `LiveActivity` (`invitee_can_admit`/`manual_pending`; `done` retained in the union, unused). ESLint + `tsc` clean. Stacked on the participants UI (#972).

🤖 Generated with [Claude Code](https://claude.com/claude-code)