### PR TITLE
feat(assessment): hub pixel-match — dark hero, exact card anatomy, site fonts

### DIFF
--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -913,11 +913,12 @@ export default function AssessmentPage() {
               mb: 3,
               position: "relative",
               overflow: "hidden",
-              borderRadius: "var(--radius-card)",
-              p: { xs: 2.5, md: 3.5 },
+              borderRadius: "22px",
+              p: { xs: 3, md: 4 },
               color: "#fff",
-              background: "linear-gradient(120deg, #351a75 0%, #5b21b6 48%, #8e2160 100%)",
-              boxShadow: "0 24px 48px -24px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+              // Deep eggplant → dark magenta, per the mockup band
+              background: "linear-gradient(115deg, #2b1244 0%, #3d1663 45%, #6b1a52 82%, #7d2058 100%)",
+              boxShadow: "0 28px 56px -28px rgba(61, 22, 99, 0.55)",
             }}
           >
             <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 340px" }, gap: 3, alignItems: "start" }}>
@@ -955,20 +956,13 @@ export default function AssessmentPage() {
                   Type a plain-English brief. AI drafts sections, questions, difficulty balance,
                   timing, and proctoring — you just review and publish. No forms to fight.
                 </Typography>
-                <Box
-                  sx={{
-                    "& .MuiInputBase-root": { bgcolor: "rgba(255,255,255,0.95)" },
-                    "& textarea": { color: "#1a1a1a" },
-                  }}
-                >
-                  <AiPromptField
-                    value={composerBrief}
-                    onChange={setComposerBrief}
-                    onSubmit={handleComposerGenerate}
-                    submitting={composerSubmitting}
-                    examples={COMPOSER_EXAMPLES}
-                  />
-                </Box>
+                <AiPromptField
+                  value={composerBrief}
+                  onChange={setComposerBrief}
+                  onSubmit={handleComposerGenerate}
+                  submitting={composerSubmitting}
+                  examples={COMPOSER_EXAMPLES}
+                />
               </Box>
 
               {/* Right: blueprints inside the band (mockup) */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -117,8 +117,11 @@
   --ai-violet: #7c3aed;
   --ai-pink: #ec4899;
   --radius-card: 18px;
-  --font-mono: "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
-  --font-jakarta: "Plus Jakarta Sans", var(--font-family-primary, "Satoshi"), system-ui, sans-serif;
+  /* Site-consistent fonts (user directive): headings use the platform's Satoshi stack —
+     same as the adaptive content/course-builder surfaces — and numeric accents use the
+     generic mono stack those surfaces already use. No third-party font downloads. */
+  --font-mono: ui-monospace, "SFMono-Regular", Menlo, monospace;
+  --font-jakarta: var(--font-family-primary, "Satoshi"), "Satoshi Variable", system-ui, sans-serif;
   /* cyan = proctored (semantic tone the chip set was missing) */
   --tone-proctored: var(--accent-cyan, #06b6d4);
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -101,13 +101,6 @@ export default async function RootLayout({
           rel="stylesheet"
           href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,600,700,800,900&display=swap"
         />
-        {/* Assessment redesign: Plus Jakarta Sans (text) + JetBrains Mono (numbers). */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
-        />
       </head>
 
       <body className={`antialiased`} suppressHydrationWarning>

--- a/components/admin/assessment/shared/AiPromptField.tsx
+++ b/components/admin/assessment/shared/AiPromptField.tsx
@@ -16,9 +16,10 @@ interface AiPromptFieldProps {
 }
 
 /**
- * The AI brief input — a large plain-English textarea with clickable example chips and a
- * gradient Generate button. The signature "describe it, we'll build it" control, shared by
- * the composer page and the hub AI-create hero.
+ * The AI brief input — a large plain-English textarea with clickable example chips and the
+ * Generate button. Styled for the DARK composer hero band on the assessments hub (white
+ * input, white Generate with violet text, translucent example chips), per the redesign
+ * mockup. The signature "describe it, we'll build it" control.
  */
 export function AiPromptField({
   value,
@@ -63,9 +64,12 @@ export function AiPromptField({
             ),
             sx: {
               alignItems: "flex-start",
-              borderRadius: "var(--radius-card)",
-              bgcolor: "var(--card-bg)",
+              borderRadius: "14px",
+              bgcolor: "rgba(255,255,255,0.97)",
               fontFamily: "var(--font-jakarta)",
+              "& fieldset": { border: "none" },
+              "& textarea": { color: "#1f1a2e" },
+              "& textarea::placeholder": { color: "#6f6a80", opacity: 1 },
             },
           }}
         />
@@ -77,14 +81,15 @@ export function AiPromptField({
             px: 3,
             py: 1.25,
             minWidth: 132,
-            borderRadius: "var(--radius-card)",
+            borderRadius: "12px",
             textTransform: "none",
             fontWeight: 700,
-            color: "#fff",
-            background: "var(--gradient-ai)",
-            boxShadow: "0 12px 24px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
-            "&:hover": { filter: "brightness(1.05)" },
-            "&.Mui-disabled": { background: "var(--surface)", color: "var(--font-tertiary)" },
+            fontSize: "0.95rem",
+            color: "var(--ai-violet)",
+            bgcolor: "#fff",
+            boxShadow: "0 10px 24px -12px rgba(0,0,0,0.45)",
+            "&:hover": { bgcolor: "#fff", filter: "brightness(0.97)" },
+            "&.Mui-disabled": { bgcolor: "rgba(255,255,255,0.55)", color: "rgba(90,80,120,0.55)" },
           }}
           endIcon={
             submitting ? (
@@ -109,11 +114,11 @@ export function AiPromptField({
               sx={{
                 cursor: "pointer",
                 maxWidth: "100%",
-                bgcolor: "color-mix(in srgb, var(--ai-violet) 8%, var(--card-bg) 92%)",
-                color: "var(--font-secondary)",
-                border: "1px solid color-mix(in srgb, var(--ai-violet) 20%, var(--border-default) 80%)",
+                bgcolor: "rgba(255,255,255,0.07)",
+                color: "rgba(255,255,255,0.92)",
+                border: "1px solid rgba(255,255,255,0.28)",
                 "& .MuiChip-label": { fontSize: "0.75rem" },
-                "&:hover": { bgcolor: "color-mix(in srgb, var(--ai-violet) 14%, var(--card-bg) 86%)" },
+                "&:hover": { bgcolor: "rgba(255,255,255,0.16)" },
               }}
             />
           ))}

--- a/components/admin/assessment/shared/AssessmentCard.tsx
+++ b/components/admin/assessment/shared/AssessmentCard.tsx
@@ -26,11 +26,11 @@ function MiniStat({ value, label }: { value: string | number; label: string }) {
   return (
     <Box sx={{ textAlign: "center", flex: 1, minWidth: 0 }}>
       <Typography
-        sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}
+        sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "1.25rem", lineHeight: 1.2, color: "var(--font-primary)" }}
       >
         {value}
       </Typography>
-      <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+      <Typography variant="caption" sx={{ color: "var(--font-tertiary)", fontSize: "0.78rem" }}>
         {label}
       </Typography>
     </Box>
@@ -92,9 +92,12 @@ export function AssessmentCard({
       onClick={() => onClick?.(assessment)}
       sx={{
         position: "relative",
-        borderRadius: "var(--radius-card)",
+        borderRadius: "16px",
         bgcolor: "var(--card-bg)",
-        border: isDraft ? "1.5px dashed var(--border-light)" : "1px solid var(--border-default)",
+        border: isDraft
+          ? "1.5px dashed color-mix(in srgb, var(--warning-500) 45%, var(--border-default) 55%)"
+          : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
         overflow: "hidden",
         cursor: onClick ? "pointer" : "default",
         transition: "box-shadow 0.15s ease, transform 0.15s ease",
@@ -106,12 +109,12 @@ export function AssessmentCard({
           : {},
       }}
     >
-      <Box sx={{ p: 2.25 }}>
-        {/* top row: status + badges + action */}
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1.25, flexWrap: "wrap" }}>
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.6 }}>
-            <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: accent }} />
-            <Typography variant="caption" sx={{ fontWeight: 700, color: accent }}>
+      {/* header: status + badges + title + course (mockup) */}
+      <Box sx={{ px: 2.5, pt: 2.25, pb: isDraft ? 0.5 : 2 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1.5, flexWrap: "wrap" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.7 }}>
+            <Box sx={{ width: 9, height: 9, borderRadius: "50%", bgcolor: accent }} />
+            <Typography sx={{ fontSize: "0.83rem", fontWeight: 700, color: accent }}>
               {status.label}
             </Typography>
           </Box>
@@ -122,12 +125,12 @@ export function AssessmentCard({
                 display: "inline-flex",
                 alignItems: "center",
                 gap: 0.4,
-                px: 0.85,
-                height: 22,
+                px: 1,
+                height: 24,
                 borderRadius: 999,
                 color: "#fff",
                 background: "var(--gradient-ai)",
-                fontSize: "0.68rem",
+                fontSize: "0.72rem",
                 fontWeight: 700,
               }}
             >
@@ -135,83 +138,99 @@ export function AssessmentCard({
             </Box>
           ) : null}
           {assessment.proctoring_enabled ? (
-            <StatusChip label="Proctored" tone="info" icon="mdi:shield-check-outline" />
+            <StatusChip label="Proctored" tone="proctored" icon="mdi:shield-check-outline" />
           ) : null}
           {assessment.is_paid ? <StatusChip label="Paid" tone="warning" icon="mdi:currency-inr" /> : null}
           {actionSlot ? <Box onClick={(e) => e.stopPropagation()}>{actionSlot}</Box> : null}
         </Box>
 
-        <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)", lineHeight: 1.3 }}>
+        <Typography
+          sx={{
+            fontWeight: 800,
+            fontFamily: "var(--font-jakarta)",
+            fontSize: "1.2rem",
+            color: "var(--font-primary)",
+            lineHeight: 1.25,
+          }}
+        >
           {assessment.title}
         </Typography>
         {course || college ? (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.4, minWidth: 0 }}>
-            <IconWrapper icon="mdi:book-outline" size={14} color="var(--font-tertiary)" />
-            <Typography variant="caption" sx={{ color: "var(--font-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.6, mt: 0.6, minWidth: 0 }}>
+            <IconWrapper icon="mdi:bookmark-outline" size={15} color="var(--font-tertiary)" />
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
               {[course, college].filter(Boolean).join(" · ")}
             </Typography>
           </Box>
         ) : null}
+      </Box>
 
-        {isDraft ? (
-          /* Draft card: amber "continue setup" panel instead of stats (mockup) */
+      {isDraft ? (
+        /* Draft card: amber "continue setup" panel instead of stats (mockup) */
+        <Box sx={{ px: 2.5, pb: 2.5, pt: 1.25 }}>
           <Box
             sx={{
-              mt: 1.75,
-              px: 1.75,
-              py: 1.5,
-              borderRadius: 2,
+              px: 2,
+              py: 1.6,
+              borderRadius: "10px",
               display: "flex",
               alignItems: "center",
               gap: 1,
-              bgcolor: "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+              bgcolor: "color-mix(in srgb, var(--warning-500) 13%, var(--card-bg) 87%)",
               color: "var(--warning-600, var(--warning-500))",
             }}
           >
             <IconWrapper icon="mdi:pencil-outline" size={16} />
-            <Typography variant="caption" sx={{ fontWeight: 700, flexGrow: 1 }}>
+            <Typography sx={{ fontSize: "0.9rem", fontWeight: 700, flexGrow: 1 }}>
               Draft — continue setup
             </Typography>
-            <IconWrapper icon="mdi:arrow-right" size={16} />
+            <IconWrapper icon="mdi:arrow-right" size={17} />
           </Box>
-        ) : (
-          <>
-            {/* mini-stats — vertical dividers, mono values (mockup) */}
-            <Box sx={{ display: "flex", alignItems: "stretch", mt: 1.75, mb: 1.5, borderTop: "1px solid var(--border-default)", borderBottom: "1px solid var(--border-default)", py: 1.25 }}>
-              <MiniStat value={assessment.total_questions ?? 0} label="Questions" />
-              <Box sx={{ width: "1px", bgcolor: "var(--border-default)" }} />
-              <MiniStat value={`${assessment.duration_minutes}m`} label="Duration" />
-              <Box sx={{ width: "1px", bgcolor: "var(--border-default)" }} />
-              <MiniStat value={sections} label="Sections" />
-            </Box>
+        </Box>
+      ) : (
+        <>
+          {/* mini-stats band — EDGE-TO-EDGE rules + full-height dividers (mockup) */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "stretch",
+              borderTop: "1px solid var(--border-default)",
+              borderBottom: "1px solid var(--border-default)",
+              py: 1.5,
+            }}
+          >
+            <MiniStat value={assessment.total_questions ?? 0} label="Questions" />
+            <Box sx={{ width: "1px", my: -1.5, bgcolor: "var(--border-default)" }} />
+            <MiniStat value={`${assessment.duration_minutes}m`} label="Duration" />
+            <Box sx={{ width: "1px", my: -1.5, bgcolor: "var(--border-default)" }} />
+            <MiniStat value={sections} label="Sections" />
+          </Box>
 
-            {/* footer: opens (scheduled) | submissions + pass% + difficulty bar */}
+          {/* footer: opens (scheduled) | submissions + pass% + difficulty bar */}
+          <Box sx={{ px: 2.5, pt: 1.75, pb: 2.25 }}>
             {opens ? (
-              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, pt: 0.25, color: "var(--accent-indigo)" }}>
-                <IconWrapper icon="mdi:calendar-clock" size={16} />
-                <Typography variant="caption" sx={{ fontWeight: 600 }}>Opens {opens}</Typography>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, color: "var(--accent-indigo)" }}>
+                <IconWrapper icon="mdi:calendar-clock" size={17} />
+                <Typography sx={{ fontSize: "0.92rem", fontWeight: 700 }}>Opens {opens}</Typography>
               </Box>
             ) : (
               <Box>
-                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: hasBalance ? 0.75 : 0 }}>
-                  <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-                    <Box component="span" sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--font-primary)" }}>
-                      {assessment.submissions_count ?? 0}
-                    </Box>{" "}
-                    submissions
+                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: hasBalance ? 1 : 0 }}>
+                  <Typography sx={{ fontSize: "0.9rem", color: "var(--font-primary)" }}>
+                    {assessment.submissions_count ?? 0} submissions
                   </Typography>
                   {typeof passRate === "number" ? (
-                    <Typography variant="caption" sx={{ fontWeight: 700, color: "var(--success-500)" }}>
-                      <Box component="span" sx={{ fontFamily: "var(--font-mono)" }}>{passRate}%</Box> pass
+                    <Typography sx={{ fontSize: "0.88rem", fontWeight: 700, color: "var(--success-500)", fontFamily: "var(--font-mono)" }}>
+                      {passRate}% pass
                     </Typography>
                   ) : null}
                 </Box>
-                {hasBalance ? <DifficultyBalanceMeter balance={balance!} legend={false} height={6} /> : null}
+                {hasBalance ? <DifficultyBalanceMeter balance={balance!} legend={false} height={8} /> : null}
               </Box>
             )}
-          </>
-        )}
-      </Box>
+          </Box>
+        </>
+      )}
     </Box>
   );
 }

--- a/components/admin/assessment/shared/AssessmentStatusChip.tsx
+++ b/components/admin/assessment/shared/AssessmentStatusChip.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 import { Box, Typography } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 
-export type ChipTone = "success" | "warning" | "error" | "info" | "neutral" | "ai";
+export type ChipTone = "success" | "warning" | "error" | "info" | "neutral" | "ai" | "proctored";
 
 /** Resolves a tone to its token-backed foreground color. */
 const TONE_COLOR: Record<ChipTone, string> = {
@@ -23,6 +23,8 @@ const TONE_COLOR: Record<ChipTone, string> = {
   neutral: "var(--font-secondary)",
   // Redesign: pink AI/identity chips (e.g. "Non-adaptive · same for all").
   ai: "var(--ai-pink)",
+  // Redesign: cyan proctoring chips (mockup's semantic proctored tone).
+  proctored: "var(--tone-proctored)",
 };
 
 export interface StatusChipProps {


### PR DESCRIPTION
- **Hero band** → the mockup's deep eggplant→dark-magenta gradient; white borderless input, **white Generate button (violet text)**, translucent example chips.
- **Cards** → exact mockup anatomy: soft constant shadow, **edge-to-edge mini-stat band** with full-height dividers, bigger title, bookmark course line, **cyan Proctored chip** (new `proctored` ChipTone), larger mono numbers, 8px difficulty bar.
- **Font consistency (user directive)**: `--font-jakarta` → the site's **Satoshi** stack, `--font-mono` → generic ui-monospace (what adaptive surfaces use); Google-Fonts links removed. All redesign surfaces conform via tokens.

**Verified before push:** tsc 0 · eslint 0 (baseline 0) · real `next build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)