### PR TITLE
feat(assessment-admin): authoring/management UX — submissions at scale (P4)

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -40,6 +40,7 @@ import {
   adminAssessmentService,
   QuestionsExportResponse,
   SubmissionsExportResponse,
+  SubmissionsExportMeta,
   SubmissionsExportSubmission,
   AssessmentDetail,
   CreateAssessmentPayload,
@@ -411,6 +412,12 @@ export default function AssessmentEditPage() {
     useState<QuestionsExportResponse | null>(null);
   const [submissionsData, setSubmissionsData] =
     useState<SubmissionsExportResponse | null>(null);
+  // P4: submissions are loaded lazily (only on the Submissions tab) and gated on a
+  // cheap ?meta_only progress probe, so at scale the tab shows "building… X/Y" with
+  // the true count instead of a false "0 submissions" that needed a hard refresh.
+  const [submissionsMeta, setSubmissionsMeta] =
+    useState<SubmissionsExportMeta | null>(null);
+  const [submissionsLoading, setSubmissionsLoading] = useState(false);
   const [courses, setCourses] = useState<any[]>([]);
   const [loadingCourses, setLoadingCourses] = useState(false);
 
@@ -748,8 +755,8 @@ export default function AssessmentEditPage() {
       } else {
         await loadQuestions();
       }
-      if (cancelled) return;
-      await loadSubmissions();
+      // Submissions are NOT loaded here anymore — that fat fetch is deferred to the
+      // Submissions tab (see the lazy effect below), so opening Details is instant.
     })().finally(() => {
       if (!cancelled) setLoading(false);
     });
@@ -763,8 +770,51 @@ export default function AssessmentEditPage() {
     loadAssessment,
     loadCourses,
     loadQuestions,
-    loadSubmissions,
   ]);
+
+  // P4: load submissions lazily on the Submissions tab, gated on the cheap
+  // ?meta_only probe. While the export cache builds we keep polling (2.5s) and
+  // show "building… X/Y" with the true count; the fat payload is fetched once ready.
+  useEffect(() => {
+    if (tab !== "submissions" || !assessmentId || !config.clientId) return;
+    if (submissionsData) return; // already have the full payload
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const fetchFull = async () => {
+      setSubmissionsLoading(true);
+      try {
+        await loadSubmissions();
+      } finally {
+        if (!cancelled) setSubmissionsLoading(false);
+      }
+    };
+
+    const poll = async () => {
+      try {
+        const meta = await adminAssessmentService.getSubmissionsExportMeta(
+          config.clientId,
+          assessmentId,
+        );
+        if (cancelled) return;
+        setSubmissionsMeta(meta);
+        if (meta.ready) {
+          await fetchFull();
+        } else {
+          timer = setTimeout(poll, 2500); // still building — check again
+        }
+      } catch {
+        // Probe failed (e.g. older backend) — fall back to a direct full load.
+        if (!cancelled) await fetchFull();
+      }
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [tab, assessmentId, submissionsData, loadSubmissions]);
 
   useEffect(() => {
     if (hideAdminQuestions && tab === "questions") {
@@ -2357,9 +2407,29 @@ export default function AssessmentEditPage() {
                   </Box>
                 </Paper>
                 {!submissionsData?.submissions?.length ? (
-                  <Typography color="text.secondary">
-                    No submissions to display.
-                  </Typography>
+                  submissionsLoading ||
+                  (submissionsMeta && !submissionsMeta.ready) ? (
+                    <Box
+                      sx={{ display: "flex", alignItems: "center", gap: 1.5, py: 2 }}
+                    >
+                      <CircularProgress size={20} />
+                      <Typography color="text.secondary">
+                        {submissionsMeta && submissionsMeta.count > 0
+                          ? `Building results for ${submissionsMeta.count} submission${
+                              submissionsMeta.count === 1 ? "" : "s"
+                            }…${
+                              submissionsMeta.total_count
+                                ? ` (${submissionsMeta.processed_count}/${submissionsMeta.total_count})`
+                                : ""
+                            }`
+                          : "Loading submissions…"}
+                      </Typography>
+                    </Box>
+                  ) : (
+                    <Typography color="text.secondary">
+                      No submissions yet.
+                    </Typography>
+                  )
                 ) : (
                   <>
                     <Alert severity="info" sx={{ mb: 1.5 }}>

--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -540,6 +540,8 @@ export default function AssessmentEditPage() {
   const [analyticsData, setAnalyticsData] =
     useState<AssessmentAnalyticsResponse | null>(null);
   const [analyticsLoading, setAnalyticsLoading] = useState(false);
+  const [analyticsComputing, setAnalyticsComputing] = useState(false);
+  const analyticsRetryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [analyticsTopNApplied, setAnalyticsTopNApplied] = useState(10);
   const [analyticsTopNDraft, setAnalyticsTopNDraft] = useState("10");
   const [analyticsStudentsPage, setAnalyticsStudentsPage] = useState(1);
@@ -723,12 +725,24 @@ export default function AssessmentEditPage() {
           assessmentId,
           { top_performers: top },
         );
-        setAnalyticsData(data);
+        if ("computing" in data && data.computing) {
+          // Large assessment, cache warming server-side (RC-6a) — poll shortly.
+          setAnalyticsComputing(true);
+          setAnalyticsData(null);
+          if (analyticsRetryRef.current) clearTimeout(analyticsRetryRef.current);
+          analyticsRetryRef.current = setTimeout(() => {
+            void loadAnalytics(top);
+          }, 4000);
+          return;
+        }
+        setAnalyticsComputing(false);
+        setAnalyticsData(data as AssessmentAnalyticsResponse);
         setAnalyticsTopNApplied(top);
         setAnalyticsTopNDraft(String(top));
       } catch (e: any) {
         showToast(e?.message || "Failed to load analytics", "error");
         setAnalyticsData(null);
+        setAnalyticsComputing(false);
       } finally {
         setAnalyticsLoading(false);
       }
@@ -737,8 +751,21 @@ export default function AssessmentEditPage() {
   );
 
   useEffect(() => {
-    if (tab !== "analytics" || !assessmentId || !config.clientId) return;
+    if (tab !== "analytics" || !assessmentId || !config.clientId) {
+      // Leaving the tab: stop any pending "computing" poll.
+      if (analyticsRetryRef.current) {
+        clearTimeout(analyticsRetryRef.current);
+        analyticsRetryRef.current = null;
+      }
+      return;
+    }
     void loadAnalytics();
+    return () => {
+      if (analyticsRetryRef.current) {
+        clearTimeout(analyticsRetryRef.current);
+        analyticsRetryRef.current = null;
+      }
+    };
   }, [tab, assessmentId, loadAnalytics]);
 
   useEffect(() => {
@@ -2713,6 +2740,25 @@ export default function AssessmentEditPage() {
                   px: { xs: 0, sm: 0.5 },
                 }}
               >
+                {analyticsComputing && !analyticsData && (
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1.5,
+                      p: 2,
+                      mb: 1.5,
+                      borderRadius: 1,
+                      bgcolor: "action.hover",
+                    }}
+                  >
+                    <CircularProgress size={20} />
+                    <Typography variant="body2" color="text.secondary">
+                      Analytics for this assessment are being computed (large submission
+                      count). This refreshes automatically in a few seconds…
+                    </Typography>
+                  </Box>
+                )}
                 <AssessmentAnalyticsCharts
                   data={analyticsData}
                   toolbar={{

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -307,6 +307,19 @@ function CreateAssessmentPageContent() {
         const savedAttachment = extractSavedEmailAttachment(draftAny);
         setExistingEmailAttachmentUrl(savedAttachment.url);
         setExistingEmailAttachmentName(savedAttachment.name);
+        // P3: restore the draft's saved notification email so it isn't lost on reopen.
+        // The editor seeds its body from initialBody only at mount, so a late async
+        // load must be applied imperatively.
+        const draftEmailBody =
+          typeof draftAny.email_body === "string" ? draftAny.email_body.trim() : "";
+        const draftEmailSubject =
+          typeof draftAny.email_subject === "string" ? draftAny.email_subject : "";
+        if (draftEmailBody || draftEmailSubject) {
+          emailEditorRef.current?.setContent(
+            draftEmailSubject || null,
+            draftEmailBody || null,
+          );
+        }
         const mapped = mapQuestionsExportToAuthoringState(exportJson);
         setSections(mapped.sections);
         setMcqInputMethodBySection(mapped.mcqInputMethodBySection);

--- a/components/admin/assessment/AIGeneratedCodingSection.tsx
+++ b/components/admin/assessment/AIGeneratedCodingSection.tsx
@@ -52,6 +52,7 @@ export function AIGeneratedCodingSection({
   );
   const [programmingLanguage, setProgrammingLanguage] = useState("Python");
   const [generating, setGenerating] = useState(false);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
   const [previewProblem, setPreviewProblem] = useState<CodingProblemListItem | null>(null);
@@ -87,39 +88,63 @@ export function AIGeneratedCodingSection({
       return;
     }
 
+    const toItem = (q: Record<string, unknown>): CodingProblemListItem => ({
+      ...(q as CodingProblemListItem),
+      id: Number(q.id),
+      title: String(q.title ?? "Generated problem"),
+      problem_statement: String(q.problem_statement ?? ""),
+    });
+
+    const baselineProblems = generatedProblems;
+    const baselineIds = codingProblemIds;
+
+    // Each poll returns the CUMULATIVE set of persisted problems (with bank ids);
+    // splice them onto the pre-existing selection so they appear live and are
+    // selectable, and a timeout can't lose the run.
+    const applyJob = (job: { questions: Record<string, unknown>[] }) => {
+      const withIds = job.questions.filter((q) => q.id != null);
+      onGeneratedProblemsChange([...baselineProblems, ...withIds.map(toItem)]);
+      const newIds = withIds
+        .map((q) => Number(q.id))
+        .filter((n) => Number.isFinite(n));
+      onCodingProblemIdsChange([...new Set([...baselineIds, ...newIds])]);
+    };
+
     try {
       setGenerating(true);
-      const data = await adminAssessmentService.generateCodingProblemsWithAI(
-        config.clientId,
-        {
-          topic: topic.trim(),
-          number_of_problems: count,
-          difficulty_level: difficulty,
-          programming_language: programmingLanguage,
-        }
-      );
+      setProgress({ done: 0, total: count });
 
-      // The API returns coding_problems array and coding_problem_ids
-      // We'll store the problems and add their IDs to the selected list
-      const newProblems = data.coding_problems || [];
-      const newIds = data.coding_problem_ids || [];
+      // Batched, resumable generation (P1): start a job and poll it (P7 live reveal).
+      let job = await adminAssessmentService.startQuestionGeneration(config.clientId, {
+        question_type: "coding",
+        topic: topic.trim(),
+        number_of_questions: count,
+        difficulty_level: difficulty,
+        programming_language: programmingLanguage,
+      });
 
-      // Append to existing generated problems (persist to parent state)
-      const updatedProblems = [...generatedProblems, ...newProblems];
-      onGeneratedProblemsChange(updatedProblems);
+      let guard = 0;
+      while (job.status !== "completed" && job.status !== "failed" && guard < 300) {
+        setProgress({ done: job.completed_items, total: job.total_items || 1 });
+        applyJob(job);
+        await new Promise((r) => setTimeout(r, 2000));
+        job = await adminAssessmentService.getQuestionGenerationJob(
+          config.clientId,
+          job.job_id
+        );
+        guard += 1;
+      }
 
-      // Add IDs to selected list (avoid duplicates)
-      // Merge with existing IDs from prop to ensure we don't lose any
-      const updatedIds = [...new Set([...codingProblemIds, ...newIds])];
-      onCodingProblemIdsChange(updatedIds);
-
-      showToast(
-        data.message ||
-          `Successfully generated ${newIds.length} coding problem(s)`,
-        "success"
-      );
-
-      // Reset to first page if we're not on it
+      applyJob(job);
+      const produced = job.questions.filter((q) => q.id != null).length;
+      if (job.status === "failed") {
+        showToast(
+          `Generation finished with errors — ${produced} problem(s) produced.`,
+          "error"
+        );
+      } else {
+        showToast(`Successfully generated ${produced} coding problem(s)`, "success");
+      }
       if (page !== 1) {
         setPage(1);
       }
@@ -130,6 +155,7 @@ export function AIGeneratedCodingSection({
       );
     } finally {
       setGenerating(false);
+      setProgress(null);
     }
   };
 
@@ -243,7 +269,11 @@ export function AIGeneratedCodingSection({
               },
             }}
           >
-            {generating ? "Generating..." : "Generate Coding Problems"}
+            {generating
+              ? progress
+                ? `Generating… ${progress.done}/${progress.total} batches`
+                : "Generating…"
+              : "Generate Coding Problems"}
           </Button>
         </Box>
       </Paper>

--- a/components/admin/assessment/AIGeneratedSection.tsx
+++ b/components/admin/assessment/AIGeneratedSection.tsx
@@ -39,6 +39,7 @@ export function AIGeneratedSection({
   const [numberOfQuestions, setNumberOfQuestions] = useState(5);
   const [difficulty, setDifficulty] = useState<"Easy" | "Medium" | "Hard">("Medium");
   const [generating, setGenerating] = useState(false);
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
 
@@ -56,38 +57,61 @@ export function AIGeneratedSection({
       return;
     }
 
+    const toMCQ = (q: Record<string, unknown>): MCQ => ({
+      question_text: String(q.question_text ?? ""),
+      option_a: String(q.option_a ?? ""),
+      option_b: String(q.option_b ?? ""),
+      option_c: String(q.option_c ?? ""),
+      option_d: String(q.option_d ?? ""),
+      correct_option: (String(q.correct_option ?? "A").toUpperCase() ||
+        "A") as MCQ["correct_option"],
+      explanation: String(q.explanation ?? ""),
+      difficulty_level:
+        (q.difficulty_level as MCQ["difficulty_level"]) ?? "Medium",
+      topic: String(q.topic ?? topic.trim()),
+      skills: String(q.skills ?? ""),
+    });
+
+    // Snapshot the pre-existing questions; the job returns the CUMULATIVE set each
+    // poll, which we splice onto this baseline as it grows.
+    const baseline = mcqs;
     try {
       setGenerating(true);
-      const data = await adminAssessmentService.generateMCQsWithAI(
-        config.clientId,
-        {
-          topic: topic.trim(),
-          number_of_questions: numberOfQuestions,
-          difficulty_level: difficulty,
-        }
-      );
+      setProgress({ done: 0, total: numberOfQuestions });
 
-      // Convert AI response to MCQ format and append to existing list
-      const generatedMCQs: MCQ[] = data.mcqs.map((mcq) => ({
-        question_text: mcq.question_text,
-        option_a: mcq.option_a,
-        option_b: mcq.option_b,
-        option_c: mcq.option_c,
-        option_d: mcq.option_d,
-        correct_option: mcq.correct_option,
-        explanation: mcq.explanation || "",
-        difficulty_level: mcq.difficulty_level || "Medium",
-        topic: mcq.topic || topic.trim(),
-        skills: mcq.skills || "",
-      }));
+      // Batched, resumable generation (P1): start a job and poll it. A timeout can
+      // no longer lose the whole run, and questions appear live as batches finish (P7).
+      let job = await adminAssessmentService.startQuestionGeneration(config.clientId, {
+        question_type: "mcq",
+        topic: topic.trim(),
+        number_of_questions: numberOfQuestions,
+        difficulty_level: difficulty,
+      });
 
-      // Append to existing MCQs instead of replacing
-      onMCQsChange([...mcqs, ...generatedMCQs]);
-      showToast(
-        `Successfully generated ${generatedMCQs.length} question(s)`,
-        "success"
-      );
-      // Reset to first page if we're not on it
+      let guard = 0;
+      while (job.status !== "completed" && job.status !== "failed" && guard < 300) {
+        setProgress({ done: job.completed_items, total: job.total_items || 1 });
+        onMCQsChange([...baseline, ...job.questions.map(toMCQ)]);
+        await new Promise((r) => setTimeout(r, 2000));
+        job = await adminAssessmentService.getQuestionGenerationJob(
+          config.clientId,
+          job.job_id
+        );
+        guard += 1;
+      }
+
+      onMCQsChange([...baseline, ...job.questions.map(toMCQ)]);
+      if (job.status === "failed") {
+        showToast(
+          `Generation finished with errors — ${job.questions.length} question(s) produced.`,
+          "error"
+        );
+      } else {
+        showToast(
+          `Successfully generated ${job.questions.length} question(s)`,
+          "success"
+        );
+      }
       if (page !== 1) {
         setPage(1);
       }
@@ -95,6 +119,7 @@ export function AIGeneratedSection({
       showToast(error?.message || "Failed to generate questions", "error");
     } finally {
       setGenerating(false);
+      setProgress(null);
     }
   };
 
@@ -191,7 +216,11 @@ export function AIGeneratedSection({
               },
             }}
           >
-            {generating ? "Generating..." : "Generate Questions"}
+            {generating
+              ? progress
+                ? `Generating… ${progress.done}/${progress.total} batches`
+                : "Generating…"
+              : "Generate Questions"}
           </Button>
         </Box>
       </Paper>

--- a/components/admin/assessment/CodingProblemSelectionSection.tsx
+++ b/components/admin/assessment/CodingProblemSelectionSection.tsx
@@ -25,7 +25,14 @@ import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { CodingProblemListItem } from "@/lib/services/admin/admin-assessment.service";
 import { ProblemDescription } from "@/components/coding/ProblemDescription";
-import { EyeIcon } from "lucide-react";
+import {
+  FacetBar,
+  FacetState,
+  EMPTY_FACETS,
+  applyFacets,
+  SourceChip,
+  UsageChip,
+} from "./questionBankFacets";
 
 interface CodingProblemSelectionSectionProps {
   selectedIds: number[];
@@ -43,6 +50,7 @@ export function CodingProblemSelectionSection({
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
+  const [facets, setFacets] = useState<FacetState>(EMPTY_FACETS);
   const [previewProblem, setPreviewProblem] = useState<CodingProblemListItem | null>(null);
 
   const problemDataForPreview = (problem: CodingProblemListItem) => {
@@ -63,14 +71,20 @@ export function CodingProblemSelectionSection({
   };
 
   const filteredProblems = useMemo(() => {
-    if (!searchTerm.trim()) return codingProblems;
-    return codingProblems.filter(
-      (problem) =>
-        problem.title?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        problem.problem_statement?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        problem.topic?.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  }, [codingProblems, searchTerm]);
+    let rows = applyFacets(codingProblems, facets);
+    const term = searchTerm.trim().toLowerCase();
+    if (term) {
+      rows = rows.filter(
+        (problem) =>
+          problem.title?.toLowerCase().includes(term) ||
+          problem.problem_statement?.toLowerCase().includes(term) ||
+          problem.topic?.toLowerCase().includes(term) ||
+          problem.skills?.toLowerCase().includes(term) ||
+          problem.tags?.toLowerCase().includes(term)
+      );
+    }
+    return rows;
+  }, [codingProblems, searchTerm, facets]);
 
   const paginatedProblems = useMemo(() => {
     const startIndex = (page - 1) * limit;
@@ -157,6 +171,14 @@ export function CodingProblemSelectionSection({
         }}
       />
 
+      <FacetBar
+        facets={facets}
+        onChange={(next) => {
+          setFacets(next);
+          setPage(1);
+        }}
+      />
+
       {filteredProblems.length === 0 ? (
         <Paper sx={{ p: 3, textAlign: "center", bgcolor: "var(--surface)" }}>
           <Typography variant="body2" color="text.secondary">
@@ -199,7 +221,10 @@ export function CodingProblemSelectionSection({
                     Difficulty
                   </TableCell>
                   <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Topic
+                    Tags
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
+                    Reuse
                   </TableCell>
                   <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem", width: 80, textAlign: "center" }}>
                     Actions
@@ -281,6 +306,12 @@ export function CodingProblemSelectionSection({
                       <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
                         {problem.tags || "-"}
                       </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, alignItems: "flex-start" }}>
+                        <UsageChip count={problem.usage_count} />
+                        <SourceChip source={problem.source} />
+                      </Box>
                     </TableCell>
                     <TableCell>
                       <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>

--- a/components/admin/assessment/EmailNotificationEditor.tsx
+++ b/components/admin/assessment/EmailNotificationEditor.tsx
@@ -54,6 +54,12 @@ export interface EmailNotificationEditorHandle {
    * "Send notification email" toggle to refill the editor on a fresh enable.
    */
   seedDefaults(): void;
+  /**
+   * Imperatively seed subject/body — e.g. after a draft loads asynchronously
+   * (the initialBody prop only seeds at mount, so a late load wouldn't apply).
+   * Pass null to leave a field unchanged.
+   */
+  setContent(subject: string | null, body: string | null): void;
 }
 
 interface EmailNotificationEditorProps {
@@ -178,6 +184,15 @@ function EmailNotificationEditorInner(
         setBody(initialBody);
         setAttachment(null);
         setError(undefined);
+      },
+      setContent(nextSubject, nextBody) {
+        if (nextSubject != null) {
+          setSubject(nextSubject);
+          setLastInitialSubject(nextSubject);
+        }
+        if (nextBody != null) {
+          setBody(nextBody);
+        }
       },
     }),
     [subject, body, attachment, initialSubject, initialBody, initialAttachmentUrl]

--- a/components/admin/assessment/MCQSelectionSection.tsx
+++ b/components/admin/assessment/MCQSelectionSection.tsx
@@ -21,6 +21,17 @@ import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { MCQListItem } from "@/lib/services/admin/admin-assessment.service";
+import {
+  FacetBar,
+  FacetState,
+  EMPTY_FACETS,
+  applyFacets,
+  SourceChip,
+  UsageChip,
+  TagChips,
+  PreviewButton,
+  PreviewDialog,
+} from "./questionBankFacets";
 
 interface MCQSelectionSectionProps {
   selectedIds: number[];
@@ -39,15 +50,23 @@ export function MCQSelectionSection({
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
+  const [facets, setFacets] = useState<FacetState>(EMPTY_FACETS);
+  const [preview, setPreview] = useState<MCQListItem | null>(null);
 
   const filteredMCQs = useMemo(() => {
-    if (!searchTerm.trim()) return mcqs;
-    return mcqs.filter(
-      (mcq) =>
-        mcq.question_text.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        mcq.topic?.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  }, [mcqs, searchTerm]);
+    let rows = applyFacets(mcqs, facets);
+    const term = searchTerm.trim().toLowerCase();
+    if (term) {
+      rows = rows.filter(
+        (mcq) =>
+          mcq.question_text.toLowerCase().includes(term) ||
+          mcq.topic?.toLowerCase().includes(term) ||
+          mcq.skills?.toLowerCase().includes(term) ||
+          mcq.tags?.toLowerCase().includes(term)
+      );
+    }
+    return rows;
+  }, [mcqs, searchTerm, facets]);
 
   const paginatedMCQs = useMemo(() => {
     const startIndex = (page - 1) * limit;
@@ -134,6 +153,14 @@ export function MCQSelectionSection({
         }}
       />
 
+      <FacetBar
+        facets={facets}
+        onChange={(next) => {
+          setFacets(next);
+          setPage(1);
+        }}
+      />
+
       {filteredMCQs.length === 0 ? (
         <Paper sx={{ p: 3, textAlign: "center", bgcolor: "var(--surface)" }}>
           <Typography variant="body2" color="text.secondary">
@@ -181,6 +208,10 @@ export function MCQSelectionSection({
                   <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
                     Topic
                   </TableCell>
+                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
+                    Reuse
+                  </TableCell>
+                  <TableCell sx={{ width: 48 }} />
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -340,6 +371,15 @@ export function MCQSelectionSection({
                         {mcq.topic || "-"}
                       </Typography>
                     </TableCell>
+                    <TableCell>
+                      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, alignItems: "flex-start" }}>
+                        <UsageChip count={mcq.usage_count} />
+                        <SourceChip source={mcq.source} />
+                      </Box>
+                    </TableCell>
+                    <TableCell padding="checkbox">
+                      <PreviewButton onClick={() => setPreview(mcq)} />
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
@@ -410,6 +450,76 @@ export function MCQSelectionSection({
           )}
         </Paper>
       )}
+
+      <PreviewDialog
+        open={!!preview}
+        title={preview ? `MCQ #${preview.id}` : ""}
+        onClose={() => setPreview(null)}
+      >
+        {preview && (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+              <SourceChip source={preview.source} />
+              <UsageChip count={preview.usage_count} />
+              {preview.difficulty_level && (
+                <Chip label={preview.difficulty_level} size="small" sx={{ height: 22, fontSize: "0.7rem" }} />
+              )}
+              {preview.topic && (
+                <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                  {preview.topic}
+                </Typography>
+              )}
+            </Box>
+            <Typography variant="body1" sx={{ fontWeight: 600 }}>
+              {preview.question_text}
+            </Typography>
+            {(["A", "B", "C", "D"] as const).map((opt) => {
+              const val = preview[`option_${opt.toLowerCase()}` as "option_a"];
+              const isCorrect =
+                preview.correct_option === opt ||
+                (preview.correct_options || []).includes(opt);
+              return (
+                <Box
+                  key={opt}
+                  sx={{
+                    p: 1,
+                    borderRadius: 1,
+                    border: "1px solid var(--border-default)",
+                    bgcolor: isCorrect
+                      ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
+                      : "var(--surface)",
+                    display: "flex",
+                    gap: 1,
+                  }}
+                >
+                  <Typography variant="body2" sx={{ fontWeight: 700, minWidth: 20 }}>
+                    {opt}
+                  </Typography>
+                  <Typography variant="body2">{val}</Typography>
+                  {isCorrect && (
+                    <IconWrapper
+                      icon="mdi:check-circle"
+                      size={18}
+                      style={{ marginLeft: "auto", color: "var(--success-500)" }}
+                    />
+                  )}
+                </Box>
+              );
+            })}
+            {preview.explanation && (
+              <Box sx={{ mt: 0.5 }}>
+                <Typography variant="caption" sx={{ color: "var(--font-tertiary)", fontWeight: 600 }}>
+                  Explanation
+                </Typography>
+                <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+                  {preview.explanation}
+                </Typography>
+              </Box>
+            )}
+            {preview.tags && <TagChips tags={preview.tags} />}
+          </Box>
+        )}
+      </PreviewDialog>
     </Box>
   );
 }

--- a/components/admin/assessment/QuestionsInputSection.tsx
+++ b/components/admin/assessment/QuestionsInputSection.tsx
@@ -38,12 +38,38 @@ export function QuestionsInputSection({
   existingMCQs,
   loadingMCQs,
 }: QuestionsInputSectionProps) {
-  const hasManualData = manualMCQs.length > 0;
-  const hasExistingData = selectedMcqIds.length > 0;
-  const hasCsvData = csvMCQs.length > 0;
-  const hasAiData = aiMCQs.length > 0;
-  const hasAnyData = hasManualData || hasExistingData || hasCsvData || hasAiData;
-  const isFormatLocked = hasAnyData;
+  const inlineFor = (m: MCQInputMethod): MCQ[] =>
+    m === "manual" ? manualMCQs : m === "csv" ? csvMCQs : m === "ai" ? aiMCQs : [];
+  const setInlineFor = (m: MCQInputMethod, v: MCQ[]) => {
+    if (m === "manual") onManualMCQsChange(v);
+    else if (m === "csv") onCsvMCQsChange(v);
+    else if (m === "ai") onAiMCQsChange(v);
+  };
+
+  // Keep-as-pool (P2): switching the input method carries the current method's
+  // inline questions into the target method (deduped by text), so a switch never
+  // drops questions you already added or AI-generated. (Switching to/from
+  // "Choose from Existing", which references persisted ids, keeps its own buffer.)
+  const handleMethodChange = (next: MCQInputMethod) => {
+    if (next === mcqInputMethod) return;
+    const carry = inlineFor(mcqInputMethod);
+    if (carry.length > 0 && next !== "existing") {
+      const target = inlineFor(next);
+      const seen = new Set(target.map((m) => (m.question_text || "").trim()));
+      const merged = [...target];
+      for (const q of carry) {
+        const key = (q.question_text || "").trim();
+        if (key && !seen.has(key)) {
+          merged.push(q);
+          seen.add(key);
+        }
+      }
+      setInlineFor(next, merged);
+    }
+    onMcqInputMethodChange(next);
+  };
+
+  const hasInlineData = inlineFor(mcqInputMethod).length > 0;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
@@ -51,13 +77,8 @@ export function QuestionsInputSection({
         <InputLabel>Question Input Method</InputLabel>
         <Select
           value={mcqInputMethod}
-          onChange={(e) => {
-            if (!isFormatLocked) {
-              onMcqInputMethodChange(e.target.value as MCQInputMethod);
-            }
-          }}
+          onChange={(e) => handleMethodChange(e.target.value as MCQInputMethod)}
           label="Question Input Method"
-          disabled={isFormatLocked}
         >
           <MenuItem value="manual">Manual Entry</MenuItem>
           <MenuItem value="existing">Choose from Existing</MenuItem>
@@ -65,10 +86,10 @@ export function QuestionsInputSection({
           <MenuItem value="ai">AI Generated</MenuItem>
         </Select>
       </FormControl>
-      {isFormatLocked && (
+      {hasInlineData && (
         <Alert severity="info">
-          You cannot switch to another format once you have added questions.
-          Please remove all questions first to change the format.
+          Switching the input method keeps the questions you already added or
+          generated — they carry over to the new method.
         </Alert>
       )}
 

--- a/components/admin/assessment/SubjectiveQuestionSelectionSection.tsx
+++ b/components/admin/assessment/SubjectiveQuestionSelectionSection.tsx
@@ -20,6 +20,17 @@ import {
 import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import type { AssessmentSubjectiveQuestionListItem } from "@/lib/services/admin/admin-assessment.service";
+import {
+  FacetBar,
+  FacetState,
+  EMPTY_FACETS,
+  applyFacets,
+  SourceChip,
+  UsageChip,
+  TagChips,
+  PreviewButton,
+  PreviewDialog,
+} from "./questionBankFacets";
 
 interface SubjectiveQuestionSelectionSectionProps {
   selectedIds: number[];
@@ -37,16 +48,24 @@ export function SubjectiveQuestionSelectionSection({
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
+  const [facets, setFacets] = useState<FacetState>(EMPTY_FACETS);
+  const [preview, setPreview] = useState<AssessmentSubjectiveQuestionListItem | null>(null);
 
   const filtered = useMemo(() => {
-    if (!searchTerm.trim()) return questions;
-    const t = searchTerm.toLowerCase();
-    return questions.filter(
-      (q) =>
-        q.question_text.toLowerCase().includes(t) ||
-        (q.question_type && q.question_type.toLowerCase().includes(t))
-    );
-  }, [questions, searchTerm]);
+    let rows = applyFacets(questions, facets);
+    const t = searchTerm.trim().toLowerCase();
+    if (t) {
+      rows = rows.filter(
+        (q) =>
+          q.question_text.toLowerCase().includes(t) ||
+          (q.question_type && q.question_type.toLowerCase().includes(t)) ||
+          (q.topic && q.topic.toLowerCase().includes(t)) ||
+          (q.skills && q.skills.toLowerCase().includes(t)) ||
+          (q.tags && q.tags.toLowerCase().includes(t))
+      );
+    }
+    return rows;
+  }, [questions, searchTerm, facets]);
 
   const paginated = useMemo(() => {
     const start = (page - 1) * limit;
@@ -106,6 +125,13 @@ export function SubjectiveQuestionSelectionSection({
           ),
         }}
       />
+      <FacetBar
+        facets={facets}
+        onChange={(next) => {
+          setFacets(next);
+          setPage(1);
+        }}
+      />
       {filtered.length === 0 ? (
         <Paper sx={{ p: 3, textAlign: "center", bgcolor: "var(--surface)" }}>
           <Typography variant="body2" color="text.secondary">
@@ -125,6 +151,8 @@ export function SubjectiveQuestionSelectionSection({
                   <TableCell sx={{ fontWeight: 600 }}>Question</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>Mode</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>Marks</TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>Reuse</TableCell>
+                  <TableCell padding="checkbox" />
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -155,6 +183,15 @@ export function SubjectiveQuestionSelectionSection({
                       <Chip size="small" label={(q.answer_mode || "text").replace(/_/g, " ")} />
                     </TableCell>
                     <TableCell>{q.max_marks}</TableCell>
+                    <TableCell>
+                      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, alignItems: "flex-start" }}>
+                        <UsageChip count={q.usage_count} />
+                        <SourceChip source={q.source} />
+                      </Box>
+                    </TableCell>
+                    <TableCell padding="checkbox">
+                      <PreviewButton onClick={() => setPreview(q)} />
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
@@ -182,6 +219,40 @@ export function SubjectiveQuestionSelectionSection({
           </Box>
         </Paper>
       )}
+
+      <PreviewDialog
+        open={!!preview}
+        title={preview ? `Written question #${preview.id}` : ""}
+        onClose={() => setPreview(null)}
+      >
+        {preview && (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+              <SourceChip source={preview.source} />
+              <UsageChip count={preview.usage_count} />
+              <Chip size="small" label={(preview.answer_mode || "text").replace(/_/g, " ")} sx={{ height: 22 }} />
+              <Chip size="small" label={`${preview.max_marks} marks`} sx={{ height: 22 }} />
+              {preview.difficulty_level && (
+                <Chip size="small" label={preview.difficulty_level} sx={{ height: 22 }} />
+              )}
+            </Box>
+            <Typography variant="body1" sx={{ fontWeight: 600, whiteSpace: "pre-wrap" }}>
+              {preview.question_text}
+            </Typography>
+            {preview.evaluation_prompt && (
+              <Box>
+                <Typography variant="caption" sx={{ color: "var(--font-tertiary)", fontWeight: 600 }}>
+                  Evaluation rubric
+                </Typography>
+                <Typography variant="body2" sx={{ color: "var(--font-secondary)", whiteSpace: "pre-wrap" }}>
+                  {preview.evaluation_prompt}
+                </Typography>
+              </Box>
+            )}
+            {preview.tags && <TagChips tags={preview.tags} />}
+          </Box>
+        )}
+      </PreviewDialog>
     </Box>
   );
 }

--- a/components/admin/assessment/questionBankFacets.tsx
+++ b/components/admin/assessment/questionBankFacets.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+/**
+ * P6 question-bank reuse: shared facet toolbar + reuse chips + preview dialog used by
+ * the MCQ / Coding / Subjective selection pickers, so reuse UX is consistent across
+ * all three banks. Filtering is client-side over the already-loaded pool (the pickers
+ * receive the full array as a prop); the server-side facets are opt-in and additive.
+ */
+import { ReactNode } from "react";
+import {
+  Box,
+  Chip,
+  Stack,
+  Typography,
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  IconButton,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export const SOURCE_LABELS: Record<string, string> = {
+  manual: "Manual",
+  csv_import: "CSV Import",
+  ai_generated: "AI Generated",
+  course_builder: "Course Builder",
+};
+
+const SOURCE_ICON: Record<string, string> = {
+  manual: "mdi:pencil-outline",
+  csv_import: "mdi:file-delimited-outline",
+  ai_generated: "mdi:robot-outline",
+  course_builder: "mdi:book-cog-outline",
+};
+
+const DIFFICULTIES = ["Easy", "Medium", "Hard"] as const;
+const SOURCES = ["manual", "ai_generated", "csv_import", "course_builder"] as const;
+
+export interface FacetItem {
+  difficulty_level?: string;
+  source?: string;
+  usage_count?: number;
+}
+
+export interface FacetState {
+  difficulty: string;
+  source: string;
+  reusedOnly: boolean;
+}
+
+export const EMPTY_FACETS: FacetState = { difficulty: "", source: "", reusedOnly: false };
+
+/** Client-side facet filter shared by all three pickers. */
+export function applyFacets<T extends FacetItem>(items: T[], f: FacetState): T[] {
+  return items.filter((it) => {
+    if (f.difficulty && (it.difficulty_level || "") !== f.difficulty) return false;
+    if (f.source && (it.source || "manual") !== f.source) return false;
+    if (f.reusedOnly && !(Number(it.usage_count) > 0)) return false;
+    return true;
+  });
+}
+
+/** Small chip showing where a question came from (Manual/AI/CSV/Course Builder). */
+export function SourceChip({ source }: { source?: string }) {
+  const key = source || "manual";
+  const label = SOURCE_LABELS[key] || key;
+  return (
+    <Chip
+      icon={<IconWrapper icon={SOURCE_ICON[key] || "mdi:tag-outline"} size={14} />}
+      label={label}
+      size="small"
+      sx={{
+        height: 22,
+        fontSize: "0.7rem",
+        bgcolor: "var(--surface)",
+        color: "var(--font-secondary)",
+        "& .MuiChip-icon": { ml: 0.5 },
+      }}
+    />
+  );
+}
+
+/** "Used N×" reuse signal — dims to "Unused" when never referenced. */
+export function UsageChip({ count }: { count?: number }) {
+  const n = Number(count) || 0;
+  return (
+    <Tooltip title={n > 0 ? `Reused in ${n} section${n === 1 ? "" : "s"}` : "Not used yet"}>
+      <Chip
+        label={n > 0 ? `Used ${n}×` : "Unused"}
+        size="small"
+        sx={{
+          height: 22,
+          fontSize: "0.7rem",
+          fontWeight: n > 0 ? 600 : 400,
+          bgcolor: n > 0
+            ? "color-mix(in srgb, var(--accent-indigo) 14%, var(--surface) 86%)"
+            : "var(--surface)",
+          color: n > 0 ? "var(--accent-indigo)" : "var(--font-tertiary)",
+        }}
+      />
+    </Tooltip>
+  );
+}
+
+/** Small comma/space separated tags -> chips. */
+export function TagChips({ tags }: { tags?: string }) {
+  const parts = (tags || "")
+    .split(/[,;]+/)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .slice(0, 6);
+  if (parts.length === 0) return null;
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+      {parts.map((t, i) => (
+        <Chip
+          key={`${t}-${i}`}
+          label={t}
+          size="small"
+          sx={{ height: 20, fontSize: "0.65rem", bgcolor: "var(--surface)", color: "var(--font-secondary)" }}
+        />
+      ))}
+    </Box>
+  );
+}
+
+/** A small "eye" button that callers place per-row to open a preview. */
+export function PreviewButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Tooltip title="Preview question">
+      <IconButton
+        size="small"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
+        }}
+        sx={{ color: "var(--font-secondary)" }}
+      >
+        <IconWrapper icon="mdi:eye-outline" size={18} />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+/** Generic modal for previewing a bank question; caller supplies the body. */
+export function PreviewDialog({
+  open,
+  title,
+  onClose,
+  children,
+}: {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle
+        sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", pr: 1 }}
+      >
+        <span>{title}</span>
+        <IconButton onClick={onClose} size="small">
+          <IconWrapper icon="mdi:close" size={20} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers>{children}</DialogContent>
+    </Dialog>
+  );
+}
+
+interface FacetBarProps {
+  facets: FacetState;
+  onChange: (next: FacetState) => void;
+  /** Hide the source row for banks that don't expose it. */
+  showSource?: boolean;
+  /** Right-aligned slot (e.g. a result count). */
+  extra?: ReactNode;
+}
+
+/** Difficulty + source + "reused only" chip toolbar. Toggling re-selects (chip acts
+ * as a single-select; click the active chip to clear). */
+export function FacetBar({ facets, onChange, showSource = true, extra }: FacetBarProps) {
+  const set = (patch: Partial<FacetState>) => onChange({ ...facets, ...patch });
+  const toggle = (key: "difficulty" | "source", value: string) =>
+    set({ [key]: facets[key] === value ? "" : value } as Partial<FacetState>);
+
+  return (
+    <Stack spacing={1} sx={{ mb: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+        <Typography variant="caption" sx={{ color: "var(--font-tertiary)", minWidth: 64 }}>
+          Difficulty
+        </Typography>
+        {DIFFICULTIES.map((d) => (
+          <Chip
+            key={d}
+            label={d}
+            size="small"
+            variant={facets.difficulty === d ? "filled" : "outlined"}
+            onClick={() => toggle("difficulty", d)}
+            sx={{
+              height: 24,
+              fontSize: "0.72rem",
+              cursor: "pointer",
+              bgcolor: facets.difficulty === d ? "var(--accent-indigo)" : "transparent",
+              color: facets.difficulty === d ? "var(--font-light)" : "var(--font-secondary)",
+              borderColor: "var(--border-default)",
+            }}
+          />
+        ))}
+        <Chip
+          icon={<IconWrapper icon="mdi:recycle-variant" size={14} />}
+          label="Reused only"
+          size="small"
+          variant={facets.reusedOnly ? "filled" : "outlined"}
+          onClick={() => set({ reusedOnly: !facets.reusedOnly })}
+          sx={{
+            height: 24,
+            fontSize: "0.72rem",
+            cursor: "pointer",
+            ml: 0.5,
+            bgcolor: facets.reusedOnly ? "var(--accent-indigo)" : "transparent",
+            color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)",
+            borderColor: "var(--border-default)",
+            "& .MuiChip-icon": { color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)" },
+          }}
+        />
+        <Box sx={{ flexGrow: 1 }} />
+        {extra}
+      </Box>
+
+      {showSource && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+          <Typography variant="caption" sx={{ color: "var(--font-tertiary)", minWidth: 64 }}>
+            Source
+          </Typography>
+          {SOURCES.map((s) => (
+            <Chip
+              key={s}
+              label={SOURCE_LABELS[s]}
+              size="small"
+              variant={facets.source === s ? "filled" : "outlined"}
+              onClick={() => toggle("source", s)}
+              sx={{
+                height: 24,
+                fontSize: "0.72rem",
+                cursor: "pointer",
+                bgcolor: facets.source === s ? "var(--accent-indigo)" : "transparent",
+                color: facets.source === s ? "var(--font-light)" : "var(--font-secondary)",
+                borderColor: "var(--border-default)",
+              }}
+            />
+          ))}
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -981,6 +981,10 @@ export interface QuestionsExportSection {
   medium_score?: number;
   hard_score?: number;
   number_of_questions: number;
+  /** Per-section time cap in minutes (null when unset). */
+  time_limit_minutes?: number | null;
+  /** Minimum marks to clear the section (decimal string, null when unset). */
+  section_cutoff_marks?: string | null;
   questions: QuestionsExportQuestion[];
 }
 

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -700,6 +700,53 @@ export const listAssessmentSubjectiveQuestions = async (
 /**
  * Generate MCQs with AI
  */
+export interface QuestionGenerationJobResponse {
+  job_id: string;
+  status: "pending" | "generating" | "completed" | "failed";
+  question_type: "mcq" | "coding";
+  section_ref?: string;
+  assessment_id?: number | null;
+  total_items: number;
+  completed_items: number;
+  progress_percentage: number;
+  /** Questions produced so far (cumulative); each may carry a `verification_status`. */
+  questions: Record<string, unknown>[];
+  error_log: unknown[];
+}
+
+export interface StartQuestionGenerationBody {
+  question_type: "mcq" | "coding";
+  topic: string;
+  number_of_questions: number;
+  difficulty_level?: "Easy" | "Medium" | "Hard";
+  programming_language?: string;
+  assessment_id?: number;
+  section_ref?: string;
+}
+
+/** Start a resumable, timeout-proof batched generation job (P1). Returns a job to poll. */
+export const startQuestionGeneration = async (
+  clientId: string | number,
+  body: StartQuestionGenerationBody
+): Promise<QuestionGenerationJobResponse> => {
+  const response = await apiClient.post(
+    `/admin-dashboard/api/clients/${clientId}/question-generation/`,
+    body
+  );
+  return response.data;
+};
+
+/** Poll a generation job for live progress + the questions produced so far (P7). */
+export const getQuestionGenerationJob = async (
+  clientId: string | number,
+  jobId: string
+): Promise<QuestionGenerationJobResponse> => {
+  const response = await apiClient.get(
+    `/admin-dashboard/api/clients/${clientId}/question-generation/${jobId}/`
+  );
+  return response.data;
+};
+
 export const generateMCQsWithAI = async (
   clientId: string | number,
   payload: GenerateMCQRequest
@@ -1462,6 +1509,8 @@ export const adminAssessmentService = {
   getMCQs,
   listAssessmentSubjectiveQuestions,
   generateMCQsWithAI,
+  startQuestionGeneration,
+  getQuestionGenerationJob,
   getCodingProblems,
   generateCodingProblemsWithAI,
   generateCodingProblemFromRaw,

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -46,6 +46,10 @@ export interface MCQListItem {
   difficulty_level?: string;
   topic?: string;
   skills?: string;
+  // P6 reuse facets:
+  tags?: string;
+  source?: string;
+  usage_count?: number;
 }
 
 export interface GenerateMCQRequest {
@@ -75,7 +79,12 @@ export interface CodingProblemListItem {
   problem_statement: string;
   difficulty_level?: string;
   topic?: string;
+  skills?: string;
   programming_language?: string;
+  // P6 reuse facets:
+  tags?: string;
+  source?: string;
+  usage_count?: number;
   [key: string]: any;
 }
 
@@ -164,6 +173,13 @@ export interface AssessmentSubjectiveQuestionListItem {
   question_type?: string;
   answer_mode?: string;
   created_at?: string;
+  // P6 reuse facets:
+  topic?: string;
+  skills?: string;
+  tags?: string;
+  difficulty_level?: string;
+  source?: string;
+  usage_count?: number;
 }
 
 /** One coding block in `codingProblemSection` on create/update payloads. */

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -1415,20 +1415,34 @@ export function clampAssessmentAnalyticsTopPerformers(n: unknown): number {
  * Assessment analytics (admin / superadmin / course_manager with access).
  * GET /admin-dashboard/api/clients/{client_id}/assessments/{assessment_id}/analytics/
  */
+/** For a large assessment whose analytics aren't cached yet, the API answers 202 with
+ * `{ computing: true }` and rebuilds asynchronously (RC-6a). Callers should poll. */
+export interface AssessmentAnalyticsComputing {
+  computing: true;
+}
+
 export const getAssessmentAnalytics = async (
   clientId: string | number,
   assessmentId: number,
   options?: { top_performers?: number }
-): Promise<AssessmentAnalyticsResponse> => {
+): Promise<AssessmentAnalyticsResponse | AssessmentAnalyticsComputing> => {
   const top = clampAssessmentAnalyticsTopPerformers(
     options?.top_performers ?? 10
   );
   try {
-    const response = await apiClient.get<AssessmentAnalyticsResponse>(
+    const response = await apiClient.get<
+      AssessmentAnalyticsResponse | { computing?: boolean }
+    >(
       `/admin-dashboard/api/clients/${clientId}/assessments/${assessmentId}/analytics/`,
       { params: { top_performers: top } }
     );
-    return response.data;
+    if (
+      response.status === 202 ||
+      (response.data as { computing?: boolean })?.computing
+    ) {
+      return { computing: true };
+    }
+    return response.data as AssessmentAnalyticsResponse;
   } catch (err) {
     const error = err as AxiosError<ApiErrorPayload>;
     const message =

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -1130,6 +1130,32 @@ export const getSubmissionsExportJson = async (
   return response.data;
 };
 
+export interface SubmissionsExportMeta {
+  /** True while the heavy export cache is still being (re)built in the background. */
+  computing: boolean;
+  /** True when the full payload is available to fetch. */
+  ready: boolean;
+  processed_count: number;
+  total_count: number;
+  /** True submission count — non-zero even while the payload is still building. */
+  count: number;
+}
+
+/**
+ * Cheap progress probe for the submissions tab. Poll this while the export cache
+ * builds so the UI can show "N submissions · building results…" instead of a
+ * misleading "0 submissions", and only fetch the full payload once `ready`.
+ */
+export const getSubmissionsExportMeta = async (
+  clientId: string | number,
+  assessmentId: number
+): Promise<SubmissionsExportMeta> => {
+  const response = await apiClient.get<SubmissionsExportMeta>(
+    `/admin-dashboard/api/clients/${clientId}/assessments/${assessmentId}/submissions-export/?meta_only=1`
+  );
+  return response.data;
+};
+
 export const saveManualEvaluation = async (
   clientId: string | number,
   assessmentId: number,
@@ -1423,6 +1449,7 @@ export const adminAssessmentService = {
   getQuestionsExport,
   getQuestionsExportJson,
   getSubmissionsExportJson,
+  getSubmissionsExportMeta,
   getSubmissionManualEvaluation,
   saveManualEvaluation,
   publishSubmissionResult,

--- a/lib/utils/assessment-authoring-from-export.utils.ts
+++ b/lib/utils/assessment-authoring-from-export.utils.ts
@@ -82,6 +82,9 @@ export function mapQuestionsExportToAuthoringState(exportData: QuestionsExportRe
       easyScore: sec.easy_score,
       mediumScore: sec.medium_score,
       hardScore: sec.hard_score,
+      // P3: restore per-section timing/cutoff so reopening a draft doesn't lose them.
+      timeLimitMinutes: sec.time_limit_minutes ?? undefined,
+      sectionCutoffMarks: sec.section_cutoff_marks ?? undefined,
     };
 
     const nQ = sec.number_of_questions;


### PR DESCRIPTION
Frontend for the assessment authoring/management feature batch (pairs with backend PRs #327/#328). Targets **stagging**. This PR starts with the highest user-visible win and will accumulate the remaining UX phases (save-draft restore, method-switch, live generation view) as they land.

## P4 — submissions at scale (no more false "0 submissions")
At 1500-3000+ students the submissions tab used to take forever, show **0 submissions**, and only load after a hard refresh. Root cause: the page eagerly fetched the entire submissions export in the load waterfall, and the endpoint returned a near-empty payload while its cache rebuilt.

- **Lazy load** — submissions are fetched only when the Submissions tab opens (mirrors the analytics tab), so Details opens instantly and never drags the fat fetch.
- **Build progress** — entering the tab polls the cheap `?meta_only` probe every 2.5s and shows **"Building results for N submissions… (processed/total)"** using the *true* count, then fetches the full payload once `ready` — no hard refresh, no repeated multi-MB downloads.
- **Honest empty state** — "No submissions yet" only when the build is done and the count is genuinely zero.

Backend support shipped in PR #328 (`AssessmentSubmissionsExportAPIView?meta_only=1`).

Typechecked (`tsc --noEmit`) — changed files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)