### PR TITLE
feat(assessment): Phase 2 — AI Composer frontend (one-click → draft)

### DIFF
--- a/app/admin/assessment/compose/[jobId]/page.tsx
+++ b/app/admin/assessment/compose/[jobId]/page.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { Box, Typography, Button, LinearProgress, CircularProgress } from "@mui/material";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import { config } from "@/lib/config";
+import {
+  DifficultyBalanceMeter,
+  StatusChip,
+} from "@/components/admin/assessment/shared";
+import { publishAssessment } from "@/lib/services/admin/admin-assessment.service";
+import {
+  getAssessmentComposerJob,
+  composerErrorMessage,
+  isComposerTerminal,
+  type ComposerJobResponse,
+} from "@/lib/services/admin/admin-assessment-composer.service";
+
+const STAGE_LABEL: Record<string, string> = {
+  pending: "Starting…",
+  generating_blueprint: "Designing the blueprint…",
+  blueprint_ready: "Blueprint ready — generating questions…",
+  generating_questions: "Writing & calibrating questions…",
+  assembling: "Assembling your draft…",
+  completed: "Draft ready",
+  failed: "Generation failed",
+};
+
+const DIFF_TONE: Record<string, "success" | "warning" | "error" | "neutral"> = {
+  easy: "success",
+  medium: "warning",
+  hard: "error",
+};
+
+export default function ComposerJobPage() {
+  const router = useRouter();
+  const params = useParams();
+  const jobId = String(params?.jobId || "");
+  const { showToast } = useToast();
+  const [job, setJob] = useState<ComposerJobResponse | null>(null);
+  const [loadError, setLoadError] = useState("");
+  const [publishing, setPublishing] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const poll = useCallback(async () => {
+    try {
+      const data = await getAssessmentComposerJob(config.clientId, jobId);
+      setJob(data);
+      if (!isComposerTerminal(data.status)) {
+        pollRef.current = setTimeout(poll, 2000);
+      }
+    } catch (e: unknown) {
+      setLoadError((e as { message?: string })?.message || "Failed to load the composer job");
+    }
+  }, [jobId]);
+
+  useEffect(() => {
+    poll();
+    return () => {
+      if (pollRef.current) clearTimeout(pollRef.current);
+    };
+  }, [poll]);
+
+  const blueprint = job?.blueprint;
+  const overallBalance = useMemo(() => {
+    const b = { easy: 0, medium: 0, hard: 0 };
+    (blueprint?.sections || []).forEach((s) => {
+      b.easy += s.difficulty_split?.easy || 0;
+      b.medium += s.difficulty_split?.medium || 0;
+      b.hard += s.difficulty_split?.hard || 0;
+    });
+    return b;
+  }, [blueprint]);
+
+  const questionsBySection = useMemo(() => {
+    const map: Record<string, ComposerJobResponse["questions"]> = {};
+    (job?.questions || []).forEach((q) => {
+      const ref = String(q._section_ref ?? "unassigned");
+      (map[ref] ||= []).push(q);
+    });
+    return map;
+  }, [job]);
+
+  const handlePublish = async () => {
+    if (!job?.generated_assessment_id) return;
+    try {
+      setPublishing(true);
+      await publishAssessment(config.clientId, job.generated_assessment_id);
+      showToast("Assessment published to learners", "success");
+      router.push(`/admin/assessment/${job.generated_assessment_id}/edit`);
+    } catch (e: unknown) {
+      showToast((e as { message?: string })?.message || "Failed to publish", "error");
+      setPublishing(false);
+    }
+  };
+
+  const handleFineTune = () => {
+    if (job?.generated_assessment_id) {
+      router.push(`/admin/assessment/create?fromDraft=${job.generated_assessment_id}`);
+    }
+  };
+
+  const isFailed = job?.status === "failed";
+  const isDone = job?.status === "completed";
+  const generating = job != null && !isComposerTerminal(job.status);
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%" }}>
+        <Button
+          startIcon={<IconWrapper icon="mdi:arrow-left" size={20} />}
+          onClick={() => router.push("/admin/assessment/compose")}
+          sx={{ mb: 2, color: "var(--ai-violet)", textTransform: "none" }}
+        >
+          Back to composer
+        </Button>
+
+        {/* Header */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.75, mb: 3 }}>
+          <Box
+            sx={{
+              width: 52,
+              height: 52,
+              borderRadius: 3,
+              display: "grid",
+              placeItems: "center",
+              color: "#fff",
+              background: "var(--gradient-ai)",
+              boxShadow: "0 14px 28px -14px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+            }}
+          >
+            <IconWrapper icon="mdi:auto-fix" size={26} />
+          </Box>
+          <Box>
+            <Typography sx={{ fontSize: "0.72rem", fontWeight: 800, letterSpacing: "0.1em", color: "var(--ai-violet)" }}>
+              AI ASSESSMENT COMPOSER
+            </Typography>
+            <Typography sx={{ fontFamily: "var(--font-jakarta)", fontWeight: 800, fontSize: "1.6rem", color: "var(--font-primary)" }}>
+              {isDone ? "Review your draft" : isFailed ? "Generation failed" : "Building your assessment"}
+            </Typography>
+          </Box>
+        </Box>
+
+        {loadError ? (
+          <Box sx={{ p: 3, borderRadius: "var(--radius-card)", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+            <Typography color="error">{loadError}</Typography>
+          </Box>
+        ) : !job ? (
+          <Box sx={{ display: "flex", justifyContent: "center", p: 6 }}>
+            <CircularProgress sx={{ color: "var(--ai-violet)" }} />
+          </Box>
+        ) : isFailed ? (
+          <Box sx={{ p: 3, borderRadius: "var(--radius-card)", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", maxWidth: 640 }}>
+            <Typography sx={{ fontWeight: 700, mb: 1, color: "var(--error-500)" }}>
+              We couldn&apos;t finish this assessment.
+            </Typography>
+            <Typography sx={{ color: "var(--font-secondary)", mb: 2 }}>
+              {composerErrorMessage(job) ||
+                "The AI provider may be rate-limited or over quota. Please try again shortly."}
+            </Typography>
+            <Button
+              variant="contained"
+              onClick={() => router.push("/admin/assessment/compose")}
+              sx={{ background: "var(--gradient-ai)", color: "#fff", textTransform: "none", fontWeight: 700, borderRadius: 2 }}
+            >
+              Try another brief
+            </Button>
+          </Box>
+        ) : (
+          <>
+            {/* progress bar while generating */}
+            {generating ? (
+              <Box sx={{ mb: 3, p: 2.5, borderRadius: "var(--radius-card)", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+                  <CircularProgress size={16} sx={{ color: "var(--ai-violet)" }} />
+                  <Typography sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
+                    {STAGE_LABEL[job.status] || "Working…"}
+                  </Typography>
+                  <Box sx={{ flexGrow: 1 }} />
+                  <Typography sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--ai-violet)" }}>
+                    {job.progress_percentage}%
+                  </Typography>
+                </Box>
+                <LinearProgress
+                  variant="determinate"
+                  value={job.progress_percentage}
+                  sx={{
+                    height: 8,
+                    borderRadius: 999,
+                    bgcolor: "var(--surface)",
+                    "& .MuiLinearProgress-bar": { borderRadius: 999, background: "var(--gradient-ai)" },
+                  }}
+                />
+              </Box>
+            ) : null}
+
+            <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "320px 1fr" }, gap: 2.5, alignItems: "start" }}>
+              {/* AI Blueprint sidebar */}
+              <Box sx={{ borderRadius: "var(--radius-card)", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", overflow: "hidden" }}>
+                <Box sx={{ p: 2, background: "var(--gradient-ai-soft)", borderBottom: "1px solid var(--border-default)" }}>
+                  <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, letterSpacing: "0.1em", color: "var(--ai-violet)" }}>
+                    AI BLUEPRINT
+                  </Typography>
+                  <Typography sx={{ fontWeight: 700, color: "var(--font-primary)", mt: 0.25 }}>
+                    {blueprint?.title || "…"}
+                  </Typography>
+                </Box>
+                <Box sx={{ p: 2 }}>
+                  <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, mb: 2 }}>
+                    {blueprint?.proctoring_enabled ? <StatusChip label="Proctored" tone="info" icon="mdi:shield-check-outline" /> : null}
+                    {blueprint?.duration_minutes ? <StatusChip label={`${blueprint.duration_minutes} min`} tone="neutral" icon="mdi:clock-outline" /> : null}
+                    {blueprint?.evaluation_mode === "auto" ? <StatusChip label="Auto-graded" tone="success" icon="mdi:auto-fix" /> : <StatusChip label="Manual grading" tone="warning" /> }
+                  </Box>
+
+                  {blueprint?.sections?.length ? (
+                    <>
+                      <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: "0.08em", color: "var(--font-tertiary)", mb: 1 }}>
+                        DIFFICULTY BALANCE
+                      </Typography>
+                      <DifficultyBalanceMeter balance={overallBalance} />
+
+                      <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: "0.08em", color: "var(--font-tertiary)", mt: 2.5, mb: 1 }}>
+                        SECTIONS
+                      </Typography>
+                      {blueprint.sections.map((s) => (
+                        <Box key={s.id} sx={{ display: "flex", alignItems: "center", gap: 1.25, py: 1, borderTop: "1px solid var(--border-default)" }}>
+                          <Box sx={{ width: 30, height: 30, borderRadius: 1.5, display: "grid", placeItems: "center", color: "var(--ai-violet)", bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)" }}>
+                            <IconWrapper icon={s.type === "coding" ? "mdi:code-tags" : "mdi:help-circle-outline"} size={16} />
+                          </Box>
+                          <Box>
+                            <Typography sx={{ fontWeight: 600, fontSize: "0.85rem", color: "var(--font-primary)" }}>{s.title}</Typography>
+                            <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                              {s.type === "coding" ? "Coding" : "Quiz"} · {s.count} question{s.count === 1 ? "" : "s"}
+                            </Typography>
+                          </Box>
+                        </Box>
+                      ))}
+                    </>
+                  ) : (
+                    <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>Designing the blueprint…</Typography>
+                  )}
+                </Box>
+              </Box>
+
+              {/* Generated questions */}
+              <Box>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 3, mb: 1.5, flexWrap: "wrap" }}>
+                  <Typography sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+                    Generated questions{" "}
+                    <Box component="span" sx={{ fontFamily: "var(--font-mono)", color: "var(--ai-violet)" }}>
+                      {job.questions.length}
+                    </Box>
+                  </Typography>
+                  {generating ? (
+                    <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                      appearing live as they&apos;re written…
+                    </Typography>
+                  ) : null}
+                </Box>
+
+                {job.questions.length === 0 ? (
+                  <Box sx={{ p: 4, textAlign: "center", borderRadius: "var(--radius-card)", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+                    <CircularProgress size={22} sx={{ color: "var(--ai-violet)", mb: 1 }} />
+                    <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+                      Questions will appear here as the AI writes them.
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+                    {Object.entries(questionsBySection).flatMap(([, qs]) =>
+                      qs.map((q, i) => {
+                        const diff = String(q._difficulty || "").toLowerCase();
+                        const qtext = String(q.question_text ?? q.title ?? "");
+                        return (
+                          <Box
+                            key={`${q._section_ref}-${i}-${qtext.slice(0, 12)}`}
+                            sx={{ p: 2, borderRadius: "var(--radius-card)", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}
+                          >
+                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 0.75, flexWrap: "wrap" }}>
+                              <StatusChip label={q._question_type === "coding" ? "Coding" : "MCQ"} tone="info" />
+                              {diff ? <StatusChip label={diff[0].toUpperCase() + diff.slice(1)} tone={DIFF_TONE[diff] || "neutral"} /> : null}
+                            </Box>
+                            <Typography sx={{ fontWeight: 600, color: "var(--font-primary)", lineHeight: 1.4 }}>
+                              {qtext.length > 220 ? qtext.slice(0, 220) + "…" : qtext}
+                            </Typography>
+                          </Box>
+                        );
+                      })
+                    )}
+                  </Box>
+                )}
+              </Box>
+            </Box>
+
+            {/* sticky action bar (only when done) */}
+            {isDone ? (
+              <Box
+                sx={{
+                  position: "sticky",
+                  bottom: 16,
+                  mt: 3,
+                  display: "flex",
+                  gap: 1.5,
+                  justifyContent: "flex-end",
+                  flexWrap: "wrap",
+                  p: 1.5,
+                  borderRadius: "var(--radius-card)",
+                  bgcolor: "var(--card-bg)",
+                  border: "1px solid var(--border-default)",
+                  boxShadow: "0 12px 32px -18px color-mix(in srgb, var(--font-primary) 45%, transparent)",
+                }}
+              >
+                <Button onClick={() => router.push("/admin/assessment/compose")} sx={{ textTransform: "none", color: "var(--font-secondary)" }}>
+                  Edit brief
+                </Button>
+                <Button
+                  onClick={handleFineTune}
+                  startIcon={<IconWrapper icon="mdi:tune-variant" size={18} />}
+                  sx={{ textTransform: "none", fontWeight: 600, color: "var(--ai-violet)", border: "1px solid color-mix(in srgb, var(--ai-violet) 40%, var(--border-default) 60%)", borderRadius: 2, px: 2 }}
+                >
+                  Fine-tune in builder
+                </Button>
+                <Button
+                  onClick={handlePublish}
+                  disabled={publishing}
+                  startIcon={publishing ? <CircularProgress size={16} sx={{ color: "#fff" }} /> : <IconWrapper icon="mdi:check" size={18} />}
+                  sx={{ textTransform: "none", fontWeight: 700, color: "#fff", background: "var(--gradient-ai)", borderRadius: 2, px: 3, "&:hover": { filter: "brightness(1.05)" } }}
+                >
+                  {publishing ? "Publishing…" : "Publish assessment"}
+                </Button>
+              </Box>
+            ) : null}
+          </>
+        )}
+      </Box>
+    </MainLayout>
+  );
+}

--- a/app/admin/assessment/compose/page.tsx
+++ b/app/admin/assessment/compose/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, Typography, Button } from "@mui/material";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import { config } from "@/lib/config";
+import { AiPromptField } from "@/components/admin/assessment/shared";
+import {
+  startAssessmentComposer,
+  type ComposerPreset,
+} from "@/lib/services/admin/admin-assessment-composer.service";
+
+const EXAMPLES = [
+  "45-min proctored cybersecurity screening · 10 MCQ medium + 2 hard coding",
+  "Week 1 final for Data Science, 30 fixed questions, non-adaptive",
+  "Quick 15-min SQL diagnostic, auto-graded, no proctoring",
+];
+
+const BLUEPRINTS: {
+  preset: Exclude<ComposerPreset, "">;
+  label: string;
+  icon: string;
+  starter: string;
+}[] = [
+  {
+    preset: "proctored_screening",
+    label: "Proctored screening",
+    icon: "mdi:shield-check-outline",
+    starter: "45-min proctored screening — 10 medium MCQs + 2 hard coding problems",
+  },
+  {
+    preset: "final_exam",
+    label: "Course final exam",
+    icon: "mdi:target",
+    starter: "Course final exam, 30 questions, comprehensive, non-adaptive, 90 minutes",
+  },
+  {
+    preset: "coding_challenge",
+    label: "Coding challenge",
+    icon: "mdi:code-tags",
+    starter: "Coding challenge — 3 DSA problems, 90 minutes, auto-graded",
+  },
+];
+
+export default function AssessmentComposePage() {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const [brief, setBrief] = useState("");
+  const [preset, setPreset] = useState<ComposerPreset>("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleGenerate = async () => {
+    if (!brief.trim() || submitting) return;
+    try {
+      setSubmitting(true);
+      const job = await startAssessmentComposer(config.clientId, {
+        brief: brief.trim(),
+        preset: preset || undefined,
+      });
+      router.push(`/admin/assessment/compose/${job.job_id}`);
+    } catch (e: unknown) {
+      const msg = (e as { message?: string })?.message || "Failed to start the composer";
+      showToast(msg, "error");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%" }}>
+        <Button
+          startIcon={<IconWrapper icon="mdi:arrow-left" size={20} />}
+          onClick={() => router.push("/admin/assessment")}
+          sx={{ mb: 2, color: "var(--ai-violet)", textTransform: "none" }}
+        >
+          Back to assessments
+        </Button>
+
+        {/* AI hero band */}
+        <Box
+          sx={{
+            position: "relative",
+            overflow: "hidden",
+            borderRadius: "var(--radius-card)",
+            p: { xs: 3, md: 4 },
+            color: "#fff",
+            background: "linear-gradient(135deg, #4c1d95 0%, #7c3aed 45%, #be185d 100%)",
+            boxShadow: "0 24px 48px -24px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+          }}
+        >
+          <Box
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 999,
+              bgcolor: "rgba(255,255,255,0.16)",
+              fontSize: "0.72rem",
+              fontWeight: 800,
+              letterSpacing: "0.1em",
+              mb: 1.5,
+            }}
+          >
+            <IconWrapper icon="mdi:auto-fix" size={15} /> AI ASSESSMENT COMPOSER
+          </Box>
+          <Typography
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: { xs: "1.6rem", md: "2.2rem" },
+              lineHeight: 1.15,
+              mb: 1,
+            }}
+          >
+            Describe it — we&apos;ll build the whole thing.
+          </Typography>
+          <Typography sx={{ opacity: 0.9, maxWidth: 620, mb: 2.5 }}>
+            Type a plain-English brief. AI drafts sections, questions, difficulty balance, timing,
+            and proctoring — you just review and publish. No forms to fight.
+          </Typography>
+
+          {/* Brief input — dark surface so the violet button pops */}
+          <Box
+            sx={{
+              "& .MuiInputBase-root": { bgcolor: "rgba(255,255,255,0.95)" },
+              "& textarea": { color: "#1a1a1a" },
+            }}
+          >
+            <AiPromptField
+              value={brief}
+              onChange={setBrief}
+              onSubmit={handleGenerate}
+              submitting={submitting}
+              examples={EXAMPLES}
+            />
+          </Box>
+        </Box>
+
+        {/* Blueprints */}
+        <Typography
+          sx={{ mt: 4, mb: 1.5, fontSize: "0.75rem", fontWeight: 800, letterSpacing: "0.1em", color: "var(--font-tertiary)" }}
+        >
+          OR START FROM A BLUEPRINT
+        </Typography>
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" }, gap: 1.5 }}>
+          {BLUEPRINTS.map((bp) => {
+            const active = preset === bp.preset;
+            return (
+              <Box
+                key={bp.preset}
+                onClick={() => {
+                  setPreset(bp.preset);
+                  setBrief(bp.starter);
+                }}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1.5,
+                  p: 2,
+                  borderRadius: "var(--radius-card)",
+                  cursor: "pointer",
+                  bgcolor: "var(--card-bg)",
+                  border: active
+                    ? "1.5px solid var(--ai-violet)"
+                    : "1px solid var(--border-default)",
+                  transition: "border-color 0.15s ease, box-shadow 0.15s ease",
+                  "&:hover": { boxShadow: "0 10px 24px -16px color-mix(in srgb, var(--ai-violet) 60%, transparent)" },
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 38,
+                    height: 38,
+                    borderRadius: 2,
+                    display: "grid",
+                    placeItems: "center",
+                    color: "var(--ai-violet)",
+                    bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
+                  }}
+                >
+                  <IconWrapper icon={bp.icon} size={20} />
+                </Box>
+                <Typography sx={{ fontWeight: 700, color: "var(--font-primary)", flexGrow: 1 }}>
+                  {bp.label}
+                </Typography>
+                <IconWrapper icon="mdi:chevron-right" size={20} color="var(--font-tertiary)" />
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    </MainLayout>
+  );
+}

--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -715,33 +715,60 @@ export default function AssessmentPage() {
             accent="indigo"
             icon="mdi:clipboard-text-outline"
             rightSlot={
-              <Button
-                variant="contained"
-                startIcon={<IconWrapper icon="mdi:plus" size={20} />}
-                onClick={() => router.push("/admin/assessment/create")}
-                disabled={
+              (() => {
+                const blocked =
                   isCourseManager ||
                   (!!user &&
                     typeof user.role === "string" &&
                     ["content manager", "content_manager"].includes(
                       user.role.toLowerCase().replace(/\s+/g, " ")
-                    ))
-                }
-                sx={{
-                  bgcolor: "var(--accent-indigo)",
-                  color: "var(--font-light)",
-                  fontWeight: 600,
-                  px: 3,
-                  py: 1.1,
-                  borderRadius: 2,
-                  whiteSpace: "nowrap",
-                  boxShadow:
-                    "0 4px 6px -1px color-mix(in srgb, var(--accent-indigo) 30%, transparent)",
-                  "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
-                }}
-              >
-                {t("admin.assessment.createAssessment")}
-              </Button>
+                    ));
+                return (
+                  <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                    <Button
+                      startIcon={<IconWrapper icon="mdi:auto-fix" size={20} />}
+                      onClick={() => router.push("/admin/assessment/compose")}
+                      disabled={blocked}
+                      sx={{
+                        color: "#fff",
+                        fontWeight: 700,
+                        px: 3,
+                        py: 1.1,
+                        borderRadius: 2,
+                        whiteSpace: "nowrap",
+                        textTransform: "none",
+                        background: "var(--gradient-ai)",
+                        boxShadow:
+                          "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+                        "&:hover": { filter: "brightness(1.05)" },
+                        "&.Mui-disabled": { background: "var(--surface)", color: "var(--font-tertiary)" },
+                      }}
+                    >
+                      Build with AI
+                    </Button>
+                    <Button
+                      variant="contained"
+                      startIcon={<IconWrapper icon="mdi:plus" size={20} />}
+                      onClick={() => router.push("/admin/assessment/create")}
+                      disabled={blocked}
+                      sx={{
+                        bgcolor: "var(--accent-indigo)",
+                        color: "var(--font-light)",
+                        fontWeight: 600,
+                        px: 3,
+                        py: 1.1,
+                        borderRadius: 2,
+                        whiteSpace: "nowrap",
+                        boxShadow:
+                          "0 4px 6px -1px color-mix(in srgb, var(--accent-indigo) 30%, transparent)",
+                        "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+                      }}
+                    >
+                      {t("admin.assessment.createAssessment")}
+                    </Button>
+                  </Box>
+                );
+              })()
             }
           />
         </Box>

--- a/lib/services/admin/admin-assessment-composer.service.ts
+++ b/lib/services/admin/admin-assessment-composer.service.ts
@@ -1,0 +1,104 @@
+import apiClient from "../api";
+
+/** One section in the AI-generated blueprint. */
+export interface ComposerBlueprintSection {
+  id: string;
+  type: "mcq" | "coding";
+  title: string;
+  topic: string;
+  count: number;
+  difficulty_split: { easy: number; medium: number; hard: number };
+  time_limit_minutes?: number | null;
+  programming_language?: string;
+}
+
+export interface ComposerBlueprint {
+  title?: string;
+  instructions?: string;
+  duration_minutes?: number;
+  proctoring_enabled?: boolean;
+  evaluation_mode?: "auto" | "manual";
+  show_result?: boolean;
+  sections?: ComposerBlueprintSection[];
+}
+
+export type ComposerStatus =
+  | "pending"
+  | "generating_blueprint"
+  | "blueprint_ready"
+  | "generating_questions"
+  | "assembling"
+  | "completed"
+  | "failed";
+
+/** One generated question, tagged with its blueprint section + difficulty. */
+export interface ComposerQuestion {
+  _section_ref?: string | null;
+  _question_type?: "mcq" | "coding";
+  _difficulty?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ComposerJobResponse {
+  job_id: string;
+  status: ComposerStatus;
+  brief: string;
+  preset: string;
+  progress_percentage: number;
+  question_progress: { total: number; completed: number; percentage: number };
+  blueprint: ComposerBlueprint;
+  questions: ComposerQuestion[];
+  generated_assessment_id: number | null;
+  error_log: Array<{ type?: string; message?: string }>;
+  created_at: string | null;
+}
+
+export type ComposerPreset =
+  | "proctored_screening"
+  | "final_exam"
+  | "coding_challenge"
+  | "";
+
+export interface StartAssessmentComposerBody {
+  brief: string;
+  preset?: ComposerPreset;
+  attach_course_id?: number;
+}
+
+/** Start the AI Assessment Composer — one brief → whole draft assessment (background). */
+export const startAssessmentComposer = async (
+  clientId: string | number,
+  body: StartAssessmentComposerBody
+): Promise<ComposerJobResponse> => {
+  const response = await apiClient.post(
+    `/admin-dashboard/api/clients/${clientId}/assessment-composer/`,
+    body
+  );
+  return response.data;
+};
+
+/** Poll a composer job for live progress, the blueprint, and generated questions. */
+export const getAssessmentComposerJob = async (
+  clientId: string | number,
+  jobId: string
+): Promise<ComposerJobResponse> => {
+  const response = await apiClient.get(
+    `/admin-dashboard/api/clients/${clientId}/assessment-composer/${jobId}/`
+  );
+  return response.data;
+};
+
+/** Latest human-readable reason from a composer job's error_log (or ""). */
+export function composerErrorMessage(job: Pick<ComposerJobResponse, "error_log">): string {
+  const entries = job.error_log || [];
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const m = entries[i]?.message;
+    if (typeof m === "string" && m.trim()) return m.trim();
+  }
+  return "";
+}
+
+/** True for the two terminal states. */
+export function isComposerTerminal(status: ComposerStatus): boolean {
+  return status === "completed" || status === "failed";
+}


### PR DESCRIPTION
Phase 2 of the assessment redesign — the flagship **AI Assessment Composer** frontend, end-to-end against the composer backend (already live on prod).

- **Service** `admin-assessment-composer.service.ts`: `startAssessmentComposer` / `getAssessmentComposerJob` + blueprint/job types + `composerErrorMessage` / `isComposerTerminal`.
- **`/admin/assessment/compose`**: the violet→pink AI hero band ("Describe it — we'll build the whole thing."), the brief `AiPromptField` with example chips, and three one-click **blueprint presets** (proctored screening / course final exam / coding challenge) that prefill a tuned starter brief.
- **`/admin/assessment/compose/[jobId]`**: a 2s poll with a gradient progress bar + stage labels; a live **AI Blueprint** sidebar (settings chips + `DifficultyBalanceMeter` + sections) and generated questions appearing **live** as they're written; on completion the **"Review your draft"** screen with a sticky **Edit brief · Fine-tune in builder · Publish** action bar. Publish → `publishAssessment`; Fine-tune → `/create?fromDraft=`. Fails gracefully with the backend's reason.
- **List header**: a gradient **"Build with AI"** entry point alongside Create.

One click on a brief now generates a whole draft assessment in the background. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
