### PR TITLE
fix(adaptive/analytics): heatmap palette followed the OS, not the surface + page UX pass

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
@@ -38,6 +38,32 @@ const RISK_CHIP: Record<StudentAnalytics["kpis"]["risk_level"], { label: string;
   at_risk: { label: "At risk", icon: "mdi:alert-octagon-outline" },
 };
 
+/** Groups the wall of cards into scannable sections, so the page has a reading order. */
+function SectionHeading({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <Box sx={{ mt: 4, mb: 1.5 }}>
+      <Typography
+        sx={{
+          fontSize: "0.7rem",
+          fontWeight: 700,
+          letterSpacing: 0.8,
+          textTransform: "uppercase",
+          color: "var(--font-tertiary,#8b8b98)",
+        }}
+      >
+        {title}
+      </Typography>
+      {hint && (
+        <Typography sx={{ fontSize: "0.78rem", color: "var(--font-tertiary,#8b8b98)", mt: 0.25 }}>
+          {hint}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+const grid2 = { display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" } } as const;
+
 export default function StudentPerformancePage() {
   const router = useRouter();
   const params = useParams();
@@ -117,55 +143,53 @@ export default function StudentPerformancePage() {
           </Box>
         </Stack>
 
-        <Typography sx={{ color: "var(--font-tertiary,#8b8b98)", fontSize: "0.8rem", mb: 2.5 }}>
+        <Typography sx={{ color: "var(--font-tertiary,#8b8b98)", fontSize: "0.8rem", mb: 3 }}>
           Everything this student has done on <strong>{data.course.title}</strong>.
         </Typography>
 
         {/* Risk first — it's the reason an admin opened this page. */}
-        <Box sx={{ mb: 2.5 }}>
+        <Box sx={{ mb: 2 }}>
           <RiskPanel signals={data.risk_signals} />
         </Box>
 
-        <Box sx={{ mb: 2.5 }}>
-          <KpiRail k={data.kpis} />
-        </Box>
+        <KpiRail k={data.kpis} />
 
-        {/* The headline contrast, full width. */}
+        <SectionHeading title="Mastery & progress" hint="Are they finishing the course — and are they actually learning it?" />
         <Box sx={{ mb: 2 }}>
           <MasteryVsCompletion d={data.mastery_vs_completion} />
         </Box>
-
-        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "2fr 1fr" }, mb: 2 }}>
+        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "2fr 1fr" } }}>
           <ProgressOverTime rows={data.progress_over_time} />
           <CohortComparison c={data.cohort} completion={data.kpis.completion_pct} points={data.kpis.points} />
         </Box>
 
+        <SectionHeading title="Engagement" hint="How consistently they show up, and when." />
         <Box sx={{ mb: 2 }}>
           <ActivityHeatmap cells={data.activity_heatmap} />
         </Box>
-
-        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" }, mb: 2 }}>
-          <SkillMastery rows={data.skill_mastery} />
+        <Box sx={grid2}>
+          <StudyPattern pattern={data.study_pattern} />
           <EffortVsOutcome points={data.effort_vs_outcome} total={data.effort_vs_outcome_total} />
         </Box>
 
-        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" }, mb: 2 }}>
-          <DifficultyMix rows={data.difficulty} />
+        <SectionHeading title="Skills & understanding" hint="What they know, what's fading, and what they only think they know." />
+        <Box sx={{ ...grid2, mb: 2 }}>
+          <SkillMastery rows={data.skill_mastery} />
           <ConfidenceCalibration rows={data.quiz.confidence_calibration} />
         </Box>
+        <Box sx={grid2}>
+          <DifficultyMix rows={data.difficulty} />
+          <StruggleItems rows={data.struggle_items} />
+        </Box>
 
-        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" }, mb: 2 }}>
+        <SectionHeading title="Practice & interviews" hint="Coding performance and mock-interview trajectory." />
+        <Box sx={grid2}>
           <CodingInsights c={data.coding} />
-          <Box sx={{ display: "grid", gap: 2, gridTemplateRows: "auto auto" }}>
-            <StruggleItems rows={data.struggle_items} />
-            <StudyPattern pattern={data.study_pattern} />
-          </Box>
+          <MockInterviewTrend rows={data.mock_interviews} />
         </Box>
 
-        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" } }}>
-          <MockInterviewTrend rows={data.mock_interviews} />
-          <ActivityTimeline rows={data.timeline} />
-        </Box>
+        <SectionHeading title="Activity log" hint="The raw feed, newest first." />
+        <ActivityTimeline rows={data.timeline} />
       </Box>
     </MainLayout>
   );

--- a/components/admin/adaptive-course/analytics/ChartCard.tsx
+++ b/components/admin/adaptive-course/analytics/ChartCard.tsx
@@ -36,13 +36,18 @@ export function ChartCard({
   return (
     <Box
       sx={{
-        p: 2.25,
+        p: 2.5,
         borderRadius: 3,
         bgcolor: "var(--card-bg, #fff)",
         border: "1px solid var(--border-default, #ececf1)",
         display: "flex",
         flexDirection: "column",
         minWidth: 0,
+        transition: "box-shadow 160ms ease, border-color 160ms ease",
+        "&:hover": {
+          boxShadow: "0 6px 24px rgba(15,15,35,0.06)",
+          borderColor: "color-mix(in srgb, var(--border-default) 55%, transparent)",
+        },
       }}
     >
       <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 1, mb: subtitle ? 0.25 : 1.25 }}>

--- a/components/admin/adaptive-course/analytics/charts.tsx
+++ b/components/admin/adaptive-course/analytics/charts.tsx
@@ -23,7 +23,7 @@ import {
 } from "recharts";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import type { StudentAnalytics, RiskSeverity } from "@/lib/services/admin/admin-adaptive-course.service";
-import { ACTIVITY_LABEL, MASTERY_LADDER, sequentialStep, useVizPalette, VizPalette } from "./vizPalette";
+import { ACTIVITY_LABEL, emptyCell, MASTERY_LADDER, sequentialStep, useVizPalette, VizPalette } from "./vizPalette";
 import { ChartCard, EmptyState, tooltipStyles } from "./ChartCard";
 
 const axisProps = (p: VizPalette) => ({
@@ -58,9 +58,20 @@ export function KpiRail({ k }: { k: StudentAnalytics["kpis"] }) {
         <Box
           key={t.label}
           sx={{
-            p: 1.75, borderRadius: 3,
+            position: "relative",
+            overflow: "hidden",
+            p: 1.75, pl: 2.1, borderRadius: 3,
             bgcolor: "var(--card-bg,#fff)",
             border: "1px solid var(--border-default,#ececf1)",
+            transition: "box-shadow 160ms ease",
+            "&:hover": { boxShadow: "0 6px 20px rgba(15,15,35,0.06)" },
+            // A 3px accent rail ties the tile to its series color without tinting the text.
+            "&::before": {
+              content: '""',
+              position: "absolute",
+              left: 0, top: 0, bottom: 0, width: 3,
+              bgcolor: t.accent,
+            },
           }}
         >
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 0.75 }}>
@@ -234,13 +245,14 @@ export function ProgressOverTime({ rows }: { rows: StudentAnalytics["progress_ov
 
 export function ActivityHeatmap({ cells }: { cells: StudentAnalytics["activity_heatmap"] }) {
   const p = useVizPalette();
-  const { weeks, max } = useMemo(() => {
+  const { weeks, max, monthMarks } = useMemo(() => {
     const map = new Map(cells.map((c) => [c.date, c]));
     const max = cells.reduce((m, c) => Math.max(m, c.count), 0);
     const end = new Date();
     const start = new Date(end);
     start.setDate(start.getDate() - 181);
-    start.setDate(start.getDate() - start.getDay()); // align to Sunday
+    start.setDate(start.getDate() - start.getDay()); // align to a Sunday column
+
     const weeks: { date: string; count: number; minutes: number }[][] = [];
     const cur = new Date(start);
     while (cur <= end) {
@@ -253,40 +265,91 @@ export function ActivityHeatmap({ cells }: { cells: StudentAnalytics["activity_h
       }
       weeks.push(week);
     }
-    return { weeks, max };
+
+    // A month label sits above the first week that lands in a new month.
+    const monthMarks: { week: number; label: string }[] = [];
+    let last = -1;
+    weeks.forEach((w, i) => {
+      const d = new Date(`${w[0].date}T00:00:00`);
+      if (d.getMonth() !== last) {
+        last = d.getMonth();
+        monthMarks.push({ week: i, label: d.toLocaleDateString("en-US", { month: "short" }) });
+      }
+    });
+    return { weeks, max, monthMarks };
   }, [cells]);
 
-  const CELL = 11, GAP = 3;
+  const CELL = 12;
+  const GAP = 3;
+  const STEP = CELL + GAP;
+  const LEFT = 30;  // weekday gutter
+  const TOP = 18;   // month gutter
+  const WEEKDAYS = [[1, "Mon"], [3, "Wed"], [5, "Fri"]] as const;
+
+  const totalActive = cells.length;
+  const totalActivities = cells.reduce((n, c) => n + c.count, 0);
+
   return (
     <ChartCard
       title="Activity"
       icon="mdi:calendar-heart"
-      subtitle="Consistency beats intensity — look for gaps, not peaks."
-      height={190}
+      subtitle={
+        totalActive
+          ? `${totalActivities} activities across ${totalActive} active days. Consistency beats intensity — look for gaps, not peaks.`
+          : "Consistency beats intensity — look for gaps, not peaks."
+      }
+      height={210}
       table={{ head: ["Date", "Activities", "Minutes"], rows: cells.map((c) => [c.date, c.count, c.minutes]) }}
     >
       {cells.length === 0 ? (
         <EmptyState message="No activity in the last 6 months." />
       ) : (
-        <Box sx={{ overflowX: "auto", pb: 1 }}>
-          <svg width={weeks.length * (CELL + GAP)} height={7 * (CELL + GAP) + 4} role="img" aria-label="Activity calendar heatmap">
-            {weeks.map((week, wi) =>
-              week.map((day, di) => (
-                <rect
-                  key={day.date}
-                  x={wi * (CELL + GAP)} y={di * (CELL + GAP)}
-                  width={CELL} height={CELL} rx={2.5}
-                  fill={sequentialStep(p, day.count, max)}
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+          <Box sx={{ maxWidth: "100%", overflowX: "auto", pb: 0.5 }}>
+            <svg
+              width={LEFT + weeks.length * STEP}
+              height={TOP + 7 * STEP}
+              role="img"
+              aria-label={`Activity calendar: ${totalActivities} activities over ${totalActive} active days`}
+            >
+              {monthMarks.map((m) => (
+                <text
+                  key={`${m.label}-${m.week}`}
+                  x={LEFT + m.week * STEP}
+                  y={11}
+                  fill={p.inkMuted}
+                  fontSize={10}
                 >
-                  <title>{`${day.date}: ${day.count} activities · ${day.minutes} min`}</title>
-                </rect>
-              )),
-            )}
-          </svg>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 1 }}>
+                  {m.label}
+                </text>
+              ))}
+              {WEEKDAYS.map(([row, label]) => (
+                <text key={label} x={0} y={TOP + row * STEP + CELL - 2} fill={p.inkMuted} fontSize={10}>
+                  {label}
+                </text>
+              ))}
+              {weeks.map((week, wi) =>
+                week.map((day, di) => (
+                  <rect
+                    key={day.date}
+                    x={LEFT + wi * STEP}
+                    y={TOP + di * STEP}
+                    width={CELL}
+                    height={CELL}
+                    rx={2.5}
+                    fill={sequentialStep(p, day.count, max)}
+                  >
+                    <title>{`${day.date}: ${day.count} ${day.count === 1 ? "activity" : "activities"} · ${day.minutes} min`}</title>
+                  </rect>
+                )),
+              )}
+            </svg>
+          </Box>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 1.25 }}>
             <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary,#8b8b98)", mr: 0.5 }}>Less</Typography>
+            <Box sx={{ width: 11, height: 11, borderRadius: 0.5, bgcolor: emptyCell(p) }} />
             {p.sequential.map((c) => (
-              <Box key={c} sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: c }} />
+              <Box key={c} sx={{ width: 11, height: 11, borderRadius: 0.5, bgcolor: c }} />
             ))}
             <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary,#8b8b98)", ml: 0.5 }}>More</Typography>
           </Box>

--- a/components/admin/adaptive-course/analytics/vizPalette.ts
+++ b/components/admin/adaptive-course/analytics/vizPalette.ts
@@ -78,24 +78,87 @@ export const ACTIVITY_LABEL: Record<string, string> = {
   article: "Articles",
 };
 
-/** Follows the OS color scheme. Recharts needs concrete strings, not `var(--x)`. */
+/** Parse `#rgb`, `#rrggbb` or `rgb(r,g,b)` into [r,g,b]; null if unrecognised. */
+function parseColor(raw: string): [number, number, number] | null {
+  const s = raw.trim();
+  const hex = s.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    const h = hex[1].length === 3 ? hex[1].split("").map((c) => c + c).join("") : hex[1];
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+  }
+  const rgb = s.match(/^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/i);
+  if (rgb) return [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])];
+  return null;
+}
+
+/** WCAG relative luminance. */
+function luminance([r, g, b]: [number, number, number]): number {
+  const lin = [r, g, b].map((v) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+}
+
+/** True when the chart's actual surface is dark. */
+function surfaceIsDark(): boolean {
+  if (typeof window === "undefined" || typeof document === "undefined") return false;
+  const raw = getComputedStyle(document.documentElement).getPropertyValue("--card-bg");
+  const rgb = parseColor(raw || "");
+  return rgb ? luminance(rgb) < 0.5 : false;
+}
+
+/**
+ * Picks the palette from the SURFACE THE CHART ACTUALLY RENDERS ON, not the OS.
+ *
+ * This used to follow `prefers-color-scheme`. That was wrong: this app has no dark theme —
+ * `--card-bg` is `#ffffff` unconditionally — so a viewer whose OS was in dark mode got the
+ * dark ramp painted onto a white card. Every empty heatmap cell rendered near-black and the
+ * Less→More legend ran backwards. Reading the resolved surface token is correct today, adapts
+ * to tenant theming, and will pick up a real dark theme automatically if one is ever added.
+ *
+ * Recharts needs concrete color strings, not `var(--x)`, hence resolving to hex here.
+ */
 export function useVizPalette(): VizPalette {
+  // Light on the server and first paint: the app's surface is light, so this never flashes.
   const [dark, setDark] = useState(false);
+
   useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const sync = () => setDark(mq.matches);
+    const sync = () => setDark(surfaceIsDark());
     sync();
-    mq.addEventListener("change", sync);
-    return () => mq.removeEventListener("change", sync);
+
+    // Re-read whenever the theme could have changed the resolved token.
+    const observer = new MutationObserver(sync);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style", "data-theme", "data-hydrated"],
+    });
+    const mq = window.matchMedia?.("(prefers-color-scheme: dark)");
+    mq?.addEventListener("change", sync);
+
+    return () => {
+      observer.disconnect();
+      mq?.removeEventListener("change", sync);
+    };
   }, []);
+
   return dark ? DARK : LIGHT;
 }
 
-/** Bucket a 0-100 magnitude onto the sequential ramp (heatmap cells). */
+/** Empty (zero-activity) heatmap cell — recedes toward the surface, never a dark block. */
+export const emptyCell = (p: VizPalette) => (p.isDark ? "#232322" : "#eceef2");
+
+/** Bucket a magnitude onto the sequential ramp (heatmap cells).
+ *
+ * Uses ceil-then-decrement so the ends are exact: the smallest non-zero count lands on the
+ * lightest step and `value === max` lands on the darkest. (A plain `floor(value/max * n)`
+ * skips step 0, and `floor((value-1)/max * n)` paints the busiest day as the emptiest when
+ * max is 1.)
+ */
 export function sequentialStep(p: VizPalette, value: number, max: number): string {
-  if (value <= 0 || max <= 0) return p.isDark ? "#232322" : "#f0efec";
-  const i = Math.min(p.sequential.length - 1, Math.floor((value / max) * p.sequential.length));
+  if (value <= 0 || max <= 0) return emptyCell(p);
+  const n = p.sequential.length;
+  const i = Math.min(n - 1, Math.max(0, Math.ceil((value / max) * n) - 1));
   return p.sequential[i];
 }
 


### PR DESCRIPTION
Follow-up to the merged student-performance dashboard (#977 / backend #323). Fixes a real rendering bug the screenshot exposed, redesigns the activity heatmap, and gives the page an information hierarchy.

## The bug

<img width="420" alt="every cell black, legend runs dark→light" src="https://user-images.githubusercontent.com/placeholder" />

Every empty heatmap cell rendered **near-black**, and the `Less → More` legend ran **backwards** — on a white card.

**Root cause:** `useVizPalette()` keyed off `prefers-color-scheme`. This app has **no dark theme** — `--card-bg` is `#ffffff` unconditionally and `globals.css` contains no dark selector. So a viewer whose *OS* was in dark mode got the DARK ramp painted onto a LIGHT surface. The dark sequential ramp runs dark→light (hence the inverted legend) and its empty-cell token `#232322` became a grid of black squares.

**Fix:** derive the palette from the surface the chart *actually renders on* — resolve `--card-bg`, compute WCAG relative luminance, pick light/dark. Correct today, adapts to tenant theming, and picks up a real dark theme for free if one is ever added. A `MutationObserver` re-reads it if the theme token changes.

## A second bug found while fixing the first
`sequentialStep` skipped the lightest step entirely. My first attempt at a fix *inverted the ends* — a day whose count equalled the max rendered as the **emptiest** when max was 1 (i.e. the busiest day looked like a rest day). Now `ceil`-then-decrement, checked against invariants: smallest non-zero → lightest, `value === max` → darkest, zero → empty.

## Activity heatmap redesign (the requested change)
- **Centered** in its card instead of hugging the left edge with dead space
- **Month labels** across the top and **Mon/Wed/Fri** down the side — the grid finally has a readable time axis
- `"N activities across M active days"` summary in the subtitle
- Explicit empty-cell swatch in the legend, and a softer `#eceef2` empty tone

## Page UX
- The undifferentiated wall of cards is grouped into scannable sections — **Mastery & progress / Engagement / Skills & understanding / Practice & interviews / Activity log** — each with a one-line statement of the question it answers.
- Cards regrouped so paired charts sit together: skill decay beside confidence calibration; difficulty beside what they're stuck on.
- KPI tiles gain a 3px accent rail in their series color; cards get a subtle hover lift.

## Verification
ESLint + `tsc --noEmit` clean. Heatmap bucketing verified against explicit invariants.

Still outstanding: a full visual pass in a browser on a student with real data (this fixes what the screenshot revealed, but I haven't rendered every chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)