### PR TITLE
feat(assessment-mgmt): Phase 3 — edit tabs on adaptive SegmentedTabs

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -60,6 +60,7 @@ import { escapeCsvCell } from "@/lib/utils/csv-export";
 import {
   AssessmentSectionHero,
   StatusChip,
+  SegmentedTabs,
 } from "@/components/admin/assessment/shared";
 import { BasicInfoSection } from "@/components/admin/assessment/BasicInfoSection";
 import { AssessmentSettingsSection } from "@/components/admin/assessment/AssessmentSettingsSection";
@@ -1593,30 +1594,36 @@ export default function AssessmentEditPage() {
             </Alert>
           )}
 
-        <Paper sx={{ borderRadius: 2, overflow: "hidden", boxShadow: 1 }}>
-          <Tabs
+        <Box sx={{ mb: 3 }}>
+          <SegmentedTabs<TabValue>
             value={tab}
-            onChange={(_, v: TabValue) => {
+            onChange={(v) => {
               setTab(v);
               const next = new URLSearchParams(searchParams.toString());
               next.set("tab", v);
               router.replace(`${pathname}?${next.toString()}`, { scroll: false });
             }}
-            sx={{
-              borderBottom: 1,
-              borderColor: "divider",
-              px: 2,
-              "& .MuiTab-root": { textTransform: "none", fontWeight: 600 },
-            }}
-          >
-            <Tab value="details" label="Details" />
-            {!hideAdminQuestions && (
-              <Tab value="questions" label="Questions" />
-            )}
-            <Tab value="submissions" label="Submissions" />
-            <Tab value="analytics" label="Analytics" />
-          </Tabs>
-
+            tabs={[
+              { value: "details", label: "Details", icon: "mdi:information-outline" },
+              ...(!hideAdminQuestions
+                ? [
+                    {
+                      value: "questions" as TabValue,
+                      label: "Questions",
+                      icon: "mdi:help-box-outline",
+                    },
+                  ]
+                : []),
+              {
+                value: "submissions",
+                label: "Submissions",
+                icon: "mdi:file-document-multiple-outline",
+              },
+              { value: "analytics", label: "Analytics", icon: "mdi:chart-box-outline" },
+            ]}
+          />
+        </Box>
+        <Paper sx={{ borderRadius: 2, overflow: "hidden", boxShadow: 1 }}>
           <Box sx={{ p: { xs: 2, sm: 3 } }}>
             {tab === "details" && (
               <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>

--- a/components/admin/assessment/shared/SegmentedTabs.tsx
+++ b/components/admin/assessment/shared/SegmentedTabs.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Box } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export interface SegmentedTab<T extends string = string> {
+  value: T;
+  label: string;
+  icon?: string;
+  /** Optional trailing count badge. */
+  count?: number;
+}
+
+interface SegmentedTabsProps<T extends string> {
+  tabs: SegmentedTab<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  /** Fill available width (equal segments) vs. hug content. */
+  fullWidth?: boolean;
+}
+
+/**
+ * Adaptive pill/segmented tab control — a single rounded track with a filled active
+ * segment, replacing the MUI underline Tabs. Keeps the caller's value/onChange contract
+ * (so URL-driven tab state is unchanged); this is purely the presentation.
+ */
+export function SegmentedTabs<T extends string>({
+  tabs,
+  value,
+  onChange,
+  fullWidth = false,
+}: SegmentedTabsProps<T>) {
+  return (
+    <Box
+      role="tablist"
+      sx={{
+        display: "inline-flex",
+        gap: 0.5,
+        p: 0.5,
+        borderRadius: 999,
+        border: "1px solid var(--border-default)",
+        bgcolor: "var(--surface)",
+        maxWidth: "100%",
+        overflowX: "auto",
+        ...(fullWidth ? { display: "flex", width: "100%" } : {}),
+      }}
+    >
+      {tabs.map((tab) => {
+        const active = tab.value === value;
+        return (
+          <Box
+            key={tab.value}
+            role="tab"
+            aria-selected={active}
+            tabIndex={0}
+            onClick={() => onChange(tab.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onChange(tab.value);
+              }
+            }}
+            sx={{
+              flex: fullWidth ? 1 : "0 0 auto",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 0.75,
+              px: 2,
+              py: 0.9,
+              borderRadius: 999,
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+              fontSize: "0.85rem",
+              fontWeight: active ? 700 : 500,
+              color: active ? "var(--font-light)" : "var(--font-secondary)",
+              bgcolor: active ? "var(--accent-indigo)" : "transparent",
+              boxShadow: active
+                ? "0 6px 14px -8px color-mix(in srgb, var(--accent-indigo) 70%, transparent)"
+                : "none",
+              transition: "background-color 0.15s ease, color 0.15s ease",
+              "&:hover": active
+                ? {}
+                : {
+                    bgcolor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--surface) 90%)",
+                    color: "var(--accent-indigo-dark)",
+                  },
+            }}
+          >
+            {tab.icon ? <IconWrapper icon={tab.icon} size={17} /> : null}
+            <span>{tab.label}</span>
+            {typeof tab.count === "number" ? (
+              <Box
+                component="span"
+                sx={{
+                  ml: 0.25,
+                  px: 0.75,
+                  py: 0.05,
+                  borderRadius: 999,
+                  fontSize: "0.7rem",
+                  fontWeight: 700,
+                  bgcolor: active
+                    ? "color-mix(in srgb, var(--font-light) 26%, transparent)"
+                    : "color-mix(in srgb, var(--accent-indigo) 14%, var(--surface) 86%)",
+                  color: active ? "var(--font-light)" : "var(--accent-indigo-dark)",
+                }}
+              >
+                {tab.count}
+              </Box>
+            ) : null}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/index.ts
+++ b/components/admin/assessment/shared/index.ts
@@ -24,6 +24,7 @@ export {
   type ActiveFilterChip,
 } from "./AssessmentFilterBar";
 export { AssessmentSharedPagination } from "./AssessmentSharedPagination";
+export { SegmentedTabs, type SegmentedTab } from "./SegmentedTabs";
 export {
   AssessmentTableSkeleton,
   AssessmentFilterBarSkeleton,


### PR DESCRIPTION
Phase 3 (part 1) of the assessment-management FE revamp — the **edit page tabs** move to an adaptive segmented control.

- New **SegmentedTabs** primitive: a rounded pill track with a filled active segment, per-tab icon + optional count badge, keyboard-accessible (Enter/Space), tokenized + theme-aware. The caller's value/onChange contract is unchanged, so URL-driven tab state still works.
- Edit page (`/admin/assessment/[id]/edit`): the MUI underline Tabs (Details / Questions / Submissions / Analytics) now render via SegmentedTabs, lifted above the content card with per-tab icons.

Typecheck clean. Follow-up: create-wizard section cards + the analytics card, then the AssessmentTable → AssessmentDataTable migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
