### PR TITLE
feat(assessment): reminder-email scheduling + email module revamp

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -430,6 +430,10 @@ export default function AssessmentEditPage() {
   const [proctoringEnabled, setProctoringEnabled] = useState(true);
   const [liveStreaming, setLiveStreaming] = useState(false);
   const [sendCommunication, setSendCommunication] = useState(false);
+  // Scheduled-reminder opt-in + chosen lead times (minutes before start). Seeded
+  // from the saved assessment on load so the checkboxes re-check themselves.
+  const [emailRemindersEnabled, setEmailRemindersEnabled] = useState(false);
+  const [emailReminderOffsets, setEmailReminderOffsets] = useState<number[]>([]);
   // Email subject/body/attachment are owned by <EmailNotificationEditor /> to
   // keep typing snappy. We snapshot them through this ref at submit time.
   const emailEditorRef = useRef<EmailNotificationEditorHandle>(null);
@@ -443,6 +447,11 @@ export default function AssessmentEditPage() {
   >(null);
   const [existingEmailAttachmentName, setExistingEmailAttachmentName] =
     useState<string | null>(null);
+  // The email body the admin last saved. Seeds the editor on load so a
+  // customised message survives a reload; empty means "use the title-derived
+  // default". Kept separate from the live-built default because the backend
+  // does persist and return email_body — we just weren't reading it back.
+  const [savedEmailBody, setSavedEmailBody] = useState("");
   const [showResult, setShowResult] = useState(true);
   const [evaluationMode, setEvaluationMode] = useState<"auto" | "manual">("auto");
   const [allowMovementAcrossSections, setAllowMovementAcrossSections] =
@@ -489,6 +498,14 @@ export default function AssessmentEditPage() {
       `<p><strong>Assessment:</strong> ${title.trim() || "New Assessment"}</p>`,
     ].join("");
   }, [title]);
+  // What the editor is actually seeded with: the admin's saved body when one
+  // exists, otherwise the title-derived default. The editor mounts only after
+  // loadAssessment completes (the page is gated on `loading`), so this is
+  // correct on the editor's first — and only — mount.
+  const emailBodySeed = useMemo(
+    () => (savedEmailBody ? savedEmailBody : defaultEmailBody),
+    [savedEmailBody, defaultEmailBody]
+  );
 
   const emailSchedule = useMemo(
     () => ({
@@ -588,6 +605,19 @@ export default function AssessmentEditPage() {
       const savedAttachment = extractSavedEmailAttachment(dAny);
       setExistingEmailAttachmentUrl(savedAttachment.url);
       setExistingEmailAttachmentName(savedAttachment.name);
+      // Read the saved message body back so a customised email survives reload.
+      // (Subject is intentionally left title-derived — it auto-syncs with the
+      // assessment title by design; only the body is admin-authored content.)
+      setSavedEmailBody(
+        typeof dAny.email_body === "string" ? dAny.email_body.trim() : ""
+      );
+      // Re-check the saved reminder boxes on load.
+      setEmailRemindersEnabled(dAny.email_reminders_enabled === true);
+      setEmailReminderOffsets(
+        Array.isArray(dAny.email_reminder_offsets)
+          ? (dAny.email_reminder_offsets as number[])
+          : []
+      );
       setShowResult((data as any).show_result ?? true);
       setEvaluationMode((data as any).evaluation_mode === "manual" ? "manual" : "auto");
       setAllowMovementAcrossSections(anyData.allow_movement !== false);
@@ -834,6 +864,13 @@ export default function AssessmentEditPage() {
           })
         : undefined;
       payload.email_base_url = getPublicAppOrigin();
+      // Scheduled reminders are additive to the on-publish send; only meaningful
+      // when notifications are on. Offsets are always sent (empty clears them).
+      payload.email_reminders_enabled =
+        emailNotificationEnabled && emailRemindersEnabled;
+      payload.email_reminder_offsets = emailRemindersEnabled
+        ? emailReminderOffsets
+        : [];
       const emailAttachment = emailSnapshot?.attachment ?? null;
       // Keep the saved attachment when no new file is picked.
       payload.attachment_url = emailSnapshot?.attachmentUrl ?? undefined;
@@ -1526,9 +1563,13 @@ export default function AssessmentEditPage() {
                   sendCommunication={sendCommunication}
                   emailNotificationEnabled={emailNotificationEnabled}
                   onEmailEnabledChange={setEmailEditorHasData}
+                  emailRemindersEnabled={emailRemindersEnabled}
+                  emailReminderOffsets={emailReminderOffsets}
+                  onEmailRemindersEnabledChange={setEmailRemindersEnabled}
+                  onEmailReminderOffsetsChange={setEmailReminderOffsets}
                   emailEditorRef={emailEditorRef}
                   defaultEmailSubject={defaultEmailSubject}
-                  defaultEmailBody={defaultEmailBody}
+                  defaultEmailBody={emailBodySeed}
                   existingEmailAttachmentUrl={existingEmailAttachmentUrl}
                   existingEmailAttachmentName={existingEmailAttachmentName}
                   emailSchedule={emailSchedule}

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -108,6 +108,9 @@ function CreateAssessmentPageContent() {
   const [proctoringEnabled, setProctoringEnabled] = useState(true);
   const [liveStreaming, setLiveStreaming] = useState(false);
   const [sendCommunication, setSendCommunication] = useState(false);
+  // Scheduled-reminder opt-in + chosen lead times (minutes before start).
+  const [emailRemindersEnabled, setEmailRemindersEnabled] = useState(false);
+  const [emailReminderOffsets, setEmailReminderOffsets] = useState<number[]>([]);
   // Email subject/body/attachment live INSIDE <EmailNotificationEditor /> so
   // typing in them doesn't re-render this huge page. We read the final values
   // through this ref at submit time only.
@@ -1191,6 +1194,12 @@ function CreateAssessmentPageContent() {
           })
         : undefined;
       payload.email_base_url = getPublicAppOrigin();
+      // Scheduled reminders — additive to the on-publish send, only when notifications on.
+      payload.email_reminders_enabled =
+        emailNotificationEnabled && emailRemindersEnabled;
+      payload.email_reminder_offsets = emailRemindersEnabled
+        ? emailReminderOffsets
+        : [];
       const emailAttachment = emailSnapshot?.attachment ?? null;
       // When the admin is keeping the previously-saved attachment (no new
       // file picked), pass the existing URL so the backend retains it.
@@ -1602,6 +1611,10 @@ function CreateAssessmentPageContent() {
               sendCommunication={sendCommunication}
               emailNotificationEnabled={emailNotificationEnabled}
               onEmailEnabledChange={setEmailEditorHasData}
+              emailRemindersEnabled={emailRemindersEnabled}
+              emailReminderOffsets={emailReminderOffsets}
+              onEmailRemindersEnabledChange={setEmailRemindersEnabled}
+              onEmailReminderOffsetsChange={setEmailReminderOffsets}
               emailEditorRef={emailEditorRef}
               defaultEmailSubject={defaultEmailSubject}
               defaultEmailBody={defaultEmailBody}

--- a/app/admin/emails/[jobId]/page.tsx
+++ b/app/admin/emails/[jobId]/page.tsx
@@ -7,7 +7,6 @@ import {
   Typography,
   Paper,
   CircularProgress,
-  Chip,
   Button,
   Table,
   TableBody,
@@ -19,24 +18,20 @@ import {
   Tab,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
+import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import { KpiRail } from "@/components/scorecard/shared";
+import { statusTone, triggerChip } from "@/components/admin/emails/EmailJobCard";
 import {
   adminEmailJobsService,
   EmailJobDetail,
   EmailRecipient,
 } from "@/lib/services/admin/admin-email-jobs.service";
 import { config } from "@/lib/config";
-
-const getStatusColor = (status: string) => {
-  const s = (status || "").toLowerCase();
-  if (s === "completed" || s === "success" || s === "sent")
-    return "var(--success-500)";
-  if (s === "failed" || s === "error") return "var(--error-500)";
-  if (s === "pending" || s === "queued") return "var(--warning-500)";
-  return "var(--font-secondary)";
-};
 
 const formatDate = (s: string) => {
   try {
@@ -162,114 +157,73 @@ export default function EmailJobDetailPage() {
     0;
   const emailBody = data.email_body ?? data.body ?? "";
   const title = data.task_name || data.subject || t("adminEmailJobs.emailJobDetails");
+  const tone = statusTone(data.status);
+  const trig = triggerChip(
+    (data as unknown as Record<string, unknown>).trigger_source as string | undefined
+  );
 
   return (
-    <MainLayout>
-      <Box sx={{ p: { xs: 2, sm: 3 } }}>
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1200, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
         <Button
           startIcon={<IconWrapper icon="mdi:arrow-left" size={18} />}
           onClick={() => router.push("/admin/emails")}
-          sx={{ mb: 2, textTransform: "none" }}
+          sx={{ mb: 1.5, textTransform: "none", color: "var(--font-secondary)" }}
         >
           {t("adminEmailJobs.backToEmailJobs")}
         </Button>
 
-        <Typography
-          variant="h4"
-          sx={{
-            fontWeight: 700,
-            color: "var(--font-primary)",
-            fontSize: { xs: "1.5rem", sm: "2rem" },
-            mb: 1,
-          }}
-        >
-          {title}
-        </Typography>
-        {data.task_name && data.subject && data.task_name !== data.subject && (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {data.subject}
-          </Typography>
-        )}
+        <AdaptiveSectionShell>
+          <AdaptiveSectionHero
+            chapter="Notifications · Email job"
+            title={title}
+            subtitle={
+              data.task_name && data.subject && data.task_name !== data.subject
+                ? data.subject
+                : `Sent ${formatDate(data.created_at || "")}`
+            }
+            icon="mdi:email-check-outline"
+            accent="indigo"
+            rightSlot={
+              <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 1.4, py: 0.7, borderRadius: 999, bgcolor: tone.bg }}>
+                <Icon icon={tone.icon} width={16} style={{ color: tone.color }} />
+                <Typography sx={{ fontWeight: 800, color: tone.color, textTransform: "capitalize", fontSize: "0.85rem" }}>
+                  {tone.label}
+                </Typography>
+              </Box>
+            }
+          />
 
-        <Paper
-          sx={{
-            p: 3,
-            borderRadius: 2,
-            border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
-            mb: 2,
-          }}
-        >
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                {t("adminEmailJobs.taskId")}
-              </Typography>
-              <Typography variant="body2">{data.task_id}</Typography>
-            </Box>
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                {t("adminEmailJobs.status")}
-              </Typography>
-              <Box sx={{ mt: 0.5 }}>
-                <Chip
-                  label={data.status}
-                  size="small"
-                  sx={{
-                    bgcolor: `${getStatusColor(data.status)}20`,
-                    color: getStatusColor(data.status),
-                    fontWeight: 600,
-                  }}
-                />
-              </Box>
-            </Box>
-            <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  {t("adminEmailJobs.totalRecipients")}
-                </Typography>
-                <Typography variant="body2">{recipientsCount}</Typography>
-              </Box>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  {t("adminEmailJobs.successful")}
-                </Typography>
-                <Typography variant="body2" sx={{ color: "var(--success-500)" }}>
-                  {successfulCount}
-                </Typography>
-              </Box>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  {t("adminEmailJobs.failedLabel")}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{ color: failedCount > 0 ? "var(--error-500)" : "inherit" }}
-                >
-                  {failedCount}
-                </Typography>
-              </Box>
-            </Box>
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                {t("adminEmailJobs.created")}
-              </Typography>
-              <Typography variant="body2">
-                {formatDate(data.created_at || "")}
-              </Typography>
-            </Box>
+          <Box sx={{ mt: 2.5 }}>
+            <KpiRail
+              items={[
+                { value: recipientsCount, label: "Recipients", accent: "#6366f1" },
+                { value: successfulCount, label: "Delivered", accent: "#10b981" },
+                { value: failedCount, label: "Failed", accent: failedCount > 0 ? "#ef4444" : "#94a3b8" },
+              ]}
+            />
           </Box>
-        </Paper>
+
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 2, alignItems: "center" }}>
+            {trig ? (
+              <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, px: 1, py: 0.4, borderRadius: 999, border: `1px solid color-mix(in srgb, ${trig.color} 35%, transparent)` }}>
+                <Icon icon={trig.icon} width={14} style={{ color: trig.color }} />
+                <Typography sx={{ fontSize: "0.75rem", fontWeight: 700, color: trig.color }}>{trig.label}</Typography>
+              </Box>
+            ) : null}
+            <Typography variant="caption" sx={{ color: "var(--font-tertiary, var(--font-secondary))", ml: "auto" }}>
+              {t("adminEmailJobs.taskId")}: {data.task_id}
+            </Typography>
+          </Box>
 
         <Paper
           sx={{
-            borderRadius: 2,
+            mt: 2.5,
+            borderRadius: 4,
             border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
+            background: "color-mix(in srgb, var(--card-bg) 75%, transparent)",
+            backdropFilter: "blur(6px)",
+            boxShadow: "none",
             overflow: "hidden",
           }}
         >
@@ -334,6 +288,7 @@ export default function EmailJobDetailPage() {
             )}
           </Box>
         </Paper>
+        </AdaptiveSectionShell>
       </Box>
     </MainLayout>
   );

--- a/app/admin/emails/assessment/[jobId]/page.tsx
+++ b/app/admin/emails/assessment/[jobId]/page.tsx
@@ -17,12 +17,16 @@ import {
   TableRow,
   Tabs,
   Tab,
-  LinearProgress,
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
+import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
+import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import { KpiRail } from "@/components/scorecard/shared";
+import { statusTone, triggerChip } from "@/components/admin/emails/EmailJobCard";
 import {
   adminAssessmentEmailJobsService,
   AssessmentEmailJobDetail,
@@ -34,14 +38,6 @@ import { extractSavedEmailAttachment } from "@/lib/utils/assessment-email-attach
 const POLL_INTERVAL_MS = 3000;
 const TERMINAL_STATUSES = ["COMPLETED", "FAILED", "completed", "failed"];
 
-const getStatusColor = (status: string) => {
-  const s = (status || "").toLowerCase();
-  if (s === "completed" || s === "success" || s === "sent")
-    return "var(--success-500)";
-  if (s === "failed" || s === "error") return "var(--error-500)";
-  if (s === "pending" || s === "queued") return "var(--warning-500)";
-  return "var(--font-secondary)";
-};
 
 const formatDate = (s: string) => {
   try {
@@ -128,7 +124,7 @@ export default function AssessmentEmailJobDetailPage() {
       router.push("/admin/emails");
       return null;
     }
-  }, [jobId, showToast, router]);
+  }, [jobId, showToast, router, t]);
 
   useEffect(() => {
     if (!jobId) return;
@@ -198,160 +194,111 @@ export default function AssessmentEmailJobDetailPage() {
     data as unknown as Record<string, unknown>
   );
 
+  const tone = statusTone(data.status);
+  const trig = triggerChip(
+    (data as unknown as Record<string, unknown>).trigger_source as string | undefined
+  );
+
   return (
-    <MainLayout>
-      <Box sx={{ p: { xs: 2, sm: 3 } }}>
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1200, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
         <Button
           startIcon={<IconWrapper icon="mdi:arrow-left" size={18} />}
-          onClick={() => router.push("/admin/emails")}
-          sx={{ mb: 2, textTransform: "none" }}
+          onClick={() => router.push("/admin/emails?tab=assessment")}
+          sx={{ mb: 1.5, textTransform: "none", color: "var(--font-secondary)" }}
         >
           {t("adminEmailJobs.backToEmailJobs")}
         </Button>
 
-        <Typography
-          variant="h4"
-          sx={{
-            fontWeight: 700,
-            color: "var(--font-primary)",
-            fontSize: { xs: "1.5rem", sm: "2rem" },
-            mb: 1,
-          }}
-        >
-          {title}
-        </Typography>
-        {data.task_name && data.subject && data.task_name !== data.subject && (
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            {data.subject}
-          </Typography>
-        )}
+        <AdaptiveSectionShell>
+          <AdaptiveSectionHero
+            chapter="Notifications · Assessment email"
+            title={title}
+            subtitle={
+              data.task_name && data.subject && data.task_name !== data.subject
+                ? data.subject
+                : `Sent ${formatDate(data.created_at || "")}`
+            }
+            icon="mdi:email-check-outline"
+            accent="indigo"
+            rightSlot={
+              <Box
+                sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 1.4, py: 0.7, borderRadius: 999, bgcolor: tone.bg }}
+              >
+                <Icon icon={tone.icon} width={16} style={{ color: tone.color }} />
+                <Typography sx={{ fontWeight: 800, color: tone.color, textTransform: "capitalize", fontSize: "0.85rem" }}>
+                  {tone.label}
+                </Typography>
+              </Box>
+            }
+          />
 
-        {isPolling && (
-          <Box sx={{ mb: 2 }}>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {t("adminEmailJobs.progressEmailsSent", { success: successfulCount, total: recipientsCount })}
-            </Typography>
-            <LinearProgress
-              variant="determinate"
-              value={recipientsCount ? (successfulCount / recipientsCount) * 100 : 0}
-              sx={{ height: 6, borderRadius: 1 }}
-            />
-          </Box>
-        )}
-
-        <Paper
-          sx={{
-            p: 3,
-            borderRadius: 2,
-            border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
-            mb: 2,
-          }}
-        >
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                {t("adminEmailJobs.taskId")}
+          {/* live progress while sending */}
+          {isPolling && (
+            <Box sx={{ mt: 1 }}>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
+                {t("adminEmailJobs.progressEmailsSent", { success: successfulCount, total: recipientsCount })}
               </Typography>
-              <Typography variant="body2">{data.task_id}</Typography>
-            </Box>
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                {t("adminEmailJobs.status")}
-              </Typography>
-              <Box sx={{ mt: 0.5 }}>
-                <Chip
-                  label={data.status}
-                  size="small"
+              <Box sx={{ height: 8, borderRadius: 999, bgcolor: "var(--surface)", overflow: "hidden" }}>
+                <Box
                   sx={{
-                    bgcolor: `${getStatusColor(data.status)}20`,
-                    color: getStatusColor(data.status),
-                    fontWeight: 600,
+                    height: "100%",
+                    width: `${recipientsCount ? (successfulCount / recipientsCount) * 100 : 0}%`,
+                    borderRadius: 999,
+                    background: "linear-gradient(90deg, #6366f1, #a855f7, #ec4899)",
+                    transition: "width 400ms ease",
                   }}
                 />
               </Box>
             </Box>
-            <Box sx={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  {t("adminEmailJobs.totalRecipients")}
-                </Typography>
-                <Typography variant="body2">{recipientsCount}</Typography>
-              </Box>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  {t("adminEmailJobs.successful")}
-                </Typography>
-                <Typography variant="body2" sx={{ color: "var(--success-500)" }}>
-                  {successfulCount}
-                </Typography>
-              </Box>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  {t("adminEmailJobs.failedLabel")}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  sx={{ color: failedCount > 0 ? "var(--error-500)" : "inherit" }}
-                >
-                  {failedCount}
-                </Typography>
-              </Box>
-            </Box>
-            <Box>
-              <Typography variant="caption" color="text.secondary">
-                {t("adminEmailJobs.created")}
-              </Typography>
-              <Typography variant="body2">
-                {formatDate(data.created_at || "")}
-              </Typography>
-            </Box>
-            {jobAttachment.url ? (
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  Attachment
-                </Typography>
-                <Box sx={{ mt: 0.5 }}>
-                  <Chip
-                    icon={<IconWrapper icon="mdi:paperclip" size={16} />}
-                    label={
-                      jobAttachment.name?.trim() ||
-                      jobAttachment.url.split("?")[0].split("/").pop() ||
-                      "attachment"
-                    }
-                    clickable
-                    size="small"
-                    onClick={() =>
-                      jobAttachment.url &&
-                      window.open(
-                        jobAttachment.url,
-                        "_blank",
-                        "noopener,noreferrer"
-                      )
-                    }
-                    sx={{
-                      maxWidth: 360,
-                      bgcolor:
-                        "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-                      color: "var(--accent-indigo)",
-                      "& .MuiChip-icon": { color: "var(--accent-indigo)" },
-                    }}
-                  />
-                </Box>
+          )}
+
+          <Box sx={{ mt: 2.5 }}>
+            <KpiRail
+              items={[
+                { value: recipientsCount, label: "Recipients", accent: "#6366f1" },
+                { value: successfulCount, label: "Delivered", accent: "#10b981" },
+                { value: failedCount, label: "Failed", accent: failedCount > 0 ? "#ef4444" : "#94a3b8" },
+              ]}
+            />
+          </Box>
+
+          {/* provenance + attachment */}
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 2, alignItems: "center" }}>
+            {trig ? (
+              <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, px: 1, py: 0.4, borderRadius: 999, border: `1px solid color-mix(in srgb, ${trig.color} 35%, transparent)` }}>
+                <Icon icon={trig.icon} width={14} style={{ color: trig.color }} />
+                <Typography sx={{ fontSize: "0.75rem", fontWeight: 700, color: trig.color }}>{trig.label}</Typography>
               </Box>
             ) : null}
+            {jobAttachment.url ? (
+              <Chip
+                icon={<IconWrapper icon="mdi:paperclip" size={16} />}
+                label={jobAttachment.name?.trim() || jobAttachment.url.split("?")[0].split("/").pop() || "attachment"}
+                clickable
+                size="small"
+                onClick={() => jobAttachment.url && window.open(jobAttachment.url, "_blank", "noopener,noreferrer")}
+                sx={{
+                  maxWidth: 360,
+                  bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
+                  color: "var(--accent-indigo)",
+                  "& .MuiChip-icon": { color: "var(--accent-indigo)" },
+                }}
+              />
+            ) : null}
+            <Typography variant="caption" sx={{ color: "var(--font-tertiary, var(--font-secondary))", ml: "auto" }}>
+              {t("adminEmailJobs.taskId")}: {data.task_id}
+            </Typography>
           </Box>
-        </Paper>
 
         <Paper
           sx={{
-            borderRadius: 2,
+            mt: 2.5,
+            borderRadius: 4,
             border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
+            background: "color-mix(in srgb, var(--card-bg) 75%, transparent)",
+            backdropFilter: "blur(6px)",
+            boxShadow: "none",
             overflow: "hidden",
           }}
         >
@@ -453,6 +400,7 @@ export default function AssessmentEmailJobDetailPage() {
             )}
           </Box>
         </Paper>
+        </AdaptiveSectionShell>
       </Box>
     </MainLayout>
   );

--- a/app/admin/emails/page.tsx
+++ b/app/admin/emails/page.tsx
@@ -5,29 +5,22 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   Box,
   Typography,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Button,
+  ButtonBase,
   CircularProgress,
-  Chip,
   TextField,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
+  InputAdornment,
   Pagination,
-  Tabs,
-  Tab,
 } from "@mui/material";
+import { Icon } from "@iconify/react";
 import { useTranslation } from "react-i18next";
 import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
+import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
+import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import { KpiRail } from "@/components/scorecard/shared";
+import { Reveal } from "@/components/scorecard/shared/Reveal";
+import { EmailJobCard } from "@/components/admin/emails/EmailJobCard";
 import {
   adminEmailJobsService,
   EmailJob,
@@ -38,283 +31,229 @@ import {
 } from "@/lib/services/admin/admin-assessment-email-jobs.service";
 import { config } from "@/lib/config";
 
+type AnyJob = EmailJob | AssessmentEmailJob;
+
 const isFailedStatus = (status: string) => {
   const s = (status || "").toLowerCase();
   return s === "failed" || s === "error";
 };
 
-function JobsTable({
-  jobs,
-  loading,
-  filterName,
-  filterStatus,
-  setFilterName,
-  setFilterStatus,
-  page,
-  limit,
-  setPage,
-  setLimit,
-  retryingId,
-  onView,
-  onRetry,
-  getStatusColor,
-  formatDate,
-  isAssessment = false,
-}: {
-  jobs: (EmailJob | AssessmentEmailJob)[];
-  loading: boolean;
-  filterName: string;
-  filterStatus: string;
-  setFilterName: (v: string) => void;
-  setFilterStatus: (v: string) => void;
-  page: number;
-  limit: number;
-  setPage: (v: number) => void;
-  setLimit: (v: number) => void;
-  retryingId: string | null;
-  onView: (job: EmailJob | AssessmentEmailJob) => void;
-  onRetry: (job: EmailJob | AssessmentEmailJob) => void;
-  getStatusColor: (s: string) => string;
-  formatDate: (s: string) => string;
-  isAssessment?: boolean;
-}) {
-  const { t } = useTranslation("common");
-  const filteredJobs = useMemo(() => {
-    return jobs.filter((job) => {
-      const search = filterName.trim().toLowerCase();
-      const matchName =
-        !search ||
-        (job.subject || "").toLowerCase().includes(search) ||
-        (job.task_name || "").toLowerCase().includes(search) ||
-        ((job as AssessmentEmailJob).assessment_title || "")
-          .toLowerCase()
-          .includes(search);
-      const matchStatus =
-        filterStatus === "all" ||
-        (job.status || "").toLowerCase() === filterStatus.toLowerCase();
-      return matchName && matchStatus;
-    });
-  }, [jobs, filterName, filterStatus]);
+const STATUS_FILTERS = [
+  { value: "all", label: "All statuses" },
+  { value: "completed", label: "Completed" },
+  { value: "pending", label: "Pending" },
+  { value: "failed", label: "Failed" },
+];
 
-  const paginatedJobs = useMemo(() => {
-    const start = (page - 1) * limit;
-    return filteredJobs.slice(start, start + limit);
-  }, [filteredJobs, page, limit]);
+function formatDate(s: string) {
+  try {
+    const d = new Date(s);
+    return isNaN(d.getTime()) ? s : d.toLocaleString();
+  } catch {
+    return s;
+  }
+}
 
-  const totalPages = Math.max(1, Math.ceil(filteredJobs.length / limit));
-
-  useEffect(() => {
-    setPage(1);
-  }, [filterName, filterStatus, limit, setPage]);
-
-  const displayName = (job: EmailJob | AssessmentEmailJob) =>
+function displayName(job: AnyJob) {
+  return (
     (job as AssessmentEmailJob).assessment_title ||
     job.task_name ||
     job.subject ||
-    "—";
+    "—"
+  );
+}
+
+/** Fold varied backend status strings into the four the filter chips expose. */
+function normalizedStatus(status: string): "completed" | "pending" | "failed" | "other" {
+  const s = (status || "").toLowerCase();
+  if (["completed", "success", "sent"].includes(s)) return "completed";
+  if (["failed", "error"].includes(s)) return "failed";
+  if (["pending", "queued", "in_progress", "sending"].includes(s)) return "pending";
+  return "other";
+}
+
+/** One tab body: filter row + KPI rail + card grid + pagination. Purely presentational. */
+function JobsPanel({
+  jobs,
+  loading,
+  retryingId,
+  onView,
+  onRetry,
+  showMetrics,
+}: {
+  jobs: AnyJob[];
+  loading: boolean;
+  retryingId: string | null;
+  onView: (job: AnyJob) => void;
+  onRetry: (job: AnyJob) => void;
+  showMetrics: boolean;
+}) {
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState("all");
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(12);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return jobs.filter((job) => {
+      const matchName =
+        !q ||
+        (job.subject || "").toLowerCase().includes(q) ||
+        (job.task_name || "").toLowerCase().includes(q) ||
+        ((job as AssessmentEmailJob).assessment_title || "").toLowerCase().includes(q);
+      const matchStatus = status === "all" || normalizedStatus(job.status) === status;
+      return matchName && matchStatus;
+    });
+  }, [jobs, search, status]);
+
+  const kpis = useMemo(() => {
+    let completed = 0, failed = 0, pending = 0, recipients = 0;
+    for (const j of jobs) {
+      const n = normalizedStatus(j.status);
+      if (n === "completed") completed += 1;
+      else if (n === "failed") failed += 1;
+      else if (n === "pending") pending += 1;
+      recipients += (j as AssessmentEmailJob).total_emails ?? 0;
+    }
+    const items = [
+      { value: jobs.length, label: "Total jobs", accent: "#6366f1" },
+      { value: completed, label: "Completed", accent: "#10b981" },
+      { value: pending, label: "Pending", accent: "#f59e0b" },
+      { value: failed, label: "Failed", accent: "#ef4444" },
+    ];
+    if (showMetrics) items.push({ value: recipients, label: "Recipients", accent: "#a855f7" });
+    return items;
+  }, [jobs, showMetrics]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / limit));
+  // Clamp during render (no setState-in-effect): if a filter shrinks the list
+  // below the current page, fall back to the last valid page for display.
+  const safePage = Math.min(page, totalPages);
+  const paginated = useMemo(
+    () => filtered.slice((safePage - 1) * limit, (safePage - 1) * limit + limit),
+    [filtered, safePage, limit]
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "grid", placeItems: "center", py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (jobs.length === 0) {
+    return (
+      <Box
+        sx={{
+          mt: 3,
+          py: 8,
+          display: "grid",
+          placeItems: "center",
+          textAlign: "center",
+          border: "1px dashed var(--border-default)",
+          borderRadius: 4,
+        }}
+      >
+        <Icon icon="mdi:email-off-outline" width={44} style={{ color: "var(--font-tertiary, var(--font-secondary))" }} />
+        <Typography sx={{ mt: 1.5, fontWeight: 700, color: "var(--font-primary)" }}>No email jobs yet</Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 380, mt: 0.5 }}>
+          Notification and reminder emails you send from assessments and other tools will appear here with their delivery status.
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
-    <Box>
-      {!loading && jobs.length > 0 && (
+    <Box sx={{ mt: 2.5 }}>
+      <KpiRail items={kpis} />
+
+      {/* filters */}
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 3, mb: 2, alignItems: "center" }}>
+        <TextField
+          size="small"
+          placeholder="Search by subject or assessment…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ minWidth: 260, flex: "1 1 260px", maxWidth: 420 }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Icon icon="mdi:magnify" width={18} />
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
+          {STATUS_FILTERS.map((f) => {
+            const active = status === f.value;
+            return (
+              <ButtonBase
+                key={f.value}
+                onClick={() => setStatus(f.value)}
+                sx={{
+                  px: 1.5, py: 0.6, borderRadius: 999, fontSize: "0.8rem", fontWeight: 600,
+                  color: active ? "white" : "var(--font-secondary)",
+                  background: active ? "linear-gradient(135deg, #6366f1, #a855f7)" : "transparent",
+                  border: active ? "none" : "1px solid var(--border-default)",
+                }}
+              >
+                {f.label}
+              </ButtonBase>
+            );
+          })}
+        </Box>
+      </Box>
+
+      {paginated.length === 0 ? (
+        <Typography sx={{ py: 6, textAlign: "center", color: "var(--font-secondary)" }}>
+          No jobs match your filters.
+        </Typography>
+      ) : (
         <Box
           sx={{
-            display: "flex",
+            display: "grid",
             gap: 2,
-            mb: 2,
-            flexWrap: "wrap",
-            alignItems: "center",
+            gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
           }}
         >
-          <TextField
-            size="small"
-            placeholder={t("adminEmailJobs.filterByNamePlaceholder")}
-            value={filterName}
-            onChange={(e) => setFilterName(e.target.value)}
-            sx={{ minWidth: 200 }}
-          />
-          <FormControl size="small" sx={{ minWidth: 140 }}>
-            <InputLabel>{t("adminEmailJobs.status")}</InputLabel>
-            <Select
-              value={filterStatus}
-              onChange={(e) => setFilterStatus(e.target.value)}
-              label={t("adminEmailJobs.status")}
-            >
-              <MenuItem value="all">{t("adminEmailJobs.all")}</MenuItem>
-              <MenuItem value="failed">{t("adminEmailJobs.failed")}</MenuItem>
-              <MenuItem value="pending">{t("adminEmailJobs.pending")}</MenuItem>
-              <MenuItem value="completed">{t("adminEmailJobs.completed")}</MenuItem>
-              <MenuItem value="COMPLETED">{t("adminEmailJobs.completed")}</MenuItem>
-              <MenuItem value="FAILED">{t("adminEmailJobs.failed")}</MenuItem>
-              <MenuItem value="success">{t("adminEmailJobs.success")}</MenuItem>
-              <MenuItem value="sent">{t("adminEmailJobs.sent")}</MenuItem>
-              <MenuItem value="queued">{t("adminEmailJobs.queued")}</MenuItem>
-              <MenuItem value="error">{t("adminEmailJobs.error")}</MenuItem>
-            </Select>
-          </FormControl>
+          {paginated.map((job, idx) => (
+            <Reveal key={job.task_id} delay={Math.min(idx * 0.04, 0.3)}>
+              <EmailJobCard
+                job={job}
+                displayName={displayName(job)}
+                createdLabel={formatDate(job.created_at || "")}
+                isFailed={isFailedStatus(job.status)}
+                retrying={retryingId === job.task_id}
+                onView={() => onView(job)}
+                onRetry={() => onRetry(job)}
+                showMetrics={showMetrics}
+              />
+            </Reveal>
+          ))}
         </Box>
       )}
 
-      {loading ? (
-        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-          <CircularProgress />
+      {filtered.length > limit || limit !== 12 ? (
+        <Box sx={{ mt: 3, display: "flex", flexWrap: "wrap", gap: 1.5, justifyContent: "space-between", alignItems: "center" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+              {`Showing ${(safePage - 1) * limit + 1}–${Math.min(filtered.length, safePage * limit)} of ${filtered.length}`}
+            </Typography>
+            <PerPageSelect value={limit} onChange={(v) => { setLimit(v); setPage(1); }} minWidth={100} />
+          </Box>
+          <Pagination
+            count={totalPages}
+            page={safePage}
+            onChange={(_, v) => setPage(v)}
+            color="primary"
+            size="small"
+            siblingCount={0}
+            boundaryCount={1}
+            disabled={totalPages <= 1}
+          />
         </Box>
-      ) : (
-        <Paper
-          sx={{
-            borderRadius: 2,
-            border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
-            overflow: "hidden",
-          }}
-        >
-          <TableContainer>
-            <Table size="small" sx={{ minWidth: 500 }}>
-              <TableHead>
-                <TableRow sx={{ backgroundColor: "var(--surface)" }}>
-                  <TableCell sx={{ fontWeight: 600, py: 1.5 }}>
-                    {isAssessment ? t("adminEmailJobs.assessmentSubject") : t("adminEmailJobs.taskSubject")}
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, py: 1.5 }}>{t("adminEmailJobs.status")}</TableCell>
-                  <TableCell sx={{ fontWeight: 600, py: 1.5 }}>{t("adminEmailJobs.created")}</TableCell>
-                  <TableCell sx={{ fontWeight: 600, py: 1.5 }}>{t("adminEmailJobs.actions")}</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {paginatedJobs.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={4} align="center" sx={{ py: 4 }}>
-                      <Typography variant="body2" color="text.secondary">
-                        {jobs.length === 0
-                          ? t("adminEmailJobs.noEmailJobsFound")
-                          : t("adminEmailJobs.noJobsMatchFilters")}
-                      </Typography>
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  paginatedJobs.map((job) => (
-                    <TableRow
-                      key={job.task_id}
-                      sx={{ "&:hover": { backgroundColor: "var(--surface)" } }}
-                    >
-                      <TableCell sx={{ py: 1.5 }}>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            fontWeight: 500,
-                            maxWidth: 280,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                          title={displayName(job)}
-                        >
-                          {displayName(job)}
-                        </Typography>
-                      </TableCell>
-                      <TableCell sx={{ py: 1.5 }}>
-                        <Chip
-                          label={job.status || "—"}
-                          size="small"
-                          sx={{
-                            bgcolor: `${getStatusColor(job.status)}20`,
-                            color: getStatusColor(job.status),
-                            fontWeight: 600,
-                            fontSize: "0.75rem",
-                          }}
-                        />
-                      </TableCell>
-                      <TableCell sx={{ py: 1.5 }}>
-                        <Typography variant="body2" color="text.secondary">
-                          {formatDate(job.created_at || "")}
-                        </Typography>
-                      </TableCell>
-                      <TableCell sx={{ py: 1.5 }}>
-                        <Box sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
-                          <Button
-                            size="small"
-                            variant="outlined"
-                            onClick={() => onView(job)}
-                            sx={{ minWidth: 70 }}
-                          >
-                            {t("adminEmailJobs.view")}
-                          </Button>
-                          {isFailedStatus(job.status) && (
-                            <Button
-                              size="small"
-                              variant="outlined"
-                              color="secondary"
-                              onClick={() => onRetry(job)}
-                              disabled={retryingId === job.task_id}
-                              sx={{ minWidth: 70 }}
-                            >
-                              {retryingId === job.task_id ? (
-                                <CircularProgress size={16} color="inherit" />
-                              ) : (
-                                t("adminEmailJobs.retry")
-                              )}
-                            </Button>
-                          )}
-                        </Box>
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </TableContainer>
-          {filteredJobs.length > 0 && (
-            <Box
-              sx={{
-                p: { xs: 1.5, sm: 2 },
-                borderTop: "1px solid var(--border-default)",
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                flexDirection: { xs: "column", sm: "row" },
-                gap: { xs: 1.5, sm: 2 },
-              }}
-            >
-              <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: "var(--font-secondary)",
-                    fontSize: { xs: "0.75rem", sm: "0.875rem" },
-                  }}
-                >
-                  {t("adminEmailJobs.showing", {
-                    start: (page - 1) * limit + 1,
-                    end: Math.min(filteredJobs.length, page * limit),
-                    total: filteredJobs.length,
-                  })}
-                </Typography>
-                <PerPageSelect
-                  value={limit}
-                  onChange={(v) => {
-                    setLimit(v);
-                    setPage(1);
-                  }}
-                  minWidth={100}
-                />
-              </Box>
-              <Pagination
-                count={totalPages}
-                page={page}
-                onChange={(_, value) => setPage(value)}
-                color="primary"
-                size="small"
-                showFirstButton={false}
-                showLastButton={false}
-                boundaryCount={1}
-                siblingCount={0}
-                disabled={totalPages <= 1}
-              />
-            </Box>
-          )}
-        </Paper>
-      )}
+      ) : null}
     </Box>
   );
 }
@@ -324,12 +263,10 @@ export default function AdminEmailsPage() {
   const { t } = useTranslation("common");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [tabValue, setTabValue] = useState(0);
+  const [tab, setTab] = useState<0 | 1>(0);
 
   useEffect(() => {
-    if (searchParams?.get("tab") === "assessment") {
-      setTabValue(1);
-    }
+    if (searchParams?.get("tab") === "assessment") setTab(1);
   }, [searchParams]);
 
   const [allJobs, setAllJobs] = useState<EmailJob[]>([]);
@@ -337,16 +274,6 @@ export default function AdminEmailsPage() {
   const [loadingAll, setLoadingAll] = useState(true);
   const [loadingAssessment, setLoadingAssessment] = useState(true);
   const [retryingId, setRetryingId] = useState<string | null>(null);
-
-  const [filterNameAll, setFilterNameAll] = useState("");
-  const [filterStatusAll, setFilterStatusAll] = useState("all");
-  const [pageAll, setPageAll] = useState(1);
-  const [limitAll, setLimitAll] = useState(10);
-
-  const [filterNameAssess, setFilterNameAssess] = useState("");
-  const [filterStatusAssess, setFilterStatusAssess] = useState("all");
-  const [pageAssess, setPageAssess] = useState(1);
-  const [limitAssess, setLimitAssess] = useState(10);
 
   const loadAllJobs = useCallback(async () => {
     try {
@@ -364,15 +291,10 @@ export default function AdminEmailsPage() {
   const loadAssessmentJobs = useCallback(async () => {
     try {
       setLoadingAssessment(true);
-      const data = await adminAssessmentEmailJobsService.getAssessmentEmailJobs(
-        config.clientId
-      );
+      const data = await adminAssessmentEmailJobsService.getAssessmentEmailJobs(config.clientId);
       setAssessmentJobs(Array.isArray(data) ? data : []);
     } catch (e: unknown) {
-      showToast(
-        (e as Error)?.message || t("adminEmailJobs.failedToLoadAssessmentEmailJobs"),
-        "error"
-      );
+      showToast((e as Error)?.message || t("adminEmailJobs.failedToLoadAssessmentEmailJobs"), "error");
       setAssessmentJobs([]);
     } finally {
       setLoadingAssessment(false);
@@ -380,40 +302,27 @@ export default function AdminEmailsPage() {
   }, [showToast, t]);
 
   useEffect(() => {
-    if (tabValue === 0) loadAllJobs();
+    if (tab === 0) loadAllJobs();
     else loadAssessmentJobs();
-  }, [tabValue, loadAllJobs, loadAssessmentJobs]);
+  }, [tab, loadAllJobs, loadAssessmentJobs]);
 
-  const handleViewAll = (job: EmailJob | AssessmentEmailJob) => {
-    router.push(`/admin/emails/${encodeURIComponent(job.task_id)}`);
+  const handleView = (job: AnyJob) => {
+    const path = tab === 1 ? "assessment/" : "";
+    router.push(`/admin/emails/${path}${encodeURIComponent(job.task_id)}`);
   };
 
-  const handleViewAssessment = (job: EmailJob | AssessmentEmailJob) => {
-    router.push(`/admin/emails/assessment/${encodeURIComponent(job.task_id)}`);
-  };
-
-  const handleRetryAll = async (job: EmailJob | AssessmentEmailJob) => {
+  const handleRetry = async (job: AnyJob) => {
     try {
       setRetryingId(job.task_id);
-      await adminEmailJobsService.resendEmailJob(config.clientId, job.task_id);
-      showToast(t("adminEmailJobs.emailJobQueuedResending"), "success");
-      loadAllJobs();
-    } catch (e: unknown) {
-      showToast((e as Error)?.message || t("adminEmailJobs.failedToResend"), "error");
-    } finally {
-      setRetryingId(null);
-    }
-  };
-
-  const handleRetryAssessment = async (job: EmailJob | AssessmentEmailJob) => {
-    try {
-      setRetryingId(job.task_id);
-      await adminAssessmentEmailJobsService.retryAssessmentEmailJob(
-        config.clientId,
-        job.task_id
-      );
-      showToast(t("adminEmailJobs.assessmentEmailJobQueuedRetry"), "success");
-      loadAssessmentJobs();
+      if (tab === 1) {
+        await adminAssessmentEmailJobsService.retryAssessmentEmailJob(config.clientId, job.task_id);
+        showToast(t("adminEmailJobs.assessmentEmailJobQueuedRetry"), "success");
+        loadAssessmentJobs();
+      } else {
+        await adminEmailJobsService.resendEmailJob(config.clientId, job.task_id);
+        showToast(t("adminEmailJobs.emailJobQueuedResending"), "success");
+        loadAllJobs();
+      }
     } catch (e: unknown) {
       showToast((e as Error)?.message || t("adminEmailJobs.failedToRetry"), "error");
     } finally {
@@ -421,89 +330,81 @@ export default function AdminEmailsPage() {
     }
   };
 
-  const formatDate = (s: string) => {
-    try {
-      const d = new Date(s);
-      return isNaN(d.getTime()) ? s : d.toLocaleString();
-    } catch {
-      return s;
-    }
-  };
-
-  const getStatusColor = (status: string) => {
-    const s = (status || "").toLowerCase();
-    if (s === "completed" || s === "success" || s === "sent")
-      return "var(--success-500)";
-    if (s === "failed" || s === "error") return "var(--error-500)";
-    if (s === "pending" || s === "queued") return "var(--warning-500)";
-    return "var(--font-secondary)";
-  };
+  const TABS: { label: string; icon: string }[] = [
+    { label: "All emails", icon: "mdi:email-multiple-outline" },
+    { label: "Assessment emails", icon: "mdi:clipboard-text-clock-outline" },
+  ];
 
   return (
-    <MainLayout>
-      <Box sx={{ p: { xs: 2, sm: 3 } }}>
-        <Typography
-          variant="h4"
-          sx={{
-            fontWeight: 700,
-            color: "var(--font-primary)",
-            fontSize: { xs: "1.5rem", sm: "2rem" },
-            mb: 3,
-          }}
-        >
-          {t("adminEmailJobs.title")}
-        </Typography>
-
-        <Tabs
-          value={tabValue}
-          onChange={(_, v) => setTabValue(v)}
-          sx={{ borderBottom: 1, borderColor: "divider", mb: 2 }}
-        >
-          <Tab label={t("adminEmailJobs.allEmails")} />
-          <Tab label={t("adminEmailJobs.assessmentEmails")} />
-        </Tabs>
-
-        {tabValue === 0 && (
-          <JobsTable
-            jobs={allJobs}
-            loading={loadingAll}
-            filterName={filterNameAll}
-            filterStatus={filterStatusAll}
-            setFilterName={setFilterNameAll}
-            setFilterStatus={setFilterStatusAll}
-            page={pageAll}
-            limit={limitAll}
-            setPage={setPageAll}
-            setLimit={setLimitAll}
-            retryingId={retryingId}
-            onView={handleViewAll}
-            onRetry={handleRetryAll}
-            getStatusColor={getStatusColor}
-            formatDate={formatDate}
-            isAssessment={false}
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1500, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        <AdaptiveSectionShell>
+          <AdaptiveSectionHero
+            chapter="Manage · Notifications"
+            title="Email delivery"
+            subtitle="Every notification and scheduled reminder sent from your workspace, with live delivery status. Assessment reminders you schedule appear here automatically as they go out."
+            icon="mdi:email-fast-outline"
+            accent="indigo"
+            rightSlot={
+              <ButtonBase
+                onClick={() => router.push("/admin/assessment")}
+                sx={{
+                  px: 3, py: 1.4, borderRadius: 999, fontWeight: 800, color: "white",
+                  background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
+                  boxShadow: "0 18px 36px -16px rgba(168, 85, 247, 0.55)",
+                  fontSize: "0.92rem", display: "inline-flex", alignItems: "center", gap: 0.75,
+                  "&:hover": { transform: "translateY(-1px)" }, transition: "transform 120ms ease",
+                }}
+              >
+                <Icon icon="mdi:clipboard-plus-outline" width={16} />
+                Go to assessments
+              </ButtonBase>
+            }
           />
-        )}
 
-        {tabValue === 1 && (
-          <JobsTable
-            jobs={assessmentJobs}
-            loading={loadingAssessment}
-            filterName={filterNameAssess}
-            filterStatus={filterStatusAssess}
-            setFilterName={setFilterNameAssess}
-            setFilterStatus={setFilterStatusAssess}
-            page={pageAssess}
-            limit={limitAssess}
-            setPage={setPageAssess}
-            setLimit={setLimitAssess}
-            retryingId={retryingId}
-            onView={handleViewAssessment}
-            onRetry={handleRetryAssessment}
-            getStatusColor={getStatusColor}
-            formatDate={formatDate}
-            isAssessment={true}
-          />
-        )}
+          {/* tab switch */}
+          <Box sx={{ display: "flex", gap: 0.75, mt: 1 }}>
+            {TABS.map((tb, i) => {
+              const active = tab === i;
+              return (
+                <ButtonBase
+                  key={tb.label}
+                  onClick={() => setTab(i as 0 | 1)}
+                  sx={{
+                    px: 2, py: 1, borderRadius: 3, fontWeight: 700, fontSize: "0.85rem",
+                    display: "inline-flex", alignItems: "center", gap: 0.75,
+                    color: active ? "var(--accent-indigo)" : "var(--font-secondary)",
+                    bgcolor: active ? "color-mix(in srgb, var(--accent-indigo) 10%, transparent)" : "transparent",
+                    border: active ? "1px solid color-mix(in srgb, var(--accent-indigo) 30%, transparent)" : "1px solid var(--border-default)",
+                  }}
+                >
+                  <Icon icon={tb.icon} width={17} />
+                  {tb.label}
+                </ButtonBase>
+              );
+            })}
+          </Box>
+
+          {tab === 0 ? (
+            <JobsPanel
+              jobs={allJobs}
+              loading={loadingAll}
+              retryingId={retryingId}
+              onView={handleView}
+              onRetry={handleRetry}
+              showMetrics={false}
+            />
+          ) : (
+            <JobsPanel
+              jobs={assessmentJobs}
+              loading={loadingAssessment}
+              retryingId={retryingId}
+              onView={handleView}
+              onRetry={handleRetry}
+              showMetrics
+            />
+          )}
+        </AdaptiveSectionShell>
       </Box>
     </MainLayout>
   );

--- a/components/admin/assessment/AssessmentSettingsSection.tsx
+++ b/components/admin/assessment/AssessmentSettingsSection.tsx
@@ -20,8 +20,19 @@ import {
   ListItemIcon,
   ListItemText,
   ListSubheader,
+  Checkbox,
+  FormControlLabel,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+
+/** Lead times (minutes before start) offered as reminder checkboxes. Mirrors the
+ *  backend's ALLOWED_REMINDER_OFFSETS in assessment/reminders.py. */
+export const REMINDER_OFFSET_OPTIONS: { minutes: number; label: string }[] = [
+  { minutes: 120, label: "2 hours before" },
+  { minutes: 360, label: "6 hours before" },
+  { minutes: 720, label: "12 hours before" },
+  { minutes: 1440, label: "1 day before" },
+];
 import {
   EmailNotificationEditor,
   type EmailNotificationEditorHandle,
@@ -58,6 +69,12 @@ interface AssessmentSettingsSectionProps {
   emailNotificationEnabled?: boolean;
   /** Reports editor data-presence transitions back up to the parent. */
   onEmailEnabledChange?: (enabled: boolean) => void;
+  /** Auto-send the notification email at chosen lead times before start_time. */
+  emailRemindersEnabled?: boolean;
+  /** Lead times in minutes (subset of 120/360/720/1440) at which to send reminders. */
+  emailReminderOffsets?: number[];
+  onEmailRemindersEnabledChange?: (enabled: boolean) => void;
+  onEmailReminderOffsetsChange?: (offsets: number[]) => void;
   /**
    * Ref handle so the parent can read the email editor state at submit time.
    * The editor owns subject/body/attachment locally to keep typing snappy.
@@ -400,6 +417,10 @@ export function AssessmentSettingsSection({
   sendCommunication = false,
   emailNotificationEnabled = false,
   onEmailEnabledChange,
+  emailRemindersEnabled = false,
+  emailReminderOffsets = [],
+  onEmailRemindersEnabledChange,
+  onEmailReminderOffsetsChange,
   emailEditorRef,
   defaultEmailSubject = "",
   defaultEmailBody = "",
@@ -891,6 +912,93 @@ export function AssessmentSettingsSection({
                   readOnly={readOnly}
                   onEnabledChange={onEmailEnabledChange}
                 />
+
+                {/* Scheduled reminders — additive to the on-publish send. */}
+                <Box
+                  sx={{
+                    mt: 1.5,
+                    p: 1.75,
+                    borderRadius: 2,
+                    border: "1px solid var(--border-default)",
+                    bgcolor:
+                      "color-mix(in srgb, var(--accent-indigo) 4%, var(--surface) 96%)",
+                  }}
+                >
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={emailRemindersEnabled}
+                        disabled={readOnly}
+                        onChange={(e) =>
+                          onEmailRemindersEnabledChange?.(e.target.checked)
+                        }
+                      />
+                    }
+                    label={
+                      <Box>
+                        <Typography
+                          sx={{ fontWeight: 700, fontSize: "0.9rem", color: "var(--font-primary)" }}
+                        >
+                          Send reminder emails before it starts
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          Automatically re-sends this email at the times you pick before the start
+                          time. The announcement on publish is still sent.
+                        </Typography>
+                      </Box>
+                    }
+                  />
+
+                  {emailRemindersEnabled ? (
+                    <Box
+                      sx={{
+                        mt: 1,
+                        pl: 3.5,
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: 0.5,
+                      }}
+                    >
+                      {REMINDER_OFFSET_OPTIONS.map((opt) => {
+                        const checked = emailReminderOffsets.includes(opt.minutes);
+                        return (
+                          <FormControlLabel
+                            key={opt.minutes}
+                            sx={{ minWidth: 150 }}
+                            control={
+                              <Checkbox
+                                size="small"
+                                checked={checked}
+                                disabled={readOnly}
+                                onChange={(e) => {
+                                  const next = e.target.checked
+                                    ? [...emailReminderOffsets, opt.minutes]
+                                    : emailReminderOffsets.filter((m) => m !== opt.minutes);
+                                  // keep sorted + de-duped so the payload is stable
+                                  onEmailReminderOffsetsChange?.(
+                                    Array.from(new Set(next)).sort((a, b) => a - b)
+                                  );
+                                }}
+                              />
+                            }
+                            label={
+                              <Typography sx={{ fontSize: "0.85rem" }}>{opt.label}</Typography>
+                            }
+                          />
+                        );
+                      })}
+                      {emailReminderOffsets.length === 0 ? (
+                        <Typography
+                          variant="caption"
+                          sx={{ display: "block", width: "100%", color: "var(--warning-500)", pl: 0.5 }}
+                        >
+                          Pick at least one time, or no reminder will be sent.
+                        </Typography>
+                      ) : null}
+                    </Box>
+                  ) : null}
+                </Box>
               </Box>
             ) : null}
             <ListItem

--- a/components/admin/emails/EmailJobCard.tsx
+++ b/components/admin/emails/EmailJobCard.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { Box, Typography, ButtonBase, CircularProgress } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { EmailJob } from "@/lib/services/admin/admin-email-jobs.service";
+import type { AssessmentEmailJob } from "@/lib/services/admin/admin-assessment-email-jobs.service";
+
+type AnyJob = EmailJob | AssessmentEmailJob;
+
+/** Status → semantic color + icon. Reserved status hues, never the accent. */
+export function statusTone(status: string): { color: string; bg: string; icon: string; label: string } {
+  const s = (status || "").toLowerCase();
+  if (s === "completed" || s === "success" || s === "sent")
+    return { color: "var(--success-500)", bg: "color-mix(in srgb, var(--success-500) 14%, transparent)", icon: "mdi:check-circle", label: status };
+  if (s === "failed" || s === "error")
+    return { color: "var(--error-500)", bg: "color-mix(in srgb, var(--error-500) 14%, transparent)", icon: "mdi:alert-circle", label: status };
+  if (s === "in_progress" || s === "sending")
+    return { color: "var(--accent-indigo)", bg: "color-mix(in srgb, var(--accent-indigo) 14%, transparent)", icon: "mdi:progress-clock", label: status };
+  return { color: "var(--warning-500)", bg: "color-mix(in srgb, var(--warning-500) 14%, transparent)", icon: "mdi:clock-outline", label: status || "—" };
+}
+
+/** How the job was triggered → a small provenance chip. Reminders are the point of the new feature. */
+export function triggerChip(source?: string): { label: string; icon: string; color: string } | null {
+  if (!source) return null;
+  const s = source.toLowerCase();
+  if (s.startsWith("reminder")) {
+    // reminder_120m -> "2h", 360 -> "6h", 720 -> "12h", 1440 -> "1d"
+    const m = /reminder_(\d+)m/.exec(s);
+    const map: Record<string, string> = { "120": "2h", "360": "6h", "720": "12h", "1440": "1d" };
+    const lead = m ? map[m[1]] ?? `${m[1]}m` : "";
+    return { label: lead ? `Reminder · ${lead} before` : "Reminder", icon: "mdi:bell-ring-outline", color: "var(--accent-indigo)" };
+  }
+  if (s.includes("publish")) return { label: "On publish", icon: "mdi:rocket-launch-outline", color: "#a855f7" };
+  if (s.includes("create")) return { label: "On create", icon: "mdi:plus-circle-outline", color: "#0ea5e9" };
+  if (s === "manual") return { label: "Manual", icon: "mdi:cursor-default-click-outline", color: "var(--font-secondary)" };
+  return null;
+}
+
+interface Props {
+  job: AnyJob;
+  displayName: string;
+  createdLabel: string;
+  isFailed: boolean;
+  retrying: boolean;
+  onView: () => void;
+  onRetry: () => void;
+  /** Assessment jobs carry per-job counts; generic jobs don't. */
+  showMetrics?: boolean;
+}
+
+function Metric({ icon, value, label, color }: { icon: string; value: number | string; label: string; color: string }) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }} title={label}>
+      <Icon icon={icon} width={15} style={{ color }} />
+      <Typography sx={{ fontSize: "0.8rem", fontWeight: 700, color: "var(--font-primary)", fontVariantNumeric: "tabular-nums" }}>
+        {value}
+      </Typography>
+      <Typography sx={{ fontSize: "0.72rem", color: "var(--font-tertiary, var(--font-secondary))" }}>{label}</Typography>
+    </Box>
+  );
+}
+
+export function EmailJobCard({ job, displayName, createdLabel, isFailed, retrying, onView, onRetry, showMetrics }: Props) {
+  const tone = statusTone(job.status);
+  const trig = triggerChip((job as { trigger_source?: string }).trigger_source);
+  const aj = job as AssessmentEmailJob;
+  const total = aj.total_emails;
+  const ok = aj.successful_count;
+  const failed = aj.failed_count;
+
+  return (
+    <Box
+      sx={{
+        p: 2,
+        borderRadius: 4,
+        border: "1px solid var(--border-default)",
+        background: "color-mix(in srgb, var(--card-bg) 75%, transparent)",
+        backdropFilter: "blur(6px)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.25,
+        height: "100%",
+        transition: "transform 120ms ease, box-shadow 120ms ease",
+        "&:hover": {
+          transform: "translateY(-2px)",
+          boxShadow: "0 20px 40px -24px color-mix(in srgb, var(--font-primary) 40%, transparent)",
+        },
+      }}
+    >
+      {/* header: name + status pill */}
+      <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 1 }}>
+        <Typography
+          sx={{ fontWeight: 700, fontSize: "0.95rem", color: "var(--font-primary)", lineHeight: 1.3, overflow: "hidden", textOverflow: "ellipsis", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical" }}
+          title={displayName}
+        >
+          {displayName}
+        </Typography>
+        <Box
+          sx={{ flexShrink: 0, display: "inline-flex", alignItems: "center", gap: 0.5, px: 1, py: 0.4, borderRadius: 999, bgcolor: tone.bg }}
+        >
+          <Icon icon={tone.icon} width={13} style={{ color: tone.color }} />
+          <Typography sx={{ fontSize: "0.68rem", fontWeight: 700, color: tone.color, textTransform: "capitalize" }}>
+            {tone.label}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* provenance chip */}
+      {trig ? (
+        <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, alignSelf: "flex-start", px: 0.9, py: 0.3, borderRadius: 999, border: `1px solid color-mix(in srgb, ${trig.color} 35%, transparent)` }}>
+          <Icon icon={trig.icon} width={13} style={{ color: trig.color }} />
+          <Typography sx={{ fontSize: "0.7rem", fontWeight: 600, color: trig.color }}>{trig.label}</Typography>
+        </Box>
+      ) : null}
+
+      {/* metrics (assessment jobs only) */}
+      {showMetrics && (total != null || ok != null || failed != null) ? (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, mt: 0.25 }}>
+          <Metric icon="mdi:account-group-outline" value={total ?? 0} label="recipients" color="var(--accent-indigo)" />
+          <Metric icon="mdi:check-circle-outline" value={ok ?? 0} label="sent" color="var(--success-500)" />
+          {(failed ?? 0) > 0 ? (
+            <Metric icon="mdi:close-circle-outline" value={failed ?? 0} label="failed" color="var(--error-500)" />
+          ) : null}
+        </Box>
+      ) : null}
+
+      {/* footer: created + actions */}
+      <Box sx={{ mt: "auto", pt: 0.5, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1 }}>
+        <Typography sx={{ fontSize: "0.72rem", color: "var(--font-tertiary, var(--font-secondary))" }} title={createdLabel}>
+          {createdLabel}
+        </Typography>
+        <Box sx={{ display: "flex", gap: 0.75 }}>
+          {isFailed ? (
+            <ButtonBase
+              onClick={onRetry}
+              disabled={retrying}
+              sx={{ px: 1.5, py: 0.6, borderRadius: 999, fontSize: "0.78rem", fontWeight: 700, color: "var(--error-500)", border: "1px solid color-mix(in srgb, var(--error-500) 40%, transparent)", display: "inline-flex", alignItems: "center", gap: 0.5, "&:hover": { bgcolor: "color-mix(in srgb, var(--error-500) 8%, transparent)" } }}
+            >
+              {retrying ? <CircularProgress size={13} color="inherit" /> : <Icon icon="mdi:refresh" width={14} />}
+              Retry
+            </ButtonBase>
+          ) : null}
+          <ButtonBase
+            onClick={onView}
+            sx={{ px: 1.75, py: 0.6, borderRadius: 999, fontSize: "0.78rem", fontWeight: 700, color: "var(--accent-indigo)", border: "1px solid color-mix(in srgb, var(--accent-indigo) 40%, transparent)", display: "inline-flex", alignItems: "center", gap: 0.5, "&:hover": { bgcolor: "color-mix(in srgb, var(--accent-indigo) 8%, transparent)" } }}
+          >
+            <Icon icon="mdi:eye-outline" width={14} />
+            View
+          </ButtonBase>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -216,6 +216,10 @@ export interface CreateAssessmentPayload {
    * can forward this verbatim without re-running its own template.
    */
   email_html?: string;
+  /** Auto-send the notification email at each lead time before start_time. */
+  email_reminders_enabled?: boolean;
+  /** Reminder lead times in minutes before start_time (subset of 120/360/720/1440). */
+  email_reminder_offsets?: number[];
   /**
    * URL of the previously-saved attachment when the admin chose to keep it
    * (i.e. did not upload a new file). Sent so the backend knows to retain
@@ -332,6 +336,9 @@ export interface AssessmentDetail extends Assessment {
   currency?: string;
   show_result?: boolean;
   evaluation_mode?: "auto" | "manual";
+  /** Reminder scheduling, read back so the form re-checks the saved boxes on edit. */
+  email_reminders_enabled?: boolean;
+  email_reminder_offsets?: number[];
   certificate_available?: boolean;
   
   pass_band_lower_min_percent?: string;


### PR DESCRIPTION
Pairs with backend **ai-linc-backend#feat/assessment-scheduled-reminder-emails** — merge that first.

## Scheduled reminders
The assessment form's notification section gains a **"Send reminder emails before it starts"** checkbox that reveals 2h / 6h / 12h / 1 day options (any combination). Additive to the on-publish send. Lives in `AssessmentSettingsSection` (shared by create + edit); on edit the saved boxes re-check themselves. Sends `email_reminders_enabled` + `email_reminder_offsets`.

## Email module revamp — adaptive-course design language
Rebuilt `app/admin/emails/*` on the shared `AdaptiveSectionShell` + `AdaptiveSectionHero` + `KpiRail` + `Reveal` system instead of bare MUI tables:
- **List**: radial-mesh shell, gradient hero, KPI rail (total / completed / pending / failed / recipients), pill status filters, and a `Reveal`-staggered grid of `EmailJobCard`s (status pill, provenance chip, per-job metric chips, rounded View/Retry) replacing the table. Tabs, search, client-side pagination kept.
- **Both detail pages**: shell + hero with a status pill, KPI tiles, the 3s live-poll drawn with the adaptive gradient progress bar, recipient tabs + email-body preview retained. A `trigger_source` chip surfaces reminders (e.g. "Reminder · 2h before").

## Also
Fixes the assessment notification **body not surviving reload** — `loadAssessment` now reads `email_body` back and seeds the editor from it (falling back to the title-derived default).

## Verified
`tsc --noEmit` clean; **no new eslint errors** versus `stagging` on any changed file (pre-existing `any`/compiler notices in untouched code left as-is). Not yet exercised against a running backend — worth a staging click-through once the BE PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)