### PR TITLE
feat(assessment-mgmt): Phase 1 — adaptive design primitives + list page redesign

### DIFF
--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -14,15 +14,6 @@ import {
   DialogContentText,
   DialogActions,
   Alert,
-  TextField,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  InputAdornment,
-  Chip,
-  useTheme,
-  CircularProgress,
 } from "@mui/material";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -47,13 +38,16 @@ import { AssessmentPagination } from "@/components/admin/assessment/AssessmentPa
 import { EmailTemplatePreview } from "@/components/common/EmailTemplatePreview";
 import { extractSavedEmailAttachment } from "@/lib/utils/assessment-email-attachment";
 import { escapeCsvCell } from "@/lib/utils/csv-export";
+import {
+  AssessmentSectionHero,
+  AssessmentFilterBar,
+  AssessmentTableSkeleton,
+} from "@/components/admin/assessment/shared";
 
 export default function AssessmentPage() {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const router = useRouter();
-  const theme = useTheme();
-  const rtl = theme.direction === "rtl";
   const { user } = useAuth();
   const isCourseManager = isCourseManagerRole(user?.role);
   const [assessments, setAssessments] = useState<Assessment[]>([]);
@@ -712,333 +706,127 @@ export default function AssessmentPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ p: { xs: 2, sm: 3, md: 4 } }}>
-        {/* Header */}
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: { xs: "flex-start", sm: "center" },
-            mb: 4,
-            flexDirection: { xs: "column", sm: rtl ? "row-reverse" : "row" },
-            gap: 3,
-          }}
-        >
-          <Box>
-            <Typography
-              variant="h4"
-              sx={{
-                fontWeight: 700,
-                color: "var(--font-primary)",
-                fontSize: { xs: "1.5rem", sm: "2rem" },
-                mb: 0.5,
-                background:
-                  "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-purple) 100%)",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
-                backgroundClip: "text",
-              }}
-            >
-              {t("admin.assessment.title")}
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{
-                color: "var(--font-secondary)",
-                fontSize: "0.875rem",
-                mt: 0.5,
-              }}
-            >
-              {t("admin.assessment.subtitle")}
-            </Typography>
-          </Box>
-          <Button
-            variant="contained"
-            startIcon={<IconWrapper icon="mdi:plus" size={20} />}
-            onClick={() => router.push("/admin/assessment/create")}
-            disabled={
-              isCourseManager ||
-              (!!user &&
-                typeof user.role === "string" &&
-                ["content manager", "content_manager"].includes(
-                  user.role.toLowerCase().replace(/\s+/g, " ")
-                ))
-            }
-            fullWidth={false}
-            sx={{
-              bgcolor: "var(--accent-indigo)",
-              color: "var(--font-light)",
-              fontWeight: 600,
-              px: { xs: 2, sm: 3 },
-              py: 1.25,
-              borderRadius: 2,
-              width: { xs: "100%", sm: "auto" },
-              boxShadow:
-                "0 4px 6px -1px color-mix(in srgb, var(--accent-indigo) 30%, transparent)",
-              "&:hover": {
-                bgcolor: "var(--accent-indigo-dark)",
-                boxShadow:
-                  "0 10px 15px -3px color-mix(in srgb, var(--accent-indigo) 40%, transparent)",
-                transform: { xs: "none", sm: "translateY(-1px)" },
-              },
-              transition: "all 0.2s ease",
-            }}
-          >
-            {t("admin.assessment.createAssessment")}
-          </Button>
-        </Box>
-
-        {/* Filters */}
-        <Paper
-          sx={{
-            p: { xs: 2, sm: 2.5 },
-            mb: 3,
-            borderRadius: 2,
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 12%, transparent)",
-            border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-          }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: 2,
-              alignItems: "stretch",
-              direction: rtl ? "rtl" : "ltr",
-            }}
-          >
-            <TextField
-              placeholder={t("admin.assessment.searchPlaceholder")}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <IconWrapper icon="mdi:magnify" size={20} color="var(--font-tertiary)" />
-                  </InputAdornment>
-                ),
-              }}
-              sx={{
-                flex: "1 1 280px",
-                minWidth: { xs: "100%", sm: 220 },
-                "& .MuiOutlinedInput-root": {
-                  backgroundColor: "var(--card-bg)",
-                },
-              }}
-              fullWidth
-            />
-
-            <FormControl sx={{ flex: "1 1 160px", minWidth: 140 }} fullWidth>
-              <InputLabel>Status</InputLabel>
-              <Select
-                value={statusFilter}
-                label="Status"
-                onChange={(e) =>
-                  setStatusFilter(e.target.value as "all" | "active" | "inactive")
-                }
-              >
-                <MenuItem value="all">All Status</MenuItem>
-                <MenuItem value="active">Active</MenuItem>
-                <MenuItem value="inactive">Inactive</MenuItem>
-              </Select>
-            </FormControl>
-
-            <FormControl sx={{ flex: "1 1 160px", minWidth: 140 }} fullWidth>
-              <InputLabel>Authoring</InputLabel>
-              <Select
-                value={draftFilter}
-                label="Authoring"
-                onChange={(e) =>
-                  setDraftFilter(e.target.value as "all" | "draft" | "live")
-                }
-              >
-                <MenuItem value="all">All</MenuItem>
-                <MenuItem value="draft">Draft only</MenuItem>
-                <MenuItem value="live">Published only</MenuItem>
-              </Select>
-            </FormControl>
-
-            <FormControl sx={{ flex: "1 1 160px", minWidth: 140 }} fullWidth>
-              <InputLabel>Proctoring</InputLabel>
-              <Select
-                value={proctoringFilter}
-                label="Proctoring"
-                onChange={(e) =>
-                  setProctoringFilter(
-                    e.target.value as "all" | "enabled" | "disabled"
-                  )
-                }
-              >
-                <MenuItem value="all">All</MenuItem>
-                <MenuItem value="enabled">Enabled</MenuItem>
-                <MenuItem value="disabled">Disabled</MenuItem>
-              </Select>
-            </FormControl>
-
-            <FormControl sx={{ flex: "1 1 160px", minWidth: 140 }} fullWidth>
-              <InputLabel>Payment</InputLabel>
-              <Select
-                value={paidFilter}
-                label="Payment"
-                onChange={(e) =>
-                  setPaidFilter(e.target.value as "all" | "paid" | "free")
-                }
-              >
-                <MenuItem value="all">All</MenuItem>
-                <MenuItem value="paid">Paid</MenuItem>
-                <MenuItem value="free">Free</MenuItem>
-              </Select>
-            </FormControl>
-
-            <FormControl sx={{ flex: "1 1 180px", minWidth: 160 }} fullWidth>
-              <InputLabel id="admin-assessment-eval-filter-label">
-                {t("admin.assessment.filterEvaluation")}
-              </InputLabel>
-              <Select
-                labelId="admin-assessment-eval-filter-label"
-                value={evaluationFilter}
-                label={t("admin.assessment.filterEvaluation")}
-                onChange={(e) =>
-                  setEvaluationFilter(e.target.value as "all" | "manual" | "auto")
-                }
-              >
-                <MenuItem value="all">{t("admin.assessment.filterEvaluationAll")}</MenuItem>
-                <MenuItem value="manual">{t("admin.assessment.filterEvaluationManual")}</MenuItem>
-                <MenuItem value="auto">{t("admin.assessment.filterEvaluationAuto")}</MenuItem>
-              </Select>
-            </FormControl>
-
-            {hasActiveFilters && (
+        {/* Header — adaptive-course design language (Phase 1 revamp) */}
+        <Box sx={{ mb: 4 }}>
+          <AssessmentSectionHero
+            chapter="ASSESSMENTS"
+            title={t("admin.assessment.title")}
+            subtitle={t("admin.assessment.subtitle")}
+            accent="indigo"
+            icon="mdi:clipboard-text-outline"
+            rightSlot={
               <Button
-                variant="outlined"
-                onClick={handleClearFilters}
-                startIcon={<IconWrapper icon="mdi:close" size={18} />}
+                variant="contained"
+                startIcon={<IconWrapper icon="mdi:plus" size={20} />}
+                onClick={() => router.push("/admin/assessment/create")}
+                disabled={
+                  isCourseManager ||
+                  (!!user &&
+                    typeof user.role === "string" &&
+                    ["content manager", "content_manager"].includes(
+                      user.role.toLowerCase().replace(/\s+/g, " ")
+                    ))
+                }
                 sx={{
-                  flex: "0 0 auto",
-                  alignSelf: "center",
-                  borderColor: "var(--border-default)",
-                  color: "var(--font-secondary)",
+                  bgcolor: "var(--accent-indigo)",
+                  color: "var(--font-light)",
+                  fontWeight: 600,
+                  px: 3,
+                  py: 1.1,
+                  borderRadius: 2,
                   whiteSpace: "nowrap",
-                  "&:hover": {
-                    borderColor:
-                      "color-mix(in srgb, var(--font-secondary) 34%, var(--border-default) 66%)",
-                    backgroundColor: "var(--surface)",
-                  },
+                  boxShadow:
+                    "0 4px 6px -1px color-mix(in srgb, var(--accent-indigo) 30%, transparent)",
+                  "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
                 }}
               >
-                Clear
+                {t("admin.assessment.createAssessment")}
               </Button>
-            )}
-          </Box>
+            }
+          />
+        </Box>
 
-          {/* Active filters display */}
-          {hasActiveFilters && (
-            <Box sx={{ mt: 2, display: "flex", flexWrap: "wrap", gap: 1 }}>
-              <Typography variant="caption" sx={{ color: "var(--font-secondary)", mr: 1, alignSelf: "center" }}>
-                Active filters:
-              </Typography>
-              {searchQuery && (
-                <Chip
-                  label={`Search: "${searchQuery}"`}
-                  size="small"
-                  onDelete={() => setSearchQuery("")}
-                  sx={{
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-                    color: "var(--accent-indigo)",
-                  }}
-                />
-              )}
-              {statusFilter !== "all" && (
-                <Chip
-                  label={`Status: ${statusFilter}`}
-                  size="small"
-                  onDelete={() => setStatusFilter("all")}
-                  sx={{
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-                    color: "var(--accent-indigo)",
-                  }}
-                />
-              )}
-              {draftFilter !== "all" && (
-                <Chip
-                  label={draftFilter === "draft" ? "Authoring: draft" : "Authoring: published"}
-                  size="small"
-                  onDelete={() => setDraftFilter("all")}
-                  sx={{
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-                    color: "var(--accent-indigo)",
-                  }}
-                />
-              )}
-              {proctoringFilter !== "all" && (
-                <Chip
-                  label={`Proctoring: ${proctoringFilter}`}
-                  size="small"
-                  onDelete={() => setProctoringFilter("all")}
-                  sx={{
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-                    color: "var(--accent-indigo)",
-                  }}
-                />
-              )}
-              {paidFilter !== "all" && (
-                <Chip
-                  label={`Payment: ${paidFilter}`}
-                  size="small"
-                  onDelete={() => setPaidFilter("all")}
-                  sx={{
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-                    color: "var(--accent-indigo)",
-                  }}
-                />
-              )}
-              {evaluationFilter !== "all" && (
-                <Chip
-                  label={
-                    evaluationFilter === "manual"
-                      ? t("admin.assessment.filterEvaluationManual")
-                      : t("admin.assessment.filterEvaluationAuto")
-                  }
-                  size="small"
-                  onDelete={() => setEvaluationFilter("all")}
-                  sx={{
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-                    color: "var(--accent-indigo)",
-                  }}
-                />
-              )}
-            </Box>
-          )}
+        {/* Filters — AssessmentFilterBar (Phase 1 revamp) */}
+        <Box sx={{ mb: 3 }}>
+          <AssessmentFilterBar
+            search={searchQuery}
+            onSearchChange={setSearchQuery}
+            searchPlaceholder={t("admin.assessment.searchPlaceholder")}
+            selects={[
+              {
+                key: "status",
+                label: "Status",
+                value: statusFilter === "all" ? "" : statusFilter,
+                options: [
+                  { value: "active", label: "Active" },
+                  { value: "inactive", label: "Inactive" },
+                ],
+                onChange: (v) => setStatusFilter((v || "all") as "all" | "active" | "inactive"),
+              },
+              {
+                key: "draft",
+                label: "Authoring",
+                value: draftFilter === "all" ? "" : draftFilter,
+                options: [
+                  { value: "draft", label: "Draft only" },
+                  { value: "live", label: "Published only" },
+                ],
+                onChange: (v) => setDraftFilter((v || "all") as "all" | "draft" | "live"),
+              },
+              {
+                key: "proctoring",
+                label: "Proctoring",
+                value: proctoringFilter === "all" ? "" : proctoringFilter,
+                options: [
+                  { value: "enabled", label: "Enabled" },
+                  { value: "disabled", label: "Disabled" },
+                ],
+                onChange: (v) => setProctoringFilter((v || "all") as "all" | "enabled" | "disabled"),
+              },
+              {
+                key: "paid",
+                label: "Payment",
+                value: paidFilter === "all" ? "" : paidFilter,
+                options: [
+                  { value: "paid", label: "Paid" },
+                  { value: "free", label: "Free" },
+                ],
+                onChange: (v) => setPaidFilter((v || "all") as "all" | "paid" | "free"),
+              },
+              {
+                key: "evaluation",
+                label: t("admin.assessment.filterEvaluation"),
+                value: evaluationFilter === "all" ? "" : evaluationFilter,
+                options: [
+                  { value: "manual", label: t("admin.assessment.filterEvaluationManual") },
+                  { value: "auto", label: t("admin.assessment.filterEvaluationAuto") },
+                ],
+                onChange: (v) => setEvaluationFilter((v || "all") as "all" | "manual" | "auto"),
+              },
+            ]}
+            activeChips={[
+              ...(searchQuery ? [{ key: "search", label: `Search: "${searchQuery}"`, onClear: () => setSearchQuery("") }] : []),
+              ...(statusFilter !== "all" ? [{ key: "status", label: `Status: ${statusFilter}`, onClear: () => setStatusFilter("all") }] : []),
+              ...(draftFilter !== "all" ? [{ key: "draft", label: draftFilter === "draft" ? "Authoring: draft" : "Authoring: published", onClear: () => setDraftFilter("all") }] : []),
+              ...(proctoringFilter !== "all" ? [{ key: "proctoring", label: `Proctoring: ${proctoringFilter}`, onClear: () => setProctoringFilter("all") }] : []),
+              ...(paidFilter !== "all" ? [{ key: "paid", label: `Payment: ${paidFilter}`, onClear: () => setPaidFilter("all") }] : []),
+              ...(evaluationFilter !== "all" ? [{ key: "evaluation", label: evaluationFilter === "manual" ? t("admin.assessment.filterEvaluationManual") : t("admin.assessment.filterEvaluationAuto"), onClear: () => setEvaluationFilter("all") }] : []),
+            ]}
+            onClearAll={handleClearFilters}
+            rightSlot={
+              hasActiveFilters ? (
+                <Typography variant="caption" sx={{ color: "var(--font-secondary)", whiteSpace: "nowrap" }}>
+                  Showing {filteredAssessments.length} of {assessments.length}
+                </Typography>
+              ) : undefined
+            }
+          />
+        </Box>
 
-          {/* Results count */}
-          {hasActiveFilters && (
-            <Box sx={{ mt: 1.5 }}>
-              <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-                Showing {filteredAssessments.length} of {assessments.length} assessments
-              </Typography>
-            </Box>
-          )}
-        </Paper>
 
         {/* Table */}
         {loading ? (
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              minHeight: 400,
-            }}
-          >
-            <CircularProgress size={48} sx={{ color: "var(--accent-indigo)" }} />
-          </Box>
+          <AssessmentTableSkeleton rows={8} columns={7} />
         ) : (
           <Paper
             sx={{

--- a/components/admin/assessment/AssessmentTable.tsx
+++ b/components/admin/assessment/AssessmentTable.tsx
@@ -570,7 +570,7 @@ export function AssessmentTable({
                     onClick={() => handleMenuClose(assessment.id)}
                   >
                     <ListItemIcon>
-                      <IconWrapper icon="mdi:certificate" size={18} color="#0d9488" />
+                      <IconWrapper icon="mdi:certificate" size={18} color="var(--accent-teal, var(--accent-indigo))" />
                     </ListItemIcon>
                     <ListItemText>{t("certificatesUpload.menuCertificates")}</ListItemText>
                   </MenuItem>
@@ -1356,7 +1356,7 @@ export function AssessmentTable({
                         onClick={() => handleMenuClose(assessment.id)}
                       >
                         <ListItemIcon>
-                          <IconWrapper icon="mdi:certificate" size={18} color="#0d9488" />
+                          <IconWrapper icon="mdi:certificate" size={18} color="var(--accent-teal, var(--accent-indigo))" />
                         </ListItemIcon>
                         <ListItemText>{t("certificatesUpload.menuCertificates")}</ListItemText>
                       </MenuItem>

--- a/components/admin/assessment/shared/AssessmentDataTable.tsx
+++ b/components/admin/assessment/shared/AssessmentDataTable.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+/**
+ * AssessmentDataTable — a generic, fully tokenized table primitive for the
+ * assessment-management admin redesign.
+ *
+ * Renders an MUI Table inside a rounded hairline card. The header uses the
+ * surface token with uppercase, letter-spaced labels; body rows carry hairline
+ * bottom borders and become clickable when `onRowClick` is provided. Columns
+ * support alignment, sizing and responsive hiding via `hideBelow`. All colors
+ * come from CSS custom properties so the table is theme-aware out of the box.
+ *
+ * @example
+ * <AssessmentDataTable<Assessment>
+ *   columns={[
+ *     { key: "title", header: "Title", minWidth: 200 },
+ *     { key: "status", header: "Status", render: (r) => <StatusChip s={r.status} /> },
+ *     { key: "createdAt", header: "Created", align: "right", hideBelow: "sm" },
+ *   ]}
+ *   rows={assessments}
+ *   rowKey={(r) => r.id}
+ *   onRowClick={(r) => openAssessment(r)}
+ *   emptyState={<EmptyAssessments />}
+ * />
+ */
+
+import * as React from "react";
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+
+export interface AssessmentColumn<T> {
+  /** Stable identity for the column; also the fallback value accessor when `render` is omitted. */
+  key: string;
+  /** Header content (text or node). */
+  header: React.ReactNode;
+  /** Cell renderer. When omitted, the raw `(row as any)[key]` value is shown. */
+  render?: (row: T) => React.ReactNode;
+  align?: "left" | "right" | "center";
+  width?: number | string;
+  minWidth?: number;
+  /** Hide this column at/below the given breakpoint (e.g. "sm" hides below sm). */
+  hideBelow?: "sm" | "md" | "lg";
+}
+
+export interface AssessmentDataTableProps<T> {
+  columns: AssessmentColumn<T>[];
+  rows: T[];
+  rowKey: (row: T) => string | number;
+  onRowClick?: (row: T) => void;
+  dense?: boolean;
+  emptyState?: React.ReactNode;
+  stickyHeader?: boolean;
+}
+
+/** Maps a `hideBelow` breakpoint to a responsive `display` sx that hides the cell below it. */
+function hideSx(
+  hideBelow?: AssessmentColumn<unknown>["hideBelow"]
+): Record<string, string> | undefined {
+  if (!hideBelow) return undefined;
+  // Hidden from xs up to (but not including) the named breakpoint, then shown.
+  return { xs: "none", [hideBelow]: "table-cell" };
+}
+
+export function AssessmentDataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  onRowClick,
+  dense,
+  emptyState,
+  stickyHeader = true,
+}: AssessmentDataTableProps<T>): React.ReactElement {
+  const clickable = Boolean(onRowClick);
+  const size = dense ? "small" : "medium";
+
+  return (
+    <Box
+      sx={{
+        borderRadius: 2,
+        border: "1px solid var(--border-default)",
+        background: "var(--card-bg)",
+        overflow: "hidden",
+      }}
+    >
+      <TableContainer sx={{ overflowX: "auto", maxWidth: "100%" }}>
+        <Table stickyHeader={stickyHeader} size={size} aria-rowcount={rows.length}>
+          <TableHead>
+            <TableRow>
+              {columns.map((col) => (
+                <TableCell
+                  key={col.key}
+                  align={col.align ?? "left"}
+                  sx={{
+                    background: "var(--surface)",
+                    color: "var(--font-tertiary)",
+                    fontSize: "0.72rem",
+                    fontWeight: 600,
+                    lineHeight: 1.4,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.06em",
+                    whiteSpace: "nowrap",
+                    borderBottom: "1px solid var(--border-default)",
+                    width: col.width,
+                    minWidth: col.minWidth,
+                    ...(hideSx(col.hideBelow)
+                      ? { display: hideSx(col.hideBelow) }
+                      : null),
+                  }}
+                >
+                  {col.header}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+
+          <TableBody>
+            {rows.length === 0
+              ? emptyState != null && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={columns.length}
+                      sx={{
+                        borderBottom: "none",
+                        p: 0,
+                        color: "var(--font-secondary)",
+                      }}
+                    >
+                      {emptyState}
+                    </TableCell>
+                  </TableRow>
+                )
+              : rows.map((row) => (
+                  <TableRow
+                    key={rowKey(row)}
+                    hover
+                    onClick={clickable ? () => onRowClick?.(row) : undefined}
+                    tabIndex={clickable ? 0 : undefined}
+                    onKeyDown={
+                      clickable
+                        ? (e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              onRowClick?.(row);
+                            }
+                          }
+                        : undefined
+                    }
+                    sx={{
+                      cursor: clickable ? "pointer" : "default",
+                      transition: "background 120ms ease",
+                      "&:last-of-type td": { borderBottom: "none" },
+                      "&:hover": clickable
+                        ? { background: "var(--surface)" }
+                        : undefined,
+                      "&.MuiTableRow-hover:hover": {
+                        backgroundColor: "var(--surface)",
+                      },
+                    }}
+                  >
+                    {columns.map((col) => (
+                      <TableCell
+                        key={col.key}
+                        align={col.align ?? "left"}
+                        sx={{
+                          color: "var(--font-primary)",
+                          fontSize: dense ? "0.82rem" : "0.875rem",
+                          borderBottom: "1px solid var(--border-default)",
+                          width: col.width,
+                          minWidth: col.minWidth,
+                          ...(hideSx(col.hideBelow)
+                            ? { display: hideSx(col.hideBelow) }
+                            : null),
+                        }}
+                      >
+                        {col.render
+                          ? col.render(row)
+                          : ((row as Record<string, unknown>)[
+                              col.key
+                            ] as React.ReactNode)}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}
+
+export default AssessmentDataTable;

--- a/components/admin/assessment/shared/AssessmentEmptyState.tsx
+++ b/components/admin/assessment/shared/AssessmentEmptyState.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * AssessmentEmptyState
+ * --------------------
+ * Shared empty-state primitive for the assessment-management admin redesign.
+ *
+ * A centered block inside a rounded, hairline-bordered card that reads well as
+ * both a table-empty state (e.g. "No submissions yet") and a full-page-empty
+ * state (e.g. "No assessments created"). Composed of a soft indigo-tinted icon
+ * tile, a title, an optional muted description, and an optional caller-supplied
+ * action node (typically a primary button).
+ *
+ * Theme-aware via CSS custom properties; no hard-coded colors.
+ */
+
+import * as React from "react";
+import { Box, Typography } from "@mui/material";
+
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export interface AssessmentEmptyStateProps {
+  /** MDI iconify name for the tile glyph. */
+  icon?: string;
+  /** Primary line — what is empty. */
+  title: string;
+  /** Optional supporting copy explaining the state or next step. */
+  description?: string;
+  /** Optional action node, e.g. a primary button the caller passes in. */
+  action?: React.ReactNode;
+}
+
+export function AssessmentEmptyState({
+  icon = "mdi:clipboard-text-outline",
+  title,
+  description,
+  action,
+}: AssessmentEmptyStateProps): React.ReactElement {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        textAlign: "center",
+        gap: 1.5,
+        px: 3,
+        py: 5,
+        borderRadius: 2,
+        border: "1px solid var(--border-default)",
+        backgroundColor: "var(--card-bg)",
+      }}
+    >
+      {/* Soft indigo-tinted rounded icon tile */}
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 56,
+          height: 56,
+          borderRadius: 2,
+          border:
+            "1px solid color-mix(in srgb, var(--accent-indigo) 24%, var(--surface) 76%)",
+          backgroundColor:
+            "color-mix(in srgb, var(--accent-indigo) 14%, var(--surface) 86%)",
+        }}
+      >
+        <IconWrapper icon={icon} size={28} color="var(--accent-indigo)" />
+      </Box>
+
+      <Typography
+        component="h3"
+        sx={{
+          m: 0,
+          fontSize: "1rem",
+          fontWeight: 600,
+          lineHeight: 1.4,
+          color: "var(--font-primary)",
+        }}
+      >
+        {title}
+      </Typography>
+
+      {description ? (
+        <Typography
+          component="p"
+          sx={{
+            m: 0,
+            maxWidth: 420,
+            fontSize: "0.875rem",
+            lineHeight: 1.5,
+            color: "var(--font-secondary)",
+          }}
+        >
+          {description}
+        </Typography>
+      ) : null}
+
+      {action ? <Box sx={{ mt: 1 }}>{action}</Box> : null}
+    </Box>
+  );
+}
+
+export default AssessmentEmptyState;

--- a/components/admin/assessment/shared/AssessmentFilterBar.tsx
+++ b/components/admin/assessment/shared/AssessmentFilterBar.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+/**
+ * AssessmentFilterBar — a tokenized search + facet toolbar for the
+ * assessment-management admin redesign.
+ *
+ * Renders a rounded hairline card containing a growing search field, an
+ * arbitrary set of "All"-defaulted facet selects, an optional right-pinned
+ * slot, and a wrap row of removable active-filter chips with a "Clear"
+ * shortcut. All surfaces/borders/text use CSS custom-property tokens so the
+ * bar is theme-aware (light + dark) with no hard-coded colors.
+ */
+
+import * as React from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  MenuItem,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+/** A single facet select rendered in the toolbar's top row. */
+export interface FilterSelectDef {
+  key: string;
+  label: string;
+  /** Current selected value; `''` represents the "All" option. */
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+}
+
+/** A removable chip describing one active filter. */
+export interface ActiveFilterChip {
+  key: string;
+  label: string;
+  onClear: () => void;
+}
+
+export interface AssessmentFilterBarProps {
+  search: string;
+  onSearchChange: (v: string) => void;
+  searchPlaceholder?: string;
+  selects?: FilterSelectDef[];
+  activeChips?: ActiveFilterChip[];
+  onClearAll?: () => void;
+  rightSlot?: React.ReactNode;
+}
+
+const CARD_SX = {
+  bgcolor: "var(--card-bg)",
+  border: "1px solid var(--border-default)",
+  borderRadius: 2,
+  p: { xs: 1.5, sm: 2 },
+} as const;
+
+/** Shared field styling so search + selects read as one tokenized set. */
+const fieldSx = {
+  "& .MuiOutlinedInput-root": {
+    bgcolor: "var(--surface)",
+    color: "var(--font-primary)",
+    borderRadius: 2,
+    "& fieldset": { borderColor: "var(--border-default)" },
+    "&:hover fieldset": { borderColor: "var(--border-default)" },
+    "&.Mui-focused fieldset": { borderColor: "var(--accent-indigo)" },
+  },
+  "& .MuiInputLabel-root": { color: "var(--font-tertiary)" },
+  "& .MuiInputLabel-root.Mui-focused": { color: "var(--accent-indigo)" },
+  "& .MuiSvgIcon-root": { color: "var(--font-tertiary)" },
+} as const;
+
+export function AssessmentFilterBar({
+  search,
+  onSearchChange,
+  searchPlaceholder = "Search…",
+  selects = [],
+  activeChips = [],
+  onClearAll,
+  rightSlot,
+}: AssessmentFilterBarProps) {
+  const hasActive = activeChips.length > 0;
+
+  return (
+    <Box sx={CARD_SX}>
+      {/* Top row: search grows, facet selects, optional Clear, right slot. */}
+      <Stack
+        direction="row"
+        flexWrap="wrap"
+        alignItems="center"
+        gap={1.5}
+      >
+        <TextField
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={searchPlaceholder}
+          size="small"
+          sx={{ flex: "1 1 220px", minWidth: 200, ...fieldSx }}
+          InputProps={{
+            startAdornment: (
+              <Box
+                sx={{
+                  display: "inline-flex",
+                  mr: 1,
+                  color: "var(--font-tertiary)",
+                }}
+              >
+                <IconWrapper icon="mdi:magnify" size={20} />
+              </Box>
+            ),
+          }}
+        />
+
+        {selects.map((sel) => (
+          <TextField
+            key={sel.key}
+            select
+            label={sel.label}
+            value={sel.value}
+            onChange={(e) => sel.onChange(e.target.value)}
+            size="small"
+            sx={{ width: { xs: "100%", sm: 170 }, ...fieldSx }}
+          >
+            <MenuItem value="">All</MenuItem>
+            {sel.options.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        ))}
+
+        {hasActive && onClearAll ? (
+          <Button
+            onClick={onClearAll}
+            size="small"
+            startIcon={<IconWrapper icon="mdi:close-circle-outline" size={18} />}
+            sx={{
+              textTransform: "none",
+              color: "var(--font-secondary)",
+              "&:hover": {
+                bgcolor:
+                  "color-mix(in srgb, var(--accent-indigo) 14%, var(--surface) 86%)",
+                color: "var(--accent-indigo-dark)",
+              },
+            }}
+          >
+            Clear
+          </Button>
+        ) : null}
+
+        {rightSlot ? (
+          <Box sx={{ ml: "auto", display: "flex", alignItems: "center" }}>
+            {rightSlot}
+          </Box>
+        ) : null}
+      </Stack>
+
+      {/* Active-filter chips: removable, wrapping. */}
+      {hasActive ? (
+        <Stack
+          direction="row"
+          flexWrap="wrap"
+          alignItems="center"
+          gap={1}
+          sx={{ mt: 1.5 }}
+        >
+          <Typography
+            variant="caption"
+            sx={{ color: "var(--font-tertiary)", mr: 0.5 }}
+          >
+            Filters
+          </Typography>
+          {activeChips.map((chip) => (
+            <Chip
+              key={chip.key}
+              label={chip.label}
+              onDelete={chip.onClear}
+              size="small"
+              deleteIcon={
+                <Box sx={{ display: "inline-flex" }}>
+                  <IconWrapper icon="mdi:close" size={16} />
+                </Box>
+              }
+              sx={{
+                borderRadius: 999,
+                bgcolor:
+                  "color-mix(in srgb, var(--accent-indigo) 14%, var(--surface) 86%)",
+                border: "1px solid var(--border-default)",
+                color: "var(--font-primary)",
+                "& .MuiChip-deleteIcon": {
+                  color: "var(--font-tertiary)",
+                  "&:hover": { color: "var(--error-500)" },
+                },
+              }}
+            />
+          ))}
+        </Stack>
+      ) : null}
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/AssessmentSectionHero.tsx
+++ b/components/admin/assessment/shared/AssessmentSectionHero.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { SectionHero } from "@/components/scorecard/shared";
+import { ASSESSMENT_ACCENTS, type AssessmentAccent } from "./AssessmentSectionShell";
+
+interface AssessmentSectionHeroProps {
+  /** Small eyebrow above the title (e.g. "ASSESSMENTS", "MANAGE · Testing 01"). */
+  chapter: string;
+  title: string;
+  subtitle?: string;
+  accent?: AssessmentAccent;
+  /** Iconify (MDI) name for the gradient badge. */
+  icon?: string;
+  /** Right-aligned actions (primary button, status chips, etc.). */
+  rightSlot?: ReactNode;
+}
+
+/**
+ * The canonical assessment-admin page header. Wraps the scorecard `SectionHero`
+ * (eyebrow + gradient icon badge + title + subtitle + rightSlot) with the module's
+ * accent, replacing the bespoke gradient-clip `<Typography variant="h4">` headers.
+ */
+export function AssessmentSectionHero({
+  chapter,
+  title,
+  subtitle,
+  accent = "indigo",
+  icon = "mdi:clipboard-text-outline",
+  rightSlot,
+}: AssessmentSectionHeroProps) {
+  const tone = ASSESSMENT_ACCENTS[accent];
+  return (
+    <SectionHero
+      chapter={chapter}
+      title={title}
+      subtitle={subtitle}
+      accentTop={tone.top}
+      accentBottom={tone.bottom}
+      iconBadge={{
+        icon,
+        gradient: `linear-gradient(135deg, ${tone.top} 0%, ${tone.bottom} 100%)`,
+        shadow: `0 18px 32px -16px color-mix(in srgb, ${tone.top} 60%, transparent)`,
+      }}
+      rightSlot={rightSlot}
+    />
+  );
+}

--- a/components/admin/assessment/shared/AssessmentSectionShell.tsx
+++ b/components/admin/assessment/shared/AssessmentSectionShell.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { SectionShell } from "@/components/scorecard/shared";
+
+/**
+ * The assessment-management module's signature card shell + accents, mirroring the
+ * adaptive-course/quiz pattern (which wraps the scorecard `SectionShell`). A cool
+ * indigo→sky→teal radial mesh gives every assessment admin surface one identity, the
+ * same way the adaptive module has its indigo→purple→pink mesh.
+ */
+export const ASSESSMENT_RADIAL_MESH = [
+  "radial-gradient(circle at 8% 0%, color-mix(in srgb, #6366f1 20%, transparent) 0%, transparent 55%)",
+  "radial-gradient(circle at 95% 5%, color-mix(in srgb, #0ea5e9 16%, transparent) 0%, transparent 55%)",
+  "radial-gradient(circle at 50% 110%, color-mix(in srgb, #14b8a6 18%, transparent) 0%, transparent 60%)",
+];
+
+interface AssessmentSectionShellProps {
+  radialMesh?: string[];
+  meshOpacity?: number;
+  children: ReactNode;
+}
+
+export function AssessmentSectionShell({
+  radialMesh = ASSESSMENT_RADIAL_MESH,
+  meshOpacity = 0.5,
+  children,
+}: AssessmentSectionShellProps) {
+  return (
+    <SectionShell radialMesh={radialMesh} meshOpacity={meshOpacity}>
+      {children}
+    </SectionShell>
+  );
+}
+
+/** Per-surface accent gradients, matching the scorecard/adaptive convention. */
+export const ASSESSMENT_ACCENTS = {
+  indigo: { top: "#6366f1", bottom: "#4338ca" },
+  sky: { top: "#0ea5e9", bottom: "#0369a1" },
+  teal: { top: "#14b8a6", bottom: "#0f766e" },
+  amber: { top: "#f59e0b", bottom: "#b45309" },
+  rose: { top: "#f43f5e", bottom: "#be123c" },
+} as const;
+
+export type AssessmentAccent = keyof typeof ASSESSMENT_ACCENTS;

--- a/components/admin/assessment/shared/AssessmentSharedPagination.tsx
+++ b/components/admin/assessment/shared/AssessmentSharedPagination.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+/**
+ * AssessmentSharedPagination — the single footer pagination row for the
+ * assessment-management admin redesign. Replaces three inconsistent
+ * pagination implementations with one token-driven, theme-aware primitive.
+ *
+ * Left:  "Showing X–Y of Z" range (clamped) + optional PerPageSelect.
+ * Right: MUI <Pagination> (compact, single sibling/boundary).
+ * Stacks on xs; the whole row sits above a hairline border-top.
+ */
+
+import { Box, Pagination, Typography } from "@mui/material";
+import { PerPageSelect } from "@/components/common/PerPageSelect";
+
+export interface AssessmentSharedPaginationProps {
+  /** Current 1-based page. */
+  page: number;
+  /** Rows per page. */
+  pageSize: number;
+  /** Total number of rows across all pages. */
+  total: number;
+  /** Called with the next 1-based page. */
+  onPageChange: (page: number) => void;
+  /** When provided, renders a PerPageSelect wired to this handler. */
+  onPageSizeChange?: (size: number) => void;
+  /** Optional per-page choices forwarded to PerPageSelect. */
+  perPageOptions?: number[];
+}
+
+export function AssessmentSharedPagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onPageSizeChange,
+  perPageOptions,
+}: AssessmentSharedPaginationProps): React.JSX.Element {
+  const safeTotal = Math.max(0, Math.floor(total));
+  const safePageSize = Math.max(1, Math.floor(pageSize));
+  const pageCount = Math.max(1, Math.ceil(safeTotal / safePageSize));
+  const safePage = Math.min(Math.max(1, Math.floor(page)), pageCount);
+
+  // Range is clamped so an out-of-bounds page or empty result never lies.
+  const start = safeTotal === 0 ? 0 : (safePage - 1) * safePageSize + 1;
+  const end = safeTotal === 0 ? 0 : Math.min(safePage * safePageSize, safeTotal);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", sm: "row" },
+        alignItems: { xs: "stretch", sm: "center" },
+        justifyContent: "space-between",
+        gap: 1.5,
+        px: 2,
+        py: 1.5,
+        borderTop: "1px solid var(--border-default)",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 1.5,
+        }}
+      >
+        <Typography
+          component="span"
+          sx={{
+            fontSize: 13,
+            color: "var(--font-secondary)",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {`Showing ${start}–${end} of ${safeTotal}`}
+        </Typography>
+
+        {onPageSizeChange ? (
+          <PerPageSelect
+            value={safePageSize}
+            onChange={onPageSizeChange}
+            options={perPageOptions}
+          />
+        ) : null}
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: { xs: "center", sm: "flex-end" },
+          overflowX: "auto",
+        }}
+      >
+        <Pagination
+          count={pageCount}
+          page={safePage}
+          onChange={(_event, value) => onPageChange(value)}
+          color="primary"
+          size="small"
+          siblingCount={0}
+          boundaryCount={1}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+export default AssessmentSharedPagination;

--- a/components/admin/assessment/shared/AssessmentSkeletons.tsx
+++ b/components/admin/assessment/shared/AssessmentSkeletons.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+/**
+ * AssessmentSkeletons — loading placeholders for the assessment-management admin
+ * redesign. Each skeleton mirrors the footprint of the real component it stands in
+ * for (data table, filter bar, form) so the swap from loading → loaded produces no
+ * layout jump. Tokenized (var(--card-bg) / var(--border-default)); wave animation.
+ */
+
+import { Box, Skeleton } from "@mui/material";
+
+const CARD_SX = {
+  bgcolor: "var(--card-bg)",
+  border: "1px solid var(--border-default)",
+  borderRadius: 2,
+  overflow: "hidden",
+} as const;
+
+const SKELETON_BG = "color-mix(in srgb, var(--font-primary) 11%, var(--card-bg) 89%)";
+
+type AssessmentTableSkeletonProps = {
+  rows?: number;
+  columns?: number;
+};
+
+/**
+ * Mirrors AssessmentDataTable: a rounded hairline card with a header-ish row
+ * followed by `rows` rows of `columns` rectangular cells. The whole grid lives in
+ * an overflow-x:auto container so a wide table never scrolls the page body.
+ */
+export function AssessmentTableSkeleton({
+  rows = 8,
+  columns = 5,
+}: AssessmentTableSkeletonProps) {
+  const rowKeys = Array.from({ length: Math.max(0, rows) }, (_, i) => i);
+  const colKeys = Array.from({ length: Math.max(1, columns) }, (_, i) => i);
+
+  // First column reads as a "primary" label; the last as a compact actions cell.
+  const cellFlex = (col: number) => {
+    if (col === 0) return 2.2;
+    if (col === colKeys.length - 1) return 0.9;
+    return 1.4;
+  };
+
+  return (
+    <Box sx={CARD_SX} aria-hidden="true">
+      <Box sx={{ overflowX: "auto" }}>
+        <Box sx={{ minWidth: columns * 120 }}>
+          {/* Header row */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 2,
+              px: 2,
+              py: 1.75,
+              borderBottom: "1px solid var(--border-default)",
+              bgcolor:
+                "color-mix(in srgb, var(--font-primary) 4%, var(--card-bg) 96%)",
+            }}
+          >
+            {colKeys.map((col) => (
+              <Box key={col} sx={{ flex: cellFlex(col), minWidth: 0 }}>
+                <Skeleton
+                  animation="wave"
+                  variant="rounded"
+                  height={12}
+                  width={col === 0 ? "55%" : "70%"}
+                  sx={{ bgcolor: SKELETON_BG, borderRadius: 999 }}
+                />
+              </Box>
+            ))}
+          </Box>
+
+          {/* Body rows */}
+          {rowKeys.map((row) => (
+            <Box
+              key={row}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+                px: 2,
+                py: 1.75,
+                borderBottom:
+                  row === rowKeys.length - 1
+                    ? "none"
+                    : "1px solid var(--border-default)",
+              }}
+            >
+              {colKeys.map((col) => (
+                <Box key={col} sx={{ flex: cellFlex(col), minWidth: 0 }}>
+                  <Skeleton
+                    animation="wave"
+                    variant="rounded"
+                    height={col === colKeys.length - 1 ? 28 : 16}
+                    width={col === colKeys.length - 1 ? 64 : `${60 + ((row * 7 + col * 13) % 30)}%`}
+                    sx={{ bgcolor: SKELETON_BG, borderRadius: col === colKeys.length - 1 ? 1 : 999 }}
+                  />
+                </Box>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Mirrors the assessment filter bar: a rounded hairline card with one wide search
+ * field skeleton and a handful of pill (chip) skeletons.
+ */
+export function AssessmentFilterBarSkeleton() {
+  const pillKeys = [96, 72, 108, 84];
+
+  return (
+    <Box
+      sx={{
+        ...CARD_SX,
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: 1.5,
+        px: 2,
+        py: 1.75,
+      }}
+      aria-hidden="true"
+    >
+      <Skeleton
+        animation="wave"
+        variant="rounded"
+        height={40}
+        sx={{
+          bgcolor: SKELETON_BG,
+          borderRadius: 2,
+          flex: "1 1 240px",
+          minWidth: 200,
+          maxWidth: 420,
+        }}
+      />
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, flex: "1 1 auto" }}>
+        {pillKeys.map((width, i) => (
+          <Skeleton
+            key={i}
+            animation="wave"
+            variant="rounded"
+            height={32}
+            width={width}
+            sx={{ bgcolor: SKELETON_BG, borderRadius: 999 }}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+type AssessmentFormSkeletonProps = {
+  fields?: number;
+};
+
+/**
+ * Mirrors an assessment edit/create form: `fields` stacked label + input skeleton
+ * pairs inside a rounded hairline card, with a trailing action-button row.
+ */
+export function AssessmentFormSkeleton({ fields = 4 }: AssessmentFormSkeletonProps) {
+  const fieldKeys = Array.from({ length: Math.max(1, fields) }, (_, i) => i);
+
+  return (
+    <Box
+      sx={{
+        ...CARD_SX,
+        display: "flex",
+        flexDirection: "column",
+        gap: 2.5,
+        p: 2.5,
+      }}
+      aria-hidden="true"
+    >
+      {fieldKeys.map((field) => {
+        // Every third field renders as a taller multi-line input (textarea-ish).
+        const isMultiline = field % 3 === 2;
+        return (
+          <Box
+            key={field}
+            sx={{ display: "flex", flexDirection: "column", gap: 1 }}
+          >
+            <Skeleton
+              animation="wave"
+              variant="rounded"
+              height={11}
+              width={`${28 + ((field * 11) % 18)}%`}
+              sx={{ bgcolor: SKELETON_BG, borderRadius: 999 }}
+            />
+            <Skeleton
+              animation="wave"
+              variant="rounded"
+              height={isMultiline ? 88 : 44}
+              width="100%"
+              sx={{ bgcolor: SKELETON_BG, borderRadius: 2 }}
+            />
+          </Box>
+        );
+      })}
+
+      {/* Action row */}
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "flex-end",
+          gap: 1.5,
+          pt: 1,
+        }}
+      >
+        <Skeleton
+          animation="wave"
+          variant="rounded"
+          height={40}
+          width={96}
+          sx={{ bgcolor: SKELETON_BG, borderRadius: 2 }}
+        />
+        <Skeleton
+          animation="wave"
+          variant="rounded"
+          height={40}
+          width={128}
+          sx={{ bgcolor: SKELETON_BG, borderRadius: 2 }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/AssessmentStatusChip.tsx
+++ b/components/admin/assessment/shared/AssessmentStatusChip.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * AssessmentStatusChip — shared status/label primitives for the assessment-management
+ * admin redesign. Provides a tone-driven pill (StatusChip), a difficulty mapper
+ * (DifficultyChip), a compact count badge (CountBadge), and a status→tone helper
+ * (assessmentStatusTone). All colors flow through CSS custom-property tokens so the
+ * primitives stay theme-aware in light and dark.
+ */
+
+import * as React from "react";
+import { Box, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export type ChipTone = "success" | "warning" | "error" | "info" | "neutral";
+
+/** Resolves a tone to its token-backed foreground color. */
+const TONE_COLOR: Record<ChipTone, string> = {
+  success: "var(--success-500)",
+  warning: "var(--warning-500)",
+  error: "var(--error-500)",
+  info: "var(--accent-indigo)",
+  neutral: "var(--font-secondary)",
+};
+
+export interface StatusChipProps {
+  label: string;
+  tone?: ChipTone;
+  icon?: string;
+}
+
+/**
+ * StatusChip — a small tinted pill. Background is a 14% tint of the tone color
+ * over the surface; foreground text/icon use the tone color directly.
+ */
+export function StatusChip({ label, tone = "neutral", icon }: StatusChipProps) {
+  const color = TONE_COLOR[tone];
+  const bg = `color-mix(in srgb, ${color} 14%, var(--surface) 86%)`;
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.5,
+        height: 23,
+        px: 1,
+        borderRadius: 999,
+        backgroundColor: bg,
+        border: "1px solid transparent",
+        color,
+        fontSize: "0.72rem",
+        fontWeight: 600,
+        lineHeight: 1,
+        whiteSpace: "nowrap",
+        maxWidth: "100%",
+      }}
+    >
+      {icon ? <IconWrapper icon={icon} size={13} color={color} /> : null}
+      <Box
+        component="span"
+        sx={{ overflow: "hidden", textOverflow: "ellipsis" }}
+      >
+        {label}
+      </Box>
+    </Box>
+  );
+}
+
+export interface DifficultyChipProps {
+  level?: string;
+}
+
+/** Maps a difficulty level to a toned StatusChip. Unknown/empty → neutral "—". */
+export function DifficultyChip({ level }: DifficultyChipProps) {
+  const key = (level ?? "").trim().toLowerCase();
+
+  let tone: ChipTone;
+  let label: string;
+  switch (key) {
+    case "easy":
+      tone = "success";
+      label = "Easy";
+      break;
+    case "medium":
+      tone = "warning";
+      label = "Medium";
+      break;
+    case "hard":
+      tone = "error";
+      label = "Hard";
+      break;
+    default:
+      tone = "neutral";
+      label = "—";
+  }
+
+  return <StatusChip label={label} tone={tone} icon="mdi:speedometer" />;
+}
+
+export interface CountBadgeProps {
+  count: number;
+  label?: string;
+}
+
+/** CountBadge — compact indigo-tinted badge showing a count and optional label. */
+export function CountBadge({ count, label }: CountBadgeProps) {
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "baseline",
+        gap: 0.5,
+        px: 0.75,
+        py: 0.25,
+        borderRadius: 1,
+        backgroundColor:
+          "color-mix(in srgb, var(--accent-indigo) 14%, var(--surface) 86%)",
+        color: "var(--accent-indigo-dark)",
+        lineHeight: 1,
+        whiteSpace: "nowrap",
+      }}
+    >
+      <Typography
+        component="span"
+        sx={{ fontSize: "0.78rem", fontWeight: 700, lineHeight: 1 }}
+      >
+        {count}
+      </Typography>
+      {label ? (
+        <Typography
+          component="span"
+          sx={{
+            fontSize: "0.68rem",
+            fontWeight: 500,
+            lineHeight: 1,
+            opacity: 0.85,
+          }}
+        >
+          {label}
+        </Typography>
+      ) : null}
+    </Box>
+  );
+}
+
+/** Title-cases a raw token (hyphen/underscore/space separated). */
+function titleCase(raw: string): string {
+  return raw
+    .trim()
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+/**
+ * assessmentStatusTone — maps a raw assessment status to a display tone + label.
+ * active/published → success, draft → warning, inactive/archived → neutral,
+ * scheduled → info. Unknown values fall back to neutral with a Title-cased label.
+ */
+export function assessmentStatusTone(status: string): {
+  tone: ChipTone;
+  label: string;
+} {
+  switch ((status ?? "").trim().toLowerCase()) {
+    case "active":
+    case "published":
+      return { tone: "success", label: "Active" };
+    case "draft":
+      return { tone: "warning", label: "Draft" };
+    case "inactive":
+    case "archived":
+      return { tone: "neutral", label: "Inactive" };
+    case "scheduled":
+      return { tone: "info", label: "Scheduled" };
+    default:
+      return { tone: "neutral", label: titleCase(status || "Unknown") };
+  }
+}

--- a/components/admin/assessment/shared/index.ts
+++ b/components/admin/assessment/shared/index.ts
@@ -1,0 +1,31 @@
+// Assessment-management shared design primitives (adaptive-course language).
+export { AssessmentSectionHero } from "./AssessmentSectionHero";
+export {
+  AssessmentSectionShell,
+  ASSESSMENT_ACCENTS,
+  ASSESSMENT_RADIAL_MESH,
+  type AssessmentAccent,
+} from "./AssessmentSectionShell";
+export {
+  StatusChip,
+  DifficultyChip,
+  CountBadge,
+  assessmentStatusTone,
+  type ChipTone,
+} from "./AssessmentStatusChip";
+export { AssessmentEmptyState } from "./AssessmentEmptyState";
+export {
+  AssessmentDataTable,
+  type AssessmentColumn,
+} from "./AssessmentDataTable";
+export {
+  AssessmentFilterBar,
+  type FilterSelectDef,
+  type ActiveFilterChip,
+} from "./AssessmentFilterBar";
+export { AssessmentSharedPagination } from "./AssessmentSharedPagination";
+export {
+  AssessmentTableSkeleton,
+  AssessmentFilterBarSkeleton,
+  AssessmentFormSkeleton,
+} from "./AssessmentSkeletons";


### PR DESCRIPTION
Second phase of the assessment-management FE revamp — the **adaptive-course design language** lands on the list page, built on a new shared primitive library.

## Shared primitives (components/admin/assessment/shared/)
Mirror the adaptive-course pattern (wrap the scorecard SectionHero / SectionShell / KpiRail):
- **AssessmentSectionHero** + **AssessmentSectionShell** (module accent + radial mesh)
- **StatusChip / DifficultyChip / CountBadge** (tokenized semantic chips; Hard=error)
- **AssessmentDataTable** (generic, responsive, sticky header, scroll-contained)
- **AssessmentFilterBar** (search + facet selects + removable active chips + clear)
- **AssessmentEmptyState**, **AssessmentSharedPagination** (replaces 3 impls), skeletons

All fully tokenized + theme-aware (light/dark), typecheck-clean.

## List page (/admin/assessment)
- Gradient-clip h4 header to **AssessmentSectionHero** (eyebrow + gradient icon badge + Create action)
- Bespoke filter Paper (5 Selects + manual chips) to **AssessmentFilterBar**
- Bare spinner to **AssessmentTableSkeleton** (no more spinner to table jump)
- Certificate icon: dropped a hard-coded hex for a theme token; removed dead MUI imports

Follow-up (next phases): migrate AssessmentTable rows onto AssessmentDataTable, then the create wizard + edit tabs.

Typecheck clean (0 TS errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
