### PR TITLE
fix(tickets): show Assignees only to org admins

### DIFF
--- a/app/admin/tickets/page.tsx
+++ b/app/admin/tickets/page.tsx
@@ -30,7 +30,7 @@ import { AssigneesDialog } from "@/components/tickets/AssigneesDialog";
 import { config } from "@/lib/config";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { useAuth } from "@/lib/auth/auth-context";
-import { canAccessAdminArea } from "@/lib/auth/role-utils";
+import { canAccessAdminArea, isClientOrgAdminRole } from "@/lib/auth/role-utils";
 import {
   ticketService,
   AdminTicketListResponse,
@@ -147,6 +147,9 @@ export default function AdminTicketsPage() {
   );
 
   const isAdmin = canAccessAdminArea(user?.role);
+  // Mirrors the backend gate on the assignee endpoints: org admins only, since this list
+  // decides which mailboxes receive every student's ticket details.
+  const canManageAssignees = isClientOrgAdminRole(user?.role);
 
   const [statusFilter, setStatusFilter] = useState<TicketStatus | "">("OPEN");
   const [categoryFilter, setCategoryFilter] = useState<TicketCategory | "">("");
@@ -244,27 +247,29 @@ export default function AdminTicketsPage() {
               resolve.
             </Typography>
           </Box>
-          <Button
-            variant="contained"
-            startIcon={<IconWrapper icon="mdi:account-group" size={18} />}
-            onClick={() => setAssigneesOpen(true)}
-            sx={{
-              textTransform: "none",
-              fontWeight: 600,
-              borderRadius: 999,
-              px: 2.5,
-              py: 1,
-              backgroundColor: "var(--ticket-cta-green)",
-              color: "var(--font-light)",
-              boxShadow: "0 4px 12px rgba(22,163,74,0.28)",
-              "&:hover": {
-                backgroundColor: "var(--ticket-cta-green-hover)",
-                boxShadow: "0 6px 16px rgba(22,163,74,0.36)",
-              },
-            }}
-          >
-            Assignees
-          </Button>
+          {canManageAssignees && (
+            <Button
+              variant="contained"
+              startIcon={<IconWrapper icon="mdi:account-group" size={18} />}
+              onClick={() => setAssigneesOpen(true)}
+              sx={{
+                textTransform: "none",
+                fontWeight: 600,
+                borderRadius: 999,
+                px: 2.5,
+                py: 1,
+                backgroundColor: "var(--ticket-cta-green)",
+                color: "var(--font-light)",
+                boxShadow: "0 4px 12px rgba(22,163,74,0.28)",
+                "&:hover": {
+                  backgroundColor: "var(--ticket-cta-green-hover)",
+                  boxShadow: "0 6px 16px rgba(22,163,74,0.36)",
+                },
+              }}
+            >
+              Assignees
+            </Button>
+          )}
         </Stack>
 
         <Stack
@@ -710,11 +715,13 @@ export default function AdminTicketsPage() {
         </Paper>
       </Box>
 
-      <AssigneesDialog
-        open={assigneesOpen}
-        clientId={clientId}
-        onClose={() => setAssigneesOpen(false)}
-      />
+      {canManageAssignees && (
+        <AssigneesDialog
+          open={assigneesOpen}
+          clientId={clientId}
+          onClose={() => setAssigneesOpen(false)}
+        />
+      )}
     </MainLayout>
   );
 }


### PR DESCRIPTION
## What

Hide the **Assignees** button and skip mounting `AssigneesDialog` for roles that cannot use it.

## Why

Pairs with backend PR AI-Linc-LMS/ai-linc-backend#322, which tightens the gate on the three assignee endpoints.

That list decides which mailboxes receive every student's name, email and ticket description, but it was gated on a role check that admitted `instructor` and `course_manager` and never checked whether the profile was active. On a client with instructor self-signup, an *unapproved* instructor still holds a valid JWT and could add their own address to receive every ticket, or delete the real support rows and silently blackhole all notifications. The backend now accepts only active `admin`/`superadmin`.

Without this change those roles would still see the button and get a 403 toast on open.

## How

`isClientOrgAdminRole(user?.role)` is the exact frontend mirror of the backend's `('admin', 'superadmin')` gate, and is already what `app/setup`, `app/admin/branding`, `Sidebar` and `BottomNavigation` use for org-admin-only surfaces — so the role string is known to work for this purpose.

Instructors and course managers keep the rest of the admin ticket surface (list, detail, resolve, status); only the assignee-management dialog is hidden.

## Verification

- `tsc --noEmit` clean on the touched files.
- The one eslint complaint in this file (`react/no-unescaped-entities` on "You don't have permission…") is pre-existing on `stagging`, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)