### PR TITLE
feat(adaptive/analytics): revamp the student performance page

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Avatar, Box, ButtonBase, Chip, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, ButtonBase, CircularProgress, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
+import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
+import { StudentAvatar } from "@/components/admin/adaptive-course/studentVisuals";
 import { useToast } from "@/components/common/Toast";
 import {
   adminAdaptiveCourseService,
@@ -27,42 +29,40 @@ import {
   StruggleItems,
   StudyPattern,
 } from "@/components/admin/adaptive-course/analytics/charts";
+import {
+  InsightLine,
+  NextActions,
+  StickySummaryBar,
+  VerdictPlate,
+  useHeroOffscreen,
+  useJumpTo,
+} from "@/components/admin/adaptive-course/analytics/hero";
+import {
+  buildInsight,
+  buildNextActions,
+  buildVerdict,
+  isNeverActive,
+} from "@/components/admin/adaptive-course/analytics/studentInsights";
 import { useVizPalette } from "@/components/admin/adaptive-course/analytics/vizPalette";
 
-const initials = (name: string) =>
-  name.trim().split(/\s+/).slice(0, 2).map((w) => w[0]?.toUpperCase() ?? "").join("") || "?";
+const SEVERITY_RANK: Record<string, number> = { critical: 0, serious: 1, warning: 2 };
 
-const RISK_CHIP: Record<StudentAnalytics["kpis"]["risk_level"], { label: string; icon: string }> = {
-  ok: { label: "On track", icon: "mdi:check-circle-outline" },
-  watch: { label: "Watch", icon: "mdi:eye-outline" },
-  at_risk: { label: "At risk", icon: "mdi:alert-octagon-outline" },
-};
+const grid2 = { display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" } } as const;
+const gridWide = { display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "2fr 1fr" } } as const;
 
-/** Groups the wall of cards into scannable sections, so the page has a reading order. */
-function SectionHeading({ title, hint }: { title: string; hint?: string }) {
+/** A numbered, question-shaped divider. The section titles are the questions, not the nouns. */
+function SectionDivider({ n, question }: { n: string; question: string }) {
   return (
-    <Box sx={{ mt: 4, mb: 1.5 }}>
-      <Typography
-        sx={{
-          fontSize: "0.7rem",
-          fontWeight: 700,
-          letterSpacing: 0.8,
-          textTransform: "uppercase",
-          color: "var(--font-tertiary,#8b8b98)",
-        }}
-      >
-        {title}
+    <Box sx={{ mt: { xs: 4, md: 5 }, mb: { xs: 2, md: 2.5 } }}>
+      <Typography sx={{ fontSize: "0.7rem", fontWeight: 700, letterSpacing: "0.18em", color: "var(--font-tertiary,#8b8b98)" }}>
+        {n}
       </Typography>
-      {hint && (
-        <Typography sx={{ fontSize: "0.78rem", color: "var(--font-tertiary,#8b8b98)", mt: 0.25 }}>
-          {hint}
-        </Typography>
-      )}
+      <Typography sx={{ fontSize: { xs: "1.35rem", md: "1.6rem" }, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.15, color: "var(--font-primary)", mt: 0.25 }}>
+        {question}
+      </Typography>
     </Box>
   );
 }
-
-const grid2 = { display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "1fr 1fr" } } as const;
 
 export default function StudentPerformancePage() {
   const router = useRouter();
@@ -74,6 +74,9 @@ export default function StudentPerformancePage() {
 
   const [data, setData] = useState<StudentAnalytics | null>(null);
   const [loading, setLoading] = useState(true);
+  const sentinel = useRef<HTMLDivElement | null>(null);
+  const heroGone = useHeroOffscreen(sentinel);
+  const { register, jump } = useJumpTo();
 
   const load = useCallback(async () => {
     try {
@@ -90,7 +93,14 @@ export default function StudentPerformancePage() {
     if (Number.isFinite(courseId) && Number.isFinite(studentId)) load();
   }, [courseId, studentId, load]);
 
-  if (loading || !data) {
+  const verdict = useMemo(() => (data ? buildVerdict(data) : null), [data]);
+  const actions = useMemo(() => (data ? buildNextActions(data) : []), [data]);
+  const signals = useMemo(
+    () => (data ? [...data.risk_signals].sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]) : []),
+    [data],
+  );
+
+  if (loading || !data || !verdict) {
     return (
       <MainLayout fullWidthContent>
         <Box sx={{ display: "grid", placeItems: "center", minHeight: "60vh" }}>
@@ -100,96 +110,133 @@ export default function StudentPerformancePage() {
     );
   }
 
-  const risk = RISK_CHIP[data.kpis.risk_level];
-  const riskColor =
-    data.kpis.risk_level === "at_risk" ? p.status.critical
-      : data.kpis.risk_level === "watch" ? p.status.warning
-      : p.status.good;
+  const neverActive = isNeverActive(data);
 
   return (
     <MainLayout fullWidthContent>
-      <Box sx={{ maxWidth: 1320, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 4 } }}>
-        <ButtonBase
-          onClick={() => router.push(`/admin/adaptive-courses/${courseId}`)}
-          sx={{ mb: 2, color: "#6366f1", fontWeight: 700, gap: 0.5, fontSize: "0.9rem" }}
-        >
-          <Icon icon="mdi:arrow-left" width={18} /> Back to {data.course.title}
-        </ButtonBase>
+      <StickySummaryBar visible={heroGone} student={data.student} verdict={verdict} kpis={data.kpis} />
 
-        {/* Identity */}
-        <Stack direction="row" spacing={1.75} alignItems="center" sx={{ mb: 1 }} flexWrap="wrap" useFlexGap>
-          <Avatar sx={{ width: 52, height: 52, fontWeight: 700, background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
-            {initials(data.student.name)}
-          </Avatar>
-          <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap>
-              <Typography sx={{ fontWeight: 900, fontSize: "1.35rem", color: "var(--font-primary)" }}>
-                {data.student.name}
-              </Typography>
-              {/* Status color never alone: icon + label. */}
-              <Chip
-                size="small"
-                icon={<Icon icon={risk.icon} width={14} style={{ color: riskColor }} />}
-                label={risk.label}
-                sx={{ height: 22, fontWeight: 700, fontSize: "0.7rem", color: riskColor, bgcolor: `${riskColor}1a`, "& .MuiChip-icon": { ml: "6px" } }}
-              />
-            </Stack>
-            <Typography sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
-              {data.student.email}
-              {data.student.last_active
-                ? ` · last active ${new Date(data.student.last_active).toLocaleDateString()}`
-                : " · never active"}
-            </Typography>
+      {/* Evidence cards are white; they need a plane to lift off, so the page runs on --surface. */}
+      <Box sx={{ bgcolor: "var(--surface, #f9fafb)", minHeight: "100%" }}>
+        <Box sx={{ maxWidth: 1600, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+
+          {/* ---------------------------------------------------------------- HERO */}
+          <AdaptiveSectionShell>
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+              <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 1 }}>
+                <ButtonBase
+                  onClick={() => router.push(`/admin/adaptive-courses/${courseId}`)}
+                  sx={{
+                    display: "flex", alignItems: "center", gap: 0.5,
+                    px: 1.5, py: 0.75, borderRadius: 999,
+                    fontSize: "0.82rem", fontWeight: 700, color: "#6366f1",
+                    border: "1px solid color-mix(in srgb, #6366f1 30%, transparent)",
+                    "&:hover": { bgcolor: "color-mix(in srgb, #6366f1 8%, transparent)" },
+                    "&:focus-visible": { outline: "2px solid color-mix(in srgb,#6366f1 60%,transparent)", outlineOffset: 2 },
+                  }}
+                >
+                  <Icon icon="mdi:arrow-left" width={17} /> Back to {data.course.title}
+                </ButtonBase>
+              </Box>
+
+              {/* Identity + the verdict, side by side: who, and are they in trouble. */}
+              <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1fr minmax(300px, 0.72fr)" }, gap: 2.5, alignItems: { md: "center" } }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 2, minWidth: 0 }}>
+                  <StudentAvatar name={data.student.name} email={data.student.email} size={64} />
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography sx={{ fontSize: { xs: "1.3rem", md: "1.5rem" }, fontWeight: 900, letterSpacing: "-0.02em", color: "var(--font-primary)" }}>
+                      {data.student.name}
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", overflow: "hidden", textOverflow: "ellipsis" }}>
+                      {data.student.email}
+                      {data.student.last_active
+                        ? ` · last active ${new Date(data.student.last_active).toLocaleDateString()}`
+                        : " · never active"}
+                    </Typography>
+                  </Box>
+                </Box>
+                <VerdictPlate verdict={verdict} />
+              </Box>
+
+              {/* The WHY — first-class objects, sorted worst-first. */}
+              {neverActive && signals.length === 0 ? (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, p: 1.75, borderRadius: 2.5, border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)", bgcolor: "var(--card-bg,#fff)" }}>
+                  <Icon icon="mdi:information-outline" width={18} style={{ color: "var(--font-secondary)" }} />
+                  <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)" }}>
+                    Nothing to assess until they begin.
+                  </Typography>
+                </Box>
+              ) : (
+                <RiskPanel signals={signals} />
+              )}
+
+              <NextActions actions={actions} onJump={jump} />
+
+              <KpiRail k={data.kpis} />
+            </Box>
+          </AdaptiveSectionShell>
+          <Box ref={sentinel} />
+
+          {/* ------------------------------------------------------------ EVIDENCE */}
+          <SectionDivider n="01" question="Are they actually learning?" />
+          <Box sx={{ mb: 2 }}>
+            <MasteryVsCompletion d={data.mastery_vs_completion} featured accent={p.series.quiz} />
           </Box>
-        </Stack>
+          <Box sx={gridWide}>
+            <Box sx={{ minWidth: 0 }}>
+              <InsightLine insight={buildInsight("progress", data)} accent={p.series.quiz} />
+              <ProgressOverTime rows={data.progress_over_time} />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <InsightLine insight={buildInsight("cohort", data)} accent={p.series.coding} />
+              <CohortComparison c={data.cohort} completion={data.kpis.completion_pct} points={data.kpis.points} />
+            </Box>
+          </Box>
 
-        <Typography sx={{ color: "var(--font-tertiary,#8b8b98)", fontSize: "0.8rem", mb: 3 }}>
-          Everything this student has done on <strong>{data.course.title}</strong>.
-        </Typography>
+          <SectionDivider n="02" question="Are they showing up?" />
+          <Box sx={{ mb: 2 }}>
+            <ActivityHeatmap cells={data.activity_heatmap} featured accent={p.series.video} />
+          </Box>
+          <Box sx={grid2}>
+            <StudyPattern pattern={data.study_pattern} />
+            <EffortVsOutcome points={data.effort_vs_outcome} total={data.effort_vs_outcome_total} />
+          </Box>
 
-        {/* Risk first — it's the reason an admin opened this page. */}
-        <Box sx={{ mb: 2 }}>
-          <RiskPanel signals={data.risk_signals} />
-        </Box>
+          <SectionDivider n="03" question="What do they actually know?" />
+          <Box sx={{ ...grid2, mb: 2 }}>
+            <Box sx={{ minWidth: 0 }} ref={register("skills")}>
+              <InsightLine insight={buildInsight("skills", data)} accent={p.series.video} />
+              <SkillMastery rows={data.skill_mastery} />
+            </Box>
+            <Box sx={{ minWidth: 0 }} ref={register("calibration")}>
+              <ConfidenceCalibration rows={data.quiz.confidence_calibration} />
+            </Box>
+          </Box>
+          <Box sx={grid2}>
+            <Box sx={{ minWidth: 0 }} ref={register("difficulty")}>
+              <InsightLine insight={buildInsight("difficulty", data)} accent={p.ordinal[2]} />
+              <DifficultyMix rows={data.difficulty} />
+            </Box>
+            <Box sx={{ minWidth: 0 }} ref={register("struggle")}>
+              <StruggleItems rows={data.struggle_items} />
+            </Box>
+          </Box>
 
-        <KpiRail k={data.kpis} />
+          <SectionDivider n="04" question="How is their practice going?" />
+          <Box sx={grid2}>
+            <Box sx={{ minWidth: 0 }} ref={register("coding")}>
+              <InsightLine insight={buildInsight("coding", data)} accent={p.series.coding} />
+              <CodingInsights c={data.coding} />
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <InsightLine insight={buildInsight("mock", data)} accent={p.series.article} />
+              <MockInterviewTrend rows={data.mock_interviews} />
+            </Box>
+          </Box>
 
-        <SectionHeading title="Mastery & progress" hint="Are they finishing the course — and are they actually learning it?" />
-        <Box sx={{ mb: 2 }}>
-          <MasteryVsCompletion d={data.mastery_vs_completion} />
+          <SectionDivider n="05" question="What have they been doing?" />
+          <ActivityTimeline rows={data.timeline} />
         </Box>
-        <Box sx={{ display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", lg: "2fr 1fr" } }}>
-          <ProgressOverTime rows={data.progress_over_time} />
-          <CohortComparison c={data.cohort} completion={data.kpis.completion_pct} points={data.kpis.points} />
-        </Box>
-
-        <SectionHeading title="Engagement" hint="How consistently they show up, and when." />
-        <Box sx={{ mb: 2 }}>
-          <ActivityHeatmap cells={data.activity_heatmap} />
-        </Box>
-        <Box sx={grid2}>
-          <StudyPattern pattern={data.study_pattern} />
-          <EffortVsOutcome points={data.effort_vs_outcome} total={data.effort_vs_outcome_total} />
-        </Box>
-
-        <SectionHeading title="Skills & understanding" hint="What they know, what's fading, and what they only think they know." />
-        <Box sx={{ ...grid2, mb: 2 }}>
-          <SkillMastery rows={data.skill_mastery} />
-          <ConfidenceCalibration rows={data.quiz.confidence_calibration} />
-        </Box>
-        <Box sx={grid2}>
-          <DifficultyMix rows={data.difficulty} />
-          <StruggleItems rows={data.struggle_items} />
-        </Box>
-
-        <SectionHeading title="Practice & interviews" hint="Coding performance and mock-interview trajectory." />
-        <Box sx={grid2}>
-          <CodingInsights c={data.coding} />
-          <MockInterviewTrend rows={data.mock_interviews} />
-        </Box>
-
-        <SectionHeading title="Activity log" hint="The raw feed, newest first." />
-        <ActivityTimeline rows={data.timeline} />
       </Box>
     </MainLayout>
   );

--- a/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
@@ -50,16 +50,18 @@ const SEVERITY_RANK: Record<string, number> = { critical: 0, serious: 1, warning
 const grid2 = { display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" } } as const;
 const gridWide = { display: "grid", gap: 2, gridTemplateColumns: { xs: "1fr", md: "2fr 1fr" } } as const;
 
-/** A numbered, question-shaped divider. The section titles are the questions, not the nouns. */
-function SectionDivider({ n, question }: { n: string; question: string }) {
+/**
+ * A question-shaped divider. The headings are the questions an admin is asking, not nouns —
+ * that's what makes the page scannable. Deliberately NOT numbered: these are areas of evidence
+ * you jump between, not steps in a sequence, so an index would encode an order that isn't real.
+ */
+function SectionDivider({ question }: { question: string }) {
   return (
-    <Box sx={{ mt: { xs: 4, md: 5 }, mb: { xs: 2, md: 2.5 } }}>
-      <Typography sx={{ fontSize: "0.7rem", fontWeight: 700, letterSpacing: "0.18em", color: "var(--font-tertiary,#8b8b98)" }}>
-        {n}
-      </Typography>
-      <Typography sx={{ fontSize: { xs: "1.35rem", md: "1.6rem" }, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.15, color: "var(--font-primary)", mt: 0.25 }}>
+    <Box sx={{ mt: { xs: 4, md: 5 }, mb: { xs: 2, md: 2.5 }, display: "flex", alignItems: "baseline", gap: 2 }}>
+      <Typography sx={{ fontSize: { xs: "1.3rem", md: "1.5rem" }, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.15, color: "var(--font-primary)", flexShrink: 0 }}>
         {question}
       </Typography>
+      <Box sx={{ flex: 1, height: "1px", bgcolor: "color-mix(in srgb, var(--border-default) 80%, transparent)" }} />
     </Box>
   );
 }
@@ -178,9 +180,9 @@ export default function StudentPerformancePage() {
           <Box ref={sentinel} />
 
           {/* ------------------------------------------------------------ EVIDENCE */}
-          <SectionDivider n="01" question="Are they actually learning?" />
+          <SectionDivider question="Are they actually learning?" />
           <Box sx={{ mb: 2 }}>
-            <MasteryVsCompletion d={data.mastery_vs_completion} featured accent={p.series.quiz} />
+            <MasteryVsCompletion d={data.mastery_vs_completion} featured />
           </Box>
           <Box sx={gridWide}>
             <Box sx={{ minWidth: 0 }}>
@@ -193,16 +195,16 @@ export default function StudentPerformancePage() {
             </Box>
           </Box>
 
-          <SectionDivider n="02" question="Are they showing up?" />
+          <SectionDivider question="Are they showing up?" />
           <Box sx={{ mb: 2 }}>
-            <ActivityHeatmap cells={data.activity_heatmap} featured accent={p.series.video} />
+            <ActivityHeatmap cells={data.activity_heatmap} featured />
           </Box>
           <Box sx={grid2}>
             <StudyPattern pattern={data.study_pattern} />
             <EffortVsOutcome points={data.effort_vs_outcome} total={data.effort_vs_outcome_total} />
           </Box>
 
-          <SectionDivider n="03" question="What do they actually know?" />
+          <SectionDivider question="What do they actually know?" />
           <Box sx={{ ...grid2, mb: 2 }}>
             <Box sx={{ minWidth: 0 }} ref={register("skills")}>
               <InsightLine insight={buildInsight("skills", data)} accent={p.series.video} />
@@ -222,7 +224,7 @@ export default function StudentPerformancePage() {
             </Box>
           </Box>
 
-          <SectionDivider n="04" question="How is their practice going?" />
+          <SectionDivider question="How is their practice going?" />
           <Box sx={grid2}>
             <Box sx={{ minWidth: 0 }} ref={register("coding")}>
               <InsightLine insight={buildInsight("coding", data)} accent={p.series.coding} />
@@ -234,7 +236,7 @@ export default function StudentPerformancePage() {
             </Box>
           </Box>
 
-          <SectionDivider n="05" question="What have they been doing?" />
+          <SectionDivider question="What have they been doing?" />
           <ActivityTimeline rows={data.timeline} />
         </Box>
       </Box>

--- a/components/admin/adaptive-course/analytics/ChartCard.tsx
+++ b/components/admin/adaptive-course/analytics/ChartCard.tsx
@@ -21,6 +21,8 @@ export function ChartCard({
   table,
   height = 260,
   action,
+  featured = false,
+  accent,
 }: {
   title: string;
   subtitle?: string;
@@ -30,6 +32,9 @@ export function ChartCard({
   table?: { head: string[]; rows: (string | number)[][] };
   height?: number;
   action?: ReactNode;
+  /** Lifts the card and adds a 2px accent rail — for the one or two charts that lead a section. */
+  featured?: boolean;
+  accent?: string;
 }) {
   const [showTable, setShowTable] = useState(false);
 
@@ -39,12 +44,17 @@ export function ChartCard({
         p: 2.5,
         borderRadius: 3,
         bgcolor: "var(--card-bg, #fff)",
-        border: "1px solid var(--border-default, #ececf1)",
+        border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+        ...(featured && accent ? { borderTop: `2px solid ${accent}` } : null),
+        boxShadow: featured
+          ? "0 1px 2px rgba(16,24,40,0.04), 0 10px 26px -22px rgba(16,24,40,0.18)"
+          : "none",
         display: "flex",
         flexDirection: "column",
         minWidth: 0,
-        transition: "box-shadow 160ms ease, border-color 160ms ease",
+        transition: "box-shadow 160ms ease, border-color 160ms ease, transform 160ms ease",
         "&:hover": {
+          transform: "translateY(-1px)",
           boxShadow: "0 6px 24px rgba(15,15,35,0.06)",
           borderColor: "color-mix(in srgb, var(--border-default) 55%, transparent)",
         },

--- a/components/admin/adaptive-course/analytics/ChartCard.tsx
+++ b/components/admin/adaptive-course/analytics/ChartCard.tsx
@@ -22,7 +22,6 @@ export function ChartCard({
   height = 260,
   action,
   featured = false,
-  accent,
 }: {
   title: string;
   subtitle?: string;
@@ -32,9 +31,10 @@ export function ChartCard({
   table?: { head: string[]; rows: (string | number)[][] };
   height?: number;
   action?: ReactNode;
-  /** Lifts the card and adds a 2px accent rail — for the one or two charts that lead a section. */
+  /** Rests the card on a soft elevation — marks the one chart that leads a section.
+   *  Deliberately elevation, not an accent rail: a coloured bar on a rounded card is
+   *  decoration that encodes nothing the card doesn't already say. */
   featured?: boolean;
-  accent?: string;
 }) {
   const [showTable, setShowTable] = useState(false);
 
@@ -45,7 +45,6 @@ export function ChartCard({
         borderRadius: 3,
         bgcolor: "var(--card-bg, #fff)",
         border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
-        ...(featured && accent ? { borderTop: `2px solid ${accent}` } : null),
         boxShadow: featured
           ? "0 1px 2px rgba(16,24,40,0.04), 0 10px 26px -22px rgba(16,24,40,0.18)"
           : "none",

--- a/components/admin/adaptive-course/analytics/charts.tsx
+++ b/components/admin/adaptive-course/analytics/charts.tsx
@@ -45,8 +45,9 @@ const dateKey = (d: Date) =>
 
 export function KpiRail({ k }: { k: StudentAnalytics["kpis"] }) {
   const p = useVizPalette();
-  // Accent strips are DECORATIVE — series/brand hues only. A status color here would imply
-  // good/bad, and status tokens are reserved for the verdict and risk signals.
+  // The coloured icon ties each tile to its series; no accent rail — a bar on a card encodes
+  // nothing the icon doesn't. Never a STATUS hue here: that would imply good/bad, and status
+  // tokens are reserved for the verdict and the risk signals.
   const tiles: { label: string; value: number; suffix?: string; sub: string; icon: string; accent: string }[] = [
     { label: "Completion", value: Math.round(k.completion_pct), suffix: "%", sub: `${k.completed}/${k.total} items`, icon: "mdi:progress-check", accent: p.series.quiz },
     { label: "Mastery", value: Math.round(k.mastery_pct), suffix: "%", sub: "can actually do it", icon: "mdi:brain", accent: p.series.video },
@@ -77,10 +78,6 @@ export function KpiRail({ k }: { k: StudentAnalytics["kpis"] }) {
             // Hairline separators instead of six floating boxes — one instrument, six readouts.
             borderRight: { md: i < tiles.length - 1 ? "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)" : "none" },
             borderBottom: { xs: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)", md: "none" },
-            "&::before": {
-              content: '""', position: "absolute", left: 0, top: "50%", transform: "translateY(-50%)",
-              width: 2, height: 28, bgcolor: t.accent, borderRadius: 999,
-            },
           }}
         >
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.6, mb: 0.75 }}>
@@ -167,7 +164,7 @@ function Ring({ value, color, label, sub, surface }: { value: number; color: str
   );
 }
 
-export function MasteryVsCompletion({ d, featured, accent }: { d: StudentAnalytics["mastery_vs_completion"]; featured?: boolean; accent?: string }) {
+export function MasteryVsCompletion({ d, featured }: { d: StudentAnalytics["mastery_vs_completion"]; featured?: boolean }) {
   const p = useVizPalette();
   const total = MASTERY_LADDER.reduce((n, l) => n + (d.levels[l.key as keyof typeof d.levels] || 0), 0);
   const gap = Math.round(d.completion_pct - d.mastery_pct);
@@ -177,7 +174,6 @@ export function MasteryVsCompletion({ d, featured, accent }: { d: StudentAnalyti
       title="Mastery vs completion"
       icon="mdi:scale-balance"
       featured={featured}
-      accent={accent}
       subtitle="Completion says they clicked through it. Mastery says they can do it. The gap is what a completion-only view hides."
       height={220}
       table={{
@@ -256,7 +252,7 @@ export function ProgressOverTime({ rows }: { rows: StudentAnalytics["progress_ov
 
 /* ------------------------------------------------------- Activity heatmap */
 
-export function ActivityHeatmap({ cells, featured, accent }: { cells: StudentAnalytics["activity_heatmap"]; featured?: boolean; accent?: string }) {
+export function ActivityHeatmap({ cells, featured }: { cells: StudentAnalytics["activity_heatmap"]; featured?: boolean }) {
   const p = useVizPalette();
   const { weeks, max, monthMarks } = useMemo(() => {
     const map = new Map(cells.map((c) => [c.date, c]));
@@ -307,7 +303,6 @@ export function ActivityHeatmap({ cells, featured, accent }: { cells: StudentAna
       title="Activity"
       icon="mdi:calendar-heart"
       featured={featured}
-      accent={accent}
       subtitle={
         totalActive
           ? `${totalActivities} activities across ${totalActive} active days. Consistency beats intensity — look for gaps, not peaks.`

--- a/components/admin/adaptive-course/analytics/charts.tsx
+++ b/components/admin/adaptive-course/analytics/charts.tsx
@@ -45,46 +45,57 @@ const dateKey = (d: Date) =>
 
 export function KpiRail({ k }: { k: StudentAnalytics["kpis"] }) {
   const p = useVizPalette();
-  const tiles = [
-    { label: "Completion", value: `${Math.round(k.completion_pct)}%`, sub: `${k.completed}/${k.total} items`, icon: "mdi:progress-check", accent: p.series.quiz },
-    { label: "Mastery", value: `${Math.round(k.mastery_pct)}%`, sub: "can actually do it", icon: "mdi:brain", accent: p.series.coding },
-    { label: "Points", value: k.points.toLocaleString(), sub: k.points_tier || "—", icon: "mdi:trophy-outline", accent: p.series.video },
-    { label: "Streak", value: `${k.streak_current}d`, sub: `best ${k.streak_longest}d`, icon: "mdi:fire", accent: p.status.serious },
-    { label: "Time on task", value: `${Math.round(k.time_on_task_minutes)}m`, sub: `${k.active_days} active days`, icon: "mdi:clock-outline", accent: p.series.article },
+  // Accent strips are DECORATIVE — series/brand hues only. A status color here would imply
+  // good/bad, and status tokens are reserved for the verdict and risk signals.
+  const tiles: { label: string; value: number; suffix?: string; sub: string; icon: string; accent: string }[] = [
+    { label: "Completion", value: Math.round(k.completion_pct), suffix: "%", sub: `${k.completed}/${k.total} items`, icon: "mdi:progress-check", accent: p.series.quiz },
+    { label: "Mastery", value: Math.round(k.mastery_pct), suffix: "%", sub: "can actually do it", icon: "mdi:brain", accent: p.series.video },
+    { label: "Points", value: k.points, sub: k.points_tier || "no tier yet", icon: "mdi:trophy-outline", accent: "#a855f7" },
+    { label: "Streak", value: k.streak_current, suffix: "d", sub: `best ${k.streak_longest}d`, icon: "mdi:fire", accent: p.series.coding },
+    { label: "Time on task", value: Math.round(k.time_on_task_minutes), suffix: "m", sub: `${k.activities_logged} activities`, icon: "mdi:clock-outline", accent: "#0ea5e9" },
+    { label: "Active days", value: k.active_days, sub: "days with activity", icon: "mdi:calendar-check-outline", accent: "#6366f1" },
   ];
+
   return (
-    <Box sx={{ display: "grid", gap: 1.5, gridTemplateColumns: { xs: "repeat(2,1fr)", md: "repeat(5,1fr)" } }}>
-      {tiles.map((t) => (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "repeat(2,1fr)", sm: "repeat(3,1fr)", md: "repeat(6,1fr)" },
+        borderRadius: 3,
+        overflow: "hidden",
+        border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+        bgcolor: "var(--card-bg,#fff)",
+      }}
+    >
+      {tiles.map((t, i) => (
         <Box
           key={t.label}
           sx={{
             position: "relative",
-            overflow: "hidden",
-            p: 1.75, pl: 2.1, borderRadius: 3,
-            bgcolor: "var(--card-bg,#fff)",
-            border: "1px solid var(--border-default,#ececf1)",
-            transition: "box-shadow 160ms ease",
-            "&:hover": { boxShadow: "0 6px 20px rgba(15,15,35,0.06)" },
-            // A 3px accent rail ties the tile to its series color without tinting the text.
+            px: { xs: 1.75, sm: 2 },
+            py: { xs: 2.25, md: 2.5 },
+            // Hairline separators instead of six floating boxes — one instrument, six readouts.
+            borderRight: { md: i < tiles.length - 1 ? "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)" : "none" },
+            borderBottom: { xs: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)", md: "none" },
             "&::before": {
-              content: '""',
-              position: "absolute",
-              left: 0, top: 0, bottom: 0, width: 3,
-              bgcolor: t.accent,
+              content: '""', position: "absolute", left: 0, top: "50%", transform: "translateY(-50%)",
+              width: 2, height: 28, bgcolor: t.accent, borderRadius: 999,
             },
           }}
         >
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 0.75 }}>
-            <IconWrapper icon={t.icon} size={15} color={t.accent} />
-            <Typography sx={{ fontSize: "0.7rem", fontWeight: 600, color: "var(--font-tertiary,#8b8b98)", textTransform: "uppercase", letterSpacing: 0.4 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.6, mb: 0.75 }}>
+            <IconWrapper icon={t.icon} size={14} color={t.accent} />
+            <Typography sx={{ fontSize: "0.68rem", fontWeight: 700, color: "var(--font-secondary)", textTransform: "uppercase", letterSpacing: "0.12em" }}>
               {t.label}
             </Typography>
           </Box>
-          {/* Hero figures use proportional figures, never tabular-nums. */}
-          <Typography sx={{ fontSize: "1.6rem", fontWeight: 700, lineHeight: 1.1, color: "var(--font-primary)" }}>
-            {t.value}
+          {/* Hero figures: proportional digits, never tabular-nums at display size. */}
+          <Typography sx={{ fontSize: { xs: "1.6rem", md: "1.85rem" }, fontWeight: 800, letterSpacing: "-0.04em", lineHeight: 1.05, color: "var(--font-primary)" }}>
+            {t.value.toLocaleString()}
+            {t.suffix && <Box component="span" sx={{ fontSize: "0.9rem", fontWeight: 700, ml: 0.25, color: "var(--font-tertiary,#8b8b98)" }}>{t.suffix}</Box>}
           </Typography>
-          <Typography sx={{ fontSize: "0.72rem", color: "var(--font-tertiary,#8b8b98)" }}>{t.sub}</Typography>
+          {/* The relief rule applied to KPIs: the detail is on the tile, not in a tooltip. */}
+          <Typography sx={{ fontSize: "0.72rem", color: "var(--font-tertiary,#8b8b98)", mt: 0.25 }}>{t.sub}</Typography>
         </Box>
       ))}
     </Box>
@@ -156,7 +167,7 @@ function Ring({ value, color, label, sub, surface }: { value: number; color: str
   );
 }
 
-export function MasteryVsCompletion({ d }: { d: StudentAnalytics["mastery_vs_completion"] }) {
+export function MasteryVsCompletion({ d, featured, accent }: { d: StudentAnalytics["mastery_vs_completion"]; featured?: boolean; accent?: string }) {
   const p = useVizPalette();
   const total = MASTERY_LADDER.reduce((n, l) => n + (d.levels[l.key as keyof typeof d.levels] || 0), 0);
   const gap = Math.round(d.completion_pct - d.mastery_pct);
@@ -165,6 +176,8 @@ export function MasteryVsCompletion({ d }: { d: StudentAnalytics["mastery_vs_com
     <ChartCard
       title="Mastery vs completion"
       icon="mdi:scale-balance"
+      featured={featured}
+      accent={accent}
       subtitle="Completion says they clicked through it. Mastery says they can do it. The gap is what a completion-only view hides."
       height={220}
       table={{
@@ -243,7 +256,7 @@ export function ProgressOverTime({ rows }: { rows: StudentAnalytics["progress_ov
 
 /* ------------------------------------------------------- Activity heatmap */
 
-export function ActivityHeatmap({ cells }: { cells: StudentAnalytics["activity_heatmap"] }) {
+export function ActivityHeatmap({ cells, featured, accent }: { cells: StudentAnalytics["activity_heatmap"]; featured?: boolean; accent?: string }) {
   const p = useVizPalette();
   const { weeks, max, monthMarks } = useMemo(() => {
     const map = new Map(cells.map((c) => [c.date, c]));
@@ -293,6 +306,8 @@ export function ActivityHeatmap({ cells }: { cells: StudentAnalytics["activity_h
     <ChartCard
       title="Activity"
       icon="mdi:calendar-heart"
+      featured={featured}
+      accent={accent}
       subtitle={
         totalActive
           ? `${totalActivities} activities across ${totalActive} active days. Consistency beats intensity — look for gaps, not peaks.`

--- a/components/admin/adaptive-course/analytics/hero.tsx
+++ b/components/admin/adaptive-course/analytics/hero.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useEffect, useRef, useState, RefObject } from "react";
+import { Box, ButtonBase, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { StudentAvatar } from "@/components/admin/adaptive-course/studentVisuals";
+import type { StudentAnalytics } from "@/lib/services/admin/admin-adaptive-course.service";
+import { useVizPalette } from "./vizPalette";
+import { Insight, NextAction, Verdict, VerdictTone } from "./studentInsights";
+
+/* ------------------------------------------------------------------ VerdictPlate */
+
+const TONE_ICON: Record<VerdictTone, string> = {
+  ok: "mdi:check-circle-outline",
+  watch: "mdi:eye-outline",
+  at_risk: "mdi:alert-octagon-outline",
+  not_started: "mdi:timer-sand-empty",
+};
+
+/**
+ * The answer to "is this student in trouble, and why" — the reason the admin opened the page.
+ *
+ * `not_started` deliberately drops the status color entirely: a student who has never begun is
+ * not "On track" (a lying green pill), they're simply unassessed.
+ */
+export function VerdictPlate({ verdict }: { verdict: Verdict }) {
+  const p = useVizPalette();
+  const neutral = verdict.tone === "not_started";
+  const color = neutral
+    ? "var(--font-secondary, #52514e)"
+    : verdict.tone === "at_risk"
+      ? p.status.critical
+      : verdict.tone === "watch"
+        ? p.status.warning
+        : p.status.good;
+
+  const chips: [number, string, string][] = [
+    [verdict.counts.critical, "critical", p.status.critical],
+    [verdict.counts.serious, "serious", p.status.serious],
+    [verdict.counts.warning, "warning", p.status.warning],
+  ];
+  const shown = chips.filter(([n]) => n > 0);
+
+  return (
+    <Box
+      sx={{
+        p: 2.25,
+        borderRadius: 3,
+        bgcolor: neutral
+          ? "color-mix(in srgb, var(--border-default) 22%, var(--card-bg))"
+          : `color-mix(in srgb, ${color} 8%, var(--card-bg))`,
+        border: `1px solid ${neutral ? "color-mix(in srgb, var(--border-default) 80%, transparent)" : `color-mix(in srgb, ${color} 35%, transparent)`}`,
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 0.75 }}>
+        {/* Status never carries meaning alone — icon + word, always. */}
+        <Icon icon={TONE_ICON[verdict.tone]} width={30} style={{ color }} />
+        <Box>
+          <Typography sx={{ fontSize: "0.7rem", fontWeight: 700, letterSpacing: "0.18em", color: "var(--font-secondary)" }}>
+            VERDICT
+          </Typography>
+          <Typography sx={{ fontSize: "1.35rem", fontWeight: 800, letterSpacing: "-0.02em", lineHeight: 1.15, color }}>
+            {verdict.call}
+          </Typography>
+        </Box>
+      </Box>
+
+      <Typography sx={{ fontSize: "0.88rem", fontWeight: 500, lineHeight: 1.5, color: "var(--font-primary)" }}>
+        {verdict.sentence}
+      </Typography>
+
+      {shown.length > 0 && (
+        <Box sx={{ display: "flex", gap: 1.5, mt: 1 }}>
+          {shown.map(([n, label, c]) => (
+            <Box key={label} sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+              <Box sx={{ width: 7, height: 7, borderRadius: "50%", bgcolor: c }} />
+              <Typography sx={{ fontSize: "0.72rem", color: "var(--font-secondary)", fontVariantNumeric: "tabular-nums" }}>
+                {n} {label}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/* ------------------------------------------------------------------ NextActions */
+
+/** The "so what do I do" strip. Chips scroll to the evidence that justifies them. */
+export function NextActions({ actions, onJump }: { actions: NextAction[]; onJump: (target: string) => void }) {
+  if (!actions.length) return null;
+  return (
+    <Box>
+      <Typography sx={{ fontSize: "0.7rem", fontWeight: 700, letterSpacing: "0.14em", color: "var(--font-secondary)", mb: 0.9 }}>
+        DO NEXT
+      </Typography>
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+        {actions.map((a) => {
+          const clickable = Boolean(a.target);
+          return (
+            <ButtonBase
+              key={a.id}
+              disabled={!clickable}
+              onClick={() => a.target && onJump(a.target)}
+              sx={{
+                display: "flex", alignItems: "center", gap: 0.75,
+                px: 1.5, py: 0.9, borderRadius: 999,
+                bgcolor: "var(--card-bg,#fff)",
+                border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+                fontSize: "0.8rem", fontWeight: 600, color: "var(--font-primary)",
+                transition: "background-color 140ms ease, border-color 140ms ease",
+                cursor: clickable ? "pointer" : "default",
+                "&:hover": clickable ? { bgcolor: "color-mix(in srgb, #6366f1 6%, var(--card-bg))", borderColor: "color-mix(in srgb, #6366f1 40%, transparent)" } : undefined,
+                "&:focus-visible": { outline: "2px solid color-mix(in srgb, #6366f1 60%, transparent)", outlineOffset: 2 },
+              }}
+            >
+              <Icon icon={a.icon} width={16} style={{ color: "#6366f1" }} />
+              {a.label}
+              {clickable && <Icon icon="mdi:arrow-down" width={14} style={{ color: "var(--font-tertiary,#8b8b98)" }} />}
+            </ButtonBase>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+/* ------------------------------------------------------------------ InsightLine */
+
+/** Turns a chart into a sentence. Never rendered when the data can't support a claim. */
+export function InsightLine({ insight, accent }: { insight: Insight | null; accent: string }) {
+  if (!insight) return null;
+  const parts = insight.emphasis ? insight.text.split(insight.emphasis) : [insight.text];
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.9, mb: 1, px: 0.25 }}>
+      <Icon icon={insight.icon} width={16} style={{ color: accent, flexShrink: 0 }} />
+      <Typography sx={{ fontSize: "0.88rem", fontWeight: 600, color: "var(--font-secondary)", lineHeight: 1.4 }}>
+        {parts.length === 2 ? (
+          <>
+            {parts[0]}
+            <Box component="span" sx={{ fontWeight: 800, color: accent }}>{insight.emphasis}</Box>
+            {parts[1]}
+          </>
+        ) : (
+          insight.text
+        )}
+      </Typography>
+    </Box>
+  );
+}
+
+/* ------------------------------------------------------------- StickySummaryBar */
+
+/** Keeps the verdict on screen once the hero scrolls away. */
+export function useHeroOffscreen(sentinel: RefObject<HTMLElement | null>) {
+  const [off, setOff] = useState(false);
+  useEffect(() => {
+    const el = sentinel.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    const io = new IntersectionObserver(([e]) => setOff(!e.isIntersecting), { threshold: 0 });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [sentinel]);
+  return off;
+}
+
+export function StickySummaryBar({
+  visible,
+  student,
+  verdict,
+  kpis,
+}: {
+  visible: boolean;
+  student: StudentAnalytics["student"];
+  verdict: Verdict;
+  kpis: StudentAnalytics["kpis"];
+}) {
+  const p = useVizPalette();
+  const color =
+    verdict.tone === "not_started" ? "var(--font-secondary)"
+      : verdict.tone === "at_risk" ? p.status.critical
+        : verdict.tone === "watch" ? p.status.warning
+          : p.status.good;
+
+  const mini: [string, string][] = [
+    ["Completion", `${Math.round(kpis.completion_pct)}%`],
+    ["Mastery", `${Math.round(kpis.mastery_pct)}%`],
+    ["Streak", `${kpis.streak_current}d`],
+  ];
+
+  return (
+    <Box
+      sx={{
+        position: "fixed", top: 0, left: 0, right: 0, zIndex: 20,
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(-8px)",
+        pointerEvents: visible ? "auto" : "none",
+        transition: "opacity 200ms ease, transform 200ms ease",
+        bgcolor: "color-mix(in srgb, var(--card-bg) 85%, transparent)",
+        backdropFilter: "blur(8px)",
+        borderBottom: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+      }}
+    >
+      <Box sx={{ maxWidth: 1600, mx: "auto", px: { xs: 2, md: 3 }, height: 56, display: "flex", alignItems: "center", gap: 1.5 }}>
+        <StudentAvatar name={student.name} email={student.email} size={28} />
+        <Typography sx={{ fontSize: "0.9rem", fontWeight: 700, color: "var(--font-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 220 }}>
+          {student.name}
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, px: 1, py: 0.35, borderRadius: 999, bgcolor: `color-mix(in srgb, ${color} 12%, transparent)` }}>
+          <Icon icon={TONE_ICON[verdict.tone]} width={14} style={{ color }} />
+          <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, color }}>{verdict.call}</Typography>
+        </Box>
+
+        <Box sx={{ display: { xs: "none", sm: "flex" }, gap: 2.5, ml: 1 }}>
+          {mini.map(([label, value]) => (
+            <Box key={label} sx={{ display: "flex", alignItems: "baseline", gap: 0.5 }}>
+              <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary,#8b8b98)" }}>{label}</Typography>
+              <Typography sx={{ fontSize: "0.82rem", fontWeight: 700, color: "var(--font-primary)", fontVariantNumeric: "tabular-nums" }}>
+                {value}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+/** Scrolls an evidence section into view when a NextActions chip is clicked. */
+export function useJumpTo() {
+  const refs = useRef<Record<string, HTMLElement | null>>({});
+  const register = (key: string) => (el: HTMLElement | null) => { refs.current[key] = el; };
+  const jump = (key: string) => {
+    refs.current[key]?.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+  return { register, jump };
+}

--- a/components/admin/adaptive-course/analytics/studentInsights.ts
+++ b/components/admin/adaptive-course/analytics/studentInsights.ts
@@ -1,0 +1,210 @@
+import type { StudentAnalytics } from "@/lib/services/admin/admin-adaptive-course.service";
+
+/**
+ * Pure logic behind the page's prose: the verdict, the recommended next actions, and the
+ * one-line insight above each chart.
+ *
+ * The hard rule here: NEVER assert a finding the data doesn't support. When a metric is null
+ * or absent we emit a neutral, factual sentence or nothing at all. A dashboard that invents
+ * confident conclusions from empty data is worse than one that says nothing.
+ */
+
+export type VerdictTone = "ok" | "watch" | "at_risk" | "not_started";
+
+export interface Verdict {
+  tone: VerdictTone;
+  call: string;
+  sentence: string;
+  counts: { critical: number; serious: number; warning: number };
+}
+
+/** A freshly-enrolled student with nothing to assess. This is the COMMON case, not an edge case. */
+export function isNeverActive(d: StudentAnalytics): boolean {
+  return d.kpis.activities_logged === 0 && !d.student.last_active;
+}
+
+export function buildVerdict(d: StudentAnalytics): Verdict {
+  const counts = { critical: 0, serious: 0, warning: 0 };
+  d.risk_signals.forEach((s) => { counts[s.severity] += 1; });
+
+  if (isNeverActive(d)) {
+    const days = d.student.enrolled_at
+      ? Math.max(0, Math.round((Date.now() - new Date(d.student.enrolled_at).getTime()) / 86400000))
+      : null;
+    return {
+      tone: "not_started",
+      call: "Not started",
+      // Neutral, not a green "On track" — they haven't earned a verdict either way.
+      sentence: days === null
+        ? "No activity to assess yet."
+        : `Enrolled ${days} ${days === 1 ? "day" : "days"} ago — no activity to assess yet.`,
+      counts,
+    };
+  }
+
+  const n = d.risk_signals.length;
+  const gap = Math.round(d.mastery_vs_completion.completion_pct - d.mastery_vs_completion.mastery_pct);
+
+  const parts: string[] = [];
+  if (n === 0) {
+    parts.push("No risk signals.");
+  } else {
+    const crit = counts.critical ? `, ${counts.critical} critical` : "";
+    parts.push(`${n} ${n === 1 ? "signal" : "signals"}${crit}.`);
+  }
+  // Only claim a mastery gap when we actually measured mastery.
+  if (d.mastery_vs_completion.mastery_pct > 0 && gap > 5) {
+    parts.push(`Mastery trails completion by ${gap} points.`);
+  }
+
+  const call = d.kpis.risk_level === "at_risk" ? "At risk" : d.kpis.risk_level === "watch" ? "Watch" : "On track";
+  return { tone: d.kpis.risk_level, call, sentence: parts.join(" "), counts };
+}
+
+/* --------------------------------------------------------------- next actions */
+
+export interface NextAction {
+  id: string;
+  label: string;
+  icon: string;
+  /** Element id to scroll to, when the action points at evidence on this page. */
+  target?: string;
+}
+
+const SEVERITY_ORDER = 4;
+
+/**
+ * Concrete things the admin can do, derived from the data. Never empty for an active student —
+ * an analytics page that ends in "…and now what?" has failed at its job.
+ */
+export function buildNextActions(d: StudentAnalytics): NextAction[] {
+  if (isNeverActive(d)) {
+    return [{ id: "nudge", label: "Nudge to begin", icon: "mdi:bell-outline" }];
+  }
+
+  const out: NextAction[] = [];
+
+  if (d.struggle_items.length) {
+    out.push({
+      id: "stuck",
+      label: `Unblock ${d.struggle_items.length} stuck item${d.struggle_items.length === 1 ? "" : "s"}`,
+      icon: "mdi:lifebuoy",
+      target: "struggle",
+    });
+  }
+
+  const overconfident = d.quiz.confidence_calibration.find((r) => r.confidence >= 3 && r.accuracy < 60);
+  if (overconfident) {
+    out.push({ id: "overconfidence", label: "Address overconfidence", icon: "mdi:scale-unbalanced", target: "calibration" });
+  }
+
+  const decaying = d.skill_mastery.find(
+    (s) => s.retention_pct !== null && s.retention_pct < 50 && (s.days_since ?? 0) >= 14,
+  );
+  if (decaying) {
+    out.push({ id: "revise", label: `Assign revision: ${decaying.skill}`, icon: "mdi:refresh", target: "skills" });
+  }
+
+  const gap = d.coding.top_misconceptions[0];
+  if (gap) {
+    out.push({ id: "misconception", label: `Address: ${gap.gap.replace(/_/g, " ")}`, icon: "mdi:code-braces", target: "coding" });
+  }
+
+  // Always give the admin at least one lever, even for a healthy mid-range student.
+  if (!out.length) {
+    const weakest = [...d.difficulty].filter((t) => t.attempted > 0).sort((a, b) => a.accuracy - b.accuracy)[0];
+    if (weakest) {
+      out.push({ id: "weakest", label: `Review weakest tier: ${weakest.difficulty}`, icon: "mdi:target", target: "difficulty" });
+    } else {
+      out.push({ id: "encourage", label: "Keep them going", icon: "mdi:thumb-up-outline" });
+    }
+  }
+
+  return out.slice(0, SEVERITY_ORDER);
+}
+
+/* ------------------------------------------------------------- insight lines */
+
+export interface Insight {
+  text: string;
+  /** The load-bearing number, bolded in the metric's accent. */
+  emphasis?: string;
+  icon: string;
+}
+
+const daysAgo = (n: number) => Date.now() - n * 86400000;
+
+/** One-sentence finding above a chart. Returns null when the data can't support a claim. */
+export function buildInsight(kind: string, d: StudentAnalytics): Insight | null {
+  switch (kind) {
+    case "progress": {
+      if (!d.progress_over_time.length) return null;
+      const cutoff = daysAgo(7);
+      const recent = d.progress_over_time
+        .filter((r) => new Date(`${r.date}T00:00:00`).getTime() >= cutoff)
+        .reduce((n, r) => n + r.items, 0);
+      return recent === 0
+        ? { text: "No items completed in the last 7 days.", icon: "mdi:trending-neutral" }
+        : { text: `Completed ${recent} item${recent === 1 ? "" : "s"} in the last 7 days.`, emphasis: String(recent), icon: "mdi:trending-up" };
+    }
+    case "cohort": {
+      if (d.cohort.cohort_size < 2) return null;
+      return {
+        text: `Completion sits in the ${d.cohort.completion_percentile}th percentile of ${d.cohort.cohort_size} students.`,
+        emphasis: `${d.cohort.completion_percentile}th`,
+        icon: "mdi:account-group-outline",
+      };
+    }
+    case "skills": {
+      const measured = d.skill_mastery.filter((s) => s.retention_pct !== null);
+      if (!measured.length) {
+        return d.skill_mastery.length
+          ? { text: "No skill has been practised in this course yet — decay can't be measured.", icon: "mdi:help-circle-outline" }
+          : null;
+      }
+      const fading = measured.filter((s) => (s.retention_pct as number) < 50 && (s.days_since ?? 0) >= 14);
+      if (!fading.length) return { text: "No skill has decayed below 50% retention.", icon: "mdi:check-circle-outline" };
+      return {
+        text: `${fading.length} skill${fading.length === 1 ? "" : "s"} unpractised for 14+ days — retention is decaying.`,
+        emphasis: String(fading.length),
+        icon: "mdi:trending-down",
+      };
+    }
+    case "difficulty": {
+      const easy = d.difficulty.find((t) => t.difficulty === "Easy" && t.attempted > 0);
+      const hard = d.difficulty.find((t) => t.difficulty === "Hard" && t.attempted > 0);
+      if (!easy || !hard) return null;
+      return {
+        text: `Accuracy holds at ${easy.accuracy}% on Easy but falls to ${hard.accuracy}% on Hard.`,
+        emphasis: `${hard.accuracy}%`,
+        icon: "mdi:stairs-down",
+      };
+    }
+    case "coding": {
+      if (!d.coding.submissions) return null;
+      return {
+        text: `${d.coding.acceptance_rate}% acceptance, averaging ${d.coding.avg_attempts_to_solve} attempts to solve.`,
+        emphasis: `${d.coding.acceptance_rate}%`,
+        icon: "mdi:code-braces",
+      };
+    }
+    case "mock": {
+      const rows = d.mock_interviews.filter((m) => m.date);
+      if (!rows.length) return null;
+      const last = rows[rows.length - 1];
+      if (rows.length === 1) {
+        return { text: `Latest mock interview scored ${last.score}%.`, emphasis: `${last.score}%`, icon: "mdi:account-voice" };
+      }
+      const prev = rows[rows.length - 2];
+      const delta = Math.round(last.score - prev.score);
+      const dir = delta > 0 ? `up ${delta}` : delta < 0 ? `down ${Math.abs(delta)}` : "flat";
+      return {
+        text: `Latest mock interview scored ${last.score}% (${dir} vs previous).`,
+        emphasis: `${last.score}%`,
+        icon: delta >= 0 ? "mdi:trending-up" : "mdi:trending-down",
+      };
+    }
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Full UI revamp of `/admin/adaptive-courses/[courseId]/students/[studentId]`.

**👉 [Visual preview](https://claude.ai/code/artifact/b8667bb8-b883-42b2-ae68-ff7bfd27ef9a)** — toggle between the at-risk student and the never-started student (the latter is the common case right after enrolment).

## How the design was chosen
Three independent redesign directions were judged on three separate lenses — information hierarchy, visual craft, and data-viz correctness. They disagreed usefully: the **narrative** direction was the prettiest and most data-viz-literate, but buried "what do I do" at the bottom of a long scroll, which is fatal when triaging many students. **Triage Console** took the hierarchy lens outright and the balance overall; the narrative direction's best ideas were grafted in.

## The page now answers the admin's three questions, in reading order, above the fold
1. **Is this student in trouble?** A `VerdictPlate` states the call plus a computed sentence — *"3 signals, 1 critical. Mastery trails completion by 22 points."*
2. **Why?** Risk signals promoted into the hero as first-class cards, sorted `critical → serious → warning`, so the worst reason leads.
3. **What do I do?** A derived **Do next** strip (unblock stuck items · address overconfidence · assign revision · tackle a misconception). Each chip scrolls to the evidence justifying it. It is **never empty for an active student** — an analytics page that ends in "…and now what?" has failed at its job.

## Structure & craft
- Hero sits in the app's `AdaptiveSectionShell`; evidence cards sit on the real `--surface` plane so white cards actually lift. White-on-white cards inside the mesh shell read muddy, so the shell is hero-only.
- Section headings are **questions, not nouns** ("Are they actually learning?"), because the reading order should be the decision order.
- **`InsightLine`** turns each chart into a sentence with the load-bearing number bolded. It returns `null` rather than invent a finding from null data — a dashboard that fabricates confident conclusions from empty data is worse than one that says nothing.
- **`KpiRail`** is now one six-up instrument with hairline separators and detail inline on every tile (relief rule: no tooltip-only values), replacing six floating boxes.
- **`StickySummaryBar`** keeps identity + verdict + three KPIs on screen once the hero scrolls away (IntersectionObserver on a sentinel, not a pixel threshold).
- **Zero-activity students** get a neutral fourth verdict tone — **"Not started"** — instead of a lying green "On track" pill, plus a calm "Nothing to assess until they begin" note and honest zeros.

## Two things a design review caught in my own work
Both were built, then removed:
- Sections were numbered `01 · … 02 · …`. Numbering is only honest when the content is a **sequence**; these are areas you jump between, so the index encoded an order that doesn't exist.
- The featured card had a 2px accent rail and each KPI tile a coloured strip. A coloured bar on a rounded card encodes nothing the card doesn't already say — and it's one of the most recognisable generic-dashboard tells. A lead card is now marked by elevation; a KPI tile by its coloured icon.

## Data-viz constraints all hold
`vizPalette` untouched and role-correct (categorical series, one-hue **ordinal** ramp for difficulty, sequential for the heatmap). Status colours stay reserved for the verdict and risk signals and always ship with an icon + label. No dual axis. Every chart keeps its table-view twin and a real empty state.

## Notes
- `ChartCard` gains an additive `featured` prop; existing callers untouched.
- `studentInsights.ts` is pure and side-effect free (verdict / next actions / insight sentences), so the copy logic is testable in isolation.
- ESLint + `tsc --noEmit` clean. Stacked on the palette fix, which is already squash-merged into `stagging`.
- Not yet rendered in a live browser against real data — the preview mirrors the component structure and validated palette, but the scatter and line charts use recharts in the app and hand-drawn SVG in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)