### PR TITLE
feat(jobs-v2): assign a job opening to individual students

### DIFF
--- a/components/admin/jobs-v2/JobCreateEditPage.tsx
+++ b/components/admin/jobs-v2/JobCreateEditPage.tsx
@@ -34,6 +34,7 @@ import { formatJobPassoutYear } from "@/lib/services/jobs-v2.service";
 import { CreateJobIllustration } from "@/components/jobs-v2/illustrations";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { ApplicationQuestionsModal } from "./ApplicationQuestionsModal";
+import { SelectStudentsDialog, type SelectedStudent } from "./SelectStudentsDialog";
 
 interface CourseOption {
   id: number;
@@ -88,6 +89,7 @@ const emptyPayload: JobCreateUpdatePayload = {
   min_graduation_percentage: null,
   college_mappings: [],
   course_ids: [],
+  assigned_student_ids: [],
   question_ids: [],
 };
 
@@ -223,6 +225,10 @@ export function JobCreateEditPage({
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [formData, setFormData] = useState<JobCreateUpdatePayload>(emptyPayload);
   const [submitting, setSubmitting] = useState(false);
+  // Kept alongside formData.assigned_student_ids (the wire format) because the chips need the
+  // name/email the picker resolved — the payload only carries ids.
+  const [assignedStudents, setAssignedStudents] = useState<SelectedStudent[]>([]);
+  const [studentPickerOpen, setStudentPickerOpen] = useState(false);
   const [activeStep, setActiveStep] = useState(0);
   const [skillInput, setSkillInput] = useState("");
   const [collegeInput, setCollegeInput] = useState("");
@@ -294,10 +300,13 @@ export function JobCreateEditPage({
           batch: m.batch,
         })),
         course_ids: (data.courses ?? []).map((c) => c.id),
+        assigned_student_ids: (initialData.assigned_students ?? []).map((s) => s.id),
         question_ids: data.question_ids ?? [],
       });
+      setAssignedStudents(initialData.assigned_students ?? []);
     } else {
       setFormData({ ...emptyPayload, question_ids: [] });
+      setAssignedStudents([]);
     }
     setActiveStep(0);
   }, [initialData]);
@@ -410,6 +419,8 @@ export function JobCreateEditPage({
         company_logo: formData.company_logo.trim(),
         mandatory_skills: formData.key_skills ?? [],
         course_ids: formData.course_ids ?? [],
+        // Always sent, even when empty: [] is how the admin clears a curated list.
+        assigned_student_ids: formData.assigned_student_ids ?? [],
         question_ids: formData.question_ids ?? [],
         is_published: Boolean(formData.is_published),
         status: formData.status ?? "active",
@@ -920,7 +931,11 @@ export function JobCreateEditPage({
                       {...params}
                       size="small"
                       label="Select courses"
-                      placeholder="Leave empty for all students"
+                      placeholder={
+                        assignedStudents.length > 0
+                          ? "Leave empty to target the assigned students only"
+                          : "Leave empty for all students"
+                      }
                       sx={inputSx}
                     />
                   )}
@@ -937,6 +952,54 @@ export function JobCreateEditPage({
                   }
                 />
               </Box>
+              <Box sx={{ mt: 2.5 }}>
+                <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 700, color: "var(--font-primary)" }}>
+                  Assign to specific students (optional)
+                </Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                  {assignedStudents.length === 0
+                    ? "Leave empty to target by course and college only"
+                    : (formData.course_ids ?? []).length > 0
+                      ? `These ${assignedStudents.length} student(s) see this job in addition to everyone enrolled in the selected courses`
+                      : `Only these ${assignedStudents.length} student(s) will see this job`}
+                </Typography>
+
+                <Box sx={{ mt: 1, display: "flex", flexWrap: "wrap", gap: 0.75, alignItems: "center" }}>
+                  {assignedStudents.map((student) => (
+                    <Chip
+                      key={student.id}
+                      size="small"
+                      label={student.name}
+                      title={student.email}
+                      onDelete={() => {
+                        const next = assignedStudents.filter((x) => x.id !== student.id);
+                        setAssignedStudents(next);
+                        handleChange("assigned_student_ids", next.map((x) => x.id));
+                      }}
+                    />
+                  ))}
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => setStudentPickerOpen(true)}
+                    startIcon={<IconWrapper icon="mdi:account-plus-outline" size={16} />}
+                    sx={{ textTransform: "none", borderRadius: 999 }}
+                  >
+                    {assignedStudents.length > 0 ? "Edit students" : "Select students"}
+                  </Button>
+                </Box>
+
+                {assignedStudents.length > 0 && (
+                  <Typography
+                    variant="caption"
+                    sx={{ display: "block", mt: 1, color: "var(--font-tertiary, #8b8b98)" }}
+                  >
+                    Newly assigned students are emailed once the job is published. Re-saving never
+                    re-sends to someone already assigned.
+                  </Typography>
+                )}
+              </Box>
+
               <Box sx={{ mt: 2.5 }}>
                 <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 700, color: "var(--font-primary)" }}>
                   College Mapping (targeted colleges)
@@ -1278,6 +1341,17 @@ export function JobCreateEditPage({
                   </>
                 )}
               </Box>
+              <SelectStudentsDialog
+                open={studentPickerOpen}
+                initialSelected={assignedStudents}
+                onClose={() => setStudentPickerOpen(false)}
+                onConfirm={(students) => {
+                  setAssignedStudents(students);
+                  handleChange("assigned_student_ids", students.map((x) => x.id));
+                  setStudentPickerOpen(false);
+                }}
+              />
+
               <ApplicationQuestionsModal
                 open={addQuestionModalOpen}
                 onClose={() => setAddQuestionModalOpen(false)}

--- a/components/admin/jobs-v2/SelectStudentsDialog.tsx
+++ b/components/admin/jobs-v2/SelectStudentsDialog.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  InputAdornment,
+  Pagination,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import { adminStudentService, type Student } from "@/lib/services/admin/admin-student.service";
+
+const PAGE_SIZE = 20;
+
+/** The shape the job form keeps for each curated learner. */
+export interface SelectedStudent {
+  id: number;
+  name: string;
+  email: string;
+}
+
+interface Props {
+  open: boolean;
+  /** Currently curated students; pre-checked and preserved across searches. */
+  initialSelected: SelectedStudent[];
+  onClose: () => void;
+  onConfirm: (students: SelectedStudent[]) => void;
+}
+
+/**
+ * Search the tenant's learners and pick one or many to curate a job for.
+ *
+ * Mirrors EnrollAdaptiveStudentsDialog (debounced search, paginated checkbox list) but returns the
+ * selection instead of performing an action, so the job form owns the write. Selection is kept in a
+ * Map, not just a Set of ids: a student picked on page 1 must survive a search that pages them out
+ * of view, and we still need their name/email to render the chip afterwards.
+ */
+export function SelectStudentsDialog({ open, initialSelected, onClose, onConfirm }: Props) {
+  const { showToast } = useToast();
+  const [search, setSearch] = useState("");
+  const [students, setStudents] = useState<Student[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [selected, setSelected] = useState<Map<number, SelectedStudent>>(new Map());
+
+  const load = useCallback(
+    async (q: string, p: number) => {
+      setLoading(true);
+      try {
+        const res = await adminStudentService.getManageStudents({
+          search: q || undefined,
+          role: "student",
+          page: p,
+          limit: PAGE_SIZE,
+        });
+        setStudents(res.students);
+        setTotalPages(res.pagination.total_pages || 1);
+      } catch {
+        showToast("Couldn't load students.", "error");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [showToast],
+  );
+
+  // Seed from the form each time the dialog opens, so Cancel truly discards.
+  useEffect(() => {
+    if (!open) return;
+    setSearch("");
+    setPage(1);
+    setSelected(new Map(initialSelected.map((s) => [s.id, s])));
+    void load("", 1);
+  }, [open, initialSelected, load]);
+
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => {
+      setPage(1);
+      void load(search, 1);
+    }, 350);
+    return () => clearTimeout(t);
+  }, [search, open, load]);
+
+  const toggle = (s: Student) => {
+    setSelected((prev) => {
+      const next = new Map(prev);
+      if (next.has(s.id)) next.delete(s.id);
+      else next.set(s.id, { id: s.id, name: s.name || s.email, email: s.email });
+      return next;
+    });
+  };
+
+  const chosen = useMemo(() => Array.from(selected.values()), [selected]);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+      <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", pb: 1 }}>
+        <Box>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Assign to specific students</Typography>
+          <Typography sx={{ fontSize: "0.8rem", color: "var(--font-tertiary, #8b8b98)" }}>
+            Only the students you pick will see this opening.
+          </Typography>
+        </Box>
+        <IconButton size="small" onClick={onClose} aria-label="Close">
+          <Icon icon="mdi:close" width={20} />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="Search by name or email…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Icon icon="mdi:magnify" width={18} />
+              </InputAdornment>
+            ),
+          }}
+          sx={{ mb: 1.5 }}
+        />
+
+        {chosen.length > 0 && (
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, mb: 1.5 }}>
+            {chosen.map((s) => (
+              <Chip
+                key={s.id}
+                size="small"
+                label={s.name}
+                onDelete={() =>
+                  setSelected((prev) => {
+                    const next = new Map(prev);
+                    next.delete(s.id);
+                    return next;
+                  })
+                }
+              />
+            ))}
+          </Box>
+        )}
+
+        {loading ? (
+          <Box sx={{ display: "grid", placeItems: "center", py: 5 }}>
+            <CircularProgress size={26} />
+          </Box>
+        ) : students.length === 0 ? (
+          <Typography sx={{ py: 4, textAlign: "center", color: "var(--font-tertiary, #8b8b98)", fontSize: "0.85rem" }}>
+            No students match &ldquo;{search}&rdquo;.
+          </Typography>
+        ) : (
+          <Box>
+            {students.map((s) => {
+              const checked = selected.has(s.id);
+              return (
+                <Box
+                  key={s.id}
+                  onClick={() => toggle(s)}
+                  sx={{
+                    display: "flex", alignItems: "center", gap: 1.25,
+                    px: 1, py: 0.9, borderRadius: 2, cursor: "pointer",
+                    "&:hover": { bgcolor: "color-mix(in srgb, var(--border-default) 30%, transparent)" },
+                  }}
+                >
+                  <Checkbox checked={checked} size="small" sx={{ p: 0.5 }} />
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography sx={{ fontSize: "0.85rem", fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {s.name || s.email}
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.75rem", color: "var(--font-tertiary, #8b8b98)" }}>{s.email}</Typography>
+                  </Box>
+                </Box>
+              );
+            })}
+            {totalPages > 1 && (
+              <Box sx={{ display: "flex", justifyContent: "center", mt: 1.5 }}>
+                <Pagination
+                  size="small"
+                  count={totalPages}
+                  page={page}
+                  onChange={(_, p) => {
+                    setPage(p);
+                    void load(search, p);
+                  }}
+                />
+              </Box>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Typography sx={{ mr: "auto", fontSize: "0.8rem", color: "var(--font-tertiary, #8b8b98)" }}>
+          {chosen.length} selected
+        </Typography>
+        <Button onClick={onClose} sx={{ textTransform: "none" }}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={() => onConfirm(chosen)} sx={{ textTransform: "none", fontWeight: 700 }}>
+          Done
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/lib/services/admin/admin-jobs-v2.service.ts
+++ b/lib/services/admin/admin-jobs-v2.service.ts
@@ -46,6 +46,8 @@ export interface JobCreateUpdatePayload {
     batch?: string;
   }>;
   course_ids?: number[];
+  /** UserProfile ids of individually curated learners. Only they see the job. [] clears. */
+  assigned_student_ids?: number[];
   question_ids?: number[];
 }
 

--- a/lib/services/jobs-v2.service.ts
+++ b/lib/services/jobs-v2.service.ts
@@ -41,6 +41,8 @@ export interface JobV2 {
   favorites_count?: number;
   applications_count?: number;
   courses?: Array<{ id: number; title: string }>;
+  /** Present ONLY on admin endpoints — the backend never sends this to a student. */
+  assigned_students?: Array<{ id: number; name: string; email: string }>;
   college_mappings?: Array<{ id?: number; college_name: string; department?: string; batch?: string }>;
   questions?: Array<{
     id: number;


### PR DESCRIPTION
Pairs with backend **ai-linc-backend#324** — merge that first.

## Why

> "our batches usually consist of learners from completely different backgrounds, the same job opening won't be relevant for everyone"

Jobs could only be targeted by course and college. This adds a third, most-specific dimension: name the learners.

## What

In the job form's **Targeting** step (create and edit), next to Courses:

- **Select students** opens a searchable, paginated picker over the tenant's learners; pick one or many.
- Selected learners show as removable chips; the caption states the resulting audience —
  - no students → "target by course and college only"
  - students + courses → they see it *in addition to* the enrolled cohort
  - students, no courses → **only** they see it
- The courses placeholder stops promising "all students" once a curated list exists.
- Saving sends `assigned_student_ids`; `[]` clears the list. The backend emails each *newly* assigned student — re-saving never re-sends.

`assigned_students` is read back from the admin detail endpoint only; the student-facing serializer never exposes who else a job was curated for.

## Verified

- `tsc --noEmit` clean; `eslint` clean on all changed files (one pre-existing unused-var warning in `admin-jobs-v2.service.ts` left untouched).
- Not yet exercised against a running backend — worth a click-through on staging once #324 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)