### PR TITLE
fix(assessment): surface the real reason when AI question generation fails

### DIFF
--- a/components/admin/assessment/AIGeneratedCodingSection.tsx
+++ b/components/admin/assessment/AIGeneratedCodingSection.tsx
@@ -27,6 +27,7 @@ import { useToast } from "@/components/common/Toast";
 import {
   adminAssessmentService,
   CodingProblemListItem,
+  questionGenerationErrorMessage,
 } from "@/lib/services/admin/admin-assessment.service";
 import { config } from "@/lib/config";
 import { ProblemDescription } from "@/components/coding/ProblemDescription";
@@ -138,8 +139,12 @@ export function AIGeneratedCodingSection({
       applyJob(job);
       const produced = job.questions.filter((q) => q.id != null).length;
       if (job.status === "failed") {
+        const reason = questionGenerationErrorMessage(job);
         showToast(
-          `Generation finished with errors — ${produced} problem(s) produced.`,
+          reason ||
+            (produced
+              ? `Generation finished with errors — ${produced} problem(s) produced.`
+              : "Coding problem generation failed. Please try again shortly."),
           "error"
         );
       } else {

--- a/components/admin/assessment/AIGeneratedSection.tsx
+++ b/components/admin/assessment/AIGeneratedSection.tsx
@@ -22,7 +22,10 @@ import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { MCQ } from "@/lib/services/admin/admin-assessment.service";
-import { adminAssessmentService } from "@/lib/services/admin/admin-assessment.service";
+import {
+  adminAssessmentService,
+  questionGenerationErrorMessage,
+} from "@/lib/services/admin/admin-assessment.service";
 import { config } from "@/lib/config";
 
 interface AIGeneratedSectionProps {
@@ -102,8 +105,12 @@ export function AIGeneratedSection({
 
       onMCQsChange([...baseline, ...job.questions.map(toMCQ)]);
       if (job.status === "failed") {
+        const reason = questionGenerationErrorMessage(job);
         showToast(
-          `Generation finished with errors — ${job.questions.length} question(s) produced.`,
+          reason ||
+            (job.questions.length
+              ? `Generation finished with errors — ${job.questions.length} question(s) produced.`
+              : "Question generation failed. Please try again shortly."),
           "error"
         );
       } else {

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -730,6 +730,20 @@ export interface QuestionGenerationJobResponse {
   error_log: unknown[];
 }
 
+/** Most recent human-readable reason from a generation job's error_log (or "" if none).
+ * Used to surface *why* generation failed (e.g. "AI provider over quota") instead of a
+ * generic message. */
+export function questionGenerationErrorMessage(
+  job: Pick<QuestionGenerationJobResponse, "error_log">
+): string {
+  const entries = (job.error_log || []) as Array<{ message?: unknown }>;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const m = entries[i]?.message;
+    if (typeof m === "string" && m.trim()) return m.trim();
+  }
+  return "";
+}
+
 export interface StartQuestionGenerationBody {
   question_type: "mcq" | "coding";
   topic: string;


### PR DESCRIPTION
Pairs with backend fix/question-gen-terminal-failure. When a generation job ends 'failed', the UI now shows the backend's error_log reason (e.g. 'The AI provider couldn't generate questions — it may be rate-limited or over its usage quota…') instead of a generic 'finished with errors'.

- questionGenerationErrorMessage(job) reads the latest human-readable error_log message.
- MCQ + coding AI-gen sections use it, with a clear fallback when nothing was produced.

Typecheck clean (0 TS errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)