### PR TITLE
feat(assessment): Hub cards → exact mockup (pass rate, difficulty bar, AI badge, pills)

### DIFF
--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -93,6 +93,7 @@ export default function AssessmentPage() {
   const [draftFilter, setDraftFilter] = useState<"all" | "draft" | "live">("all");
   const [proctoringFilter, setProctoringFilter] = useState<"all" | "enabled" | "disabled">("all");
   const [paidFilter, setPaidFilter] = useState<"all" | "paid" | "free">("all");
+  const [aiFilter, setAiFilter] = useState<"all" | "ai" | "manual">("all");
   const [evaluationFilter, setEvaluationFilter] = useState<"all" | "manual" | "auto">("all");
 
   // Hub redesign: primary status filter is a segmented tab bar (derived status), and the
@@ -683,6 +684,12 @@ export default function AssessmentPage() {
         if (paidFilter === "free" && assessment.is_paid) return false;
       }
 
+      // AI-authored filter
+      if (aiFilter !== "all") {
+        if (aiFilter === "ai" && !assessment.is_ai_generated) return false;
+        if (aiFilter === "manual" && assessment.is_ai_generated) return false;
+      }
+
       // Manual vs auto evaluation (API default is auto when omitted)
       if (evaluationFilter !== "all") {
         const mode = assessment.evaluation_mode ?? "auto";
@@ -692,7 +699,7 @@ export default function AssessmentPage() {
 
       return true;
     });
-  }, [assessments, searchQuery, statusFilter, draftFilter, proctoringFilter, paidFilter, evaluationFilter, statusTab]);
+  }, [assessments, searchQuery, statusFilter, draftFilter, proctoringFilter, paidFilter, aiFilter, evaluationFilter, statusTab]);
 
   // Hub metric strip (6 tiles) + per-tab counts, computed over the full (unpaginated) list.
   const hubStats = useMemo<StatItem[]>(() => {
@@ -737,7 +744,7 @@ export default function AssessmentPage() {
   // Reset page when filters change
   useEffect(() => {
     setPage(1);
-  }, [searchQuery, statusFilter, draftFilter, proctoringFilter, paidFilter, evaluationFilter, statusTab]);
+  }, [searchQuery, statusFilter, draftFilter, proctoringFilter, paidFilter, aiFilter, evaluationFilter, statusTab]);
 
   // Clamp the page into range after the list shrinks (delete/duplicate/refetch) —
   // otherwise deleting the last row on the last page leaves an empty view.
@@ -753,6 +760,7 @@ export default function AssessmentPage() {
     setDraftFilter("all");
     setProctoringFilter("all");
     setPaidFilter("all");
+    setAiFilter("all");
     setEvaluationFilter("all");
   };
 
@@ -762,6 +770,7 @@ export default function AssessmentPage() {
     draftFilter !== "all" ||
     proctoringFilter !== "all" ||
     paidFilter !== "all" ||
+    aiFilter !== "all" ||
     evaluationFilter !== "all" ||
     statusTab !== "all";
 
@@ -883,6 +892,39 @@ export default function AssessmentPage() {
           }}
         >
           <SegmentedTabs<StatusTab> tabs={statusTabs} value={statusTab} onChange={setStatusTab} />
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            {/* Quick-toggle filter pills (mockup) */}
+            {([
+              { key: "proctored", icon: "mdi:shield-check-outline", label: "Proctored", active: proctoringFilter === "enabled", toggle: () => setProctoringFilter((p) => (p === "enabled" ? "all" : "enabled")) },
+              { key: "ai", icon: "mdi:auto-fix", label: "AI-authored", active: aiFilter === "ai", toggle: () => setAiFilter((p) => (p === "ai" ? "all" : "ai")) },
+              { key: "paid", icon: "mdi:lightning-bolt-outline", label: "Paid", active: paidFilter === "paid", toggle: () => setPaidFilter((p) => (p === "paid" ? "all" : "paid")) },
+            ]).map((pill) => (
+              <Box
+                key={pill.key}
+                onClick={pill.toggle}
+                role="button"
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.6,
+                  px: 1.5,
+                  height: 36,
+                  borderRadius: 999,
+                  cursor: "pointer",
+                  fontSize: "0.85rem",
+                  fontWeight: 600,
+                  userSelect: "none",
+                  color: pill.active ? "var(--accent-indigo)" : "var(--font-secondary)",
+                  bgcolor: pill.active ? "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)" : "var(--card-bg)",
+                  border: pill.active ? "1px solid var(--accent-indigo)" : "1px solid var(--border-default)",
+                  transition: "border-color 0.15s ease, background-color 0.15s ease",
+                  "&:hover": { borderColor: "var(--accent-indigo)" },
+                }}
+              >
+                <IconWrapper icon={pill.icon} size={16} />
+                {pill.label}
+              </Box>
+            ))}
           <Box sx={{ display: "flex", gap: 0.5, p: 0.5, borderRadius: 999, border: "1px solid var(--border-default)", bgcolor: "var(--surface)" }}>
             {([
               { mode: "cards" as const, icon: "mdi:view-grid-outline", label: "Card view" },
@@ -907,6 +949,7 @@ export default function AssessmentPage() {
                 </Tooltip>
               );
             })}
+          </Box>
           </Box>
         </Box>
 

--- a/components/admin/assessment/shared/AssessmentCard.tsx
+++ b/components/admin/assessment/shared/AssessmentCard.tsx
@@ -79,7 +79,13 @@ export function AssessmentCard({
   const isDraft = status.key === "draft";
   const sections = (assessment.quiz_sections_count || 0) + (assessment.coding_sections_count || 0);
   const course = assessment.courses?.[0]?.title;
+  const college = assessment.colleges?.[0];
   const opens = status.key === "scheduled" ? formatOpens(assessment.start_time) : null;
+  // Prefer the caller's overrides, else the list-endpoint fields (redesign).
+  const aiOn = aiAuthored ?? assessment.is_ai_generated ?? false;
+  const balance = difficultyBalance ?? assessment.difficulty_breakdown;
+  const hasBalance = !!balance && balance.easy + balance.medium + balance.hard > 0;
+  const passRate = assessment.pass_rate;
 
   return (
     <Box
@@ -113,7 +119,7 @@ export function AssessmentCard({
             </Typography>
           </Box>
           <Box sx={{ flexGrow: 1 }} />
-          {aiAuthored ? (
+          {aiOn ? (
             <Box
               sx={{
                 display: "inline-flex",
@@ -141,51 +147,72 @@ export function AssessmentCard({
         <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)", lineHeight: 1.3 }}>
           {assessment.title}
         </Typography>
-        {course ? (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.4 }}>
+        {course || college ? (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.4, minWidth: 0 }}>
             <IconWrapper icon="mdi:book-outline" size={14} color="var(--font-tertiary)" />
-            <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-              {course}
+            <Typography variant="caption" sx={{ color: "var(--font-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {[course, college].filter(Boolean).join(" · ")}
             </Typography>
           </Box>
         ) : null}
 
-        {/* mini-stats */}
-        <Box sx={{ display: "flex", gap: 1, mt: 1.75, mb: 1.5 }}>
-          <MiniStat value={assessment.total_questions ?? 0} label="Questions" />
-          <MiniStat value={`${assessment.duration_minutes}m`} label="Duration" />
-          <MiniStat value={sections} label="Sections" />
-        </Box>
-
-        {/* footer: opens (scheduled) | difficulty bar | submissions */}
-        {opens ? (
+        {isDraft ? (
+          /* Draft card: amber "continue setup" panel instead of stats (mockup) */
           <Box
             sx={{
+              mt: 1.75,
+              px: 1.75,
+              py: 1.5,
+              borderRadius: 2,
               display: "flex",
               alignItems: "center",
-              gap: 0.75,
-              pt: 1.25,
-              borderTop: "1px solid var(--border-default)",
-              color: "var(--accent-indigo)",
+              gap: 1,
+              bgcolor: "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+              color: "var(--warning-600, var(--warning-500))",
             }}
           >
-            <IconWrapper icon="mdi:calendar-clock" size={16} />
-            <Typography variant="caption" sx={{ fontWeight: 600 }}>
-              Opens {opens}
+            <IconWrapper icon="mdi:pencil-outline" size={16} />
+            <Typography variant="caption" sx={{ fontWeight: 700, flexGrow: 1 }}>
+              Draft — continue setup
             </Typography>
+            <IconWrapper icon="mdi:arrow-right" size={16} />
           </Box>
         ) : (
-          <Box sx={{ pt: 1.25, borderTop: "1px solid var(--border-default)" }}>
-            <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: difficultyBalance ? 0.75 : 0 }}>
-              <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-                <Box component="span" sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--font-primary)" }}>
-                  {assessment.submissions_count ?? 0}
-                </Box>{" "}
-                submissions
-              </Typography>
+          <>
+            {/* mini-stats — vertical dividers, mono values (mockup) */}
+            <Box sx={{ display: "flex", alignItems: "stretch", mt: 1.75, mb: 1.5, borderTop: "1px solid var(--border-default)", borderBottom: "1px solid var(--border-default)", py: 1.25 }}>
+              <MiniStat value={assessment.total_questions ?? 0} label="Questions" />
+              <Box sx={{ width: "1px", bgcolor: "var(--border-default)" }} />
+              <MiniStat value={`${assessment.duration_minutes}m`} label="Duration" />
+              <Box sx={{ width: "1px", bgcolor: "var(--border-default)" }} />
+              <MiniStat value={sections} label="Sections" />
             </Box>
-            {difficultyBalance ? <DifficultyBalanceMeter balance={difficultyBalance} legend={false} height={6} /> : null}
-          </Box>
+
+            {/* footer: opens (scheduled) | submissions + pass% + difficulty bar */}
+            {opens ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, pt: 0.25, color: "var(--accent-indigo)" }}>
+                <IconWrapper icon="mdi:calendar-clock" size={16} />
+                <Typography variant="caption" sx={{ fontWeight: 600 }}>Opens {opens}</Typography>
+              </Box>
+            ) : (
+              <Box>
+                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: hasBalance ? 0.75 : 0 }}>
+                  <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                    <Box component="span" sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--font-primary)" }}>
+                      {assessment.submissions_count ?? 0}
+                    </Box>{" "}
+                    submissions
+                  </Typography>
+                  {typeof passRate === "number" ? (
+                    <Typography variant="caption" sx={{ fontWeight: 700, color: "var(--success-500)" }}>
+                      <Box component="span" sx={{ fontFamily: "var(--font-mono)" }}>{passRate}%</Box> pass
+                    </Typography>
+                  ) : null}
+                </Box>
+                {hasBalance ? <DifficultyBalanceMeter balance={balance!} legend={false} height={6} /> : null}
+              </Box>
+            )}
+          </>
         )}
       </Box>
     </Box>

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -329,6 +329,11 @@ export interface Assessment {
   quiz_sections_count: number;
   coding_sections_count?: number;
   submissions_count?: number;
+  /** Admin-hub redesign fields (list endpoint). */
+  is_ai_generated?: boolean;
+  difficulty_breakdown?: { easy: number; medium: number; hard: number };
+  /** % of scored attempts that cleared the pass band; null when nothing to report. */
+  pass_rate?: number | null;
   courses?: Array<{ id: number; title: string }>;
   colleges?: string[];
   allow_desktop?: boolean;


### PR DESCRIPTION
Consumes the new list-endpoint fields (BE #334/#335 — `is_ai_generated`, `difficulty_breakdown`, `pass_rate`) and brings the hub card grid to the redesign mockup exactly:

- **AssessmentCard**: AI gradient chip from `is_ai_generated`; difficulty balance bar from `difficulty_breakdown`; footer `N submissions` + green mono `NN% pass` (only when `pass_rate` is a number); mini-stats with vertical dividers in a bordered band; `course · college` line; **draft cards** swap stats for the amber **"Draft — continue setup →"** panel.
- **Hub page**: quick-toggle filter pills (**Proctored / AI-authored / Paid**) between the status tabs and the view toggle; new `aiFilter` wired into filtering/clear-all/page-reset; proctoring/paid pills reuse the existing selects' state so the filter bar stays in sync.
- **Types**: new fields optional + guarded — cards render fine if a field is absent.

**Verified before push** (per the new discipline): tsc 0 errors · eslint clean on diff · real `npm ci` + `next build` compiled successfully (all /admin/assessment routes) · BE fields confirmed live on prod (list 200, correct `difficulty_breakdown`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)