### PR TITLE
feat(assessment): breadcrumb trail on every assessment page (mockup shell)

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -62,6 +62,7 @@ import {
   StatusChip,
   SegmentedTabs,
   DifficultyBalanceMeter,
+  AssessmentBreadcrumb,
 } from "@/components/admin/assessment/shared";
 import { BasicInfoSection } from "@/components/admin/assessment/BasicInfoSection";
 import { AssessmentSettingsSection } from "@/components/admin/assessment/AssessmentSettingsSection";
@@ -1568,6 +1569,7 @@ export default function AssessmentEditPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ p: { xs: 2, sm: 3 } }}>
+        <AssessmentBreadcrumb segments={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Assessments", href: "/admin/assessment" }, { label: displayTitle || `Assessment #${assessmentId}` }]} />
         <Button
           startIcon={<IconWrapper icon="mdi:arrow-left" size={20} />}
           onClick={() => router.push("/admin/assessment")}

--- a/app/admin/assessment/compose/[jobId]/page.tsx
+++ b/app/admin/assessment/compose/[jobId]/page.tsx
@@ -10,6 +10,7 @@ import { config } from "@/lib/config";
 import {
   DifficultyBalanceMeter,
   StatusChip,
+  AssessmentBreadcrumb,
 } from "@/components/admin/assessment/shared";
 import { publishAssessment } from "@/lib/services/admin/admin-assessment.service";
 import {
@@ -150,6 +151,7 @@ export default function ComposerJobPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%" }}>
+        <AssessmentBreadcrumb segments={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Assessments", href: "/admin/assessment" }, { label: "Create with AI", href: "/admin/assessment/compose" }, { label: "Review draft" }]} />
         <Button
           startIcon={<IconWrapper icon="mdi:arrow-left" size={20} />}
           onClick={() => router.push("/admin/assessment/compose")}

--- a/app/admin/assessment/compose/page.tsx
+++ b/app/admin/assessment/compose/page.tsx
@@ -7,7 +7,7 @@ import { MainLayout } from "@/components/layout/MainLayout";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { config } from "@/lib/config";
-import { AiPromptField } from "@/components/admin/assessment/shared";
+import { AiPromptField, AssessmentBreadcrumb } from "@/components/admin/assessment/shared";
 import {
   startAssessmentComposer,
   type ComposerPreset,
@@ -71,6 +71,7 @@ export default function AssessmentComposePage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%" }}>
+        <AssessmentBreadcrumb segments={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Assessments", href: "/admin/assessment" }, { label: "Create with AI" }]} />
         <Button
           startIcon={<IconWrapper icon="mdi:arrow-left" size={20} />}
           onClick={() => router.push("/admin/assessment")}

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/lib/services/admin/admin-assessment.service";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
 import { config } from "@/lib/config";
-import { AssessmentSectionHero } from "@/components/admin/assessment/shared";
+import { AssessmentSectionHero, AssessmentBreadcrumb } from "@/components/admin/assessment/shared";
 import { BasicInfoSection } from "@/components/admin/assessment/BasicInfoSection";
 import { AssessmentSettingsSection } from "@/components/admin/assessment/AssessmentSettingsSection";
 import type { EmailNotificationEditorHandle } from "@/components/admin/assessment/EmailNotificationEditor";
@@ -1850,6 +1850,7 @@ function CreateAssessmentPageContent() {
   return (
     <MainLayout>
       <Box sx={{ p: { xs: 2, sm: 3 } }}>
+        <AssessmentBreadcrumb segments={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Assessments", href: "/admin/assessment" }, { label: "Create assessment" }]} />
         {/* Header — adaptive design (Phase 2 revamp) */}
         <Box sx={{ mb: 3 }}>
           <Button

--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -56,6 +56,7 @@ import {
   type SegmentedTab,
   AssessmentCard,
   deriveAssessmentStatus,
+  AssessmentBreadcrumb,
 } from "@/components/admin/assessment/shared";
 
 export default function AssessmentPage() {
@@ -806,6 +807,7 @@ export default function AssessmentPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ p: { xs: 2, sm: 3, md: 4 } }}>
+        <AssessmentBreadcrumb segments={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Assessments" }]} />
         {/* Header — adaptive-course design language (Phase 1 revamp) */}
         <Box sx={{ mb: 4 }}>
           <AssessmentSectionHero

--- a/components/admin/assessment/shared/AssessmentBreadcrumb.tsx
+++ b/components/admin/assessment/shared/AssessmentBreadcrumb.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export interface BreadcrumbSegment {
+  label: string;
+  /** Route to push when clicked; the last segment is usually static (no href). */
+  href?: string;
+}
+
+/**
+ * Compact "Admin › Assessments › …" trail for the assessment-management routes
+ * (redesign mockup shell). Deliberately rendered inside the page content — the
+ * global AppBar is shared by every role/page and stays untouched.
+ */
+export function AssessmentBreadcrumb({ segments }: { segments: BreadcrumbSegment[] }) {
+  const router = useRouter();
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 1.5, flexWrap: "wrap" }}>
+      {segments.map((seg, i) => {
+        const last = i === segments.length - 1;
+        return (
+          <Box key={`${seg.label}-${i}`} sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <Typography
+              onClick={() => { if (seg.href) router.push(seg.href); }}
+              sx={{
+                fontSize: "0.82rem",
+                fontWeight: last ? 700 : 500,
+                color: last ? "var(--font-primary)" : "var(--font-tertiary)",
+                cursor: seg.href ? "pointer" : "default",
+                "&:hover": seg.href ? { color: "var(--accent-indigo)", textDecoration: "underline" } : {},
+              }}
+            >
+              {seg.label}
+            </Typography>
+            {!last ? <IconWrapper icon="mdi:chevron-right" size={15} color="var(--font-tertiary)" /> : null}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/components/admin/assessment/shared/index.ts
+++ b/components/admin/assessment/shared/index.ts
@@ -34,6 +34,7 @@ export { GradientRing } from "./GradientRing";
 export { AiPromptField } from "./AiPromptField";
 export { StatStrip, type StatItem } from "./StatStrip";
 export { AssessmentCard, deriveAssessmentStatus } from "./AssessmentCard";
+export { AssessmentBreadcrumb, type BreadcrumbSegment } from "./AssessmentBreadcrumb";
 export {
   AssessmentTableSkeleton,
   AssessmentFilterBarSkeleton,


### PR DESCRIPTION
New shared `AssessmentBreadcrumb` (`Admin › Assessments › …`, clickable segments) on all five assessment routes — hub, compose, compose review, create, edit (edit shows the live assessment title). The **global AppBar stays untouched** (1116-line all-roles component) per the minimal-shell decision.

**Verified before push:** tsc 0 errors · component eslint-clean · real `next build` compiled successfully.

This completes the mockup-exact redesign program (surfaces A–H).

🤖 Generated with [Claude Code](https://claude.com/claude-code)