### PR TITLE
feat(assessment): Phase 0 — composer redesign design foundation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -104,6 +104,24 @@
   /* Card / surface background */
   --card-bg: #ffffff;
 
+  /* ── Assessment redesign foundation ─────────────────────────────────────
+     Warm-gray page canvas, the signature violet→pink AI gradient (reserved for
+     AI moments + primary actions), an 18px card radius, a mono font stack for
+     numeric data, and a cyan=proctored tone. Scoped-in by the assessment module;
+     safe additive tokens (nothing else references them yet). */
+  --canvas: #f4f3f8;
+  --gradient-ai: linear-gradient(135deg, #7c3aed 0%, #ec4899 100%);
+  --gradient-ai-soft: linear-gradient(135deg,
+    color-mix(in srgb, #7c3aed 14%, var(--card-bg) 86%) 0%,
+    color-mix(in srgb, #ec4899 12%, var(--card-bg) 88%) 100%);
+  --ai-violet: #7c3aed;
+  --ai-pink: #ec4899;
+  --radius-card: 18px;
+  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+  --font-jakarta: "Plus Jakarta Sans", var(--font-family-primary, "Satoshi"), system-ui, sans-serif;
+  /* cyan = proctored (semantic tone the chip set was missing) */
+  --tone-proctored: var(--accent-cyan, #06b6d4);
+
   /* Chart series colors */
   --chart-articles: #234256;
   --chart-videos: #4ecdc4;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -101,6 +101,13 @@ export default async function RootLayout({
           rel="stylesheet"
           href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,600,700,800,900&display=swap"
         />
+        {/* Assessment redesign: Plus Jakarta Sans (text) + JetBrains Mono (numbers). */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+        />
       </head>
 
       <body className={`antialiased`} suppressHydrationWarning>

--- a/components/admin/assessment/shared/AiPromptField.tsx
+++ b/components/admin/assessment/shared/AiPromptField.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Box, Chip, Button, TextField, CircularProgress } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+interface AiPromptFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  placeholder?: string;
+  /** Starter briefs the admin can click to prefill the field. */
+  examples?: string[];
+  submitting?: boolean;
+  submitLabel?: string;
+  disabled?: boolean;
+}
+
+/**
+ * The AI brief input — a large plain-English textarea with clickable example chips and a
+ * gradient Generate button. The signature "describe it, we'll build it" control, shared by
+ * the composer page and the hub AI-create hero.
+ */
+export function AiPromptField({
+  value,
+  onChange,
+  onSubmit,
+  placeholder = "e.g. 45-min proctored cybersecurity screening, 10 MCQs + 2 coding problems…",
+  examples = [],
+  submitting = false,
+  submitLabel = "Generate",
+  disabled = false,
+}: AiPromptFieldProps) {
+  const canSubmit = value.trim().length > 0 && !submitting && !disabled;
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1.5,
+          flexDirection: { xs: "column", sm: "row" },
+          alignItems: { xs: "stretch", sm: "flex-start" },
+        }}
+      >
+        <TextField
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && canSubmit) {
+              e.preventDefault();
+              onSubmit();
+            }
+          }}
+          placeholder={placeholder}
+          multiline
+          minRows={1}
+          maxRows={5}
+          fullWidth
+          InputProps={{
+            startAdornment: (
+              <Box sx={{ display: "inline-flex", mr: 1, mt: 0.25, color: "var(--ai-violet)" }}>
+                <IconWrapper icon="mdi:auto-fix" size={20} />
+              </Box>
+            ),
+            sx: {
+              alignItems: "flex-start",
+              borderRadius: "var(--radius-card)",
+              bgcolor: "var(--card-bg)",
+              fontFamily: "var(--font-jakarta)",
+            },
+          }}
+        />
+        <Button
+          onClick={onSubmit}
+          disabled={!canSubmit}
+          sx={{
+            flexShrink: 0,
+            px: 3,
+            py: 1.25,
+            minWidth: 132,
+            borderRadius: "var(--radius-card)",
+            textTransform: "none",
+            fontWeight: 700,
+            color: "#fff",
+            background: "var(--gradient-ai)",
+            boxShadow: "0 12px 24px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+            "&:hover": { filter: "brightness(1.05)" },
+            "&.Mui-disabled": { background: "var(--surface)", color: "var(--font-tertiary)" },
+          }}
+          endIcon={
+            submitting ? (
+              <CircularProgress size={16} sx={{ color: "#fff" }} />
+            ) : (
+              <IconWrapper icon="mdi:arrow-right" size={18} />
+            )
+          }
+        >
+          {submitting ? "Generating…" : submitLabel}
+        </Button>
+      </Box>
+
+      {examples.length > 0 ? (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1.5 }}>
+          {examples.map((ex) => (
+            <Chip
+              key={ex}
+              label={`"${ex}"`}
+              onClick={() => onChange(ex)}
+              size="small"
+              sx={{
+                cursor: "pointer",
+                maxWidth: "100%",
+                bgcolor: "color-mix(in srgb, var(--ai-violet) 8%, var(--card-bg) 92%)",
+                color: "var(--font-secondary)",
+                border: "1px solid color-mix(in srgb, var(--ai-violet) 20%, var(--border-default) 80%)",
+                "& .MuiChip-label": { fontSize: "0.75rem" },
+                "&:hover": { bgcolor: "color-mix(in srgb, var(--ai-violet) 14%, var(--card-bg) 86%)" },
+              }}
+            />
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/AssessmentCard.tsx
+++ b/components/admin/assessment/shared/AssessmentCard.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import type { Assessment } from "@/lib/services/admin/admin-assessment.service";
+import { StatusChip } from "./AssessmentStatusChip";
+import { DifficultyBalanceMeter, type DifficultyBalance } from "./DifficultyBalanceMeter";
+
+/** Derive a display status from the list-item flags/times (no single status field exists). */
+export function deriveAssessmentStatus(a: Assessment): {
+  key: "draft" | "scheduled" | "closed" | "active" | "inactive";
+  label: string;
+  tone: "success" | "warning" | "error" | "info" | "neutral";
+} {
+  if (a.is_draft) return { key: "draft", label: "Draft", tone: "warning" };
+  const now = Date.now();
+  const start = a.start_time ? new Date(a.start_time).getTime() : null;
+  const end = a.end_time ? new Date(a.end_time).getTime() : null;
+  if (start && start > now) return { key: "scheduled", label: "Scheduled", tone: "info" };
+  if (end && end < now) return { key: "closed", label: "Closed", tone: "neutral" };
+  if (a.is_active) return { key: "active", label: "Active", tone: "success" };
+  return { key: "inactive", label: "Inactive", tone: "neutral" };
+}
+
+function MiniStat({ value, label }: { value: string | number; label: string }) {
+  return (
+    <Box sx={{ textAlign: "center", flex: 1, minWidth: 0 }}>
+      <Typography
+        sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}
+      >
+        {value}
+      </Typography>
+      <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+interface AssessmentCardProps {
+  assessment: Assessment;
+  onClick?: (a: Assessment) => void;
+  /** Optional per-row extras the hub may compute. */
+  aiAuthored?: boolean;
+  difficultyBalance?: DifficultyBalance;
+  /** Top-right action slot (e.g. the row overflow menu). */
+  actionSlot?: React.ReactNode;
+}
+
+const STATUS_ACCENT: Record<string, string> = {
+  active: "var(--success-500)",
+  scheduled: "var(--accent-indigo)",
+  draft: "var(--warning-500)",
+  closed: "var(--font-tertiary)",
+  inactive: "var(--font-tertiary)",
+};
+
+function formatOpens(iso?: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return null;
+  return d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
+/**
+ * Rich hub card for one assessment: a top status accent bar, status/AI/proctored/paid chips,
+ * title + course, question/duration/section mini-stats, and either a difficulty bar or an
+ * "Opens …" line for scheduled. Draft cards are visually dashed. Replaces the list table row.
+ */
+export function AssessmentCard({
+  assessment,
+  onClick,
+  aiAuthored,
+  difficultyBalance,
+  actionSlot,
+}: AssessmentCardProps) {
+  const status = deriveAssessmentStatus(assessment);
+  const accent = STATUS_ACCENT[status.key];
+  const isDraft = status.key === "draft";
+  const sections = (assessment.quiz_sections_count || 0) + (assessment.coding_sections_count || 0);
+  const course = assessment.courses?.[0]?.title;
+  const opens = status.key === "scheduled" ? formatOpens(assessment.start_time) : null;
+
+  return (
+    <Box
+      onClick={() => onClick?.(assessment)}
+      sx={{
+        position: "relative",
+        borderRadius: "var(--radius-card)",
+        bgcolor: "var(--card-bg)",
+        border: isDraft ? "1.5px dashed var(--border-light)" : "1px solid var(--border-default)",
+        overflow: "hidden",
+        cursor: onClick ? "pointer" : "default",
+        transition: "box-shadow 0.15s ease, transform 0.15s ease",
+        "&:hover": onClick
+          ? {
+              boxShadow: "0 14px 32px -18px color-mix(in srgb, var(--font-primary) 40%, transparent)",
+              transform: "translateY(-2px)",
+            }
+          : {},
+      }}
+    >
+      {/* status accent bar */}
+      <Box sx={{ height: 4, background: `linear-gradient(90deg, ${accent}, color-mix(in srgb, ${accent} 40%, transparent))` }} />
+
+      <Box sx={{ p: 2.25 }}>
+        {/* top row: status + badges + action */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1.25, flexWrap: "wrap" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.6 }}>
+            <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: accent }} />
+            <Typography variant="caption" sx={{ fontWeight: 700, color: accent }}>
+              {status.label}
+            </Typography>
+          </Box>
+          <Box sx={{ flexGrow: 1 }} />
+          {aiAuthored ? (
+            <Box
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.4,
+                px: 0.85,
+                height: 22,
+                borderRadius: 999,
+                color: "#fff",
+                background: "var(--gradient-ai)",
+                fontSize: "0.68rem",
+                fontWeight: 700,
+              }}
+            >
+              <IconWrapper icon="mdi:auto-fix" size={13} /> AI
+            </Box>
+          ) : null}
+          {assessment.proctoring_enabled ? (
+            <StatusChip label="Proctored" tone="info" icon="mdi:shield-check-outline" />
+          ) : null}
+          {assessment.is_paid ? <StatusChip label="Paid" tone="warning" icon="mdi:currency-inr" /> : null}
+          {actionSlot ? <Box onClick={(e) => e.stopPropagation()}>{actionSlot}</Box> : null}
+        </Box>
+
+        <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)", lineHeight: 1.3 }}>
+          {assessment.title}
+        </Typography>
+        {course ? (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.4 }}>
+            <IconWrapper icon="mdi:book-outline" size={14} color="var(--font-tertiary)" />
+            <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+              {course}
+            </Typography>
+          </Box>
+        ) : null}
+
+        {/* mini-stats */}
+        <Box sx={{ display: "flex", gap: 1, mt: 1.75, mb: 1.5 }}>
+          <MiniStat value={assessment.total_questions ?? 0} label="Questions" />
+          <MiniStat value={`${assessment.duration_minutes}m`} label="Duration" />
+          <MiniStat value={sections} label="Sections" />
+        </Box>
+
+        {/* footer: opens (scheduled) | difficulty bar | submissions */}
+        {opens ? (
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
+              pt: 1.25,
+              borderTop: "1px solid var(--border-default)",
+              color: "var(--accent-indigo)",
+            }}
+          >
+            <IconWrapper icon="mdi:calendar-clock" size={16} />
+            <Typography variant="caption" sx={{ fontWeight: 600 }}>
+              Opens {opens}
+            </Typography>
+          </Box>
+        ) : (
+          <Box sx={{ pt: 1.25, borderTop: "1px solid var(--border-default)" }}>
+            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: difficultyBalance ? 0.75 : 0 }}>
+              <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                <Box component="span" sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--font-primary)" }}>
+                  {assessment.submissions_count ?? 0}
+                </Box>{" "}
+                submissions
+              </Typography>
+            </Box>
+            {difficultyBalance ? <DifficultyBalanceMeter balance={difficultyBalance} legend={false} height={6} /> : null}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/DifficultyBalanceMeter.tsx
+++ b/components/admin/assessment/shared/DifficultyBalanceMeter.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+
+export interface DifficultyBalance {
+  easy: number;
+  medium: number;
+  hard: number;
+}
+
+interface DifficultyBalanceMeterProps {
+  balance: DifficultyBalance;
+  /** Show the "Easy N · Medium N · Hard N" legend below the bar. */
+  legend?: boolean;
+  /** Bar height in px. */
+  height?: number;
+  /** Compact single-line variant (legend inline, smaller). */
+  dense?: boolean;
+}
+
+const SEGMENTS = [
+  { key: "easy" as const, label: "Easy", color: "var(--ats-success, var(--success-500))" },
+  { key: "medium" as const, label: "Medium", color: "var(--ats-warning, var(--warning-500))" },
+  { key: "hard" as const, label: "Hard", color: "var(--ats-error, var(--error-500))" },
+];
+
+/**
+ * The reusable difficulty-balance meter — a single stacked green/amber/red bar with an
+ * optional count legend. Used across the composer blueprint, builder outline, hub cards
+ * and the detail overview so difficulty reads consistently everywhere.
+ */
+export function DifficultyBalanceMeter({
+  balance,
+  legend = true,
+  height = 8,
+  dense = false,
+}: DifficultyBalanceMeterProps) {
+  const total = Math.max(0, balance.easy) + Math.max(0, balance.medium) + Math.max(0, balance.hard);
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Box
+        role="img"
+        aria-label={`Difficulty: ${balance.easy} easy, ${balance.medium} medium, ${balance.hard} hard`}
+        sx={{
+          display: "flex",
+          height,
+          borderRadius: 999,
+          overflow: "hidden",
+          bgcolor: "var(--surface)",
+        }}
+      >
+        {total === 0 ? null : (
+          SEGMENTS.map((seg) => {
+            const n = Math.max(0, balance[seg.key]);
+            if (n === 0) return null;
+            return (
+              <Box
+                key={seg.key}
+                sx={{ width: `${(n / total) * 100}%`, bgcolor: seg.color }}
+              />
+            );
+          })
+        )}
+      </Box>
+      {legend ? (
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: dense ? 1.25 : 2,
+            mt: dense ? 0.5 : 0.75,
+          }}
+        >
+          {SEGMENTS.map((seg) => (
+            <Box key={seg.key} sx={{ display: "flex", alignItems: "center", gap: 0.6 }}>
+              <Box sx={{ width: 9, height: 9, borderRadius: "3px", bgcolor: seg.color }} />
+              <Typography
+                variant="caption"
+                sx={{ color: "var(--font-secondary)", fontSize: dense ? "0.7rem" : "0.75rem" }}
+              >
+                {seg.label}{" "}
+                <Box
+                  component="span"
+                  sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--font-primary)" }}
+                >
+                  {Math.max(0, balance[seg.key])}
+                </Box>
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/GradientRing.tsx
+++ b/components/admin/assessment/shared/GradientRing.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { AnimatedRing } from "@/components/scorecard/shared";
+
+interface GradientRingProps {
+  /** 0–100 percentage. */
+  value: number;
+  size?: number;
+  strokeWidth?: number;
+  /** Caption shown under the number (e.g. "PASS"). */
+  caption?: string;
+  valueFontSize?: number;
+  glow?: boolean;
+  /** Override the gradient stops (defaults to the signature violet→pink). */
+  from?: string;
+  to?: string;
+}
+
+/**
+ * The signature violet→pink percentage ring — a thin wrapper over the scorecard
+ * AnimatedRing fed the AI gradient stops, used for pass-rate / completion visuals.
+ */
+export function GradientRing({
+  value,
+  size = 168,
+  strokeWidth = 12,
+  caption,
+  valueFontSize,
+  glow = true,
+  from = "#7c3aed",
+  to = "#ec4899",
+}: GradientRingProps) {
+  return (
+    <AnimatedRing
+      value={value}
+      size={size}
+      strokeWidth={strokeWidth}
+      color={from}
+      colorEnd={to}
+      caption={caption}
+      valueFontSize={valueFontSize}
+      glow={glow}
+    />
+  );
+}

--- a/components/admin/assessment/shared/StatStrip.tsx
+++ b/components/admin/assessment/shared/StatStrip.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export interface StatItem {
+  label: string;
+  value: string | number;
+  icon?: string;
+  /** Tone for the icon tile: any CSS color/var. */
+  tone?: string;
+}
+
+interface StatStripProps {
+  items: StatItem[];
+}
+
+/**
+ * A horizontal strip of metric cards (total / active / scheduled / drafts / submissions /
+ * pass-rate). Numbers render in the mono stack so the strip reads like a dashboard.
+ */
+export function StatStrip({ items }: StatStripProps) {
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: {
+          xs: "repeat(2, 1fr)",
+          sm: "repeat(3, 1fr)",
+          lg: `repeat(${items.length}, 1fr)`,
+        },
+        gap: 1.5,
+      }}
+    >
+      {items.map((it) => {
+        const tone = it.tone || "var(--accent-indigo)";
+        return (
+          <Box
+            key={it.label}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              p: 2,
+              borderRadius: "var(--radius-card)",
+              bgcolor: "var(--card-bg)",
+              border: "1px solid var(--border-default)",
+              transition: "box-shadow 0.15s ease",
+              "&:hover": {
+                boxShadow: "0 8px 24px -14px color-mix(in srgb, var(--font-primary) 30%, transparent)",
+              },
+            }}
+          >
+            {it.icon ? (
+              <Box
+                sx={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 2,
+                  flexShrink: 0,
+                  display: "grid",
+                  placeItems: "center",
+                  bgcolor: `color-mix(in srgb, ${tone} 14%, var(--card-bg) 86%)`,
+                  color: tone,
+                }}
+              >
+                <IconWrapper icon={it.icon} size={20} />
+              </Box>
+            ) : null}
+            <Box sx={{ minWidth: 0 }}>
+              <Typography
+                sx={{
+                  fontFamily: "var(--font-mono)",
+                  fontWeight: 700,
+                  fontSize: "1.35rem",
+                  lineHeight: 1.1,
+                  color: "var(--font-primary)",
+                }}
+              >
+                {it.value}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{ color: "var(--font-secondary)", whiteSpace: "nowrap" }}
+              >
+                {it.label}
+              </Typography>
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/index.ts
+++ b/components/admin/assessment/shared/index.ts
@@ -25,6 +25,15 @@ export {
 } from "./AssessmentFilterBar";
 export { AssessmentSharedPagination } from "./AssessmentSharedPagination";
 export { SegmentedTabs, type SegmentedTab } from "./SegmentedTabs";
+// Assessment redesign foundation (composer + hub).
+export {
+  DifficultyBalanceMeter,
+  type DifficultyBalance,
+} from "./DifficultyBalanceMeter";
+export { GradientRing } from "./GradientRing";
+export { AiPromptField } from "./AiPromptField";
+export { StatStrip, type StatItem } from "./StatStrip";
+export { AssessmentCard, deriveAssessmentStatus } from "./AssessmentCard";
 export {
   AssessmentTableSkeleton,
   AssessmentFilterBarSkeleton,


### PR DESCRIPTION
First phase of the assessment-management redesign + AI Composer. **Foundation only — additive, no behavior change** (new tokens/fonts/primitives not yet consumed).

- **Fonts:** Plus Jakarta Sans (text) + JetBrains Mono (numbers) via Google Fonts (already allowlisted) + `--font-mono`/`--font-jakarta` tokens.
- **Tokens:** `--canvas` warm-gray (#f4f3f8), `--gradient-ai` violet->pink (#7c3aed->#ec4899) + soft variant, `--radius-card` 18px, `--tone-proctored` cyan.
- **Primitives** (components/admin/assessment/shared/): DifficultyBalanceMeter, GradientRing, AiPromptField, StatStrip, AssessmentCard (+ deriveAssessmentStatus).

Typecheck clean. Next: the AI Composer backend + frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)