### PR TITLE
feat(assessment): create-wizard end-to-end redesign (chrome + all 13 components)

### DIFF
--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useRef, Suspense } from "react";
+import { useState, useEffect, useMemo, useRef, Suspense, Fragment } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "@/lib/auth/auth-context";
@@ -14,7 +14,6 @@ import {
   CircularProgress,
   Tooltip,
   Chip,
-  Divider,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
@@ -1898,141 +1897,188 @@ function CreateAssessmentPageContent() {
           />
         </Box>
 
-        {/* 3-column wizard: step rail · content · live outline (Phase 4 redesign) */}
-        <Box sx={{ display: "flex", gap: 3, alignItems: "flex-start", flexDirection: { xs: "column", lg: "row" } }}>
-          {/* Step rail — vertical on lg, horizontal above the content on smaller screens */}
-          <Box
-            sx={{
-              width: { xs: "100%", lg: 210 },
-              flexShrink: 0,
-              position: { lg: "sticky" },
-              top: { lg: 88 },
-              display: "flex",
-              flexDirection: { xs: "row", lg: "column" },
-              gap: 1,
-            }}
-          >
-            {steps.map((label, i) => {
-              const state = i === activeStep ? "active" : i < activeStep ? "done" : "todo";
-              const clickable = i < activeStep;
-              return (
+        {/* Horizontal 3-step progress band (redesign mockup) */}
+        <Paper
+          elevation={0}
+          sx={{
+            px: { xs: 2, md: 3 },
+            py: 2,
+            mb: 3,
+            borderRadius: "16px",
+            border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+            boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+            bgcolor: "var(--card-bg)",
+            display: "flex",
+            alignItems: "center",
+            gap: { xs: 1.25, md: 2 },
+          }}
+        >
+          {steps.map((label, i) => {
+            const state = i === activeStep ? "active" : i < activeStep ? "done" : "todo";
+            const clickable = i < activeStep;
+            return (
+              <Fragment key={label}>
+                {i > 0 ? (
+                  <Box
+                    sx={{
+                      flexGrow: 1,
+                      height: "2px",
+                      minWidth: 20,
+                      borderRadius: 999,
+                      bgcolor: i <= activeStep ? "var(--success-500)" : "var(--border-default)",
+                    }}
+                  />
+                ) : null}
                 <Box
-                  key={label}
                   onClick={() => { if (clickable) setActiveStep(i); }}
                   sx={{
-                    flex: { xs: 1, lg: "unset" },
                     display: "flex",
                     alignItems: "center",
-                    gap: 1.25,
-                    p: 1.25,
-                    borderRadius: "var(--radius-card)",
+                    gap: 1.1,
+                    flexShrink: 0,
                     cursor: clickable ? "pointer" : "default",
-                    bgcolor: state === "active"
-                      ? "color-mix(in srgb, var(--accent-indigo) 10%, var(--card-bg) 90%)"
-                      : "var(--card-bg)",
-                    border: state === "active"
-                      ? "1.5px solid var(--accent-indigo)"
-                      : "1px solid var(--border-default)",
-                    transition: "border-color 0.15s ease, background-color 0.15s ease",
-                    "&:hover": clickable ? { borderColor: "var(--accent-indigo)" } : {},
                   }}
                 >
                   <Box
                     sx={{
-                      width: 28, height: 28, borderRadius: "50%", flexShrink: 0,
-                      display: "grid", placeItems: "center",
-                      fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "0.8rem",
-                      bgcolor: state === "todo" ? "var(--surface)" : "var(--accent-indigo)",
-                      color: state === "todo" ? "var(--font-tertiary)" : "#fff",
+                      width: 34,
+                      height: 34,
+                      borderRadius: "50%",
+                      display: "grid",
+                      placeItems: "center",
+                      fontFamily: "var(--font-mono)",
+                      fontWeight: 700,
+                      fontSize: "0.9rem",
+                      ...(state === "done"
+                        ? { bgcolor: "var(--success-500)", color: "#fff" }
+                        : state === "active"
+                        ? { background: "var(--gradient-ai)", color: "#fff" }
+                        : { bgcolor: "var(--surface)", color: "var(--font-tertiary)" }),
                     }}
                   >
-                    {state === "done" ? <IconWrapper icon="mdi:check" size={16} /> : i + 1}
+                    {state === "done" ? <IconWrapper icon="mdi:check" size={18} /> : i + 1}
                   </Box>
-                  <Box sx={{ minWidth: 0, display: { xs: "none", sm: "block" } }}>
-                    <Typography sx={{ fontWeight: state === "active" ? 700 : 600, fontSize: "0.85rem", lineHeight: 1.2, color: state === "active" ? "var(--accent-indigo-dark)" : "var(--font-secondary)" }}>
-                      {label}
+                  <Typography
+                    sx={{
+                      fontWeight: state === "active" ? 800 : 600,
+                      fontFamily: "var(--font-jakarta)",
+                      fontSize: "0.95rem",
+                      color:
+                        state === "active"
+                          ? "var(--font-primary)"
+                          : state === "done"
+                          ? "var(--font-secondary)"
+                          : "var(--font-tertiary)",
+                      display: { xs: state === "active" ? "block" : "none", sm: "block" },
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {label}
+                  </Typography>
+                </Box>
+              </Fragment>
+            );
+          })}
+        </Paper>
+
+        {/* Content grid: Live outline (left, steps 1 & 3 — step 2 brings its own section
+            outline inside SectionBasedQuestionsInput) + step content on the canvas */}
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: {
+              xs: "1fr",
+              lg: activeStep === 1 ? "1fr" : "minmax(260px, 300px) 1fr",
+            },
+            gap: 3,
+            alignItems: "start",
+          }}
+        >
+          {activeStep !== 1 ? (
+            <Box sx={{ position: { lg: "sticky" }, top: { lg: 88 } }}>
+              <Box
+                sx={{
+                  borderRadius: "16px",
+                  overflow: "hidden",
+                  bgcolor: "var(--card-bg)",
+                  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+                  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+                }}
+              >
+                {/* gradient header (mockup "Live outline / Updates as you build") */}
+                <Box sx={{ px: 2.25, py: 1.75, background: "var(--gradient-ai)", color: "#fff", display: "flex", alignItems: "center", gap: 1 }}>
+                  <IconWrapper icon="mdi:clipboard-text-outline" size={18} />
+                  <Box>
+                    <Typography sx={{ fontWeight: 800, fontFamily: "var(--font-jakarta)", fontSize: "0.98rem", lineHeight: 1.2 }}>
+                      Live outline
                     </Typography>
-                    <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>Step {i + 1}</Typography>
+                    <Typography sx={{ fontSize: "0.72rem", opacity: 0.85 }}>Updates as you build</Typography>
                   </Box>
                 </Box>
-              );
-            })}
-          </Box>
+                <Box sx={{ p: 2.25 }}>
+                  <Typography
+                    sx={{
+                      fontSize: "0.72rem",
+                      fontWeight: 800,
+                      letterSpacing: "0.08em",
+                      color: "var(--font-tertiary)",
+                      textTransform: "uppercase",
+                      mb: 0.75,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {title.trim() || "Untitled assessment"}
+                  </Typography>
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 1.5 }}>
+                    <IconWrapper icon="mdi:clock-outline" size={14} color="var(--font-tertiary)" />
+                    <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                      {durationMinutes} min · {sections.length} section{sections.length === 1 ? "" : "s"}
+                    </Typography>
+                  </Box>
+                  {outlineSections.length === 0 ? (
+                    <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                      Add sections below — they&apos;ll appear here with live question counts.
+                    </Typography>
+                  ) : (
+                    outlineSections.map((s) => {
+                      const meta = sectionTypeMeta(s.type);
+                      return (
+                        <Box key={s.id} sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.8, borderTop: "1px solid var(--border-default)" }}>
+                          <Box sx={{ width: 30, height: 30, borderRadius: 1.5, display: "grid", placeItems: "center", flexShrink: 0, color: "var(--accent-indigo)", bgcolor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--card-bg) 90%)" }}>
+                            <IconWrapper icon={meta.icon} size={16} />
+                          </Box>
+                          <Typography sx={{ flexGrow: 1, minWidth: 0, fontSize: "0.85rem", fontWeight: 600, color: "var(--font-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                            {s.title?.trim() || meta.label}
+                          </Typography>
+                          <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "0.85rem", color: "var(--font-primary)" }}>
+                            {sectionQuestionCount(s)}
+                          </Box>
+                        </Box>
+                      );
+                    })
+                  )}
+                  <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mt: 1.5, pt: 1.5, borderTop: "1px solid var(--border-default)" }}>
+                    <Typography sx={{ fontSize: "0.8rem", fontWeight: 600, color: "var(--font-secondary)" }}>Total questions</Typography>
+                    <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 800, fontSize: "1.1rem", color: "var(--ai-violet)" }}>
+                      {totalOutlineQuestions}
+                    </Box>
+                  </Box>
+                </Box>
+              </Box>
+            </Box>
+          ) : null}
 
-          {/* Form content */}
-          <Paper
-            sx={{
-              flexGrow: 1,
-              minWidth: 0,
-              width: "100%",
-              p: { xs: 3, sm: 4, md: 5 },
-              borderRadius: 2,
-              boxShadow:
-                "0 1px 3px color-mix(in srgb, var(--font-primary) 12%, transparent)",
-              backgroundColor: "var(--card-bg)",
-              border: "1px solid var(--border-default)",
-            }}
-          >
+          {/* Step content sits directly on the canvas; each section renders its own cards */}
+          <Box sx={{ minWidth: 0 }}>
             {loadingDraft ? (
               <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
-                <CircularProgress />
+                <CircularProgress sx={{ color: "var(--ai-violet)" }} />
               </Box>
             ) : (
               renderStepContent()
             )}
-          </Paper>
-
-          {/* Live outline sidebar */}
-          <Box
-            sx={{
-              width: { xs: "100%", lg: 272 },
-              flexShrink: 0,
-              position: { lg: "sticky" },
-              top: { lg: 88 },
-            }}
-          >
-            <Box sx={{ p: 2.25, borderRadius: "var(--radius-card)", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
-              <Typography sx={{ fontSize: "0.72rem", fontWeight: 800, letterSpacing: "0.08em", color: "var(--font-tertiary)", mb: 1.5 }}>
-                ASSESSMENT OUTLINE
-              </Typography>
-              <Typography sx={{ fontWeight: 700, color: "var(--font-primary)", lineHeight: 1.3 }}>
-                {title.trim() || "Untitled assessment"}
-              </Typography>
-              <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.4 }}>
-                <IconWrapper icon="mdi:clock-outline" size={14} color="var(--font-tertiary)" />
-                <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-                  {durationMinutes} min · {sections.length} section{sections.length === 1 ? "" : "s"}
-                </Typography>
-              </Box>
-              <Divider sx={{ my: 1.5 }} />
-              {outlineSections.length === 0 ? (
-                <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
-                  Add sections in step 1 — they&apos;ll appear here with live question counts.
-                </Typography>
-              ) : (
-                outlineSections.map((s) => {
-                  const meta = sectionTypeMeta(s.type);
-                  return (
-                    <Box key={s.id} sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.6 }}>
-                      <IconWrapper icon={meta.icon} size={16} color="var(--font-tertiary)" />
-                      <Typography sx={{ flexGrow: 1, minWidth: 0, fontSize: "0.85rem", color: "var(--font-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {s.title?.trim() || meta.label}
-                      </Typography>
-                      <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "0.85rem", color: "var(--font-primary)" }}>
-                        {sectionQuestionCount(s)}
-                      </Box>
-                    </Box>
-                  );
-                })
-              )}
-              <Divider sx={{ my: 1.5 }} />
-              <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                <Typography sx={{ fontSize: "0.8rem", fontWeight: 600, color: "var(--font-secondary)" }}>Total questions</Typography>
-                <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 800, fontSize: "1.1rem", color: "var(--accent-indigo)" }}>
-                  {totalOutlineQuestions}
-                </Box>
-              </Box>
-            </Box>
           </Box>
         </Box>
 
@@ -2049,6 +2095,17 @@ function CreateAssessmentPageContent() {
             disabled={activeStep === 0}
             onClick={handleBack}
             startIcon={<IconWrapper icon="mdi:arrow-left" size={18} />}
+            sx={{
+              textTransform: "none",
+              fontWeight: 700,
+              px: 2.5,
+              borderRadius: "12px",
+              color: "var(--font-primary)",
+              bgcolor: "var(--card-bg)",
+              border: "1px solid var(--border-default)",
+              "&:hover": { bgcolor: "var(--card-bg)", borderColor: "var(--accent-indigo)" },
+              "&.Mui-disabled": { color: "var(--font-tertiary)", bgcolor: "var(--surface)" },
+            }}
           >
             Back
           </Button>
@@ -2077,13 +2134,17 @@ function CreateAssessmentPageContent() {
                     )
                   }
                   sx={{
-                    bgcolor: "var(--accent-indigo)",
-                    color: "var(--font-light)",
-                    "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+                    textTransform: "none",
+                    fontWeight: 700,
+                    px: 3,
+                    borderRadius: "12px",
+                    color: "#fff",
+                    background: "var(--gradient-ai)",
+                    boxShadow: "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+                    "&:hover": { filter: "brightness(1.05)" },
                     "&.Mui-disabled": {
                       color: "var(--font-secondary)",
-                      backgroundColor:
-                        "color-mix(in srgb, var(--accent-indigo) 24%, var(--surface) 76%)",
+                      background: "color-mix(in srgb, var(--ai-violet) 18%, var(--surface) 82%)",
                     },
                   }}
                 >
@@ -2103,17 +2164,21 @@ function CreateAssessmentPageContent() {
                 disabled={isNextButtonDisabled || savingDraft}
                 endIcon={<IconWrapper icon="mdi:arrow-right" size={18} />}
                 sx={{
-                  bgcolor: "var(--accent-indigo)",
-                  color: "var(--font-light)",
-                  "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+                  textTransform: "none",
+                  fontWeight: 700,
+                  px: 3,
+                  borderRadius: "12px",
+                  color: "#fff",
+                  background: "var(--gradient-ai)",
+                  boxShadow: "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+                  "&:hover": { filter: "brightness(1.05)" },
                   "&.Mui-disabled": {
                     color: "var(--font-secondary)",
-                    backgroundColor:
-                      "color-mix(in srgb, var(--accent-indigo) 24%, var(--surface) 76%)",
+                    background: "color-mix(in srgb, var(--ai-violet) 18%, var(--surface) 82%)",
                   },
                 }}
               >
-                Next
+                Continue
               </Button>
             )}
           </Box>

--- a/components/admin/assessment/AIGeneratedCodingSection.tsx
+++ b/components/admin/assessment/AIGeneratedCodingSection.tsx
@@ -15,7 +15,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Chip,
   Pagination,
   Dialog,
   DialogTitle,
@@ -23,6 +22,7 @@ import {
 } from "@mui/material";
 import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { DifficultyChip } from "@/components/admin/assessment/shared";
 import { useToast } from "@/components/common/Toast";
 import {
   adminAssessmentService,
@@ -213,11 +213,30 @@ export function AIGeneratedCodingSection({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Typography variant="h6" sx={{ fontWeight: 600 }}>
-        AI Generated Coding Problems
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <IconWrapper icon="mdi:auto-fix" size={20} color="var(--ai-violet)" />
+        <Typography
+          variant="h6"
+          sx={{
+            fontWeight: 800,
+            fontFamily: "var(--font-jakarta)",
+            color: "var(--font-primary)",
+          }}
+        >
+          Generate with AI
+        </Typography>
+      </Box>
 
-      <Paper sx={{ p: 3, bgcolor: "var(--surface)", border: "1px solid var(--border-default)" }}>
+      <Paper
+        elevation={0}
+        sx={{
+          p: 3,
+          borderRadius: "var(--radius-card)",
+          bgcolor: "var(--card-bg)",
+          border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+          boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+        }}
+      >
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <TextField
             label="Topic"
@@ -269,26 +288,30 @@ export function AIGeneratedCodingSection({
           />
           <Button
             variant="contained"
+            fullWidth
             onClick={handleGenerate}
             disabled={generating || !topic.trim()}
             startIcon={
               generating ? (
                 <CircularProgress size={18} color="inherit" />
               ) : (
-                <IconWrapper icon="mdi:robot" size={18} />
+                <IconWrapper icon="mdi:auto-fix" size={18} />
               )
             }
             sx={{
-              bgcolor: "var(--success-500)",
-              color: "var(--font-light)",
-              "&:hover": {
-                bgcolor:
-                  "color-mix(in srgb, var(--success-500) 86%, var(--accent-indigo-dark))",
-              },
+              py: 1.25,
+              fontWeight: 700,
+              textTransform: "none",
+              borderRadius: 2,
+              color: "#fff",
+              background: "var(--gradient-ai)",
+              boxShadow:
+                "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+              "&:hover": { filter: "brightness(1.05)" },
               "&.Mui-disabled": {
                 color: "var(--font-secondary)",
-                backgroundColor:
-                  "color-mix(in srgb, var(--success-500) 24%, var(--surface) 76%)",
+                background:
+                  "color-mix(in srgb, var(--ai-violet) 18%, var(--surface) 82%)",
               },
             }}
           >
@@ -296,8 +319,15 @@ export function AIGeneratedCodingSection({
               ? progress
                 ? `Generating… ${progress.done}/${progress.total} batches`
                 : "Generating…"
-              : "Generate Coding Problems"}
+              : `Generate ${count || ""} coding problem${count === 1 ? "" : "s"}`}
           </Button>
+          <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1, px: 0.5 }}>
+            <IconWrapper icon="mdi:lightning-bolt-outline" size={15} color="var(--ai-violet)" />
+            <Typography variant="caption" sx={{ color: "var(--font-tertiary)", lineHeight: 1.45 }}>
+              Generated problems are saved to your coding bank and selected for this
+              assessment automatically — preview or remove any of them below.
+            </Typography>
+          </Box>
         </Box>
       </Paper>
 
@@ -313,8 +343,21 @@ export function AIGeneratedCodingSection({
               gap: 2,
             }}
           >
-            <Typography variant="h6" sx={{ fontWeight: 600 }}>
-              Generated Coding Problems ({generatedProblems.length})
+            <Typography
+              variant="h6"
+              sx={{
+                fontWeight: 700,
+                fontFamily: "var(--font-jakarta)",
+                color: "var(--font-primary)",
+              }}
+            >
+              Generated Coding Problems{" "}
+              <Box
+                component="span"
+                sx={{ fontFamily: "var(--font-mono)", color: "var(--ai-violet)" }}
+              >
+                ({generatedProblems.length})
+              </Box>
             </Typography>
             <Button
               size="small"
@@ -322,17 +365,19 @@ export function AIGeneratedCodingSection({
               color="error"
               onClick={handleClearAll}
               startIcon={<IconWrapper icon="mdi:delete-outline" size={18} />}
+              sx={{ textTransform: "none", fontWeight: 600, borderRadius: 2 }}
             >
               Clear All
             </Button>
           </Box>
 
           <Paper
+            elevation={0}
             sx={{
-              borderRadius: 2,
+              borderRadius: "16px",
               boxShadow:
-                "0 1px 3px color-mix(in srgb, var(--font-primary) 12%, transparent)",
-              border: "1px solid var(--border-default)",
+                "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+              border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
               backgroundColor: "var(--card-bg)",
               overflow: "hidden",
             }}
@@ -375,7 +420,7 @@ export function AIGeneratedCodingSection({
                         <TableCell>
                           <Typography
                             variant="body2"
-                            sx={{ color: "var(--font-secondary)", fontFamily: "monospace" }}
+                            sx={{ color: "var(--font-secondary)", fontFamily: "var(--font-mono)" }}
                           >
                             #{globalIndex + 1}
                           </Typography>
@@ -401,26 +446,7 @@ export function AIGeneratedCodingSection({
                         </TableCell>
                         <TableCell>
                           {problem.difficulty_level ? (
-                            <Chip
-                              label={problem.difficulty_level}
-                              size="small"
-                              sx={{
-                                bgcolor:
-                                  problem.difficulty_level === "Easy"
-                                    ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                                    : problem.difficulty_level === "Medium"
-                                    ? "color-mix(in srgb, var(--warning-500) 16%, var(--surface) 84%)"
-                                    : "color-mix(in srgb, var(--warning-500) 20%, var(--surface) 80%)",
-                                color:
-                                  problem.difficulty_level === "Easy"
-                                    ? "var(--success-500)"
-                                    : problem.difficulty_level === "Medium"
-                                    ? "var(--warning-500)"
-                                    : "var(--warning-500)",
-                                fontWeight: 600,
-                                fontSize: "0.75rem",
-                              }}
-                            />
+                            <DifficultyChip level={problem.difficulty_level} />
                           ) : (
                             <Typography
                               variant="body2"
@@ -507,7 +533,6 @@ export function AIGeneratedCodingSection({
                   count={totalPages}
                   page={page}
                   onChange={(_, value) => setPage(value)}
-                  color="primary"
                   size="small"
                   showFirstButton={false}
                   showLastButton={false}
@@ -517,6 +542,12 @@ export function AIGeneratedCodingSection({
                   sx={{
                     "& .MuiPaginationItem-root": {
                       fontSize: { xs: "0.75rem", sm: "0.875rem" },
+                      fontFamily: "var(--font-mono)",
+                    },
+                    "& .MuiPaginationItem-root.Mui-selected": {
+                      bgcolor: "var(--accent-indigo)",
+                      color: "#fff",
+                      "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
                     },
                   }}
                 />
@@ -531,13 +562,15 @@ export function AIGeneratedCodingSection({
         onClose={() => setPreviewProblem(null)}
         maxWidth="md"
         fullWidth
-        PaperProps={{ sx: { maxHeight: "90vh", borderRadius: 2 } }}
+        PaperProps={{ sx: { maxHeight: "90vh", borderRadius: "16px" } }}
       >
         <DialogTitle
           sx={{
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
+            fontFamily: "var(--font-jakarta)",
+            fontWeight: 700,
           }}
         >
           <span>Problem Preview</span>

--- a/components/admin/assessment/AssessmentPreviewSection.tsx
+++ b/components/admin/assessment/AssessmentPreviewSection.tsx
@@ -3,11 +3,6 @@
 import {
   Box,
   Typography,
-  Paper,
-  Chip,
-  Divider,
-  Card,
-  CardContent,
   Button,
   Table,
   TableBody,
@@ -23,6 +18,7 @@ import {
 import { useMemo, useState } from "react";
 import { Section } from "./MultipleSectionsSection";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { StatusChip, CountBadge } from "@/components/admin/assessment/shared";
 import { SectionCard, WrittenPromptPreview } from "./SectionCard";
 import { MCQQuestionsTable } from "./MCQQuestionsTable";
 import { CodingProblemsTable } from "./CodingProblemsTable";
@@ -30,6 +26,130 @@ import { PaginationControls } from "./PaginationControls";
 
 interface MCQWithSection extends MCQ {
   sectionId: string;
+}
+
+/** Section kicker label (redesign language). Text renders UPPERCASE. */
+const kickerSx = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase" as const,
+  color: "var(--font-tertiary)",
+};
+
+/** Shared card recipe from the style contract. */
+const cardSx = {
+  borderRadius: "16px",
+  bgcolor: "var(--card-bg)",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+};
+
+/** Uppercase table-head cell in the kicker voice. */
+const headCellSx = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase" as const,
+  color: "var(--font-tertiary)",
+  bgcolor: "var(--surface)",
+  borderBottom: "1px solid var(--border-default)",
+};
+
+/** KPI summary tile: accent icon tile + mono value + caption. */
+function KpiCard({
+  icon,
+  accent,
+  value,
+  caption,
+}: {
+  icon: string;
+  accent: string;
+  value: string | number;
+  caption: string;
+}) {
+  return (
+    <Box sx={{ ...cardSx, display: "flex", alignItems: "center", gap: 1.5, p: 2 }}>
+      <Box
+        sx={{
+          width: 40,
+          height: 40,
+          borderRadius: 2,
+          flexShrink: 0,
+          display: "grid",
+          placeItems: "center",
+          bgcolor: `color-mix(in srgb, ${accent} 12%, var(--card-bg) 88%)`,
+          color: accent,
+        }}
+      >
+        <IconWrapper icon={icon} size={20} />
+      </Box>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography
+          sx={{
+            fontFamily: "var(--font-mono)",
+            fontWeight: 700,
+            fontSize: "1.3rem",
+            lineHeight: 1.1,
+            color: "var(--font-primary)",
+          }}
+        >
+          {value}
+        </Typography>
+        <Typography
+          variant="caption"
+          sx={{ color: "var(--font-secondary)", whiteSpace: "nowrap", display: "block" }}
+        >
+          {caption}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+/** Section-group row header: icon tile + label + count badge. */
+function SectionGroupHeader({
+  icon,
+  accent,
+  label,
+  count,
+}: {
+  icon: string;
+  accent: string;
+  label: string;
+  count: number;
+}) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.5 }}>
+      <Box
+        sx={{
+          width: 36,
+          height: 36,
+          borderRadius: 2,
+          flexShrink: 0,
+          display: "grid",
+          placeItems: "center",
+          bgcolor: `color-mix(in srgb, ${accent} 12%, var(--card-bg) 88%)`,
+          color: accent,
+        }}
+      >
+        <IconWrapper icon={icon} size={18} />
+      </Box>
+      <Typography
+        sx={{
+          fontFamily: "var(--font-jakarta)",
+          fontWeight: 700,
+          fontSize: "0.95rem",
+          color: "var(--font-primary)",
+          flexGrow: 1,
+          minWidth: 0,
+        }}
+      >
+        {label}
+      </Typography>
+      <CountBadge count={count} label="sections" />
+    </Box>
+  );
 }
 
 function truncatePreview(text: string, maxLen: number): string {
@@ -58,63 +178,74 @@ function WrittenPromptsPreviewTable({
 
   if (prompts.length === 0) {
     return (
-      <Paper
+      <Box
         sx={{
-          p: 4,
-          textAlign: "center",
-          bgcolor: "color-mix(in srgb, var(--warning-500) 14%, var(--surface) 86%)",
+          ...cardSx,
           border:
-            "1px solid color-mix(in srgb, var(--warning-500) 35%, var(--border-default) 65%)",
+            "1.5px dashed color-mix(in srgb, var(--warning-500) 45%, var(--border-default) 55%)",
+          p: 4,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          textAlign: "center",
+          gap: 1.5,
         }}
       >
-        <Typography variant="body1" sx={{ color: "var(--warning-500)", fontWeight: 600 }}>
+        <Box
+          sx={{
+            width: 44,
+            height: 44,
+            borderRadius: 2,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+            color: "var(--warning-500)",
+          }}
+        >
+          <IconWrapper icon="mdi:pencil-off-outline" size={22} />
+        </Box>
+        <Typography sx={{ color: "var(--font-primary)", fontWeight: 700 }}>
           No written prompts found{sectionName ? ` in ${sectionName}` : ""}
         </Typography>
-      </Paper>
+      </Box>
     );
   }
 
   return (
-    <Paper
-      sx={{
-        borderRadius: 2,
-        boxShadow:
-          "0 1px 3px color-mix(in srgb, var(--font-primary) 12%, transparent)",
-        border: "1px solid var(--border-default)",
-        backgroundColor: "var(--card-bg)",
-        overflow: "hidden",
-        width: "100%",
-      }}
-    >
+    <Box sx={{ ...cardSx, overflow: "hidden", width: "100%" }}>
       <TableContainer sx={{ width: "100%" }}>
         <Table size="small">
           <TableHead>
-            <TableRow sx={{ backgroundColor: "var(--surface)" }}>
-              <TableCell sx={{ fontWeight: 600, width: 56 }}>#</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Prompt</TableCell>
-              <TableCell sx={{ fontWeight: 600, width: 100 }}>Marks</TableCell>
-              <TableCell sx={{ fontWeight: 600, width: 140 }}>Answer mode</TableCell>
+            <TableRow>
+              <TableCell sx={{ ...headCellSx, width: 56 }}>#</TableCell>
+              <TableCell sx={headCellSx}>Prompt</TableCell>
+              <TableCell sx={{ ...headCellSx, width: 100 }}>Marks</TableCell>
+              <TableCell sx={{ ...headCellSx, width: 140 }}>Answer mode</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {paginated.map((row, i) => (
               <TableRow key={`${startIndex + i}-${row.question_text.slice(0, 24)}`}>
-                <TableCell>{startIndex + i + 1}</TableCell>
+                <TableCell
+                  sx={{ fontFamily: "var(--font-mono)", color: "var(--font-tertiary)" }}
+                >
+                  {startIndex + i + 1}
+                </TableCell>
                 <TableCell sx={{ maxWidth: { xs: 200, sm: 480 } }}>
                   <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
                     {truncatePreview(row.question_text, 400)}
                   </Typography>
                 </TableCell>
-                <TableCell>{row.max_marks}</TableCell>
+                <TableCell
+                  sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, color: "var(--font-primary)" }}
+                >
+                  {row.max_marks}
+                </TableCell>
                 <TableCell>
-                  <Chip
+                  <StatusChip
                     label={row.answer_mode || "text"}
-                    size="small"
-                    sx={{
-                      bgcolor: "color-mix(in srgb, var(--warning-500) 16%, var(--surface) 84%)",
-                      color: "var(--warning-500)",
-                      fontWeight: 600,
-                    }}
+                    tone="warning"
+                    icon="mdi:pencil-outline"
                   />
                 </TableCell>
               </TableRow>
@@ -130,7 +261,7 @@ function WrittenPromptsPreviewTable({
         onLimitChange={onLimitChange}
         itemLabel="prompts"
       />
-    </Paper>
+    </Box>
   );
 }
 
@@ -353,261 +484,206 @@ export function AssessmentPreviewSection({
     <Box sx={{ display: "flex", flexDirection: "column", gap: 4 }}>
       {/* Assessment Overview */}
       <Box>
-        <Typography
-          variant="h5"
-          sx={{ fontWeight: 700, mb: 3, color: "var(--font-primary)" }}
+        <Typography sx={{ ...kickerSx, mb: 1.5 }}>Assessment overview</Typography>
+
+        {/* Identity card: title + status/paid chips */}
+        <Box
+          sx={{
+            ...cardSx,
+            p: 2.5,
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            flexWrap: "wrap",
+            mb: 1.5,
+          }}
         >
-          Assessment Overview
-        </Typography>
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              flexShrink: 0,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+              color: "var(--accent-indigo)",
+            }}
+          >
+            <IconWrapper icon="mdi:file-document" size={22} />
+          </Box>
+          <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                fontSize: "1.2rem",
+                lineHeight: 1.25,
+                color: "var(--font-primary)",
+              }}
+            >
+              {title || "Untitled Assessment"}
+            </Typography>
+            <Typography variant="caption" sx={{ color: "var(--font-tertiary)", display: "block", mt: 0.25 }}>
+              Final review of structure and content before you create
+            </Typography>
+          </Box>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, flexWrap: "wrap" }}>
+            <StatusChip
+              label={isActive ? "Active" : "Inactive"}
+              tone={isActive ? "success" : "neutral"}
+              icon={isActive ? "mdi:check-circle-outline" : "mdi:pause-circle-outline"}
+            />
+            {isPaid && price && (
+              <StatusChip
+                label={`${getCurrencySymbol(currency)}${price} · ${currency}`}
+                tone="warning"
+                icon="mdi:cash"
+              />
+            )}
+          </Box>
+        </Box>
+
+        {/* KPI summary tiles */}
         <Box
           sx={{
             display: "grid",
             gridTemplateColumns: {
-              xs: "1fr",
-              md: "repeat(2, 1fr)",
+              xs: "repeat(2, 1fr)",
+              sm: "repeat(3, 1fr)",
+              lg: "repeat(6, 1fr)",
             },
-            gap: 2,
+            gap: 1.5,
           }}
         >
-          <Card sx={{ height: "100%", border: "1px solid var(--border-default)" }}>
-            <CardContent>
-              <Box
-                sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}
-              >
-                <IconWrapper
-                  icon="mdi:file-document"
-                  size={24}
-                  color="var(--accent-indigo)"
+          <KpiCard
+            icon="mdi:clock-outline"
+            accent="var(--accent-indigo)"
+            value={`${durationMinutes}m`}
+            caption="Duration"
+          />
+          <KpiCard
+            icon="mdi:format-list-numbered"
+            accent="var(--ai-violet)"
+            value={totalQuestions}
+            caption="Total items"
+          />
+          <KpiCard
+            icon="mdi:help-circle-outline"
+            accent="var(--accent-indigo)"
+            value={totalMCQs.length}
+            caption="MCQ questions"
+          />
+          <KpiCard
+            icon="mdi:code-tags"
+            accent="var(--success-500)"
+            value={totalCodingProblemsCount}
+            caption="Coding problems"
+          />
+          <KpiCard
+            icon="mdi:pencil-outline"
+            accent="var(--warning-500)"
+            value={totalWrittenPromptsCount}
+            caption="Written prompts"
+          />
+          <KpiCard
+            icon="mdi:view-grid-outline"
+            accent="var(--accent-indigo)"
+            value={
+              quizSections.length +
+              codingSections.length +
+              subjectiveSections.length
+            }
+            caption="Sections"
+          />
+        </Box>
+      </Box>
+
+      {/* Sections Summary */}
+      <Box>
+        <Typography sx={{ ...kickerSx, mb: 1.5 }}>Sections summary</Typography>
+        <Box sx={{ ...cardSx, p: 2.5 }}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+            {quizSections.length > 0 && (
+              <Box>
+                <SectionGroupHeader
+                  icon="mdi:help-circle-outline"
+                  accent="var(--accent-indigo)"
+                  label="Quiz sections"
+                  count={quizSections.length}
                 />
-                <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                  {title || "Untitled Assessment"}
-                </Typography>
+                {quizSections.map((section) => {
+                  const sectionMCQs = mcqsBySection[section.id] || [];
+                  const isSelected = selectedSectionId === section.id;
+                  return (
+                    <SectionCard
+                      key={section.id}
+                      section={section}
+                      isSelected={isSelected}
+                      onClick={() =>
+                        handleSectionSelect(section.id, "quiz")
+                      }
+                      sectionMCQs={sectionMCQs}
+                      type="quiz"
+                    />
+                  );
+                })}
               </Box>
-              <Divider sx={{ my: 2 }} />
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                    Duration
-                  </Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    {durationMinutes} minutes
-                  </Typography>
-                </Box>
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                    Status
-                  </Typography>
-                  <Chip
-                    label={isActive ? "Active" : "Inactive"}
-                    size="small"
-                    sx={{
-                      bgcolor: isActive ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)" : "color-mix(in srgb, var(--error-500) 14%, var(--surface) 86%)",
-                      color: isActive ? "var(--success-500)" : "var(--error-500)",
-                      fontWeight: 600,
-                    }}
-                  />
-                </Box>
-                {isPaid && price && (
-                  <Box
-                    sx={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                      Price
-                    </Typography>
-                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                      {getCurrencySymbol(currency)}
-                      {price} ({currency})
-                    </Typography>
-                  </Box>
-                )}
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                    Total items (MCQ + coding + written)
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    sx={{ fontWeight: 600, fontSize: "1.1rem" }}
-                  >
-                    {totalQuestions}
-                  </Typography>
-                </Box>
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                    MCQ questions
-                  </Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    {totalMCQs.length}
-                  </Typography>
-                </Box>
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                    Coding problems
-                  </Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    {totalCodingProblemsCount}
-                  </Typography>
-                </Box>
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                    Written prompts
-                  </Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    {totalWrittenPromptsCount}
-                  </Typography>
-                </Box>
-                <Box
-                  sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                    Total Sections
-                  </Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                    {quizSections.length +
-                      codingSections.length +
-                      subjectiveSections.length}
-                  </Typography>
-                </Box>
+            )}
+            {codingSections.length > 0 && (
+              <Box>
+                <SectionGroupHeader
+                  icon="mdi:code-tags"
+                  accent="var(--success-500)"
+                  label="Coding sections"
+                  count={codingSections.length}
+                />
+                {codingSections.map((section) => {
+                  const sectionProblems =
+                    codingProblemsBySection[section.id] || [];
+                  const isSelected = selectedSectionId === section.id;
+                  return (
+                    <SectionCard
+                      key={section.id}
+                      section={section}
+                      isSelected={isSelected}
+                      onClick={() =>
+                        handleSectionSelect(section.id, "coding")
+                      }
+                      sectionProblems={sectionProblems}
+                      type="coding"
+                    />
+                  );
+                })}
               </Box>
-            </CardContent>
-          </Card>
-          <Card sx={{ height: "100%", border: "1px solid var(--border-default)" }}>
-            <CardContent>
-              <Box
-                sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}
-              >
-                <IconWrapper icon="mdi:view-list" size={24} color="var(--accent-indigo)" />
-                <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                  Sections Summary
-                </Typography>
+            )}
+            {subjectiveSections.length > 0 && (
+              <Box>
+                <SectionGroupHeader
+                  icon="mdi:pencil-outline"
+                  accent="var(--warning-500)"
+                  label="Written sections"
+                  count={subjectiveSections.length}
+                />
+                {subjectiveSections.map((section) => {
+                  const prompts = writtenPromptsBySection[section.id] || [];
+                  const isSelected = selectedSectionId === section.id;
+                  return (
+                    <SectionCard
+                      key={section.id}
+                      section={section}
+                      isSelected={isSelected}
+                      onClick={() =>
+                        handleSectionSelect(section.id, "subjective")
+                      }
+                      sectionWrittenPrompts={prompts}
+                      type="subjective"
+                    />
+                  );
+                })}
               </Box>
-              <Divider sx={{ my: 2 }} />
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                {quizSections.length > 0 && (
-                  <Box>
-                    <Typography
-                      variant="subtitle2"
-                      sx={{ fontWeight: 600, mb: 1.5, color: "var(--accent-indigo)" }}
-                    >
-                      Quiz Sections ({quizSections.length})
-                    </Typography>
-                    {quizSections.map((section) => {
-                      const sectionMCQs = mcqsBySection[section.id] || [];
-                      const isSelected = selectedSectionId === section.id;
-                      return (
-                        <SectionCard
-                          key={section.id}
-                          section={section}
-                          isSelected={isSelected}
-                          onClick={() =>
-                            handleSectionSelect(section.id, "quiz")
-                          }
-                          sectionMCQs={sectionMCQs}
-                          type="quiz"
-                        />
-                      );
-                    })}
-                  </Box>
-                )}
-                {codingSections.length > 0 && (
-                  <Box>
-                    <Typography
-                      variant="subtitle2"
-                      sx={{ fontWeight: 600, mb: 1.5, color: "var(--success-500)" }}
-                    >
-                      Coding Sections ({codingSections.length})
-                    </Typography>
-                    {codingSections.map((section) => {
-                      const sectionProblems =
-                        codingProblemsBySection[section.id] || [];
-                      const isSelected = selectedSectionId === section.id;
-                      return (
-                        <SectionCard
-                          key={section.id}
-                          section={section}
-                          isSelected={isSelected}
-                          onClick={() =>
-                            handleSectionSelect(section.id, "coding")
-                          }
-                          sectionProblems={sectionProblems}
-                          type="coding"
-                        />
-                      );
-                    })}
-                  </Box>
-                )}
-                {subjectiveSections.length > 0 && (
-                  <Box>
-                    <Typography
-                      variant="subtitle2"
-                      sx={{ fontWeight: 600, mb: 1.5, color: "var(--warning-500)" }}
-                    >
-                      Written Sections ({subjectiveSections.length})
-                    </Typography>
-                    {subjectiveSections.map((section) => {
-                      const prompts = writtenPromptsBySection[section.id] || [];
-                      const isSelected = selectedSectionId === section.id;
-                      return (
-                        <SectionCard
-                          key={section.id}
-                          section={section}
-                          isSelected={isSelected}
-                          onClick={() =>
-                            handleSectionSelect(section.id, "subjective")
-                          }
-                          sectionWrittenPrompts={prompts}
-                          type="subjective"
-                        />
-                      );
-                    })}
-                  </Box>
-                )}
-              </Box>
-            </CardContent>
-          </Card>
+            )}
+          </Box>
         </Box>
       </Box>
 
@@ -624,14 +700,27 @@ export function AssessmentPreviewSection({
               gap: 2,
             }}
           >
-            <Typography variant="h5" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
-              {selectedSection.type === "quiz"
-                ? "MCQ questions"
-                : selectedSection.type === "coding"
-                ? "Coding problems"
-                : "Written prompts"}{" "}
-              preview — {selectedSection.title}
-            </Typography>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography sx={{ ...kickerSx, mb: 0.5 }}>
+                {selectedSection.type === "quiz"
+                  ? "MCQ questions"
+                  : selectedSection.type === "coding"
+                  ? "Coding problems"
+                  : "Written prompts"}{" "}
+                preview
+              </Typography>
+              <Typography
+                sx={{
+                  fontFamily: "var(--font-jakarta)",
+                  fontWeight: 800,
+                  fontSize: "1.15rem",
+                  lineHeight: 1.3,
+                  color: "var(--font-primary)",
+                }}
+              >
+                {selectedSection.title}
+              </Typography>
+            </Box>
             <Box
               sx={{
                 display: "flex",
@@ -640,7 +729,7 @@ export function AssessmentPreviewSection({
                 flexWrap: "wrap",
               }}
             >
-              <Chip
+              <StatusChip
                 label={`${
                   selectedSection.type === "quiz"
                     ? filteredMCQs.length
@@ -654,16 +743,14 @@ export function AssessmentPreviewSection({
                     ? "problems"
                     : "prompts"
                 }`}
-                sx={{
-                  bgcolor:
-                    selectedSection.type === "quiz"
-                      ? "var(--accent-indigo)"
-                      : selectedSection.type === "coding"
-                      ? "var(--success-500)"
-                      : "var(--warning-500)",
-                  color: "var(--font-light)",
-                  fontWeight: 600,
-                }}
+                tone={
+                  selectedSection.type === "quiz"
+                    ? "info"
+                    : selectedSection.type === "coding"
+                    ? "success"
+                    : "warning"
+                }
+                icon="mdi:counter"
               />
               <Button
                 size="small"
@@ -674,7 +761,17 @@ export function AssessmentPreviewSection({
                   setCodingPage(1);
                   setWrittenPage(1);
                 }}
-                sx={{ textTransform: "none" }}
+                sx={{
+                  textTransform: "none",
+                  fontWeight: 700,
+                  borderRadius: 2,
+                  color: "var(--font-primary)",
+                  borderColor: "var(--border-default)",
+                  "&:hover": {
+                    borderColor: "var(--accent-indigo)",
+                    bgcolor: "transparent",
+                  },
+                }}
               >
                 Clear Selection
               </Button>
@@ -726,52 +823,92 @@ export function AssessmentPreviewSection({
 
       {/* Empty State - No Section Selected */}
       {!selectedSectionId && (
-        <Paper
+        <Box
           sx={{
+            ...cardSx,
+            border:
+              "1.5px dashed color-mix(in srgb, var(--accent-indigo) 35%, var(--border-default) 65%)",
             p: 4,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
             textAlign: "center",
-            bgcolor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)",
-            border: "2px dashed var(--border-default)",
+            gap: 1.5,
           }}
         >
-          <Box sx={{ mb: 2 }}>
-            <IconWrapper
-              icon="mdi:hand-pointing-up"
-              size={48}
-              color="var(--font-tertiary)"
-            />
+          <Box
+            sx={{
+              width: 56,
+              height: 56,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+              color: "var(--accent-indigo)",
+            }}
+          >
+            <IconWrapper icon="mdi:hand-pointing-up" size={28} />
           </Box>
           <Typography
-            variant="h6"
-            sx={{ color: "var(--font-secondary)", mb: 1, fontWeight: 600 }}
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 700,
+              fontSize: "1rem",
+              color: "var(--font-primary)",
+            }}
           >
             Select a Section to Preview Content
           </Typography>
-          <Typography variant="body2" sx={{ color: "var(--font-tertiary)" }}>
+          <Typography variant="body2" sx={{ color: "var(--font-tertiary)", maxWidth: 420 }}>
             Select a section card above to preview quiz questions, coding problems, or written prompts.
           </Typography>
-        </Paper>
+        </Box>
       )}
 
       {/* Empty State */}
       {totalMCQs.length === 0 &&
         allCodingProblems.length === 0 &&
         totalWrittenPromptsCount === 0 && (
-        <Paper sx={{ p: 4, textAlign: "center", bgcolor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
-          <Box sx={{ mb: 2 }}>
-            <IconWrapper
-              icon="mdi:alert-circle-outline"
-              size={48}
-              color="var(--font-tertiary)"
-            />
+        <Box
+          sx={{
+            ...cardSx,
+            border:
+              "1.5px dashed color-mix(in srgb, var(--warning-500) 45%, var(--border-default) 55%)",
+            p: 4,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+            gap: 1.5,
+          }}
+        >
+          <Box
+            sx={{
+              width: 56,
+              height: 56,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+              color: "var(--warning-500)",
+            }}
+          >
+            <IconWrapper icon="mdi:alert-circle-outline" size={28} />
           </Box>
-          <Typography variant="h6" sx={{ color: "var(--font-secondary)", mb: 1 }}>
+          <Typography
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 700,
+              fontSize: "1rem",
+              color: "var(--font-primary)",
+            }}
+          >
             No Questions Added
           </Typography>
-          <Typography variant="body2" sx={{ color: "var(--font-tertiary)" }}>
+          <Typography variant="body2" sx={{ color: "var(--font-tertiary)", maxWidth: 420 }}>
             Please go back and add questions to your assessment sections.
           </Typography>
-        </Paper>
+        </Box>
       )}
     </Box>
   );

--- a/components/admin/assessment/BasicInfoSection.tsx
+++ b/components/admin/assessment/BasicInfoSection.tsx
@@ -24,12 +24,13 @@ const helperFormProps = {
   },
 };
 
+/** Section kicker label (design contract): tiny, heavy, tracked-out uppercase. */
 const groupTitleSx = {
-  fontSize: "0.7rem",
-  fontWeight: 700,
-  letterSpacing: "0.06em",
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
   textTransform: "uppercase" as const,
-  color: "var(--font-secondary)",
+  color: "var(--font-tertiary)",
   mb: 0.25,
 };
 
@@ -73,60 +74,60 @@ function BasicInfoSectionInner({
       elevation={0}
       sx={{
         mb: 0,
-        borderRadius: 2,
-        border: "1px solid",
-        borderColor:
-          "color-mix(in srgb, var(--accent-indigo) 30%, var(--border-default) 70%)",
+        borderRadius: "16px",
+        border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
         overflow: "hidden",
-        boxShadow:
-          "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
-        background:
-          "linear-gradient(180deg, color-mix(in srgb, var(--accent-indigo) 8%, var(--surface) 92%) 0%, var(--card-bg) 56px)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+        bgcolor: "var(--card-bg)",
         opacity: readOnly ? 0.96 : 1,
       }}
     >
+      {/* Basics card header (mockup): icon tile + heading + caption */}
       <Box
         sx={{
           px: 2.5,
-          py: 2,
+          py: 2.25,
           display: "flex",
           alignItems: "flex-start",
           gap: 1.5,
-          borderBottom: "1px solid",
-          borderColor:
-            "color-mix(in srgb, var(--accent-indigo) 20%, var(--border-default) 80%)",
+          borderBottom: "1px solid var(--border-default)",
         }}
       >
         <Box
           sx={{
-            width: 44,
-            height: 44,
-            borderRadius: 1.5,
+            width: 42,
+            height: 42,
+            borderRadius: 2,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            bgcolor:
-              "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-            border:
-              "1px solid color-mix(in srgb, var(--accent-indigo) 30%, var(--border-default) 70%)",
+            bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
             flexShrink: 0,
           }}
         >
-          <IconWrapper icon="mdi:file-document-edit-outline" size={24} color="var(--accent-indigo)" />
+          <IconWrapper icon="mdi:file-document-edit-outline" size={22} color="var(--accent-indigo)" />
         </Box>
         <Box>
-          <Typography variant="subtitle1" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
-            Basic information
+          <Typography
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: "1.1rem",
+              lineHeight: 1.3,
+              color: "var(--font-primary)",
+            }}
+          >
+            Basics
           </Typography>
-          <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.5, lineHeight: 1.5 }}>
-            Name and describe your assessment so students know what to expect before they start.
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.25, lineHeight: 1.5 }}>
+            What students see before they start
           </Typography>
         </Box>
       </Box>
 
       <Box sx={{ px: { xs: 2, sm: 2.5 }, py: 2.5, display: "flex", flexDirection: "column", gap: 3 }}>
         <FieldGroup
-          title="Assessment name"
+          title="Assessment title"
           hint="Shown in lists and at the top of the attempt. Keep it specific and concise."
         >
           <TextField
@@ -146,7 +147,10 @@ function BasicInfoSectionInner({
                 }}
               >
                 <span>Maximum 255 characters.</span>
-                <Box component="span" sx={{ color: "var(--font-tertiary)", flexShrink: 0 }}>
+                <Box
+                  component="span"
+                  sx={{ color: "var(--font-tertiary)", fontFamily: "var(--font-mono)", flexShrink: 0 }}
+                >
                   {title.length}/255
                 </Box>
               </Box>
@@ -158,7 +162,7 @@ function BasicInfoSectionInner({
         </FieldGroup>
 
         <FieldGroup
-          title="Instructions"
+          title="Instructions for students"
           hint="Required. Tell students how to complete the assessment, time expectations, and any materials allowed."
         >
           <RichTextEditor

--- a/components/admin/assessment/CSVUploadSection.tsx
+++ b/components/admin/assessment/CSVUploadSection.tsx
@@ -5,8 +5,6 @@ import {
   Box,
   Typography,
   Button,
-  Paper,
-  Alert,
   Table,
   TableBody,
   TableCell,
@@ -18,6 +16,7 @@ import {
 } from "@mui/material";
 import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { DifficultyChip } from "@/components/admin/assessment/shared";
 import { useToast } from "@/components/common/Toast";
 import { MCQ } from "@/lib/services/admin/admin-assessment.service";
 import { parseCSVRows } from "@/lib/utils/csv-parse";
@@ -29,6 +28,58 @@ interface CSVUploadSectionProps {
 }
 
 const DEFAULT_PAGE_SIZE = 10;
+
+/** Section kicker label (redesign language). */
+const KICKER_SX = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--font-tertiary)",
+} as const;
+
+/** Shipped card recipe for content containers. */
+const CARD_SX = {
+  borderRadius: "16px",
+  bgcolor: "var(--card-bg)",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+} as const;
+
+/** Secondary (outline) button per the redesign button rules. */
+const SECONDARY_BUTTON_SX = {
+  textTransform: "none",
+  fontWeight: 700,
+  borderRadius: 2,
+  color: "var(--font-primary)",
+  borderColor: "var(--border-default)",
+  "&:hover": {
+    borderColor: "var(--accent-indigo)",
+    bgcolor: "color-mix(in srgb, var(--accent-indigo) 6%, var(--card-bg) 94%)",
+  },
+} as const;
+
+/** Primary (gradient) button per the redesign button rules. */
+const PRIMARY_BUTTON_SX = {
+  textTransform: "none",
+  fontWeight: 700,
+  borderRadius: 2,
+  color: "#fff",
+  background: "var(--gradient-ai)",
+  boxShadow:
+    "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+  "&:hover": { filter: "brightness(1.05)" },
+} as const;
+
+/** Sticky-header table head cell (token surface, no MUI default grey/blue). */
+const HEAD_CELL_SX = {
+  fontWeight: 700,
+  fontSize: "0.75rem",
+  letterSpacing: "0.02em",
+  color: "var(--font-secondary)",
+  bgcolor: "var(--surface)",
+  whiteSpace: "nowrap",
+} as const;
 
 export function CSVUploadSection({
   mcqs,
@@ -160,28 +211,72 @@ export function CSVUploadSection({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      <Typography sx={KICKER_SX}>Bulk upload from CSV</Typography>
+
+      {/* Dropzone: dashed import card (redesign language) */}
       <Box
         sx={{
+          p: { xs: 3, sm: 4 },
+          borderRadius: "var(--radius-card)",
+          border:
+            "1.5px dashed color-mix(in srgb, var(--ai-violet) 40%, var(--border-default) 60%)",
+          bgcolor: "color-mix(in srgb, var(--ai-violet) 3%, var(--card-bg) 97%)",
           display: "flex",
-          justifyContent: "space-between",
+          flexDirection: "column",
           alignItems: "center",
+          textAlign: "center",
+          gap: 1.5,
         }}
       >
-        <Typography variant="h6" sx={{ fontWeight: 600 }}>
-          Bulk Upload from CSV
-        </Typography>
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={downloadTemplate}
-          startIcon={<IconWrapper icon="mdi:download" size={18} />}
+        <Box
+          sx={{
+            width: 44,
+            height: 44,
+            borderRadius: 2,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
+            color: "var(--ai-violet)",
+          }}
         >
-          Download Template
-        </Button>
-      </Box>
-
-      <Paper sx={{ p: 3, bgcolor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <IconWrapper icon="mdi:tray-arrow-down" size={22} />
+        </Box>
+        <Box>
+          <Typography
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: "1.05rem",
+              color: "var(--font-primary)",
+            }}
+          >
+            Import a spreadsheet
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              color: "var(--font-tertiary)",
+              display: "block",
+              maxWidth: 560,
+              mx: "auto",
+              mt: 0.5,
+              lineHeight: 1.5,
+            }}
+          >
+            CSV format: question_text, option_a, option_b, option_c, option_d,
+            correct_option, explanation, difficulty_level, topic, skills. Use
+            double quotes for fields that contain commas (e.g. &quot;Option A, with comma&quot;).
+          </Typography>
+        </Box>
+        <Box sx={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: 1.25 }}>
+          <Button
+            variant="outlined"
+            onClick={downloadTemplate}
+            startIcon={<IconWrapper icon="mdi:download" size={18} />}
+            sx={SECONDARY_BUTTON_SX}
+          >
+            Download Template
+          </Button>
           <input
             accept=".csv"
             style={{ display: "none" }}
@@ -194,215 +289,272 @@ export function CSVUploadSection({
               variant="contained"
               component="span"
               startIcon={<IconWrapper icon="mdi:upload" size={18} />}
-              sx={{ bgcolor: "var(--accent-indigo)" }}
+              sx={PRIMARY_BUTTON_SX}
             >
               Upload CSV File
             </Button>
           </label>
-          <Typography variant="caption" color="text.secondary" display="block">
-            CSV format: question_text, option_a, option_b, option_c, option_d,
-            correct_option, explanation, difficulty_level, topic, skills. Use
-            double quotes for fields that contain commas (e.g. &quot;Option A, with comma&quot;).
-          </Typography>
         </Box>
-      </Paper>
+      </Box>
 
       {error && (
-        <Alert severity="error" onClose={() => setError("")}>
-          {error}
-        </Alert>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 1.25,
+            p: 2,
+            borderRadius: "12px",
+            border: "1px solid color-mix(in srgb, var(--error-500) 35%, transparent)",
+            bgcolor: "color-mix(in srgb, var(--error-500) 8%, var(--card-bg) 92%)",
+          }}
+        >
+          <Box
+            sx={{
+              width: 36,
+              height: 36,
+              borderRadius: 2,
+              flexShrink: 0,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--error-500) 12%, var(--card-bg) 88%)",
+              color: "var(--error-500)",
+            }}
+          >
+            <IconWrapper icon="mdi:alert-circle-outline" size={20} />
+          </Box>
+          <Box sx={{ flexGrow: 1, minWidth: 0, pt: 0.25 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: "0.85rem", color: "var(--error-500)" }}>
+              CSV import failed
+            </Typography>
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)", wordBreak: "break-word" }}>
+              {error}
+            </Typography>
+          </Box>
+          <IconButton
+            size="small"
+            onClick={() => setError("")}
+            aria-label="Dismiss error"
+            sx={{ color: "var(--error-500)" }}
+          >
+            <IconWrapper icon="mdi:close" size={16} />
+          </IconButton>
+        </Box>
       )}
 
       {mcqs.length > 0 && (
         <Box>
-          <Typography variant="h6" sx={{ fontWeight: 600, mb: 2 }}>
-            Imported Questions ({mcqs.length})
-          </Typography>
-          <TableContainer component={Paper} sx={{ maxHeight: 440, overflow: "auto" }}>
-            <Table size="small" stickyHeader>
-              <TableHead>
-                <TableRow sx={{ backgroundColor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
-                  <TableCell sx={{ fontWeight: 600 }}>Question</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Option A</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Option B</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Option C</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Option D</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Correct</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Difficulty</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Explanation</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Topic</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Skills</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Actions</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {paginatedMcqs.map((mcq, i) => {
-                  const globalIndex = (page - 1) * limit + i;
-                  return (
-                    <TableRow key={globalIndex}>
-                      <TableCell>
-                        <Typography variant="body2" sx={{ maxWidth: 300, whiteSpace: "pre-wrap" }}>
-                          {mcq.question_text}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            color: mcq.correct_option === "A" ? "var(--success-500)" : "var(--font-secondary)",
-                            fontWeight: mcq.correct_option === "A" ? 600 : 400,
-                          }}
-                        >
-                          {mcq.option_a}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            color: mcq.correct_option === "B" ? "var(--success-500)" : "var(--font-secondary)",
-                            fontWeight: mcq.correct_option === "B" ? 600 : 400,
-                          }}
-                        >
-                          {mcq.option_b}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            color: mcq.correct_option === "C" ? "var(--success-500)" : "var(--font-secondary)",
-                            fontWeight: mcq.correct_option === "C" ? 600 : 400,
-                          }}
-                        >
-                          {mcq.option_c}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            color: mcq.correct_option === "D" ? "var(--success-500)" : "var(--font-secondary)",
-                            fontWeight: mcq.correct_option === "D" ? 600 : 400,
-                          }}
-                        >
-                          {mcq.option_d}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            fontWeight: 600,
-                            color: "var(--accent-indigo)",
-                          }}
-                        >
-                          {mcq.correct_option}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography variant="body2">
-                          {mcq.difficulty_level || "Medium"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            maxWidth: 220,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                          title={mcq.explanation || ""}
-                        >
-                          {mcq.explanation || "—"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            maxWidth: 140,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                          title={mcq.topic || ""}
-                        >
-                          {mcq.topic || "—"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          sx={{
-                            maxWidth: 140,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                          title={mcq.skills || ""}
-                        >
-                          {mcq.skills || "—"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <IconButton
-                          size="small"
-                          onClick={() => handleDelete(globalIndex)}
-                          sx={{ color: "var(--error-500)" }}
-                          aria-label="Delete question"
-                        >
-                          <IconWrapper icon="mdi:delete" size={16} />
-                        </IconButton>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </TableContainer>
-          <Box
-            sx={{
-              pt: 2,
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              flexWrap: "wrap",
-              gap: 2,
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <Typography variant="body2" color="text.secondary">
-                Showing {(page - 1) * limit + 1} to{" "}
-                {Math.min(totalCount, page * limit)} of {totalCount}
-              </Typography>
-              <PerPageSelect
-                value={limit}
-                onChange={(v) => {
-                  setLimit(v);
-                  setPage(1);
+          <Box sx={{ display: "flex", alignItems: "baseline", gap: 1, mb: 1.5 }}>
+            <Typography sx={KICKER_SX}>Imported questions</Typography>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-mono)",
+                fontWeight: 700,
+                fontSize: "0.95rem",
+                lineHeight: 1,
+                color: "var(--accent-indigo)",
+              }}
+            >
+              {mcqs.length}
+            </Typography>
+          </Box>
+          <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
+            <TableContainer sx={{ maxHeight: 440, overflow: "auto" }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={HEAD_CELL_SX}>Question</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Option A</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Option B</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Option C</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Option D</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Correct</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Difficulty</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Explanation</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Topic</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Skills</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Actions</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {paginatedMcqs.map((mcq, i) => {
+                    const globalIndex = (page - 1) * limit + i;
+                    return (
+                      <TableRow
+                        key={globalIndex}
+                        sx={{ "&:hover": { backgroundColor: "var(--surface)" } }}
+                      >
+                        <TableCell>
+                          <Typography variant="body2" sx={{ maxWidth: 300, whiteSpace: "pre-wrap" }}>
+                            {mcq.question_text}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              color: mcq.correct_option === "A" ? "var(--success-500)" : "var(--font-secondary)",
+                              fontWeight: mcq.correct_option === "A" ? 600 : 400,
+                            }}
+                          >
+                            {mcq.option_a}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              color: mcq.correct_option === "B" ? "var(--success-500)" : "var(--font-secondary)",
+                              fontWeight: mcq.correct_option === "B" ? 600 : 400,
+                            }}
+                          >
+                            {mcq.option_b}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              color: mcq.correct_option === "C" ? "var(--success-500)" : "var(--font-secondary)",
+                              fontWeight: mcq.correct_option === "C" ? 600 : 400,
+                            }}
+                          >
+                            {mcq.option_c}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              color: mcq.correct_option === "D" ? "var(--success-500)" : "var(--font-secondary)",
+                              fontWeight: mcq.correct_option === "D" ? 600 : 400,
+                            }}
+                          >
+                            {mcq.option_d}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              fontFamily: "var(--font-mono)",
+                              fontWeight: 700,
+                              color: "var(--accent-indigo)",
+                            }}
+                          >
+                            {mcq.correct_option}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <DifficultyChip level={mcq.difficulty_level || "Medium"} />
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              maxWidth: 220,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                            title={mcq.explanation || ""}
+                          >
+                            {mcq.explanation || "—"}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              maxWidth: 140,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                            title={mcq.topic || ""}
+                          >
+                            {mcq.topic || "—"}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              maxWidth: 140,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                            title={mcq.skills || ""}
+                          >
+                            {mcq.skills || "—"}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <IconButton
+                            size="small"
+                            onClick={() => handleDelete(globalIndex)}
+                            sx={{ color: "var(--error-500)" }}
+                            aria-label="Delete question"
+                          >
+                            <IconWrapper icon="mdi:delete" size={16} />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+            <Box
+              sx={{
+                px: 2,
+                py: 1.5,
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: 2,
+                borderTop: "1px solid var(--border-default)",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+                  Showing {(page - 1) * limit + 1} to{" "}
+                  {Math.min(totalCount, page * limit)} of {totalCount}
+                </Typography>
+                <PerPageSelect
+                  value={limit}
+                  onChange={(v) => {
+                    setLimit(v);
+                    setPage(1);
+                  }}
+                  options={[5, 10, 25, 50]}
+                />
+              </Box>
+              <Pagination
+                count={pageCount}
+                page={page}
+                onChange={(_, p) => setPage(p)}
+                size="small"
+                showFirstButton={false}
+                showLastButton={false}
+                boundaryCount={1}
+                siblingCount={0}
+                disabled={pageCount <= 1}
+                sx={{
+                  "& .MuiPaginationItem-root": { color: "var(--font-secondary)" },
+                  "& .MuiPaginationItem-root.Mui-selected": {
+                    bgcolor: "var(--accent-indigo)",
+                    color: "#fff",
+                    "&:hover": { bgcolor: "var(--accent-indigo)" },
+                  },
                 }}
-                options={[5, 10, 25, 50]}
               />
             </Box>
-            <Pagination
-              count={pageCount}
-              page={page}
-              onChange={(_, p) => setPage(p)}
-              color="primary"
-              size="small"
-              showFirstButton={false}
-              showLastButton={false}
-              boundaryCount={1}
-              siblingCount={0}
-              disabled={pageCount <= 1}
-            />
           </Box>
         </Box>
       )}
     </Box>
   );
 }
-

--- a/components/admin/assessment/CodingCSVUploadSection.tsx
+++ b/components/admin/assessment/CodingCSVUploadSection.tsx
@@ -6,8 +6,6 @@ import {
   Typography,
   Button,
   TextField,
-  Paper,
-  Alert,
   CircularProgress,
   IconButton,
   Select,
@@ -27,6 +25,7 @@ import {
   DialogContent,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { StatusChip, DifficultyChip } from "@/components/admin/assessment/shared";
 import { useToast } from "@/components/common/Toast";
 import {
   adminAssessmentService,
@@ -41,6 +40,58 @@ const DIFFICULTY_LEVELS: Array<"Easy" | "Medium" | "Hard"> = ["Easy", "Medium", 
 const LANGUAGES = ["Python", "Java", "JavaScript", "C++", "C", "Go", "Ruby", "SQL", "Other"];
 const ROWS_PER_PAGE_OPTIONS = [5, 10, 25];
 const RAW_BATCH_CHUNK = 20;
+
+/** Section kicker label (redesign language). */
+const KICKER_SX = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--font-tertiary)",
+} as const;
+
+/** Shipped card recipe for content containers. */
+const CARD_SX = {
+  borderRadius: "16px",
+  bgcolor: "var(--card-bg)",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+} as const;
+
+/** Secondary (outline) button per the redesign button rules. */
+const SECONDARY_BUTTON_SX = {
+  textTransform: "none",
+  fontWeight: 700,
+  borderRadius: 2,
+  color: "var(--font-primary)",
+  borderColor: "var(--border-default)",
+  "&:hover": {
+    borderColor: "var(--accent-indigo)",
+    bgcolor: "color-mix(in srgb, var(--accent-indigo) 6%, var(--card-bg) 94%)",
+  },
+} as const;
+
+/** Primary (gradient) button per the redesign button rules. */
+const PRIMARY_BUTTON_SX = {
+  textTransform: "none",
+  fontWeight: 700,
+  borderRadius: 2,
+  color: "#fff",
+  background: "var(--gradient-ai)",
+  boxShadow:
+    "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+  "&:hover": { filter: "brightness(1.05)" },
+} as const;
+
+/** Sticky-header table head cell (token surface, no MUI default grey/blue). */
+const HEAD_CELL_SX = {
+  fontWeight: 700,
+  fontSize: "0.75rem",
+  letterSpacing: "0.02em",
+  color: "var(--font-secondary)",
+  bgcolor: "var(--surface)",
+  whiteSpace: "nowrap",
+} as const;
 
 function normalizeHeader(h: string): string {
   return h.trim().toLowerCase().replace(/\s+/g, "_");
@@ -317,155 +368,278 @@ export function CodingCSVUploadSection({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Typography variant="h6" sx={{ fontWeight: 600 }}>
-        Bulk upload (CSV)
-      </Typography>
-      <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-        Use plain text in cells—no HTML. Put multi-line text, code, and indented blocks inside double-quoted
-        fields; line breaks and spaces inside quotes are kept. Either use one{" "}
-        <Typography component="span" variant="body2" sx={{ fontFamily: "monospace" }}>
-          raw_problem
-        </Typography>{" "}
-        column per row, or structured columns (title, description, scenario, constraints, input_spec,
-        output_spec, sample_input, sample_output, starter_code). Optional headers accept aliases such as{" "}
-        <Typography component="span" variant="body2" sx={{ fontFamily: "monospace" }}>
-          problem_statement
+      <Box>
+        <Typography sx={KICKER_SX}>Bulk upload (CSV)</Typography>
+        <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 1 }}>
+          Use plain text in cells—no HTML. Put multi-line text, code, and indented blocks inside double-quoted
+          fields; line breaks and spaces inside quotes are kept. Either use one{" "}
+          <Typography component="span" variant="body2" sx={{ fontFamily: "var(--font-mono)" }}>
+            raw_problem
+          </Typography>{" "}
+          column per row, or structured columns (title, description, scenario, constraints, input_spec,
+          output_spec, sample_input, sample_output, starter_code). Optional headers accept aliases such as{" "}
+          <Typography component="span" variant="body2" sx={{ fontFamily: "var(--font-mono)" }}>
+            problem_statement
+          </Typography>
+          ,{" "}
+          <Typography component="span" variant="body2" sx={{ fontFamily: "var(--font-mono)" }}>
+            input_format
+          </Typography>
+          .
         </Typography>
-        ,{" "}
-        <Typography component="span" variant="body2" sx={{ fontFamily: "monospace" }}>
-          input_format
-        </Typography>
-        .
-      </Typography>
+      </Box>
 
-      <Paper sx={{ p: 3, bgcolor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-            <Button variant="outlined" size="small" onClick={downloadTemplate} startIcon={<IconWrapper icon="mdi:download" size={18} />}>
-              Structured template
-            </Button>
-            <Button variant="outlined" size="small" onClick={downloadRawTemplate} startIcon={<IconWrapper icon="mdi:download" size={18} />}>
-              raw_problem template
-            </Button>
-          </Box>
-
+      {/* Dropzone: dashed import card (redesign language) */}
+      <Box
+        sx={{
+          p: { xs: 3, sm: 4 },
+          borderRadius: "var(--radius-card)",
+          border:
+            "1.5px dashed color-mix(in srgb, var(--ai-violet) 40%, var(--border-default) 60%)",
+          bgcolor: "color-mix(in srgb, var(--ai-violet) 3%, var(--card-bg) 97%)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 2,
+        }}
+      >
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", textAlign: "center", gap: 1.5 }}>
           <Box
             sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
               display: "grid",
-              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
-              gap: 2,
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
+              color: "var(--ai-violet)",
             }}
           >
-            <FormControl fullWidth size="small">
-              <InputLabel>Difficulty (all rows)</InputLabel>
-              <Select
-                value={difficultyLevel}
-                label="Difficulty (all rows)"
-                onChange={(e) =>
-                  setDifficultyLevel(e.target.value as "Easy" | "Medium" | "Hard")
-                }
-              >
-                {DIFFICULTY_LEVELS.map((d) => (
-                  <MenuItem key={d} value={d}>
-                    {d}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <FormControl fullWidth size="small">
-              <InputLabel>Programming language (all rows)</InputLabel>
-              <Select
-                value={LANGUAGES.includes(programmingLanguage) ? programmingLanguage : "Other"}
-                label="Programming language (all rows)"
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setProgrammingLanguage(v);
-                  if (v !== "Other") setCustomLanguage("");
-                }}
-              >
-                {LANGUAGES.map((lang) => (
-                  <MenuItem key={lang} value={lang}>
-                    {lang}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <IconWrapper icon="mdi:tray-arrow-down" size={22} />
           </Box>
-          {programmingLanguage === "Other" && (
-            <TextField
-              size="small"
-              label="Specify language"
-              value={customLanguage}
-              onChange={(e) => setCustomLanguage(e.target.value)}
-              placeholder="e.g. Rust, Kotlin"
-              fullWidth
+          <Box>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                fontSize: "1.05rem",
+                color: "var(--font-primary)",
+              }}
+            >
+              Import a spreadsheet
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{
+                color: "var(--font-tertiary)",
+                display: "block",
+                maxWidth: 560,
+                mx: "auto",
+                mt: 0.5,
+                lineHeight: 1.5,
+              }}
+            >
+              Download a template, fill it in plain text, and upload the CSV — quoted cells keep
+              line breaks and indentation.
+            </Typography>
+          </Box>
+          <Box sx={{ display: "flex", flexWrap: "wrap", justifyContent: "center", gap: 1.25 }}>
+            <Button
+              variant="outlined"
+              onClick={downloadTemplate}
+              startIcon={<IconWrapper icon="mdi:download" size={18} />}
+              sx={SECONDARY_BUTTON_SX}
+            >
+              Structured template
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={downloadRawTemplate}
+              startIcon={<IconWrapper icon="mdi:download" size={18} />}
+              sx={SECONDARY_BUTTON_SX}
+            >
+              raw_problem template
+            </Button>
+            <input
+              accept=".csv"
+              style={{ display: "none" }}
+              id="coding-csv-upload"
+              type="file"
+              onChange={handleFileUpload}
             />
-          )}
-
-          <Divider />
-
-          <input
-            accept=".csv"
-            style={{ display: "none" }}
-            id="coding-csv-upload"
-            type="file"
-            onChange={handleFileUpload}
-          />
-          <label htmlFor="coding-csv-upload">
-            <Button
-              variant="contained"
-              component="span"
-              startIcon={<IconWrapper icon="mdi:upload" size={18} />}
-              sx={{ bgcolor: "var(--accent-indigo)", alignSelf: "flex-start" }}
-            >
-              Upload CSV
-            </Button>
-          </label>
-
-          {parsedProblems.length > 0 && (
-            <Button
-              variant="contained"
-              onClick={handleGenerateFromCsv}
-              disabled={generating}
-              startIcon={
-                generating ? (
-                  <CircularProgress size={18} color="inherit" />
-                ) : (
-                  <IconWrapper icon="mdi:send" size={18} />
-                )
-              }
-              sx={{ bgcolor: "var(--success-500)", alignSelf: "flex-start" }}
-            >
-              {generating ? "Creating…" : `Create ${parsedProblems.length} problem(s) from CSV`}
-            </Button>
-          )}
+            <label htmlFor="coding-csv-upload">
+              <Button
+                variant="contained"
+                component="span"
+                startIcon={<IconWrapper icon="mdi:upload" size={18} />}
+                sx={PRIMARY_BUTTON_SX}
+              >
+                Upload CSV
+              </Button>
+            </label>
+          </Box>
         </Box>
-      </Paper>
+
+        <Divider flexItem sx={{ borderColor: "var(--border-default)" }} />
+
+        <Box
+          sx={{
+            width: "100%",
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+            gap: 2,
+          }}
+        >
+          <FormControl fullWidth size="small">
+            <InputLabel>Difficulty (all rows)</InputLabel>
+            <Select
+              value={difficultyLevel}
+              label="Difficulty (all rows)"
+              onChange={(e) =>
+                setDifficultyLevel(e.target.value as "Easy" | "Medium" | "Hard")
+              }
+            >
+              {DIFFICULTY_LEVELS.map((d) => (
+                <MenuItem key={d} value={d}>
+                  {d}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth size="small">
+            <InputLabel>Programming language (all rows)</InputLabel>
+            <Select
+              value={LANGUAGES.includes(programmingLanguage) ? programmingLanguage : "Other"}
+              label="Programming language (all rows)"
+              onChange={(e) => {
+                const v = e.target.value;
+                setProgrammingLanguage(v);
+                if (v !== "Other") setCustomLanguage("");
+              }}
+            >
+              {LANGUAGES.map((lang) => (
+                <MenuItem key={lang} value={lang}>
+                  {lang}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+        {programmingLanguage === "Other" && (
+          <TextField
+            size="small"
+            label="Specify language"
+            value={customLanguage}
+            onChange={(e) => setCustomLanguage(e.target.value)}
+            placeholder="e.g. Rust, Kotlin"
+            fullWidth
+          />
+        )}
+
+        {parsedProblems.length > 0 && (
+          <Button
+            variant="contained"
+            onClick={handleGenerateFromCsv}
+            disabled={generating}
+            startIcon={
+              generating ? (
+                <CircularProgress size={18} color="inherit" />
+              ) : (
+                <IconWrapper icon="mdi:send" size={18} />
+              )
+            }
+            sx={{
+              textTransform: "none",
+              fontWeight: 700,
+              borderRadius: 2,
+              color: "#fff",
+              bgcolor: "var(--success-500)",
+              boxShadow:
+                "0 10px 22px -12px color-mix(in srgb, var(--success-500) 70%, transparent)",
+              "&:hover": { bgcolor: "var(--success-500)", filter: "brightness(1.05)" },
+              alignSelf: { xs: "stretch", sm: "center" },
+            }}
+          >
+            {generating ? "Creating…" : `Create ${parsedProblems.length} problem(s) from CSV`}
+          </Button>
+        )}
+      </Box>
 
       {error && (
-        <Alert severity="error" onClose={() => setError("")}>
-          {error}
-        </Alert>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 1.25,
+            p: 2,
+            borderRadius: "12px",
+            border: "1px solid color-mix(in srgb, var(--error-500) 35%, transparent)",
+            bgcolor: "color-mix(in srgb, var(--error-500) 8%, var(--card-bg) 92%)",
+          }}
+        >
+          <Box
+            sx={{
+              width: 36,
+              height: 36,
+              borderRadius: 2,
+              flexShrink: 0,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--error-500) 12%, var(--card-bg) 88%)",
+              color: "var(--error-500)",
+            }}
+          >
+            <IconWrapper icon="mdi:alert-circle-outline" size={20} />
+          </Box>
+          <Box sx={{ flexGrow: 1, minWidth: 0, pt: 0.25 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: "0.85rem", color: "var(--error-500)" }}>
+              CSV import failed
+            </Typography>
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)", wordBreak: "break-word" }}>
+              {error}
+            </Typography>
+          </Box>
+          <IconButton
+            size="small"
+            onClick={() => setError("")}
+            aria-label="Dismiss error"
+            sx={{ color: "var(--error-500)" }}
+          >
+            <IconWrapper icon="mdi:close" size={16} />
+          </IconButton>
+        </Box>
       )}
 
       {parsedProblems.length > 0 && (
         <Box>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-            Parsed from CSV ({parsedProblems.length} — not yet created on server)
-          </Typography>
-          <Paper variant="outlined" sx={{ overflow: "hidden" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5, flexWrap: "wrap" }}>
+            <Typography sx={KICKER_SX}>Parsed from CSV</Typography>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-mono)",
+                fontWeight: 700,
+                fontSize: "0.95rem",
+                lineHeight: 1,
+                color: "var(--accent-indigo)",
+              }}
+            >
+              {parsedProblems.length}
+            </Typography>
+            <StatusChip label="Not yet created on server" tone="warning" icon="mdi:clock-outline" />
+          </Box>
+          <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
             <TableContainer sx={{ maxHeight: 320 }}>
               <Table size="small" stickyHeader>
                 <TableHead>
-                  <TableRow sx={{ backgroundColor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
-                    <TableCell sx={{ fontWeight: 600, width: 56 }}>#</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>First line / preview</TableCell>
+                  <TableRow>
+                    <TableCell sx={{ ...HEAD_CELL_SX, width: 56 }}>#</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>First line / preview</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {previewSnippets.map((snippet, idx) => (
-                    <TableRow key={idx}>
-                      <TableCell sx={{ fontFamily: "monospace", color: "var(--font-secondary)" }}>
+                    <TableRow key={idx} sx={{ "&:hover": { backgroundColor: "var(--surface)" } }}>
+                      <TableCell sx={{ fontFamily: "var(--font-mono)", color: "var(--font-secondary)" }}>
                         {idx + 1}
                       </TableCell>
                       <TableCell>
@@ -478,25 +652,36 @@ export function CodingCSVUploadSection({
                 </TableBody>
               </Table>
             </TableContainer>
-          </Paper>
+          </Box>
         </Box>
       )}
 
       {generatedProblems.length > 0 && (
         <Box>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-            Created problems ({generatedProblems.length})
-          </Typography>
-          <Paper variant="outlined" sx={{ overflow: "hidden" }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+            <Typography sx={KICKER_SX}>Created problems</Typography>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-mono)",
+                fontWeight: 700,
+                fontSize: "0.95rem",
+                lineHeight: 1,
+                color: "var(--success-500)",
+              }}
+            >
+              {generatedProblems.length}
+            </Typography>
+          </Box>
+          <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
             <TableContainer>
               <Table size="small" stickyHeader>
                 <TableHead>
-                  <TableRow sx={{ backgroundColor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
-                    <TableCell sx={{ fontWeight: 600, width: 48 }}>#</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>Title</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>Difficulty</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>Language</TableCell>
-                    <TableCell sx={{ fontWeight: 600, width: 100, textAlign: "center" }}>
+                  <TableRow>
+                    <TableCell sx={{ ...HEAD_CELL_SX, width: 48 }}>#</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Title</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Difficulty</TableCell>
+                    <TableCell sx={HEAD_CELL_SX}>Language</TableCell>
+                    <TableCell sx={{ ...HEAD_CELL_SX, width: 100, textAlign: "center" }}>
                       Actions
                     </TableCell>
                   </TableRow>
@@ -506,7 +691,7 @@ export function CodingCSVUploadSection({
                     .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                     .map((p, idx) => (
                       <TableRow key={p.id} hover>
-                        <TableCell sx={{ color: "var(--font-secondary)", fontFamily: "monospace" }}>
+                        <TableCell sx={{ color: "var(--font-secondary)", fontFamily: "var(--font-mono)" }}>
                           {page * rowsPerPage + idx + 1}
                         </TableCell>
                         <TableCell sx={{ maxWidth: 280 }}>
@@ -514,7 +699,9 @@ export function CodingCSVUploadSection({
                             {p.title || `Problem #${p.id}`}
                           </Typography>
                         </TableCell>
-                        <TableCell>{p.difficulty_level || "—"}</TableCell>
+                        <TableCell>
+                          <DifficultyChip level={p.difficulty_level} />
+                        </TableCell>
                         <TableCell>{p.programming_language || "—"}</TableCell>
                         <TableCell sx={{ textAlign: "center" }}>
                           <IconButton
@@ -567,8 +754,12 @@ export function CodingCSVUploadSection({
               }}
               rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
               labelRowsPerPage="Rows:"
+              sx={{
+                borderTop: "1px solid var(--border-default)",
+                "& .MuiTablePagination-toolbar": { color: "var(--font-secondary)" },
+              }}
             />
-          </Paper>
+          </Box>
         </Box>
       )}
 
@@ -580,11 +771,19 @@ export function CodingCSVUploadSection({
         PaperProps={{
           sx: {
             maxHeight: "90vh",
-            borderRadius: 2,
+            borderRadius: "16px",
           },
         }}
       >
-        <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            fontFamily: "var(--font-jakarta)",
+            fontWeight: 800,
+          }}
+        >
           <span>Problem Preview</span>
           <IconButton size="small" onClick={() => setPreviewProblem(null)} aria-label="Close">
             <IconWrapper icon="mdi:close" size={20} />

--- a/components/admin/assessment/CodingProblemSelectionSection.tsx
+++ b/components/admin/assessment/CodingProblemSelectionSection.tsx
@@ -4,17 +4,9 @@ import { useState, useMemo } from "react";
 import {
   Box,
   Typography,
-  Paper,
   Checkbox,
   CircularProgress,
   TextField,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Chip,
   Pagination,
   IconButton,
   Dialog,
@@ -25,6 +17,7 @@ import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { CodingProblemListItem } from "@/lib/services/admin/admin-assessment.service";
 import { ProblemDescription } from "@/components/coding/ProblemDescription";
+import { DifficultyChip } from "@/components/admin/assessment/shared";
 import {
   FacetBar,
   FacetState,
@@ -33,7 +26,65 @@ import {
   deriveFacetOptions,
   SourceChip,
   UsageChip,
+  TagChips,
 } from "./questionBankFacets";
+
+/** Redesign card recipe (create-wizard style contract). */
+const CARD_SX = {
+  borderRadius: "16px",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+  bgcolor: "var(--card-bg)",
+} as const;
+
+/** Uppercase section kicker label. */
+const KICKER_SX = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--font-tertiary)",
+} as const;
+
+/** Token-accented checkbox (replaces the MUI default blue). */
+const CHECKBOX_SX = {
+  color: "var(--font-tertiary)",
+  "&.Mui-checked": { color: "var(--ai-violet)" },
+  "&.MuiCheckbox-indeterminate": { color: "var(--ai-violet)" },
+} as const;
+
+/** Search field with token focus accents instead of the default blue. */
+const SEARCH_FIELD_SX = {
+  "& .MuiOutlinedInput-root": {
+    borderRadius: "10px",
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: "var(--ai-violet)",
+    },
+  },
+  "& .MuiInputLabel-root.Mui-focused": { color: "var(--ai-violet)" },
+} as const;
+
+/** Soft result-row card; selected = violet ring + tint (style contract). */
+const rowCardSx = (selected: boolean) => ({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 1,
+  px: 1.5,
+  py: 1.5,
+  borderRadius: "12px",
+  bgcolor: selected
+    ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
+    : "var(--card-bg)",
+  border: selected
+    ? "1.5px solid var(--ai-violet)"
+    : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  transition: "border-color 0.15s ease, background-color 0.15s ease",
+  "&:hover": {
+    borderColor: selected
+      ? "var(--ai-violet)"
+      : "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+  },
+});
 
 interface CodingProblemSelectionSectionProps {
   selectedIds: number[];
@@ -119,7 +170,7 @@ export function CodingProblemSelectionSection({
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
-        <CircularProgress />
+        <CircularProgress sx={{ color: "var(--ai-violet)" }} />
       </Box>
     );
   }
@@ -135,200 +186,246 @@ export function CodingProblemSelectionSection({
           gap: 2,
         }}
       >
-        <Typography variant="h6" sx={{ fontWeight: 600 }}>
-          Select from Existing Coding Problems
-        </Typography>
-        {selectedIds.length > 0 && (
-          <Paper
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <Box
             sx={{
-              p: 1.5,
+              width: 40,
+              height: 40,
+              borderRadius: 2,
+              flexShrink: 0,
+              display: "grid",
+              placeItems: "center",
               bgcolor:
-                "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)",
+                "color-mix(in srgb, var(--success-500) 12%, var(--card-bg) 88%)",
             }}
           >
-            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            <IconWrapper
+              icon="mdi:code-braces"
+              size={21}
+              color="var(--success-500)"
+            />
+          </Box>
+          <Box>
+            <Typography sx={KICKER_SX}>Problem bank</Typography>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                fontSize: "1.05rem",
+                color: "var(--font-primary)",
+                lineHeight: 1.3,
+              }}
+            >
+              Select from Existing Coding Problems
+            </Typography>
+          </Box>
+        </Box>
+        {selectedIds.length > 0 && (
+          <Box
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.5,
+              py: 0.75,
+              borderRadius: 999,
+              bgcolor:
+                "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
+              border:
+                "1px solid color-mix(in srgb, var(--ai-violet) 35%, transparent)",
+            }}
+          >
+            <IconWrapper
+              icon="mdi:check-circle-outline"
+              size={15}
+              color="var(--ai-violet)"
+            />
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: 600, color: "var(--ai-violet)" }}
+            >
               Selected: {selectedIds.length} Problem(s) | Showing: {filteredProblems.length} of {codingProblems.length} total
             </Typography>
-          </Paper>
+          </Box>
         )}
       </Box>
 
-      <TextField
-        label="Search Coding Problems"
-        value={searchTerm}
-        onChange={(e) => {
-          setSearchTerm(e.target.value);
-          setPage(1);
-        }}
-        fullWidth
-        size="small"
-        InputProps={{
-          startAdornment: (
-            <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
-          ),
-        }}
-      />
-
-      <FacetBar
-        facets={facets}
-        options={facetOptions}
-        onChange={(next) => {
-          setFacets(next);
-          setPage(1);
-        }}
-      />
+      {/* Search + facet filters grouped in one card */}
+      <Box sx={{ ...CARD_SX, p: { xs: 2, sm: 2.5 } }}>
+        <Typography sx={{ ...KICKER_SX, mb: 1.5 }}>Search & filters</Typography>
+        <TextField
+          label="Search Coding Problems"
+          value={searchTerm}
+          onChange={(e) => {
+            setSearchTerm(e.target.value);
+            setPage(1);
+          }}
+          fullWidth
+          size="small"
+          InputProps={{
+            startAdornment: (
+              <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
+            ),
+          }}
+          sx={SEARCH_FIELD_SX}
+        />
+        <Box sx={{ mt: 2 }}>
+          <FacetBar
+            facets={facets}
+            options={facetOptions}
+            onChange={(next) => {
+              setFacets(next);
+              setPage(1);
+            }}
+          />
+        </Box>
+      </Box>
 
       {filteredProblems.length === 0 ? (
-        <Paper sx={{ p: 3, textAlign: "center", bgcolor: "var(--surface)" }}>
-          <Typography variant="body2" color="text.secondary">
+        <Box sx={{ ...CARD_SX, p: 4, textAlign: "center" }}>
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              mx: "auto",
+              mb: 1.5,
+              bgcolor:
+                "color-mix(in srgb, var(--success-500) 12%, var(--card-bg) 88%)",
+            }}
+          >
+            <IconWrapper icon="mdi:magnify" size={22} color="var(--success-500)" />
+          </Box>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
             {searchTerm
               ? "No coding problems found matching your search"
               : "No coding problems available. Please add coding problems first."}
           </Typography>
-        </Paper>
+        </Box>
       ) : (
-        <Paper
-          sx={{
-            borderRadius: 2,
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 12%, transparent)",
-            border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-            overflow: "hidden",
-          }}
-        >
-          <TableContainer>
-            <Table>
-              <TableHead>
-                <TableRow sx={{ backgroundColor: "var(--surface)" }}>
-                  <TableCell padding="checkbox" sx={{ width: 48 }}>
-                    <Checkbox
-                      checked={isAllSelected}
-                      indeterminate={
-                        selectedIds.length > 0 && !isAllSelected
-                      }
-                      onChange={handleSelectAll}
-                    />
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    ID
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Title
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Difficulty
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Tags
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Reuse
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem", width: 80, textAlign: "center" }}>
-                    Actions
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {paginatedProblems.map((problem) => (
-                  <TableRow
-                    key={problem.id}
-                    sx={{
-                      "&:hover": { backgroundColor: "var(--surface)" },
-                      backgroundColor: selectedIds.includes(problem.id)
-                        ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                        : "var(--font-light)",
-                    }}
-                  >
-                    <TableCell padding="checkbox">
-                      <Checkbox
-                        checked={selectedIds.includes(problem.id)}
-                        onChange={() => handleToggle(problem.id)}
-                      />
-                    </TableCell>
-                    <TableCell>
+        <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
+          {/* Select-all header */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.5,
+              px: 2,
+              py: 0.75,
+              borderBottom: "1px solid var(--border-default)",
+              bgcolor: "var(--surface)",
+            }}
+          >
+            <Checkbox
+              checked={isAllSelected}
+              indeterminate={
+                selectedIds.length > 0 && !isAllSelected
+              }
+              onChange={handleSelectAll}
+              sx={CHECKBOX_SX}
+            />
+            <Typography sx={KICKER_SX}>Select all on page</Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <Typography
+              variant="caption"
+              sx={{
+                fontFamily: "var(--font-mono)",
+                fontWeight: 700,
+                color: "var(--font-secondary)",
+              }}
+            >
+              {filteredProblems.length} result{filteredProblems.length === 1 ? "" : "s"}
+            </Typography>
+          </Box>
+
+          {/* Result rows as soft cards */}
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 1.25,
+              p: { xs: 1.5, sm: 2 },
+            }}
+          >
+            {paginatedProblems.map((problem) => {
+              const selected = selectedIds.includes(problem.id);
+              return (
+                <Box key={problem.id} sx={rowCardSx(selected)}>
+                  <Checkbox
+                    checked={selectedIds.includes(problem.id)}
+                    onChange={() => handleToggle(problem.id)}
+                    sx={{ ...CHECKBOX_SX, p: 0.5 }}
+                  />
+                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
+                        flexWrap: "wrap",
+                      }}
+                    >
                       <Typography
                         variant="body2"
-                        sx={{ color: "var(--font-secondary)", fontFamily: "monospace" }}
+                        sx={{
+                          color: "var(--font-tertiary)",
+                          fontFamily: "var(--font-mono)",
+                          fontWeight: 600,
+                        }}
                       >
                         #{problem.id}
                       </Typography>
-                    </TableCell>
-                    <TableCell sx={{ maxWidth: 400 }}>
-                      <Typography
-                        variant="body2"
-                        sx={{ fontWeight: 500, mb: 1 }}
-                      >
-                        {problem.title}
-                      </Typography>
-                      {problem.problem_statement && (
-                        <Typography
-                          variant="caption"
-                          sx={{ color: "var(--font-secondary)", display: "block" }}
-                        >
-                          {problem.problem_statement.length > 100
-                            ? problem.problem_statement.substring(0, 100) + "..."
-                            : problem.problem_statement}
-                        </Typography>
-                      )}
-                    </TableCell>
-                    <TableCell>
                       {problem.difficulty_level ? (
-                        <Chip
-                          label={problem.difficulty_level}
-                          size="small"
-                          sx={{
-                            bgcolor:
-                              problem.difficulty_level === "Easy"
-                                ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                                : problem.difficulty_level === "Medium"
-                                ? "color-mix(in srgb, var(--warning-500) 16%, var(--surface) 84%)"
-                                : "color-mix(in srgb, var(--warning-500) 20%, var(--surface) 80%)",
-                            color:
-                              problem.difficulty_level === "Easy"
-                                ? "var(--success-500)"
-                                : problem.difficulty_level === "Medium"
-                                ? "var(--warning-500)"
-                                : "var(--warning-500)",
-                            fontWeight: 600,
-                            fontSize: "0.75rem",
-                          }}
-                        />
+                        <DifficultyChip level={problem.difficulty_level} />
                       ) : (
                         <Typography variant="body2" sx={{ color: "var(--font-tertiary)" }}>
                           -
                         </Typography>
                       )}
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                        {problem.tags || "-"}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, alignItems: "flex-start" }}>
-                        <UsageChip count={problem.usage_count} />
-                        <SourceChip source={problem.source} />
-                      </Box>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+                      <UsageChip count={problem.usage_count} />
+                      <SourceChip source={problem.source} />
+                      <Box sx={{ flexGrow: 1 }} />
                       <IconButton
-                            size="small"
-                            onClick={() => setPreviewProblem(problem)}
-                            sx={{ color: "var(--accent-indigo)" }}
-                            title="Preview"
-                          >
-                            <IconWrapper icon="mdi:eye-outline" size={18} />
-                          </IconButton>
+                        size="small"
+                        onClick={() => setPreviewProblem(problem)}
+                        sx={{ color: "var(--accent-indigo)" }}
+                        title="Preview"
+                      >
+                        <IconWrapper icon="mdi:eye-outline" size={18} />
+                      </IconButton>
+                    </Box>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 600,
+                        color: "var(--font-primary)",
+                        mt: 0.75,
+                      }}
+                    >
+                      {problem.title}
+                    </Typography>
+                    {problem.problem_statement && (
+                      <Typography
+                        variant="caption"
+                        sx={{ color: "var(--font-secondary)", display: "block", mt: 0.5 }}
+                      >
+                        {problem.problem_statement.length > 100
+                          ? problem.problem_statement.substring(0, 100) + "..."
+                          : problem.problem_statement}
                       </Typography>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+                    )}
+                    {problem.tags ? (
+                      <Box sx={{ mt: 1 }}>
+                        <TagChips tags={problem.tags} />
+                      </Box>
+                    ) : null}
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
 
           {/* Pagination */}
           {filteredProblems.length > 0 && (
@@ -392,7 +489,7 @@ export function CodingProblemSelectionSection({
               />
             </Box>
           )}
-        </Paper>
+        </Box>
       )}
 
       <Dialog
@@ -434,4 +531,3 @@ export function CodingProblemSelectionSection({
     </Box>
   );
 }
-

--- a/components/admin/assessment/MCQFormSection.tsx
+++ b/components/admin/assessment/MCQFormSection.tsx
@@ -13,13 +13,12 @@ import {
   Paper,
   IconButton,
   Stack,
-  Divider,
   InputAdornment,
   ToggleButton,
   ToggleButtonGroup,
-  Chip,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { StatusChip } from "@/components/admin/assessment/shared";
 import { MCQ } from "@/lib/services/admin/admin-assessment.service";
 
 interface MCQFormSectionProps {
@@ -27,39 +26,91 @@ interface MCQFormSectionProps {
   onMCQsChange: (mcqs: MCQ[]) => void;
 }
 
-const groupTitleSx = {
-  fontSize: "0.7rem",
-  fontWeight: 700,
-  letterSpacing: "0.06em",
+/** Card recipe (contract): soft border + layered shadow on the white card token. */
+const cardSx = {
+  borderRadius: "16px",
+  bgcolor: "var(--card-bg)",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+};
+
+/** Section kicker label (contract): tiny, heavy, tracked-out uppercase. */
+const kickerSx = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
   textTransform: "uppercase" as const,
-  color: "var(--font-secondary)",
-  mb: 0.25,
+  color: "var(--font-tertiary)",
+  fontFamily: "var(--font-jakarta)",
+  lineHeight: 1.4,
+};
+
+/** Shared selected/idle styling for the correct-answer letter toggles. */
+const letterToggleGroupSx = {
+  flexWrap: "wrap" as const,
+  gap: 1,
+  "& .MuiToggleButtonGroup-grouped": {
+    border: "1px solid",
+    borderColor:
+      "color-mix(in srgb, var(--ai-violet) 24%, var(--border-default)) !important",
+    borderRadius: "10px !important",
+    px: 2,
+    py: 1,
+    fontWeight: 800,
+    fontFamily: "var(--font-jakarta)",
+    textTransform: "none" as const,
+    color: "var(--font-secondary)",
+    "&.Mui-selected": {
+      bgcolor: "color-mix(in srgb, var(--ai-violet) 14%, var(--card-bg) 86%)",
+      color: "var(--ai-violet)",
+      borderColor: "var(--ai-violet) !important",
+    },
+  },
 };
 
 function FieldGroup({
   title,
   hint,
+  icon,
+  accent = "var(--ai-violet)",
   children,
 }: {
   title: string;
   hint?: string;
+  icon: string;
+  accent?: string;
   children: React.ReactNode;
 }) {
   return (
-    <Box>
-      <Typography component="h4" variant="subtitle2" sx={groupTitleSx}>
-        {title}
-      </Typography>
-      {hint ? (
-        <Typography
-          variant="caption"
-          sx={{ color: "var(--font-secondary)", display: "block", mb: 1.25, lineHeight: 1.45 }}
+    <Box sx={{ ...cardSx, p: { xs: 2, sm: 2.5 } }}>
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 2 }}>
+        <Box
+          sx={{
+            width: 38,
+            height: 38,
+            borderRadius: 2,
+            flexShrink: 0,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: `color-mix(in srgb, ${accent} 12%, var(--card-bg) 88%)`,
+          }}
         >
-          {hint}
-        </Typography>
-      ) : (
-        <Box sx={{ mb: 1 }} />
-      )}
+          <IconWrapper icon={icon} size={20} color={accent} />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography component="h4" sx={kickerSx}>
+            {title}
+          </Typography>
+          {hint ? (
+            <Typography
+              variant="caption"
+              sx={{ color: "var(--font-secondary)", display: "block", lineHeight: 1.45 }}
+            >
+              {hint}
+            </Typography>
+          ) : null}
+        </Box>
+      </Stack>
       {children}
     </Box>
   );
@@ -69,16 +120,16 @@ function OptionLetterBadge({ letter }: { letter: "A" | "B" | "C" | "D" }) {
   return (
     <Box
       sx={{
-        minWidth: 28,
-        height: 28,
-        borderRadius: 1,
+        minWidth: 32,
+        height: 32,
+        borderRadius: 2,
         display: "grid",
         placeItems: "center",
         fontSize: "0.8125rem",
         fontWeight: 800,
-        color: "var(--accent-indigo-dark)",
-        bgcolor: "color-mix(in srgb, var(--accent-indigo) 14%, transparent)",
-        border: "1px solid color-mix(in srgb, var(--accent-indigo) 22%, transparent)",
+        fontFamily: "var(--font-jakarta)",
+        color: "var(--ai-violet)",
+        bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
       }}
     >
       {letter}
@@ -197,17 +248,24 @@ export function MCQFormSection({ mcqs, onMCQsChange }: MCQFormSectionProps) {
           sx={{
             width: 40,
             height: 40,
-            borderRadius: 1.5,
+            borderRadius: 2,
             display: "grid",
             placeItems: "center",
-            bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--accent-indigo) 20%, transparent)",
+            bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
           }}
         >
-          <IconWrapper icon="mdi:help-circle-outline" size={22} color="var(--accent-indigo-dark)" />
+          <IconWrapper icon="mdi:help-circle-outline" size={22} color="var(--ai-violet)" />
         </Box>
         <Box>
-          <Typography variant="h6" sx={{ fontWeight: 800, lineHeight: 1.2 }}>
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 800,
+              lineHeight: 1.2,
+              fontFamily: "var(--font-jakarta)",
+              color: "var(--font-primary)",
+            }}
+          >
             {editingIndex !== null ? "Edit question" : "Add MCQ questions"}
           </Typography>
           <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.25 }}>
@@ -216,368 +274,365 @@ export function MCQFormSection({ mcqs, onMCQsChange }: MCQFormSectionProps) {
         </Box>
       </Stack>
 
-      <Paper
-        elevation={0}
-        sx={{
-          p: { xs: 2, sm: 2.5 },
-          borderRadius: 2,
-          border: "1px solid",
-          borderColor:
-            "color-mix(in srgb, var(--accent-indigo) 26%, var(--border-default) 74%)",
-          bgcolor: "color-mix(in srgb, var(--surface) 88%, var(--card-bg) 12%)",
-          boxShadow: "0 1px 3px color-mix(in srgb, var(--font-primary) 8%, transparent)",
-        }}
-      >
-        <Stack spacing={2.75}>
-          <FieldGroup title="Question stem" hint="The prompt learners see above the choices.">
-            <TextField
-              label="Question text"
-              value={formData.question_text}
-              onChange={(e) =>
-                setFormData({ ...formData, question_text: e.target.value })
-              }
-              fullWidth
-              required
-              multiline
-              rows={3}
-              sx={{
-                "& .MuiOutlinedInput-root": {
-                  borderRadius: 2,
-                },
-              }}
-            />
-          </FieldGroup>
+      <Stack spacing={2}>
+        <FieldGroup
+          title="Question stem"
+          hint="The prompt learners see above the choices."
+          icon="mdi:text-box-outline"
+        >
+          <TextField
+            label="Question text"
+            value={formData.question_text}
+            onChange={(e) =>
+              setFormData({ ...formData, question_text: e.target.value })
+            }
+            fullWidth
+            required
+            multiline
+            rows={3}
+            sx={{
+              "& .MuiOutlinedInput-root": {
+                borderRadius: 2,
+              },
+            }}
+          />
+        </FieldGroup>
 
-          <Divider sx={{ borderColor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--border-default))" }} />
-
-          <FieldGroup
-            title="Answer choices"
-            hint="Four options; learners pick one (MCQ) or several (MSQ) depending on type below."
+        <FieldGroup
+          title="Answer choices"
+          hint="Four options; learners pick one (MCQ) or several (MSQ) depending on type below."
+          icon="mdi:format-list-bulleted-square"
+        >
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+              gap: 2,
+            }}
           >
-            <Box
-              sx={{
-                display: "grid",
-                gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
-                gap: 2,
-              }}
-            >
-              {(
-                [
-                  ["A", "option_a"],
-                  ["B", "option_b"],
-                  ["C", "option_c"],
-                  ["D", "option_d"],
-                ] as const
-              ).map(([letter, key]) => (
-                <TextField
-                  key={key}
-                  label={`Option ${letter}`}
-                  value={formData[key]}
-                  onChange={(e) =>
-                    setFormData({ ...formData, [key]: e.target.value })
-                  }
-                  fullWidth
-                  required
-                  inputProps={{ maxLength: 255 }}
-                  InputProps={{
-                    startAdornment: (
-                      <InputAdornment position="start" sx={{ mr: 0.5 }}>
-                        <OptionLetterBadge letter={letter} />
-                      </InputAdornment>
-                    ),
-                  }}
-                  sx={{
-                    "& .MuiOutlinedInput-root": {
-                      borderRadius: 2,
-                    },
-                  }}
-                />
-              ))}
-            </Box>
-          </FieldGroup>
+            {(
+              [
+                ["A", "option_a"],
+                ["B", "option_b"],
+                ["C", "option_c"],
+                ["D", "option_d"],
+              ] as const
+            ).map(([letter, key]) => (
+              <TextField
+                key={key}
+                label={`Option ${letter}`}
+                value={formData[key]}
+                onChange={(e) =>
+                  setFormData({ ...formData, [key]: e.target.value })
+                }
+                fullWidth
+                required
+                inputProps={{ maxLength: 255 }}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start" sx={{ mr: 0.75 }}>
+                      <OptionLetterBadge letter={letter} />
+                    </InputAdornment>
+                  ),
+                }}
+                sx={{
+                  "& .MuiOutlinedInput-root": {
+                    borderRadius: 2,
+                  },
+                }}
+              />
+            ))}
+          </Box>
+        </FieldGroup>
 
-          <Divider sx={{ borderColor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--border-default))" }} />
+        <FieldGroup
+          title="Type & grading"
+          hint="Choose MCQ vs MSQ, then mark which option letters are correct."
+          icon="mdi:checkbox-marked-circle-outline"
+        >
+          <Stack spacing={2}>
+            <FormControl fullWidth sx={{ maxWidth: { sm: 360 } }}>
+              <InputLabel id="mcq-question-type-label">Question type</InputLabel>
+              <Select
+                labelId="mcq-question-type-label"
+                value={isMsq ? "multiple" : "single"}
+                label="Question type"
+                onChange={(e) => {
+                  const v = e.target.value as "single" | "multiple";
+                  setFormData({
+                    ...formData,
+                    question_style: v,
+                    correct_options: v === "multiple" ? formData.correct_options || [] : [],
+                  });
+                }}
+                sx={{ borderRadius: 2 }}
+              >
+                <MenuItem value="single">
+                  <Stack direction="row" spacing={1.25} alignItems="center">
+                    <IconWrapper icon="mdi:radiobox-marked" size={20} color="var(--ai-violet)" />
+                    <span>Single choice (MCQ)</span>
+                  </Stack>
+                </MenuItem>
+                <MenuItem value="multiple">
+                  <Stack direction="row" spacing={1.25} alignItems="center">
+                    <IconWrapper icon="mdi:checkbox-multiple-marked-outline" size={20} color="var(--ai-violet)" />
+                    <span>Multiple select (MSQ)</span>
+                  </Stack>
+                </MenuItem>
+              </Select>
+            </FormControl>
 
-          <FieldGroup
-            title="Type & grading"
-            hint="Choose MCQ vs MSQ, then mark which option letters are correct."
-          >
-            <Stack spacing={2}>
-              <FormControl fullWidth sx={{ maxWidth: { sm: 360 } }}>
-                <InputLabel id="mcq-question-type-label">Question type</InputLabel>
-                <Select
-                  labelId="mcq-question-type-label"
-                  value={isMsq ? "multiple" : "single"}
-                  label="Question type"
-                  onChange={(e) => {
-                    const v = e.target.value as "single" | "multiple";
+            {isMsq ? (
+              <Box
+                sx={{
+                  p: 2,
+                  borderRadius: "12px",
+                  border: "1px solid",
+                  borderColor: msqNeedsMore
+                    ? "color-mix(in srgb, var(--warning-500) 45%, var(--border-default))"
+                    : "color-mix(in srgb, var(--ai-violet) 22%, var(--border-default))",
+                  bgcolor: msqNeedsMore
+                    ? "color-mix(in srgb, var(--warning-500) 6%, var(--card-bg))"
+                    : "color-mix(in srgb, var(--ai-violet) 5%, var(--card-bg))",
+                  transition: "border-color 0.2s ease, background-color 0.2s ease",
+                }}
+              >
+                <Stack
+                  direction={{ xs: "column", sm: "row" }}
+                  spacing={1.5}
+                  alignItems={{ sm: "center" }}
+                  justifyContent="space-between"
+                  sx={{ mb: 1.5 }}
+                >
+                  <Typography
+                    variant="subtitle2"
+                    sx={{
+                      fontWeight: 700,
+                      fontFamily: "var(--font-jakarta)",
+                      color: "var(--font-primary)",
+                    }}
+                  >
+                    Correct options
+                  </Typography>
+                  <Box sx={{ alignSelf: { xs: "flex-start", sm: "center" } }}>
+                    <StatusChip
+                      label={`${msqCount} selected · need ≥ 2`}
+                      tone={msqNeedsMore ? "warning" : "success"}
+                      icon={msqNeedsMore ? "mdi:alert-circle-outline" : "mdi:check-circle-outline"}
+                    />
+                  </Box>
+                </Stack>
+                <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>
+                  Toggle every letter that must be selected for a fully correct answer (exact set).
+                </Typography>
+                <ToggleButtonGroup
+                  exclusive={false}
+                  value={formData.correct_options || []}
+                  onChange={(_, next) => {
+                    const letters = (next as ("A" | "B" | "C" | "D")[]).filter(Boolean);
                     setFormData({
                       ...formData,
-                      question_style: v,
-                      correct_options: v === "multiple" ? formData.correct_options || [] : [],
+                      correct_options: [...letters].sort() as MCQ["correct_options"],
                     });
                   }}
-                  sx={{ borderRadius: 2 }}
+                  aria-label="MSQ correct options"
+                  sx={letterToggleGroupSx}
                 >
-                  <MenuItem value="single">
-                    <Stack direction="row" spacing={1.25} alignItems="center">
-                      <IconWrapper icon="mdi:radiobox-marked" size={20} color="var(--accent-indigo)" />
-                      <span>Single choice (MCQ)</span>
-                    </Stack>
-                  </MenuItem>
-                  <MenuItem value="multiple">
-                    <Stack direction="row" spacing={1.25} alignItems="center">
-                      <IconWrapper icon="mdi:checkbox-multiple-marked-outline" size={20} color="var(--accent-indigo)" />
-                      <span>Multiple select (MSQ)</span>
-                    </Stack>
-                  </MenuItem>
-                </Select>
-              </FormControl>
-
-              {isMsq ? (
-                <Box
+                  {(["A", "B", "C", "D"] as const).map((letter) => (
+                    <ToggleButton key={letter} value={letter} aria-label={`Correct ${letter}`}>
+                      {letter}
+                    </ToggleButton>
+                  ))}
+                </ToggleButtonGroup>
+              </Box>
+            ) : (
+              <Box>
+                <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1 }}>
+                  Correct option (one letter)
+                </Typography>
+                <ToggleButtonGroup
+                  exclusive
+                  value={formData.correct_option}
+                  onChange={(_, v) => {
+                    const next = (v ?? formData.correct_option) as "A" | "B" | "C" | "D";
+                    setFormData({ ...formData, correct_option: next });
+                  }}
+                  aria-label="MCQ correct option"
                   sx={{
-                    p: 2,
-                    borderRadius: 2,
-                    border: "1px solid",
-                    borderColor: msqNeedsMore
-                      ? "color-mix(in srgb, var(--warning-500) 45%, var(--border-default))"
-                      : "color-mix(in srgb, var(--accent-indigo) 18%, var(--border-default))",
-                    bgcolor: msqNeedsMore
-                      ? "color-mix(in srgb, var(--warning-500) 6%, var(--card-bg))"
-                      : "color-mix(in srgb, var(--accent-indigo) 6%, var(--card-bg))",
-                    transition: "border-color 0.2s ease, background-color 0.2s ease",
+                    ...letterToggleGroupSx,
+                    "& .MuiToggleButtonGroup-grouped": {
+                      ...letterToggleGroupSx["& .MuiToggleButtonGroup-grouped"],
+                      px: 2.25,
+                    },
                   }}
                 >
-                  <Stack
-                    direction={{ xs: "column", sm: "row" }}
-                    spacing={1.5}
-                    alignItems={{ sm: "center" }}
-                    justifyContent="space-between"
-                    sx={{ mb: 1.5 }}
-                  >
-                    <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
-                      Correct options
-                    </Typography>
-                    <Chip
-                      size="small"
-                      label={`${msqCount} selected · need ≥ 2`}
-                      sx={{
-                        alignSelf: { xs: "flex-start", sm: "center" },
-                        fontWeight: 700,
-                        bgcolor: msqNeedsMore
-                          ? "color-mix(in srgb, var(--warning-500) 14%, transparent)"
-                          : "color-mix(in srgb, var(--success-500) 14%, transparent)",
-                        color: "var(--font-primary-dark)",
-                        border: "1px solid",
-                        borderColor: msqNeedsMore
-                          ? "color-mix(in srgb, var(--warning-500) 35%, transparent)"
-                          : "color-mix(in srgb, var(--success-500) 35%, transparent)",
-                      }}
-                    />
-                  </Stack>
-                  <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>
-                    Toggle every letter that must be selected for a fully correct answer (exact set).
-                  </Typography>
-                  <ToggleButtonGroup
-                    exclusive={false}
-                    value={formData.correct_options || []}
-                    onChange={(_, next) => {
-                      const letters = (next as ("A" | "B" | "C" | "D")[]).filter(Boolean);
-                      setFormData({
-                        ...formData,
-                        correct_options: [...letters].sort() as MCQ["correct_options"],
-                      });
-                    }}
-                    aria-label="MSQ correct options"
-                    sx={{
-                      flexWrap: "wrap",
-                      gap: 1,
-                      "& .MuiToggleButtonGroup-grouped": {
-                        border: "1px solid",
-                        borderColor: "color-mix(in srgb, var(--accent-indigo) 22%, var(--border-default)) !important",
-                        borderRadius: "10px !important",
-                        px: 2,
-                        py: 1,
-                        fontWeight: 800,
-                        textTransform: "none",
-                        "&.Mui-selected": {
-                          bgcolor: "color-mix(in srgb, var(--accent-indigo) 18%, transparent)",
-                          color: "var(--accent-indigo-dark)",
-                          borderColor: "var(--accent-indigo) !important",
-                        },
-                      },
-                    }}
-                  >
-                    {(["A", "B", "C", "D"] as const).map((letter) => (
-                      <ToggleButton key={letter} value={letter} aria-label={`Correct ${letter}`}>
-                        {letter}
-                      </ToggleButton>
-                    ))}
-                  </ToggleButtonGroup>
-                </Box>
-              ) : (
-                <Box>
-                  <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1 }}>
-                    Correct option (one letter)
-                  </Typography>
-                  <ToggleButtonGroup
-                    exclusive
-                    value={formData.correct_option}
-                    onChange={(_, v) => {
-                      const next = (v ?? formData.correct_option) as "A" | "B" | "C" | "D";
-                      setFormData({ ...formData, correct_option: next });
-                    }}
-                    aria-label="MCQ correct option"
-                    sx={{
-                      flexWrap: "wrap",
-                      gap: 1,
-                      "& .MuiToggleButtonGroup-grouped": {
-                        border: "1px solid",
-                        borderColor: "color-mix(in srgb, var(--accent-indigo) 22%, var(--border-default)) !important",
-                        borderRadius: "10px !important",
-                        px: 2.25,
-                        py: 1,
-                        fontWeight: 800,
-                        textTransform: "none",
-                        "&.Mui-selected": {
-                          bgcolor: "color-mix(in srgb, var(--accent-indigo) 18%, transparent)",
-                          color: "var(--accent-indigo-dark)",
-                          borderColor: "var(--accent-indigo) !important",
-                        },
-                      },
-                    }}
-                  >
-                    {(["A", "B", "C", "D"] as const).map((letter) => (
-                      <ToggleButton key={letter} value={letter} aria-label={`Correct ${letter}`}>
-                        {letter}
-                      </ToggleButton>
-                    ))}
-                  </ToggleButtonGroup>
-                </Box>
-              )}
-            </Stack>
-          </FieldGroup>
-
-          <Divider sx={{ borderColor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--border-default))" }} />
-
-          <FieldGroup title="Metadata" hint="Optional tagging for reports and filtering.">
-            <Box
-              sx={{
-                display: "grid",
-                gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
-                gap: 2,
-              }}
-            >
-              <FormControl fullWidth>
-                <InputLabel>Difficulty level</InputLabel>
-                <Select
-                  value={formData.difficulty_level}
-                  onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      difficulty_level: e.target.value as "Easy" | "Medium" | "Hard",
-                    })
-                  }
-                  label="Difficulty level"
-                  sx={{ borderRadius: 2 }}
-                >
-                  <MenuItem value="Easy">Easy</MenuItem>
-                  <MenuItem value="Medium">Medium</MenuItem>
-                  <MenuItem value="Hard">Hard</MenuItem>
-                </Select>
-              </FormControl>
-              <TextField
-                label="Topic"
-                value={formData.topic}
-                onChange={(e) =>
-                  setFormData({ ...formData, topic: e.target.value })
-                }
-                fullWidth
-                inputProps={{ maxLength: 255 }}
-                sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
-              />
-            </Box>
-          </FieldGroup>
-
-          <Divider sx={{ borderColor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--border-default))" }} />
-
-          <FieldGroup title="Explanation & skills" hint="Shown after submit when you enable explanations.">
-            <Stack spacing={2}>
-              <TextField
-                label="Explanation"
-                value={formData.explanation}
-                onChange={(e) =>
-                  setFormData({ ...formData, explanation: e.target.value })
-                }
-                fullWidth
-                multiline
-                rows={2}
-                sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
-              />
-              <TextField
-                label="Skills"
-                value={formData.skills}
-                onChange={(e) =>
-                  setFormData({ ...formData, skills: e.target.value })
-                }
-                fullWidth
-                inputProps={{ maxLength: 255 }}
-                sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
-              />
-            </Stack>
-          </FieldGroup>
-
-          <Box sx={{ display: "flex", gap: 2, justifyContent: "flex-end", flexWrap: "wrap", pt: 0.5 }}>
-            {editingIndex !== null && (
-              <Button variant="outlined" onClick={handleCancel} sx={{ textTransform: "none", fontWeight: 600 }}>
-                Cancel
-              </Button>
+                  {(["A", "B", "C", "D"] as const).map((letter) => (
+                    <ToggleButton key={letter} value={letter} aria-label={`Correct ${letter}`}>
+                      {letter}
+                    </ToggleButton>
+                  ))}
+                </ToggleButtonGroup>
+              </Box>
             )}
-            <Button
-              variant="contained"
-              onClick={handleAddMCQ}
-              disabled={
-                !formData.question_text.trim() ||
-                !formData.option_a.trim() ||
-                !formData.option_b.trim() ||
-                !formData.option_c.trim() ||
-                !formData.option_d.trim() ||
-                (isMsq && msqCount < 2)
+          </Stack>
+        </FieldGroup>
+
+        <FieldGroup
+          title="Metadata"
+          hint="Optional tagging for reports and filtering."
+          icon="mdi:tag-outline"
+          accent="var(--accent-indigo)"
+        >
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+              gap: 2,
+            }}
+          >
+            <FormControl fullWidth>
+              <InputLabel>Difficulty level</InputLabel>
+              <Select
+                value={formData.difficulty_level}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    difficulty_level: e.target.value as "Easy" | "Medium" | "Hard",
+                  })
+                }
+                label="Difficulty level"
+                sx={{ borderRadius: 2 }}
+              >
+                <MenuItem value="Easy">Easy</MenuItem>
+                <MenuItem value="Medium">Medium</MenuItem>
+                <MenuItem value="Hard">Hard</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              label="Topic"
+              value={formData.topic}
+              onChange={(e) =>
+                setFormData({ ...formData, topic: e.target.value })
               }
-              startIcon={<IconWrapper icon="mdi:plus" size={18} />}
+              fullWidth
+              inputProps={{ maxLength: 255 }}
+              sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+            />
+          </Box>
+        </FieldGroup>
+
+        <FieldGroup
+          title="Explanation & skills"
+          hint="Shown after submit when you enable explanations."
+          icon="mdi:lightbulb-on-outline"
+          accent="var(--accent-indigo)"
+        >
+          <Stack spacing={2}>
+            <TextField
+              label="Explanation"
+              value={formData.explanation}
+              onChange={(e) =>
+                setFormData({ ...formData, explanation: e.target.value })
+              }
+              fullWidth
+              multiline
+              rows={2}
+              sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+            />
+            <TextField
+              label="Skills"
+              value={formData.skills}
+              onChange={(e) =>
+                setFormData({ ...formData, skills: e.target.value })
+              }
+              fullWidth
+              inputProps={{ maxLength: 255 }}
+              sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+            />
+          </Stack>
+        </FieldGroup>
+
+        <Box sx={{ display: "flex", gap: 2, justifyContent: "flex-end", flexWrap: "wrap", pt: 0.5 }}>
+          {editingIndex !== null && (
+            <Button
+              variant="outlined"
+              onClick={handleCancel}
               sx={{
                 textTransform: "none",
                 fontWeight: 700,
-                px: 2.5,
-                py: 1,
                 borderRadius: 2,
-                bgcolor: "var(--accent-indigo)",
-                boxShadow: "0 4px 14px color-mix(in srgb, var(--accent-indigo) 32%, transparent)",
-                "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+                px: 2.5,
+                color: "var(--font-primary)",
+                borderColor: "var(--border-default)",
+                "&:hover": {
+                  borderColor: "var(--accent-indigo)",
+                  bgcolor: "color-mix(in srgb, var(--accent-indigo) 6%, transparent)",
+                },
               }}
             >
-              {editingIndex !== null ? "Update question" : "Add question"}
+              Cancel
             </Button>
-          </Box>
-        </Stack>
-      </Paper>
+          )}
+          <Button
+            variant="contained"
+            onClick={handleAddMCQ}
+            disabled={
+              !formData.question_text.trim() ||
+              !formData.option_a.trim() ||
+              !formData.option_b.trim() ||
+              !formData.option_c.trim() ||
+              !formData.option_d.trim() ||
+              (isMsq && msqCount < 2)
+            }
+            startIcon={<IconWrapper icon="mdi:plus" size={18} />}
+            sx={{
+              textTransform: "none",
+              fontWeight: 700,
+              px: 2.75,
+              py: 1,
+              borderRadius: 2,
+              color: "#fff",
+              background: "var(--gradient-ai)",
+              boxShadow: "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+              "&:hover": { background: "var(--gradient-ai)", filter: "brightness(1.05)" },
+              "&.Mui-disabled": {
+                color: "var(--font-secondary)",
+                background: "color-mix(in srgb, var(--ai-violet) 18%, var(--surface) 82%)",
+              },
+            }}
+          >
+            {editingIndex !== null ? "Update question" : "Add question"}
+          </Button>
+        </Box>
+      </Stack>
 
       {mcqs.length > 0 && (
         <Box>
-          <Typography variant="subtitle1" sx={{ fontWeight: 800, mb: 1.5 }}>
-            Added questions ({mcqs.length})
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontWeight: 800,
+              mb: 1.5,
+              fontFamily: "var(--font-jakarta)",
+              color: "var(--font-primary)",
+            }}
+          >
+            Added questions{" "}
+            <Box
+              component="span"
+              sx={{ fontFamily: "var(--font-mono)", fontSize: "0.9em", color: "var(--font-secondary)" }}
+            >
+              ({mcqs.length})
+            </Box>
           </Typography>
           {mcqs.map((mcq, index) => (
             <Paper
               key={index}
               elevation={0}
               sx={{
-                p: 2,
+                ...cardSx,
+                p: 2.25,
                 mb: 1.5,
-                borderRadius: 2,
-                border: "1px solid var(--border-default)",
-                bgcolor: "var(--card-bg)",
                 position: "relative",
               }}
             >
@@ -591,27 +646,38 @@ export function MCQFormSection({ mcqs, onMCQsChange }: MCQFormSectionProps) {
                 }}
               >
                 <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-                  <Typography variant="subtitle2" sx={{ fontWeight: 800 }}>
-                    Question {index + 1}
+                  <Typography
+                    variant="subtitle2"
+                    sx={{ fontWeight: 800, fontFamily: "var(--font-jakarta)", color: "var(--font-primary)" }}
+                  >
+                    Question{" "}
+                    <Box component="span" sx={{ fontFamily: "var(--font-mono)" }}>
+                      {index + 1}
+                    </Box>
                   </Typography>
-                  <Chip
-                    size="small"
+                  <StatusChip
                     label={mcq.question_style === "multiple" ? "MSQ" : "MCQ"}
-                    sx={{
-                      fontWeight: 700,
-                      height: 22,
-                      bgcolor:
-                        mcq.question_style === "multiple"
-                          ? "color-mix(in srgb, var(--warning-500) 12%, transparent)"
-                          : "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
-                    }}
+                    tone={mcq.question_style === "multiple" ? "warning" : "info"}
+                    icon={
+                      mcq.question_style === "multiple"
+                        ? "mdi:checkbox-multiple-marked-outline"
+                        : "mdi:radiobox-marked"
+                    }
                   />
                 </Stack>
-                <Box sx={{ display: "flex", gap: 0.5, flexShrink: 0 }}>
+                <Box sx={{ display: "flex", gap: 0.75, flexShrink: 0 }}>
                   <IconButton
                     size="small"
                     onClick={() => handleEdit(index)}
-                    sx={{ color: "var(--accent-indigo)" }}
+                    sx={{
+                      color: "var(--accent-indigo)",
+                      border: "1px solid var(--border-default)",
+                      borderRadius: "10px",
+                      "&:hover": {
+                        borderColor: "var(--accent-indigo)",
+                        bgcolor: "color-mix(in srgb, var(--accent-indigo) 8%, transparent)",
+                      },
+                    }}
                     aria-label="Edit question"
                   >
                     <IconWrapper icon="mdi:pencil" size={18} />
@@ -619,14 +685,22 @@ export function MCQFormSection({ mcqs, onMCQsChange }: MCQFormSectionProps) {
                   <IconButton
                     size="small"
                     onClick={() => handleDelete(index)}
-                    sx={{ color: "var(--error-500)" }}
+                    sx={{
+                      color: "var(--error-500)",
+                      border: "1px solid color-mix(in srgb, var(--error-500) 35%, transparent)",
+                      borderRadius: "10px",
+                      "&:hover": {
+                        borderColor: "var(--error-500)",
+                        bgcolor: "color-mix(in srgb, var(--error-500) 8%, transparent)",
+                      },
+                    }}
                     aria-label="Delete question"
                   >
                     <IconWrapper icon="mdi:delete" size={18} />
                   </IconButton>
                 </Box>
               </Box>
-              <Typography variant="body2" sx={{ mb: 1.25, lineHeight: 1.5 }}>
+              <Typography variant="body2" sx={{ mb: 1.25, lineHeight: 1.5, color: "var(--font-primary)" }}>
                 {mcq.question_text}
               </Typography>
               <Stack spacing={0.75}>
@@ -653,14 +727,14 @@ export function MCQFormSection({ mcqs, onMCQsChange }: MCQFormSectionProps) {
                       sx={{
                         py: 0.5,
                         px: 1,
-                        borderRadius: 1,
+                        borderRadius: "10px",
                         bgcolor: isCorrect
                           ? "color-mix(in srgb, var(--success-500) 8%, transparent)"
                           : "transparent",
                       }}
                     >
                       <OptionLetterBadge letter={letter} />
-                      <Typography variant="body2" sx={{ flex: 1, pt: 0.35 }}>
+                      <Typography variant="body2" sx={{ flex: 1, pt: 0.5, color: "var(--font-primary)" }}>
                         {label}
                         {isCorrect && (
                           <IconWrapper

--- a/components/admin/assessment/MCQSelectionSection.tsx
+++ b/components/admin/assessment/MCQSelectionSection.tsx
@@ -4,16 +4,9 @@ import { useState, useMemo } from "react";
 import {
   Box,
   Typography,
-  Paper,
   Checkbox,
   CircularProgress,
   TextField,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Chip,
   Pagination,
 } from "@mui/material";
@@ -21,6 +14,7 @@ import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { MCQListItem } from "@/lib/services/admin/admin-assessment.service";
+import { DifficultyChip, StatusChip } from "@/components/admin/assessment/shared";
 import {
   FacetBar,
   FacetState,
@@ -33,6 +27,63 @@ import {
   PreviewButton,
   PreviewDialog,
 } from "./questionBankFacets";
+
+/** Redesign card recipe (create-wizard style contract). */
+const CARD_SX = {
+  borderRadius: "16px",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+  bgcolor: "var(--card-bg)",
+} as const;
+
+/** Uppercase section kicker label. */
+const KICKER_SX = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--font-tertiary)",
+} as const;
+
+/** Token-accented checkbox (replaces the MUI default blue). */
+const CHECKBOX_SX = {
+  color: "var(--font-tertiary)",
+  "&.Mui-checked": { color: "var(--ai-violet)" },
+  "&.MuiCheckbox-indeterminate": { color: "var(--ai-violet)" },
+} as const;
+
+/** Search field with token focus accents instead of the default blue. */
+const SEARCH_FIELD_SX = {
+  "& .MuiOutlinedInput-root": {
+    borderRadius: "10px",
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: "var(--ai-violet)",
+    },
+  },
+  "& .MuiInputLabel-root.Mui-focused": { color: "var(--ai-violet)" },
+} as const;
+
+/** Soft result-row card; selected = violet ring + tint (style contract). */
+const rowCardSx = (selected: boolean) => ({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 1,
+  px: 1.5,
+  py: 1.5,
+  borderRadius: "12px",
+  bgcolor: selected
+    ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
+    : "var(--card-bg)",
+  border: selected
+    ? "1.5px solid var(--ai-violet)"
+    : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  transition: "border-color 0.15s ease, background-color 0.15s ease",
+  "&:hover": {
+    borderColor: selected
+      ? "var(--ai-violet)"
+      : "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+  },
+});
 
 interface MCQSelectionSectionProps {
   selectedIds: number[];
@@ -103,7 +154,7 @@ export function MCQSelectionSection({
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
-        <CircularProgress />
+        <CircularProgress sx={{ color: "var(--ai-violet)" }} />
       </Box>
     );
   }
@@ -119,273 +170,316 @@ export function MCQSelectionSection({
           gap: 2,
         }}
       >
-        <Typography variant="h6" sx={{ fontWeight: 600 }}>
-          Select from Existing Questions
-        </Typography>
-        {selectedIds.length > 0 && (
-          <Paper
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+          <Box
             sx={{
-              p: 1.5,
+              width: 40,
+              height: 40,
+              borderRadius: 2,
+              flexShrink: 0,
+              display: "grid",
+              placeItems: "center",
               bgcolor:
-                "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
+                "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
             }}
           >
-            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            <IconWrapper
+              icon="mdi:format-list-checks"
+              size={21}
+              color="var(--accent-indigo)"
+            />
+          </Box>
+          <Box>
+            <Typography sx={KICKER_SX}>Question bank</Typography>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                fontSize: "1.05rem",
+                color: "var(--font-primary)",
+                lineHeight: 1.3,
+              }}
+            >
+              Select from Existing Questions
+            </Typography>
+          </Box>
+        </Box>
+        {selectedIds.length > 0 && (
+          <Box
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.5,
+              py: 0.75,
+              borderRadius: 999,
+              bgcolor:
+                "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
+              border:
+                "1px solid color-mix(in srgb, var(--ai-violet) 35%, transparent)",
+            }}
+          >
+            <IconWrapper
+              icon="mdi:check-circle-outline"
+              size={15}
+              color="var(--ai-violet)"
+            />
+            <Typography
+              variant="body2"
+              sx={{ fontWeight: 600, color: "var(--ai-violet)" }}
+            >
               Selected: {selectedIds.length} MCQ(s) | Showing: {filteredMCQs.length} of {mcqs.length} total
             </Typography>
-          </Paper>
+          </Box>
         )}
       </Box>
 
-      <TextField
-        label="Search Questions"
-        value={searchTerm}
-        onChange={(e) => {
-          setSearchTerm(e.target.value);
-          setPage(1);
-        }}
-        fullWidth
-        size="small"
-        InputProps={{
-          startAdornment: (
-            <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
-          ),
-        }}
-      />
-
-      <FacetBar
-        facets={facets}
-        options={facetOptions}
-        onChange={(next) => {
-          setFacets(next);
-          setPage(1);
-        }}
-      />
+      {/* Search + facet filters grouped in one card */}
+      <Box sx={{ ...CARD_SX, p: { xs: 2, sm: 2.5 } }}>
+        <Typography sx={{ ...KICKER_SX, mb: 1.5 }}>Search & filters</Typography>
+        <TextField
+          label="Search Questions"
+          value={searchTerm}
+          onChange={(e) => {
+            setSearchTerm(e.target.value);
+            setPage(1);
+          }}
+          fullWidth
+          size="small"
+          InputProps={{
+            startAdornment: (
+              <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
+            ),
+          }}
+          sx={SEARCH_FIELD_SX}
+        />
+        <Box sx={{ mt: 2 }}>
+          <FacetBar
+            facets={facets}
+            options={facetOptions}
+            onChange={(next) => {
+              setFacets(next);
+              setPage(1);
+            }}
+          />
+        </Box>
+      </Box>
 
       {filteredMCQs.length === 0 ? (
-        <Paper sx={{ p: 3, textAlign: "center", bgcolor: "var(--surface)" }}>
-          <Typography variant="body2" color="text.secondary">
+        <Box sx={{ ...CARD_SX, p: 4, textAlign: "center" }}>
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              mx: "auto",
+              mb: 1.5,
+              bgcolor:
+                "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+            }}
+          >
+            <IconWrapper icon="mdi:magnify" size={22} color="var(--accent-indigo)" />
+          </Box>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
             {searchTerm
               ? "No questions found matching your search"
               : "No questions available. Please add questions first."}
           </Typography>
-        </Paper>
+        </Box>
       ) : (
-        <Paper
-          sx={{
-            borderRadius: 2,
-            boxShadow:
-              "0 1px 3px color-mix(in srgb, var(--font-primary) 12%, transparent)",
-            border: "1px solid var(--border-default)",
-            backgroundColor: "var(--card-bg)",
-            overflow: "hidden",
-          }}
-        >
-          <TableContainer>
-            <Table>
-              <TableHead>
-                <TableRow sx={{ backgroundColor: "var(--surface)" }}>
-                  <TableCell padding="checkbox" sx={{ width: 48 }}>
-                    <Checkbox
-                      checked={isAllSelected}
-                      indeterminate={
-                        selectedIds.length > 0 && !isAllSelected
-                      }
-                      onChange={handleSelectAll}
-                    />
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    ID
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Question
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Correct
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Difficulty
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Topic
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600, fontSize: "0.875rem" }}>
-                    Reuse
-                  </TableCell>
-                  <TableCell sx={{ width: 48 }} />
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {paginatedMCQs.map((mcq) => (
-                  <TableRow
-                    key={mcq.id}
-                    sx={{
-                      "&:hover": { backgroundColor: "var(--surface)" },
-                      backgroundColor: selectedIds.includes(mcq.id)
-                        ? "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)"
-                        : "var(--font-light)",
-                    }}
-                  >
-                    <TableCell padding="checkbox">
-                      <Checkbox
-                        checked={selectedIds.includes(mcq.id)}
-                        onChange={() => handleToggle(mcq.id)}
-                      />
-                    </TableCell>
-                    <TableCell>
+        <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
+          {/* Select-all header */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.5,
+              px: 2,
+              py: 0.75,
+              borderBottom: "1px solid var(--border-default)",
+              bgcolor: "var(--surface)",
+            }}
+          >
+            <Checkbox
+              checked={isAllSelected}
+              indeterminate={
+                selectedIds.length > 0 && !isAllSelected
+              }
+              onChange={handleSelectAll}
+              sx={CHECKBOX_SX}
+            />
+            <Typography sx={KICKER_SX}>Select all on page</Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <Typography
+              variant="caption"
+              sx={{
+                fontFamily: "var(--font-mono)",
+                fontWeight: 700,
+                color: "var(--font-secondary)",
+              }}
+            >
+              {filteredMCQs.length} result{filteredMCQs.length === 1 ? "" : "s"}
+            </Typography>
+          </Box>
+
+          {/* Result rows as soft cards */}
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 1.25,
+              p: { xs: 1.5, sm: 2 },
+            }}
+          >
+            {paginatedMCQs.map((mcq) => {
+              const selected = selectedIds.includes(mcq.id);
+              return (
+                <Box key={mcq.id} sx={rowCardSx(selected)}>
+                  <Checkbox
+                    checked={selectedIds.includes(mcq.id)}
+                    onChange={() => handleToggle(mcq.id)}
+                    sx={{ ...CHECKBOX_SX, p: 0.5 }}
+                  />
+                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
+                        flexWrap: "wrap",
+                      }}
+                    >
                       <Typography
                         variant="body2"
-                        sx={{ color: "var(--font-secondary)", fontFamily: "monospace" }}
+                        sx={{
+                          color: "var(--font-tertiary)",
+                          fontFamily: "var(--font-mono)",
+                          fontWeight: 600,
+                        }}
                       >
                         #{mcq.id}
                       </Typography>
-                    </TableCell>
-                    <TableCell sx={{ maxWidth: 400 }}>
-                      <Typography
-                        variant="body2"
-                        sx={{ fontWeight: 500, mb: 1 }}
-                      >
-                        {mcq.question_text}
-                      </Typography>
-                      <Box
-                        sx={{
-                          display: "flex",
-                          flexWrap: "wrap",
-                          gap: 0.5,
-                          mt: 1,
-                        }}
-                      >
-                        <Chip
-                          label={`A: ${mcq.option_a.length > 30 ? mcq.option_a.substring(0, 30) + "..." : mcq.option_a}`}
-                          size="small"
-                          sx={{
-                            bgcolor:
-                              mcq.correct_option === "A"
-                                ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                                : "var(--surface)",
-                            color:
-                              mcq.correct_option === "A"
-                                ? "var(--success-500)"
-                                : "var(--font-primary)",
-                            fontWeight: mcq.correct_option === "A" ? 600 : 400,
-                            fontSize: "0.75rem",
-                            height: 24,
-                          }}
-                        />
-                        <Chip
-                          label={`B: ${mcq.option_b.length > 30 ? mcq.option_b.substring(0, 30) + "..." : mcq.option_b}`}
-                          size="small"
-                          sx={{
-                            bgcolor:
-                              mcq.correct_option === "B"
-                                ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                                : "var(--surface)",
-                            color:
-                              mcq.correct_option === "B"
-                                ? "var(--success-500)"
-                                : "var(--font-primary)",
-                            fontWeight: mcq.correct_option === "B" ? 600 : 400,
-                            fontSize: "0.75rem",
-                            height: 24,
-                          }}
-                        />
-                        <Chip
-                          label={`C: ${mcq.option_c.length > 30 ? mcq.option_c.substring(0, 30) + "..." : mcq.option_c}`}
-                          size="small"
-                          sx={{
-                            bgcolor:
-                              mcq.correct_option === "C"
-                                ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                                : "var(--surface)",
-                            color:
-                              mcq.correct_option === "C"
-                                ? "var(--success-500)"
-                                : "var(--font-primary)",
-                            fontWeight: mcq.correct_option === "C" ? 600 : 400,
-                            fontSize: "0.75rem",
-                            height: 24,
-                          }}
-                        />
-                        <Chip
-                          label={`D: ${mcq.option_d.length > 30 ? mcq.option_d.substring(0, 30) + "..." : mcq.option_d}`}
-                          size="small"
-                          sx={{
-                            bgcolor:
-                              mcq.correct_option === "D"
-                                ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                                : "var(--surface)",
-                            color:
-                              mcq.correct_option === "D"
-                                ? "var(--success-500)"
-                                : "var(--font-primary)",
-                            fontWeight: mcq.correct_option === "D" ? 600 : 400,
-                            fontSize: "0.75rem",
-                            height: 24,
-                          }}
-                        />
-                      </Box>
-                    </TableCell>
-                    <TableCell>
-                      <Chip
-                        label={mcq.correct_option}
-                        size="small"
-                        sx={{
-                          bgcolor: "var(--success-500)",
-                          color: "var(--font-light)",
-                          fontWeight: 700,
-                          fontSize: "0.875rem",
-                          width: 32,
-                          height: 32,
-                        }}
-                      />
-                    </TableCell>
-                    <TableCell>
                       {mcq.difficulty_level ? (
-                        <Chip
-                          label={mcq.difficulty_level}
-                          size="small"
-                          sx={{
-                            bgcolor:
-                              mcq.difficulty_level === "Easy"
-                                ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                                : mcq.difficulty_level === "Medium"
-                                ? "color-mix(in srgb, var(--warning-500) 16%, var(--surface) 84%)"
-                                : "color-mix(in srgb, var(--warning-500) 20%, var(--surface) 80%)",
-                            color:
-                              mcq.difficulty_level === "Easy"
-                                ? "var(--success-500)"
-                                : mcq.difficulty_level === "Medium"
-                                ? "var(--warning-500)"
-                                : "var(--warning-500)",
-                            fontWeight: 600,
-                            fontSize: "0.75rem",
-                          }}
-                        />
+                        <DifficultyChip level={mcq.difficulty_level} />
                       ) : (
                         <Typography variant="body2" sx={{ color: "var(--font-tertiary)" }}>
                           -
                         </Typography>
                       )}
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+                      <StatusChip
+                        label={`Correct: ${mcq.correct_option}`}
+                        tone="success"
+                        icon="mdi:check-circle-outline"
+                      />
+                      <UsageChip count={mcq.usage_count} />
+                      <SourceChip source={mcq.source} />
+                      <Box sx={{ flexGrow: 1 }} />
+                      <PreviewButton onClick={() => setPreview(mcq)} />
+                    </Box>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 600,
+                        color: "var(--font-primary)",
+                        mt: 0.75,
+                      }}
+                    >
+                      {mcq.question_text}
+                    </Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.5 }}>
+                      <IconWrapper
+                        icon="mdi:shape-outline"
+                        size={13}
+                        color="var(--font-tertiary)"
+                      />
+                      <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
                         {mcq.topic || "-"}
                       </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, alignItems: "flex-start" }}>
-                        <UsageChip count={mcq.usage_count} />
-                        <SourceChip source={mcq.source} />
-                      </Box>
-                    </TableCell>
-                    <TableCell padding="checkbox">
-                      <PreviewButton onClick={() => setPreview(mcq)} />
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+                    </Box>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: 0.5,
+                        mt: 1,
+                      }}
+                    >
+                      <Chip
+                        label={`A: ${mcq.option_a.length > 30 ? mcq.option_a.substring(0, 30) + "..." : mcq.option_a}`}
+                        size="small"
+                        sx={{
+                          bgcolor:
+                            mcq.correct_option === "A"
+                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
+                              : "var(--surface)",
+                          color:
+                            mcq.correct_option === "A"
+                              ? "var(--success-500)"
+                              : "var(--font-primary)",
+                          fontWeight: mcq.correct_option === "A" ? 600 : 400,
+                          fontSize: "0.75rem",
+                          height: 24,
+                        }}
+                      />
+                      <Chip
+                        label={`B: ${mcq.option_b.length > 30 ? mcq.option_b.substring(0, 30) + "..." : mcq.option_b}`}
+                        size="small"
+                        sx={{
+                          bgcolor:
+                            mcq.correct_option === "B"
+                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
+                              : "var(--surface)",
+                          color:
+                            mcq.correct_option === "B"
+                              ? "var(--success-500)"
+                              : "var(--font-primary)",
+                          fontWeight: mcq.correct_option === "B" ? 600 : 400,
+                          fontSize: "0.75rem",
+                          height: 24,
+                        }}
+                      />
+                      <Chip
+                        label={`C: ${mcq.option_c.length > 30 ? mcq.option_c.substring(0, 30) + "..." : mcq.option_c}`}
+                        size="small"
+                        sx={{
+                          bgcolor:
+                            mcq.correct_option === "C"
+                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
+                              : "var(--surface)",
+                          color:
+                            mcq.correct_option === "C"
+                              ? "var(--success-500)"
+                              : "var(--font-primary)",
+                          fontWeight: mcq.correct_option === "C" ? 600 : 400,
+                          fontSize: "0.75rem",
+                          height: 24,
+                        }}
+                      />
+                      <Chip
+                        label={`D: ${mcq.option_d.length > 30 ? mcq.option_d.substring(0, 30) + "..." : mcq.option_d}`}
+                        size="small"
+                        sx={{
+                          bgcolor:
+                            mcq.correct_option === "D"
+                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
+                              : "var(--surface)",
+                          color:
+                            mcq.correct_option === "D"
+                              ? "var(--success-500)"
+                              : "var(--font-primary)",
+                          fontWeight: mcq.correct_option === "D" ? 600 : 400,
+                          fontSize: "0.75rem",
+                          height: 24,
+                        }}
+                      />
+                    </Box>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
 
           {/* Pagination */}
           {filteredMCQs.length > 0 && (
@@ -449,7 +543,7 @@ export function MCQSelectionSection({
               />
             </Box>
           )}
-        </Paper>
+        </Box>
       )}
 
       <PreviewDialog
@@ -463,7 +557,7 @@ export function MCQSelectionSection({
               <SourceChip source={preview.source} />
               <UsageChip count={preview.usage_count} />
               {preview.difficulty_level && (
-                <Chip label={preview.difficulty_level} size="small" sx={{ height: 22, fontSize: "0.7rem" }} />
+                <DifficultyChip level={preview.difficulty_level} />
               )}
               {preview.topic && (
                 <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>

--- a/components/admin/assessment/MultipleSectionsSection.tsx
+++ b/components/admin/assessment/MultipleSectionsSection.tsx
@@ -14,10 +14,10 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Chip,
   Alert,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { StatusChip } from "@/components/admin/assessment/shared";
 import { DragDropContext, Droppable, Draggable, DropResult } from "@hello-pangea/dnd";
 
 export interface Section {
@@ -80,14 +80,139 @@ const helperFormProps = {
   },
 };
 
-const groupTitleSx = {
-  fontSize: "0.7rem",
-  fontWeight: 700,
-  letterSpacing: "0.06em",
+/** Section kicker label (redesign): tiny, heavy, uppercase, tertiary. */
+const kickerSx = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
   textTransform: "uppercase" as const,
-  color: "var(--font-secondary)",
+  color: "var(--font-tertiary)",
+};
+
+const groupTitleSx = {
+  ...kickerSx,
   mb: 0.25,
 };
+
+/** Card recipe from the shipped hub design. */
+const cardShellSx = {
+  bgcolor: "var(--card-bg)",
+  borderRadius: "16px",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+};
+
+/** Primary action: AI gradient, white text, no uppercase. */
+const primaryButtonSx = {
+  background: "var(--gradient-ai)",
+  color: "#fff",
+  fontWeight: 700,
+  textTransform: "none" as const,
+  borderRadius: 2,
+  px: 2.5,
+  boxShadow: "none",
+  "&:hover": {
+    background: "var(--gradient-ai)",
+    filter: "brightness(0.94)",
+    boxShadow: "none",
+  },
+  "&.Mui-disabled": {
+    background:
+      "color-mix(in srgb, var(--ai-violet) 24%, var(--surface) 76%)",
+    color: "color-mix(in srgb, #fff 72%, transparent)",
+    WebkitTextFillColor: "color-mix(in srgb, #fff 72%, transparent)",
+  },
+};
+
+/** Secondary action: quiet outline that warms to indigo. */
+const secondaryButtonSx = {
+  textTransform: "none" as const,
+  fontWeight: 700,
+  borderRadius: 2,
+  color: "var(--font-secondary)",
+  borderColor: "var(--border-default)",
+  "&:hover": {
+    borderColor: "var(--accent-indigo)",
+    color: "var(--accent-indigo)",
+    bgcolor: "transparent",
+  },
+};
+
+/** Small square icon-button used for the per-card order/edit/delete controls. */
+const cardActionButtonSx = {
+  width: 30,
+  height: 30,
+  borderRadius: "8px",
+  border: "1px solid var(--border-default)",
+  color: "var(--font-tertiary)",
+};
+
+/** Token-driven error alert (replaces the MUI default look). */
+const errorAlertSx = {
+  borderRadius: "10px",
+  bgcolor: "color-mix(in srgb, var(--error-500) 9%, var(--card-bg) 91%)",
+  border: "1px solid color-mix(in srgb, var(--error-500) 30%, transparent)",
+  color: "var(--error-500)",
+  "& .MuiAlert-icon": { color: "var(--error-500)" },
+};
+
+/** Indigo icon tile (rounded square) that brands each section-type row. */
+function TypeIconTile({ icon, size = 40 }: { icon: string; size?: number }) {
+  return (
+    <Box
+      sx={{
+        width: size,
+        height: size,
+        borderRadius: 2,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        bgcolor:
+          "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+      }}
+    >
+      <IconWrapper
+        icon={icon}
+        size={Math.round(size * 0.55)}
+        color="var(--accent-indigo)"
+      />
+    </Box>
+  );
+}
+
+/** Mono stat cell for the per-card difficulty points band. */
+function PointsStat({
+  value,
+  label,
+  color,
+}: {
+  value: number;
+  label: string;
+  color: string;
+}) {
+  return (
+    <Box sx={{ textAlign: "center", flex: 1, minWidth: 0 }}>
+      <Typography
+        sx={{
+          fontFamily: "var(--font-mono)",
+          fontWeight: 700,
+          fontSize: "1.05rem",
+          lineHeight: 1.2,
+          color,
+        }}
+      >
+        {value}
+      </Typography>
+      <Typography
+        variant="caption"
+        sx={{ color: "var(--font-tertiary)", fontSize: "0.72rem" }}
+      >
+        {label}
+      </Typography>
+    </Box>
+  );
+}
 
 function FieldGroup({
   title,
@@ -222,11 +347,13 @@ export function MultipleSectionsSection({
 
   return (
     <Box component="section" aria-labelledby="assessment-sections-heading">
+      <Typography sx={{ ...kickerSx, mb: 0.5 }}>Section builder</Typography>
       <Typography
         id="assessment-sections-heading"
         variant="h6"
         sx={{
-          fontWeight: 700,
+          fontFamily: "var(--font-jakarta)",
+          fontWeight: 800,
           color: "var(--font-primary)",
           mb: 1,
         }}
@@ -249,15 +376,13 @@ export function MultipleSectionsSection({
         elevation={0}
         sx={{
           mb: 3,
-          borderRadius: 2,
-          border: "1px solid",
-          borderColor:
-            "color-mix(in srgb, var(--accent-indigo) 30%, var(--border-default) 70%)",
-          overflow: "hidden",
+          bgcolor: "var(--card-bg)",
+          borderRadius: "var(--radius-card)",
+          border:
+            "1.5px dashed color-mix(in srgb, var(--accent-indigo) 40%, var(--border-default) 60%)",
           boxShadow:
-            "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
-          background:
-            "linear-gradient(180deg, color-mix(in srgb, var(--accent-indigo) 8%, var(--surface) 92%) 0%, var(--card-bg) 56px)",
+            "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+          overflow: "hidden",
         }}
       >
         <Box
@@ -267,31 +392,22 @@ export function MultipleSectionsSection({
             display: "flex",
             alignItems: "flex-start",
             gap: 1.5,
-            borderBottom: "1px solid",
-            borderColor:
-              "color-mix(in srgb, var(--accent-indigo) 20%, var(--border-default) 80%)",
+            borderBottom:
+              "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
           }}
         >
-          <Box
-            sx={{
-              width: 44,
-              height: 44,
-              borderRadius: 1.5,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              bgcolor:
-                "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-              border:
-                "1px solid color-mix(in srgb, var(--accent-indigo) 30%, var(--border-default) 70%)",
-              flexShrink: 0,
-            }}
-          >
-            <IconWrapper icon="mdi:layers-plus" size={24} color="var(--accent-indigo)" />
-          </Box>
+          <TypeIconTile icon="mdi:plus" size={44} />
           <Box>
-            <Typography variant="subtitle1" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
-              Add new section
+            <Typography sx={kickerSx}>Step 1 · Structure</Typography>
+            <Typography
+              variant="subtitle1"
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                color: "var(--font-primary)",
+              }}
+            >
+              Add section
             </Typography>
             <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.5, lineHeight: 1.5 }}>
               Groups below follow the same order as your API: layout → scoring → copy → pool size → limits.
@@ -332,13 +448,13 @@ export function MultipleSectionsSection({
                   </MenuItem>
                   <MenuItem value="coding">
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
-                      <IconWrapper icon="mdi:code-tags" size={20} color="var(--success-500)" />
+                      <IconWrapper icon="mdi:code-tags" size={20} color="var(--accent-indigo)" />
                       Coding problems
                     </Box>
                   </MenuItem>
                   <MenuItem value="subjective">
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
-                      <IconWrapper icon="mdi:text-box-outline" size={20} color="var(--warning-500)" />
+                      <IconWrapper icon="mdi:text-box-outline" size={20} color="var(--accent-indigo)" />
                       Written (subjective)
                     </Box>
                   </MenuItem>
@@ -559,12 +675,7 @@ export function MultipleSectionsSection({
               onClick={handleAddSection}
               disabled={!newSection.title.trim() || Boolean(newSectionTimeLimitError)}
               startIcon={<IconWrapper icon="mdi:plus" size={18} />}
-              sx={{
-                bgcolor: "var(--accent-indigo)",
-                px: 2.5,
-                fontWeight: 600,
-                "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
-              }}
+              sx={primaryButtonSx}
             >
               Add section
             </Button>
@@ -575,11 +686,34 @@ export function MultipleSectionsSection({
       {sections.length > 0 && (
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
           <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-            <IconWrapper icon="mdi:drag-vertical-variant" size={22} color="var(--font-secondary)" />
-            <Typography variant="subtitle1" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+            <IconWrapper icon="mdi:drag-vertical-variant" size={20} color="var(--font-tertiary)" />
+            <Typography
+              variant="subtitle1"
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                color: "var(--font-primary)",
+              }}
+            >
               Your sections
             </Typography>
-            <Chip label={`${sections.length} total`} size="small" variant="outlined" sx={{ fontWeight: 600 }} />
+            <Box
+              component="span"
+              sx={{
+                px: 1,
+                py: 0.4,
+                borderRadius: 999,
+                bgcolor:
+                  "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+                color: "var(--accent-indigo)",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.75rem",
+                fontWeight: 700,
+                lineHeight: 1,
+              }}
+            >
+              {sections.length} total
+            </Box>
           </Box>
           <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 0.5 }}>
             Drag the handle to reorder. Order values update automatically.
@@ -631,30 +765,26 @@ export function MultipleSectionsSection({
           sx={{
             p: 4,
             textAlign: "center",
-            borderRadius: 2,
-            border: "2px dashed",
-            borderColor:
-              "color-mix(in srgb, var(--font-secondary) 40%, var(--border-default) 60%)",
-            bgcolor: "color-mix(in srgb, var(--surface) 80%, var(--card-bg) 20%)",
+            bgcolor: "var(--card-bg)",
+            borderRadius: "16px",
+            border:
+              "1.5px dashed color-mix(in srgb, var(--accent-indigo) 40%, var(--border-default) 60%)",
+            boxShadow:
+              "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
           }}
         >
-          <Box
+          <Box sx={{ display: "flex", justifyContent: "center", mb: 2 }}>
+            <TypeIconTile icon="mdi:layers-outline" size={56} />
+          </Box>
+          <Typography
+            variant="subtitle1"
             sx={{
-              width: 56,
-              height: 56,
-              borderRadius: "50%",
-              bgcolor:
-                "color-mix(in srgb, var(--accent-indigo) 10%, var(--surface) 90%)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              mx: "auto",
-              mb: 2,
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              color: "var(--font-primary)",
+              mb: 0.5,
             }}
           >
-            <IconWrapper icon="mdi:layers-outline" size={32} color="var(--accent-indigo)" />
-          </Box>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, color: "var(--font-primary)", mb: 0.5 }}>
             No sections yet
           </Typography>
           <Typography variant="body2" sx={{ color: "var(--font-secondary)", maxWidth: 360, mx: "auto" }}>
@@ -700,18 +830,18 @@ function SectionCard({
     setIsEditing(false);
   };
 
-  const accent =
+  const typeIcon =
     section.type === "quiz"
-      ? "var(--accent-indigo)"
+      ? "mdi:help-circle-outline"
       : section.type === "coding"
-        ? "var(--success-500)"
-        : "var(--warning-500)";
-  const accentSoft =
+        ? "mdi:code-tags"
+        : "mdi:text-box-outline";
+  const typeLabel =
     section.type === "quiz"
-      ? "color-mix(in srgb, var(--accent-indigo) 8%, transparent)"
+      ? "Quiz section"
       : section.type === "coding"
-        ? "color-mix(in srgb, var(--success-500) 8%, transparent)"
-        : "color-mix(in srgb, var(--warning-500) 8%, transparent)";
+        ? "Coding section"
+        : "Written section";
 
   const editTimeLimitError = sectionTimeLimitExceedsOverallMessage(
     overallDurationMinutes,
@@ -728,22 +858,51 @@ function SectionCard({
       sx={{
         p: 0,
         overflow: "hidden",
-        border: "1px solid",
-        borderColor: isDragging ? accent : "var(--border-default)",
-        borderLeft: `4px solid ${accent}`,
-        borderRadius: 2,
-        boxShadow: isDragging
-          ? "0 8px 24px color-mix(in srgb, var(--font-primary) 20%, transparent)"
-          : "0 1px 2px color-mix(in srgb, var(--font-primary) 10%, transparent)",
-        opacity: isDragging ? 0.92 : 1,
+        ...cardShellSx,
+        ...(isDragging
+          ? {
+              border: "1.5px solid var(--accent-indigo)",
+              boxShadow:
+                "0 14px 32px -18px color-mix(in srgb, var(--font-primary) 40%, transparent)",
+            }
+          : {}),
+        opacity: isDragging ? 0.95 : 1,
         transition: "box-shadow 0.2s ease, border-color 0.2s ease, opacity 0.2s ease",
         "&:hover": {
           boxShadow:
-            "0 4px 14px color-mix(in srgb, var(--font-primary) 16%, transparent)",
+            "0 14px 32px -18px color-mix(in srgb, var(--font-primary) 40%, transparent)",
         },
       }}
     >
       {isEditing ? (
+        <Box>
+          <Box
+            sx={{
+              px: 2.5,
+              pt: 2,
+              pb: 1.5,
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              borderBottom:
+                "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+            }}
+          >
+            <TypeIconTile icon="mdi:pencil-outline" />
+            <Box sx={{ minWidth: 0 }}>
+              <Typography sx={kickerSx}>Edit section</Typography>
+              <Typography
+                sx={{
+                  fontFamily: "var(--font-jakarta)",
+                  fontWeight: 800,
+                  fontSize: "1.05rem",
+                  color: "var(--font-primary)",
+                }}
+              >
+                {section.title}
+              </Typography>
+            </Box>
+          </Box>
         <Box sx={{ p: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
           <FieldGroup title="Layout" hint="Type and display order.">
             <Box
@@ -921,235 +1080,190 @@ function SectionCard({
           {allSections.some(
             (s) => s.id !== section.id && s.order === editData.order
           ) && (
-            <Alert severity="error">
+            <Alert severity="error" sx={errorAlertSx}>
               This order number is already used by another section. Please choose
               a different order.
             </Alert>
           )}
           <Box sx={{ display: "flex", gap: 2, justifyContent: "flex-end" }}>
-            <Button variant="outlined" onClick={handleCancel}>
+            <Button variant="outlined" onClick={handleCancel} sx={secondaryButtonSx}>
               Cancel
             </Button>
             <Button
               variant="contained"
               onClick={handleSave}
               disabled={!editData.title.trim() || Boolean(editTimeLimitError)}
-              sx={{
-                bgcolor: "var(--accent-indigo)",
-                color: "var(--font-light)",
-                fontWeight: 600,
-                "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
-                "&.Mui-disabled": {
-                  bgcolor:
-                    "color-mix(in srgb, var(--accent-indigo) 24%, var(--surface) 76%)",
-                  color:
-                    "color-mix(in srgb, var(--font-light) 65%, var(--font-tertiary) 35%)",
-                  WebkitTextFillColor:
-                    "color-mix(in srgb, var(--font-light) 65%, var(--font-tertiary) 35%)",
-                },
-              }}
+              sx={primaryButtonSx}
             >
               Save
             </Button>
           </Box>
+        </Box>
         </Box>
       ) : (
         <Box>
           <Box
             sx={{
               display: "flex",
-              justifyContent: "space-between",
               alignItems: "flex-start",
-              px: 2,
-              py: 1.75,
-              bgcolor: accentSoft,
-              borderBottom: "1px solid var(--border-default)",
+              gap: 1.5,
+              px: 2.5,
+              pt: 2,
+              pb: 1.75,
             }}
           >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
-              <IconWrapper
-                icon={
-                  section.type === "quiz"
-                    ? "mdi:help-circle-outline"
-                    : section.type === "coding"
-                      ? "mdi:code-tags"
-                      : "mdi:text-box-outline"
-                }
-                size={22}
-                color={accent}
-              />
-              <Box>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-                  <Chip
-                    label={
-                      section.type === "quiz"
-                        ? "Quiz"
-                        : section.type === "coding"
-                          ? "Coding"
-                          : "Written"
-                    }
-                    size="small"
-                    sx={{
-                      bgcolor:
-                        section.type === "quiz"
-                          ? "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)"
-                          : section.type === "coding"
-                            ? "color-mix(in srgb, var(--success-500) 12%, var(--surface) 88%)"
-                            : "color-mix(in srgb, var(--warning-500) 12%, var(--surface) 88%)",
-                      color: accent,
-                      fontWeight: 700,
-                      height: 24,
-                    }}
-                  />
-                  <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontWeight: 600 }}>
-                    Order {section.order}
-                  </Typography>
-                </Box>
-                <Typography variant="h6" sx={{ fontWeight: 700, mt: 0.5, color: "var(--font-primary)" }}>
-                  {section.title}
+            <TypeIconTile icon={typeIcon} />
+            <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, flexWrap: "wrap" }}>
+                <Typography sx={kickerSx}>{typeLabel}</Typography>
+                <Typography
+                  component="span"
+                  sx={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.72rem",
+                    fontWeight: 700,
+                    color: "var(--accent-indigo)",
+                  }}
+                >
+                  #{section.order}
                 </Typography>
               </Box>
+              <Typography
+                sx={{
+                  fontFamily: "var(--font-jakarta)",
+                  fontWeight: 800,
+                  fontSize: "1.05rem",
+                  mt: 0.25,
+                  color: "var(--font-primary)",
+                }}
+              >
+                {section.title}
+              </Typography>
+              {section.description ? (
+                <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.5 }}>
+                  {section.description}
+                </Typography>
+              ) : null}
             </Box>
-            <Box sx={{ display: "flex", gap: 0.5, alignItems: "center" }}>
+            <Box sx={{ display: "flex", gap: 0.75, alignItems: "center", flexShrink: 0 }}>
               <IconButton
                 size="small"
                 {...dragHandleProps}
                 sx={{
-                  color: "var(--font-tertiary)",
+                  ...cardActionButtonSx,
                   cursor: "grab",
                   "&:hover": {
                     color: "var(--accent-indigo)",
+                    borderColor: "var(--accent-indigo)",
                     bgcolor:
                       "color-mix(in srgb, var(--accent-indigo) 8%, transparent)",
                   },
                 }}
                 aria-label="Drag to reorder"
               >
-                <IconWrapper icon="mdi:drag" size={22} />
+                <IconWrapper icon="mdi:drag" size={18} />
               </IconButton>
               <IconButton
                 size="small"
                 onClick={() => setIsEditing(true)}
-                sx={{ color: "var(--accent-indigo)" }}
+                sx={{
+                  ...cardActionButtonSx,
+                  "&:hover": {
+                    color: "var(--accent-indigo)",
+                    borderColor: "var(--accent-indigo)",
+                    bgcolor:
+                      "color-mix(in srgb, var(--accent-indigo) 8%, transparent)",
+                  },
+                }}
                 aria-label="Edit section"
               >
-                <IconWrapper icon="mdi:pencil" size={20} />
+                <IconWrapper icon="mdi:pencil" size={16} />
               </IconButton>
               <IconButton
                 size="small"
                 onClick={onDelete}
-                sx={{ color: "var(--error-500)" }}
+                sx={{
+                  ...cardActionButtonSx,
+                  "&:hover": {
+                    color: "var(--error-500)",
+                    borderColor:
+                      "color-mix(in srgb, var(--error-500) 45%, var(--border-default) 55%)",
+                    bgcolor:
+                      "color-mix(in srgb, var(--error-500) 8%, transparent)",
+                  },
+                }}
                 aria-label="Delete section"
               >
-                <IconWrapper icon="mdi:delete-outline" size={20} />
+                <IconWrapper icon="mdi:delete-outline" size={16} />
               </IconButton>
             </Box>
           </Box>
-          <Box sx={{ px: 2, py: 2 }}>
-            {section.description ? (
-              <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 1.5 }}>
-                {section.description}
-              </Typography>
-            ) : null}
-            {section.type === "quiz" && (
-              <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 1 }}>
-                <Chip
-                  label={`Easy ${section.easyScore ?? 1} pts`}
-                  size="small"
-                  variant="outlined"
-                  sx={{
-                    borderColor:
-                      "color-mix(in srgb, var(--success-500) 38%, var(--border-default) 62%)",
-                    color: "var(--success-500)",
-                  }}
-                />
-                <Chip
-                  label={`Medium ${section.mediumScore ?? 2} pts`}
-                  size="small"
-                  variant="outlined"
-                  sx={{
-                    borderColor:
-                      "color-mix(in srgb, var(--warning-500) 38%, var(--border-default) 62%)",
-                    color: "var(--warning-500)",
-                  }}
-                />
-                <Chip
-                  label={`Hard ${section.hardScore ?? 3} pts`}
-                  size="small"
-                  variant="outlined"
-                  sx={{
-                    borderColor:
-                      "color-mix(in srgb, var(--error-500) 38%, var(--border-default) 62%)",
-                    color: "var(--error-500)",
-                  }}
-                />
-              </Box>
-            )}
-            {section.type === "coding" && (
-              <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 1 }}>
-                <Chip
-                  label={`Easy ${section.easyScore ?? 1} pts`}
-                  size="small"
-                  variant="outlined"
-                  sx={{
-                    borderColor:
-                      "color-mix(in srgb, var(--success-500) 38%, var(--border-default) 62%)",
-                    color: "var(--success-500)",
-                  }}
-                />
-                <Chip
-                  label={`Medium ${section.mediumScore ?? 2} pts`}
-                  size="small"
-                  variant="outlined"
-                  sx={{
-                    borderColor:
-                      "color-mix(in srgb, var(--warning-500) 38%, var(--border-default) 62%)",
-                    color: "var(--warning-500)",
-                  }}
-                />
-                <Chip
-                  label={`Hard ${section.hardScore ?? 3} pts`}
-                  size="small"
-                  variant="outlined"
-                  sx={{
-                    borderColor:
-                      "color-mix(in srgb, var(--error-500) 38%, var(--border-default) 62%)",
-                    color: "var(--error-500)",
-                  }}
-                />
-              </Box>
-            )}
-            {section.number_of_questions_to_show ? (
-              <Typography variant="body2" sx={{ color: "var(--accent-indigo)", fontWeight: 600, mb: 1 }}>
-                Pool: show up to {section.number_of_questions_to_show} question(s)
-              </Typography>
-            ) : null}
+          {section.type === "quiz" && (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "stretch",
+                borderTop: "1px solid var(--border-default)",
+                borderBottom: "1px solid var(--border-default)",
+                py: 1.25,
+              }}
+            >
+              <PointsStat value={section.easyScore ?? 1} label="Easy pts" color="var(--success-500)" />
+              <Box sx={{ width: "1px", my: -1.25, bgcolor: "var(--border-default)" }} />
+              <PointsStat value={section.mediumScore ?? 2} label="Medium pts" color="var(--warning-500)" />
+              <Box sx={{ width: "1px", my: -1.25, bgcolor: "var(--border-default)" }} />
+              <PointsStat value={section.hardScore ?? 3} label="Hard pts" color="var(--error-500)" />
+            </Box>
+          )}
+          {section.type === "coding" && (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "stretch",
+                borderTop: "1px solid var(--border-default)",
+                borderBottom: "1px solid var(--border-default)",
+                py: 1.25,
+              }}
+            >
+              <PointsStat value={section.easyScore ?? 1} label="Easy pts" color="var(--success-500)" />
+              <Box sx={{ width: "1px", my: -1.25, bgcolor: "var(--border-default)" }} />
+              <PointsStat value={section.mediumScore ?? 2} label="Medium pts" color="var(--warning-500)" />
+              <Box sx={{ width: "1px", my: -1.25, bgcolor: "var(--border-default)" }} />
+              <PointsStat value={section.hardScore ?? 3} label="Hard pts" color="var(--error-500)" />
+            </Box>
+          )}
+          <Box sx={{ px: 2.5, pt: 1.5, pb: 2, display: "flex", flexDirection: "column", gap: 1.25 }}>
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+              {section.number_of_questions_to_show ? (
+                <StatusChip
+                  label={`Pool · show up to ${section.number_of_questions_to_show}`}
+                  tone="info"
+                  icon="mdi:filter-variant"
+                />
+              ) : null}
               {section.timeLimitMinutes != null && section.timeLimitMinutes > 0 && (
-                <Chip
-                  icon={<IconWrapper icon="mdi:timer-outline" size={16} />}
+                <StatusChip
                   label={`${section.timeLimitMinutes} min cap`}
-                  size="small"
-                  sx={{ bgcolor: "var(--surface)" }}
+                  tone="neutral"
+                  icon="mdi:timer-outline"
                 />
               )}
               {section.sectionCutoffMarks != null &&
                 String(section.sectionCutoffMarks).trim() !== "" && (
-                  <Chip
-                    icon={<IconWrapper icon="mdi:chart-bell-curve" size={16} />}
+                  <StatusChip
                     label={`Cutoff ${section.sectionCutoffMarks}`}
-                    size="small"
-                    sx={{ bgcolor: "var(--surface)" }}
+                    tone="neutral"
+                    icon="mdi:chart-bell-curve"
                   />
                 )}
             </Box>
             {orderError && (
-              <Alert severity="error" sx={{ mt: 1.5 }}>
+              <Alert severity="error" sx={errorAlertSx}>
                 {orderError}
               </Alert>
             )}
             {savedTimeLimitError && (
-              <Alert severity="error" sx={{ mt: 1.5 }}>
+              <Alert severity="error" sx={errorAlertSx}>
                 {savedTimeLimitError}
               </Alert>
             )}

--- a/components/admin/assessment/RawCodingProblemSection.tsx
+++ b/components/admin/assessment/RawCodingProblemSection.tsx
@@ -13,7 +13,6 @@ import {
   MenuItem,
   FormControl,
   InputLabel,
-  Divider,
   Table,
   TableBody,
   TableCell,
@@ -26,6 +25,7 @@ import {
   DialogContent,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { DifficultyChip } from "@/components/admin/assessment/shared";
 import { useToast } from "@/components/common/Toast";
 import {
   adminAssessmentService,
@@ -37,6 +37,22 @@ import { ProblemDescription } from "@/components/coding/ProblemDescription";
 const DIFFICULTY_LEVELS: Array<"Easy" | "Medium" | "Hard"> = ["Easy", "Medium", "Hard"];
 const LANGUAGES = ["Python", "Java", "JavaScript", "C++", "C", "Go", "Ruby", "SQL", "Other"];
 const ROWS_PER_PAGE_OPTIONS = [5, 10, 25];
+
+/** Section kicker label (redesign recipe): tiny, bold, uppercase, tertiary. */
+const kickerSx = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--font-tertiary)",
+} as const;
+
+/** Shipped card recipe for containers in the create wizard. */
+const cardSx = {
+  bgcolor: "var(--card-bg)",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+} as const;
 
 interface RawCodingProblemSectionProps {
   codingProblemIds: number[];
@@ -107,83 +123,112 @@ export function RawCodingProblemSection({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      <Typography variant="h6" sx={{ fontWeight: 600 }}>
-        Add Your Problem
-      </Typography>
-      <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-        Paste your problem statement (title, description, I/O, constraints). One problem per generation.
-      </Typography>
-
-      <Paper sx={{ p: 3, bgcolor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-          <Box
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: 2,
+            flexShrink: 0,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+            color: "var(--accent-indigo)",
+          }}
+        >
+          <IconWrapper icon="mdi:text-box-edit-outline" size={20} />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography
+            variant="h6"
             sx={{
-              display: "grid",
-              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
-              gap: 2,
+              fontWeight: 800,
+              fontFamily: "var(--font-jakarta)",
+              color: "var(--font-primary)",
+              lineHeight: 1.25,
             }}
           >
-            <FormControl fullWidth size="small">
-              <InputLabel>Difficulty (applies to all)</InputLabel>
-              <Select
-                value={difficultyLevel}
-                label="Difficulty (applies to all)"
-                onChange={(e) =>
-                  setDifficultyLevel(e.target.value as "Easy" | "Medium" | "Hard")
-                }
-              >
-                {DIFFICULTY_LEVELS.map((d) => (
-                  <MenuItem key={d} value={d}>
-                    {d}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <FormControl fullWidth size="small">
-              <InputLabel>Programming language (applies to all)</InputLabel>
-              <Select
-                value={
-                  LANGUAGES.includes(programmingLanguage)
-                    ? programmingLanguage
-                    : "Other"
-                }
-                label="Programming language (applies to all)"
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setProgrammingLanguage(v);
-                  if (v !== "Other") setCustomLanguage("");
-                }}
-              >
-                {LANGUAGES.map((lang) => (
-                  <MenuItem key={lang} value={lang}>
-                    {lang}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            Add Your Problem
+          </Typography>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+            Paste your problem statement (title, description, I/O, constraints). One problem per generation.
+          </Typography>
+        </Box>
+      </Box>
+
+      <Paper elevation={0} sx={{ p: 3, borderRadius: "var(--radius-card)", ...cardSx }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <Typography sx={kickerSx}>Problem defaults</Typography>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+                gap: 2,
+              }}
+            >
+              <FormControl fullWidth size="small">
+                <InputLabel>Difficulty (applies to all)</InputLabel>
+                <Select
+                  value={difficultyLevel}
+                  label="Difficulty (applies to all)"
+                  onChange={(e) =>
+                    setDifficultyLevel(e.target.value as "Easy" | "Medium" | "Hard")
+                  }
+                >
+                  {DIFFICULTY_LEVELS.map((d) => (
+                    <MenuItem key={d} value={d}>
+                      {d}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small">
+                <InputLabel>Programming language (applies to all)</InputLabel>
+                <Select
+                  value={
+                    LANGUAGES.includes(programmingLanguage)
+                      ? programmingLanguage
+                      : "Other"
+                  }
+                  label="Programming language (applies to all)"
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setProgrammingLanguage(v);
+                    if (v !== "Other") setCustomLanguage("");
+                  }}
+                >
+                  {LANGUAGES.map((lang) => (
+                    <MenuItem key={lang} value={lang}>
+                      {lang}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+            {programmingLanguage === "Other" && (
+              <TextField
+                size="small"
+                label="Specify language"
+                value={customLanguage}
+                onChange={(e) => setCustomLanguage(e.target.value)}
+                placeholder="e.g. Rust, Kotlin"
+                fullWidth
+              />
+            )}
           </Box>
-          {programmingLanguage === "Other" && (
+
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <Typography sx={kickerSx}>Problem statement</Typography>
             <TextField
-              size="small"
-              label="Specify language"
-              value={customLanguage}
-              onChange={(e) => setCustomLanguage(e.target.value)}
-              placeholder="e.g. Rust, Kotlin"
+              label="Problem statement (raw text)"
+              value={rawProblem}
+              onChange={(e) => setRawProblem(e.target.value)}
               fullWidth
-            />
-          )}
-
-          <Divider />
-
-          <TextField
-            label="Problem statement (raw text)"
-            value={rawProblem}
-            onChange={(e) => setRawProblem(e.target.value)}
-            fullWidth
-            multiline
-            minRows={6}
-            maxRows={12}
-            placeholder={`Title: Two Sum
+              multiline
+              minRows={6}
+              maxRows={12}
+              placeholder={`Title: Two Sum
 
 Description:
 Given an array of integers nums and an integer target, return indices of the two numbers such that they add up to target. You may assume that each input would have exactly one solution, and you may not use the same element twice.
@@ -204,8 +249,8 @@ Constraints:
 - 2 <= nums.length <= 10^4
 - -10^9 <= nums[i] <= 10^9
 - Only one valid answer exists.`}
-            sx={{ mb: 2 }}
-          />
+            />
+          </Box>
 
           <Button
             variant="contained"
@@ -218,7 +263,24 @@ Constraints:
                 <IconWrapper icon="mdi:send" size={18} />
               )
             }
-            sx={{ bgcolor: "var(--accent-indigo)", alignSelf: "flex-start" }}
+            sx={{
+              alignSelf: "flex-start",
+              px: 3,
+              py: 1,
+              fontWeight: 700,
+              textTransform: "none",
+              borderRadius: 2,
+              color: "#fff",
+              background: "var(--gradient-ai)",
+              boxShadow:
+                "0 10px 22px -12px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+              "&:hover": { filter: "brightness(1.05)" },
+              "&.Mui-disabled": {
+                color: "var(--font-secondary)",
+                background:
+                  "color-mix(in srgb, var(--ai-violet) 18%, var(--surface) 82%)",
+              },
+            }}
           >
             {generating ? "Creating..." : "Create coding problem(s)"}
           </Button>
@@ -227,14 +289,28 @@ Constraints:
 
       {generatedProblems.length > 0 && (
         <Box>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 1 }}>
-            Created problems ({generatedProblems.length})
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontWeight: 700,
+              fontFamily: "var(--font-jakarta)",
+              color: "var(--font-primary)",
+              mb: 1,
+            }}
+          >
+            Created problems{" "}
+            <Box
+              component="span"
+              sx={{ fontFamily: "var(--font-mono)", color: "var(--accent-indigo)" }}
+            >
+              ({generatedProblems.length})
+            </Box>
           </Typography>
-          <Paper variant="outlined" sx={{ overflow: "hidden" }}>
+          <Paper elevation={0} sx={{ borderRadius: "16px", overflow: "hidden", ...cardSx }}>
             <TableContainer>
               <Table size="small" stickyHeader>
                 <TableHead>
-                  <TableRow sx={{ backgroundColor: "color-mix(in srgb, var(--surface) 86%, var(--card-bg) 14%)" }}>
+                  <TableRow sx={{ backgroundColor: "var(--surface)" }}>
                     <TableCell sx={{ fontWeight: 600, width: 48 }}>#</TableCell>
                     <TableCell sx={{ fontWeight: 600 }}>Title</TableCell>
                     <TableCell sx={{ fontWeight: 600 }}>Difficulty</TableCell>
@@ -248,8 +324,11 @@ Constraints:
                   {generatedProblems
                     .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                     .map((p, idx) => (
-                      <TableRow key={p.id} hover>
-                        <TableCell sx={{ color: "var(--font-secondary)", fontFamily: "monospace" }}>
+                      <TableRow
+                        key={p.id}
+                        sx={{ "&:hover": { backgroundColor: "var(--surface)" } }}
+                      >
+                        <TableCell sx={{ color: "var(--font-secondary)", fontFamily: "var(--font-mono)" }}>
                           {page * rowsPerPage + idx + 1}
                         </TableCell>
                         <TableCell sx={{ maxWidth: 280 }}>
@@ -257,8 +336,16 @@ Constraints:
                             {p.title || `Problem #${p.id}`}
                           </Typography>
                         </TableCell>
-                        <TableCell>{p.difficulty_level || "—"}</TableCell>
-                        <TableCell>{p.programming_language || "—"}</TableCell>
+                        <TableCell>
+                          {p.difficulty_level ? (
+                            <DifficultyChip level={p.difficulty_level} />
+                          ) : (
+                            "—"
+                          )}
+                        </TableCell>
+                        <TableCell sx={{ color: "var(--font-secondary)" }}>
+                          {p.programming_language || "—"}
+                        </TableCell>
                         <TableCell sx={{ textAlign: "center" }}>
                           <IconButton
                             size="small"
@@ -304,6 +391,13 @@ Constraints:
               }}
               rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
               labelRowsPerPage="Rows:"
+              sx={{
+                borderTop: "1px solid var(--border-default)",
+                "& .MuiTablePagination-displayedRows": {
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "0.78rem",
+                },
+              }}
             />
           </Paper>
         </Box>
@@ -317,11 +411,19 @@ Constraints:
         PaperProps={{
           sx: {
             maxHeight: "90vh",
-            borderRadius: 2,
+            borderRadius: "16px",
           },
         }}
       >
-        <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <DialogTitle
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            fontFamily: "var(--font-jakarta)",
+            fontWeight: 700,
+          }}
+        >
           <span>Problem Preview</span>
           <IconButton size="small" onClick={() => setPreviewProblem(null)} aria-label="Close">
             <IconWrapper icon="mdi:close" size={20} />

--- a/components/admin/assessment/SectionQuestionsSidenav.tsx
+++ b/components/admin/assessment/SectionQuestionsSidenav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import {
   Box,
   Typography,
@@ -9,7 +9,6 @@ import {
   ListItem,
   ListItemButton,
   ListItemText,
-  Chip,
   ToggleButton,
   ToggleButtonGroup,
 } from "@mui/material";
@@ -29,22 +28,25 @@ interface SectionQuestionsSidenavProps {
 
 const TYPE_META: Record<
   SectionKind,
-  { label: string; icon: string; emptyHint: string }
+  { label: string; icon: string; emptyHint: string; accent: string }
 > = {
   quiz: {
     label: "Quiz",
     icon: "mdi:help-circle-outline",
     emptyHint: "Add a quiz block in Assessment Details to list sections here.",
+    accent: "var(--accent-indigo)",
   },
   coding: {
     label: "Coding",
     icon: "mdi:code-tags",
     emptyHint: "Add a coding block in Assessment Details to list sections here.",
+    accent: "var(--success-500)",
   },
   subjective: {
     label: "Written",
     icon: "mdi:text-box-outline",
     emptyHint: "Add a written block in Assessment Details to list sections here.",
+    accent: "var(--accent-purple)",
   },
 };
 
@@ -125,42 +127,9 @@ export function SectionQuestionsSidenav({
         ? sectionCodingCounts
         : sectionSubjectiveCounts;
 
-  const palette = useMemo(() => {
-    if (sectionType === "quiz") {
-      return {
-        accent: "var(--accent-indigo)",
-        accentDark: "var(--accent-indigo-dark)",
-        selectedBg: "color-mix(in srgb, var(--accent-indigo) 16%, var(--card-bg))",
-        listBanner: "color-mix(in srgb, var(--accent-indigo) 10%, var(--surface))",
-        chipMuted: "color-mix(in srgb, var(--accent-indigo) 22%, var(--surface))",
-        hoverList: "color-mix(in srgb, var(--accent-indigo) 8%, var(--card-bg))",
-        borderSoft: "color-mix(in srgb, var(--accent-indigo) 22%, transparent)",
-      };
-    }
-    if (sectionType === "coding") {
-      return {
-        accent: "var(--success-500)",
-        accentDark: "color-mix(in srgb, var(--success-500) 78%, var(--font-dark))",
-        selectedBg: "color-mix(in srgb, var(--success-500) 14%, var(--card-bg))",
-        listBanner: "color-mix(in srgb, var(--success-500) 10%, var(--surface))",
-        chipMuted: "color-mix(in srgb, var(--success-500) 22%, var(--surface))",
-        hoverList: "color-mix(in srgb, var(--success-500) 8%, var(--card-bg))",
-        borderSoft: "color-mix(in srgb, var(--success-500) 28%, transparent)",
-      };
-    }
-    return {
-      accent: "var(--accent-purple)",
-      accentDark: "color-mix(in srgb, var(--accent-purple) 82%, var(--font-dark))",
-      selectedBg: "color-mix(in srgb, var(--accent-purple) 12%, var(--card-bg))",
-      listBanner: "color-mix(in srgb, var(--accent-purple) 8%, var(--surface))",
-      chipMuted: "color-mix(in srgb, var(--accent-purple) 18%, var(--surface))",
-      hoverList: "color-mix(in srgb, var(--accent-purple) 7%, var(--card-bg))",
-      borderSoft: "color-mix(in srgb, var(--accent-purple) 28%, transparent)",
-    };
-  }, [sectionType]);
-
   const kindLabel = sectionType ? TYPE_META[sectionType].label : "";
   const kindIcon = sectionType ? TYPE_META[sectionType].icon : "mdi:view-dashboard-outline";
+  const kindAccent = sectionType ? TYPE_META[sectionType].accent : "var(--ai-violet)";
 
   const countLabel =
     sectionType === "quiz"
@@ -174,6 +143,7 @@ export function SectionQuestionsSidenav({
       elevation={0}
       sx={{
         width: "100%",
+        maxWidth: "100%",
         height: { xs: "auto", sm: "calc(100vh - 120px)" },
         position: { xs: "relative", sm: "sticky" },
         top: { xs: 0, sm: 20 },
@@ -181,73 +151,61 @@ export function SectionQuestionsSidenav({
         overflow: "hidden",
         display: "flex",
         flexDirection: "column",
-        borderRadius: 3,
-        border: "1px solid color-mix(in srgb, var(--accent-indigo) 12%, var(--border-default))",
-        boxShadow:
-          "0 4px 24px color-mix(in srgb, var(--font-primary) 6%, transparent), 0 1px 0 color-mix(in srgb, var(--font-light) 40%, transparent)",
+        borderRadius: "var(--radius-card)",
+        border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
         bgcolor: "var(--card-bg)",
       }}
     >
-      {/* Header */}
+      {/* Header — "Live outline" gradient band (mockup) */}
       <Box
         sx={{
-          px: 2.25,
-          py: 2,
-          background: `linear-gradient(
-            135deg,
-            var(--accent-indigo-dark) 0%,
-            var(--accent-indigo) 48%,
-            color-mix(in srgb, var(--accent-purple) 35%, var(--accent-indigo)) 100%
-          )`,
-          color: "var(--font-light)",
+          p: 2,
+          background: "var(--gradient-ai)",
+          color: "#fff",
+          display: "flex",
+          alignItems: "center",
+          gap: 1.25,
+          flexShrink: 0,
         }}
       >
-        <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5 }}>
-          <Box
+        <Box
+          sx={{
+            width: 38,
+            height: 38,
+            borderRadius: 2,
+            display: "grid",
+            placeItems: "center",
+            flexShrink: 0,
+            bgcolor: "color-mix(in srgb, #fff 18%, transparent)",
+          }}
+        >
+          <IconWrapper icon="mdi:file-tree-outline" size={20} color="#fff" />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography
             sx={{
-              width: 44,
-              height: 44,
-              borderRadius: 2,
-              display: "grid",
-              placeItems: "center",
-              flexShrink: 0,
-              bgcolor: "color-mix(in srgb, var(--font-light) 14%, transparent)",
-              border: "1px solid color-mix(in srgb, var(--font-light) 22%, transparent)",
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: "1.02rem",
+              lineHeight: 1.25,
             }}
           >
-            <IconWrapper icon="mdi:layers-triple-outline" size={24} color="var(--font-light)" />
-          </Box>
-          <Box sx={{ minWidth: 0 }}>
-            <Typography
-              variant="overline"
-              sx={{
-                letterSpacing: "0.12em",
-                fontWeight: 700,
-                opacity: 0.92,
-                fontSize: "0.68rem",
-                lineHeight: 1.2,
-                display: "block",
-              }}
-            >
-              Assessment structure
-            </Typography>
-            <Typography variant="h6" sx={{ fontWeight: 800, lineHeight: 1.25, mt: 0.35 }}>
-              Sections
-            </Typography>
-            <Typography variant="body2" sx={{ opacity: 0.9, mt: 0.75, lineHeight: 1.45, fontSize: "0.8125rem" }}>
-              Pick a section type, then choose a block to attach questions or prompts.
-            </Typography>
-          </Box>
+            Live outline
+          </Typography>
+          <Typography sx={{ fontSize: "0.78rem", opacity: 0.88, lineHeight: 1.35 }}>
+            Updates as you build
+          </Typography>
         </Box>
       </Box>
 
-      {/* Type toggles */}
+      {/* Type switcher — compact segmented pills */}
       <Box
         sx={{
           px: 1.5,
           py: 1.5,
-          borderBottom: "1px solid var(--border-default)",
-          bgcolor: "color-mix(in srgb, var(--surface) 55%, var(--card-bg))",
+          flexShrink: 0,
+          borderBottom: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
         }}
       >
         <ToggleButtonGroup
@@ -258,80 +216,53 @@ export function SectionQuestionsSidenav({
           fullWidth
           size="small"
           sx={{
-            gap: 0.75,
-            flexWrap: "wrap",
+            p: 0.5,
+            gap: 0.5,
+            borderRadius: 999,
+            border: "1px solid var(--border-default)",
+            bgcolor: "var(--surface)",
+            maxWidth: "100%",
             "& .MuiToggleButtonGroup-grouped": {
-              border: "1px solid var(--border-default) !important",
-              borderRadius: "10px !important",
+              border: "none !important",
+              borderRadius: "999px !important",
               mx: 0,
               my: 0,
-              flex: "1 1 28%",
+              flex: 1,
               minWidth: 0,
-              py: 1,
+              px: 0.75,
+              py: 0.55,
               fontWeight: 700,
-              fontSize: "0.75rem",
-              letterSpacing: "0.04em",
+              fontSize: "0.74rem",
               textTransform: "none",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
               color: "var(--font-secondary)",
-              bgcolor: "var(--card-bg)",
-              transition: "background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease",
+              bgcolor: "transparent",
+              transition: "background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease",
               "&:hover": {
-                bgcolor: "color-mix(in srgb, var(--surface) 70%, var(--card-bg))",
+                bgcolor: "color-mix(in srgb, var(--ai-violet) 8%, transparent)",
+                color: "var(--ai-violet)",
               },
               "&.Mui-disabled": {
-                opacity: 0.45,
+                border: "none !important",
+                opacity: 0.4,
               },
-            },
-            "& .MuiToggleButton-root.Mui-selected": {
-              color: "var(--font-light) !important",
-              boxShadow: "0 4px 12px color-mix(in srgb, var(--font-primary) 12%, transparent)",
+              "&.Mui-selected": {
+                bgcolor: "var(--card-bg)",
+                color: "var(--ai-violet)",
+                boxShadow: "0 1px 2px rgba(16,24,40,0.1), 0 1px 3px rgba(16,24,40,0.08)",
+                "&:hover": { bgcolor: "var(--card-bg)", color: "var(--ai-violet)" },
+              },
             },
           }}
         >
-          <ToggleButton
-            value="quiz"
-            aria-label="quiz sections"
-            disabled={quizSections.length === 0}
-            sx={{
-              "&.Mui-selected": {
-                bgcolor: "var(--accent-indigo) !important",
-                borderColor: "var(--accent-indigo-dark) !important",
-                "&:hover": { bgcolor: "var(--accent-indigo-dark) !important" },
-              },
-            }}
-          >
+          <ToggleButton value="quiz" aria-label="quiz sections" disabled={quizSections.length === 0}>
             Quiz · {quizSections.length}
           </ToggleButton>
-          <ToggleButton
-            value="coding"
-            aria-label="coding sections"
-            disabled={codingSections.length === 0}
-            sx={{
-              "&.Mui-selected": {
-                bgcolor: "var(--success-500) !important",
-                borderColor: "color-mix(in srgb, var(--success-500) 70%, var(--font-dark)) !important",
-                "&:hover": {
-                  bgcolor: "color-mix(in srgb, var(--success-500) 88%, var(--font-dark)) !important",
-                },
-              },
-            }}
-          >
+          <ToggleButton value="coding" aria-label="coding sections" disabled={codingSections.length === 0}>
             Code · {codingSections.length}
           </ToggleButton>
-          <ToggleButton
-            value="subjective"
-            aria-label="written sections"
-            disabled={subjectiveSections.length === 0}
-            sx={{
-              "&.Mui-selected": {
-                bgcolor: "var(--accent-purple) !important",
-                borderColor: "color-mix(in srgb, var(--accent-purple) 75%, var(--font-dark)) !important",
-                "&:hover": {
-                  bgcolor: "color-mix(in srgb, var(--accent-purple) 88%, var(--font-dark)) !important",
-                },
-              },
-            }}
-          >
+          <ToggleButton value="subjective" aria-label="written sections" disabled={subjectiveSections.length === 0}>
             Written · {subjectiveSections.length}
           </ToggleButton>
         </ToggleButtonGroup>
@@ -339,147 +270,129 @@ export function SectionQuestionsSidenav({
 
       {sectionType && displaySections.length > 0 && (
         <>
-          <Box
-            sx={{
-              px: 2,
-              py: 1.25,
-              flexShrink: 0,
-              display: "flex",
-              alignItems: "center",
-              gap: 1.25,
-              bgcolor: palette.listBanner,
-              borderBottom: `1px solid ${palette.borderSoft}`,
-            }}
-          >
-            <IconWrapper icon={kindIcon} size={20} color={palette.accent} />
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Typography
-                variant="subtitle2"
-                sx={{
-                  fontWeight: 800,
-                  color: palette.accentDark,
-                  letterSpacing: "0.02em",
-                  lineHeight: 1.3,
-                }}
-              >
-                {kindLabel} sections
-              </Typography>
-              <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mt: 0.15 }}>
-                {displaySections.length} block{displaySections.length === 1 ? "" : "s"} · choose one to edit
-              </Typography>
-            </Box>
+          <Box sx={{ px: 2, pt: 1.5, pb: 0.5, flexShrink: 0 }}>
+            <Typography
+              sx={{
+                fontSize: "0.72rem",
+                fontWeight: 800,
+                letterSpacing: "0.08em",
+                textTransform: "uppercase",
+                color: "var(--font-tertiary)",
+              }}
+            >
+              {kindLabel} sections
+            </Typography>
           </Box>
-          <List sx={{ p: 1.25, overflow: "auto", flex: 1, bgcolor: "var(--card-bg)" }}>
+          <List sx={{ p: 1.25, pt: 0.75, overflowY: "auto", overflowX: "hidden", flex: 1 }}>
             {displaySections.map((section) => {
               const count = displayCounts[section.id] ?? 0;
               const isSelected = selectedSectionId === section.id;
               return (
-                <ListItem key={section.id} disablePadding sx={{ mb: 1 }}>
+                <ListItem key={section.id} disablePadding sx={{ mb: 0.75 }}>
                   <ListItemButton
                     selected={isSelected}
                     onClick={() => onSectionSelect(section.id)}
                     sx={{
-                      px: 1.75,
-                      py: 1.35,
+                      px: 1.25,
+                      py: 1.1,
+                      gap: 1.25,
+                      alignItems: "center",
                       cursor: "pointer",
-                      borderRadius: 2,
+                      borderRadius: "12px",
                       border: "1px solid",
-                      borderColor: isSelected ? palette.borderSoft : "var(--border-default)",
-                      bgcolor: isSelected ? palette.selectedBg : "var(--surface)",
+                      borderColor: isSelected
+                        ? "var(--ai-violet)"
+                        : "color-mix(in srgb, var(--border-default) 55%, transparent)",
+                      bgcolor: isSelected
+                        ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
+                        : "var(--card-bg)",
                       boxShadow: isSelected
-                        ? `0 0 0 1px ${palette.borderSoft}, 0 6px 18px color-mix(in srgb, var(--font-primary) 6%, transparent)`
+                        ? "0 0 0 1px color-mix(in srgb, var(--ai-violet) 55%, transparent)"
                         : "none",
+                      transition:
+                        "background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease",
                       "&:hover": {
-                        bgcolor: isSelected ? palette.selectedBg : palette.hoverList,
-                        borderColor: palette.borderSoft,
+                        borderColor: "var(--ai-violet)",
+                        bgcolor: isSelected
+                          ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
+                          : "color-mix(in srgb, var(--ai-violet) 4%, var(--card-bg) 96%)",
                       },
-                      transition: "background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease",
                       "&.Mui-selected": {
-                        bgcolor: palette.selectedBg,
-                        "&:hover": { bgcolor: palette.selectedBg },
+                        bgcolor: "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)",
+                        "&:hover": {
+                          bgcolor: "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)",
+                        },
                       },
                     }}
                   >
                     <Box
                       sx={{
-                        width: 4,
-                        alignSelf: "stretch",
-                        borderRadius: 1,
+                        width: 36,
+                        height: 36,
+                        borderRadius: 2,
                         flexShrink: 0,
-                        mr: 1.5,
-                        bgcolor: isSelected ? palette.accent : "color-mix(in srgb, var(--font-tertiary) 35%, transparent)",
-                        transition: "background-color 0.18s ease",
+                        display: "grid",
+                        placeItems: "center",
+                        bgcolor: `color-mix(in srgb, ${kindAccent} 12%, var(--card-bg) 88%)`,
                       }}
-                    />
+                    >
+                      <IconWrapper icon={kindIcon} size={18} color={kindAccent} />
+                    </Box>
                     <ListItemText
-                      sx={{ my: 0 }}
+                      sx={{ my: 0, minWidth: 0 }}
                       primary={
-                        <Box
+                        <Typography
+                          variant="body2"
                           sx={{
-                            display: "flex",
-                            alignItems: "flex-start",
-                            justifyContent: "space-between",
-                            gap: 1,
+                            fontWeight: isSelected ? 700 : 600,
+                            color: "var(--font-primary)",
+                            fontSize: "0.88rem",
+                            lineHeight: 1.35,
+                            wordBreak: "break-word",
                           }}
                         >
-                          <Typography
-                            variant="body2"
-                            sx={{
-                              fontWeight: isSelected ? 700 : 600,
-                              color: isSelected ? palette.accentDark : "var(--font-primary)",
-                              fontSize: "0.9rem",
-                              lineHeight: 1.4,
-                              wordBreak: "break-word",
-                            }}
-                          >
-                            {section.title?.trim() || "Untitled section"}
-                          </Typography>
-                          <Chip
-                            label={count}
-                            size="small"
-                            title={`${count} ${countLabel}`}
-                            variant={count > 0 ? "filled" : "outlined"}
-                            sx={{
-                              height: 24,
-                              minWidth: 28,
-                              flexShrink: 0,
-                              fontSize: "0.72rem",
-                              fontWeight: 700,
-                              borderColor: palette.borderSoft,
-                              ...(count > 0
-                                ? {
-                                    bgcolor: palette.accent,
-                                    color: "var(--font-light)",
-                                    "& .MuiChip-label": { px: 0.85 },
-                                  }
-                                : {
-                                    bgcolor: palette.chipMuted,
-                                    color: "var(--font-secondary)",
-                                    "& .MuiChip-label": { px: 0.85 },
-                                  }),
-                            }}
-                          />
-                        </Box>
+                          {section.title?.trim() || "Untitled section"}
+                        </Typography>
                       }
                       secondary={
                         <Typography
                           variant="caption"
                           component="span"
                           sx={{
-                            color: "var(--font-secondary)",
-                            mt: 0.75,
+                            color: "var(--font-tertiary)",
                             display: "block",
-                            fontWeight: 500,
+                            mt: 0.25,
+                            lineHeight: 1.3,
                           }}
                         >
-                          Order {section.order}
-                          <Box component="span" sx={{ mx: 0.75, opacity: 0.5 }}>
-                            ·
-                          </Box>
                           {count} {countLabel}
                         </Typography>
                       }
                     />
+                    <Box
+                      component="span"
+                      title={`${count} ${countLabel}`}
+                      sx={{
+                        flexShrink: 0,
+                        minWidth: 26,
+                        height: 22,
+                        px: 0.9,
+                        borderRadius: 999,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.72rem",
+                        fontWeight: 700,
+                        bgcolor:
+                          count > 0
+                            ? `color-mix(in srgb, ${kindAccent} 14%, var(--card-bg) 86%)`
+                            : "color-mix(in srgb, var(--font-tertiary) 12%, var(--card-bg) 88%)",
+                        color: count > 0 ? kindAccent : "var(--font-tertiary)",
+                      }}
+                    >
+                      {count}
+                    </Box>
                   </ListItemButton>
                 </ListItem>
               );
@@ -499,14 +412,27 @@ export function SectionQuestionsSidenav({
             alignItems: "center",
             justifyContent: "center",
             gap: 1.25,
-            bgcolor: "color-mix(in srgb, var(--surface) 40%, var(--card-bg))",
           }}
         >
-          <IconWrapper icon="mdi:folder-open-outline" size={40} color="var(--font-tertiary)" />
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
+            }}
+          >
+            <IconWrapper icon="mdi:folder-open-outline" size={24} color="var(--ai-violet)" />
+          </Box>
           <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
             No {kindLabel.toLowerCase()} sections yet
           </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 260, lineHeight: 1.5 }}>
+          <Typography
+            variant="body2"
+            sx={{ maxWidth: 260, lineHeight: 1.5, color: "var(--font-secondary)" }}
+          >
             {sectionType ? TYPE_META[sectionType].emptyHint : ""}
           </Typography>
         </Box>
@@ -524,8 +450,22 @@ export function SectionQuestionsSidenav({
             gap: 1.25,
           }}
         >
-          <IconWrapper icon="mdi:layers-off-outline" size={40} color="var(--font-tertiary)" />
-          <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 280, lineHeight: 1.5 }}>
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
+            }}
+          >
+            <IconWrapper icon="mdi:layers-off-outline" size={24} color="var(--ai-violet)" />
+          </Box>
+          <Typography
+            variant="body2"
+            sx={{ maxWidth: 280, lineHeight: 1.5, color: "var(--font-secondary)" }}
+          >
             No sections on this assessment. Go back to <strong>Assessment Details</strong> and add at least one
             quiz, coding, or written block.
           </Typography>

--- a/components/admin/assessment/SubjectiveQuestionSelectionSection.tsx
+++ b/components/admin/assessment/SubjectiveQuestionSelectionSection.tsx
@@ -4,22 +4,15 @@ import { useMemo, useState } from "react";
 import {
   Box,
   Typography,
-  Paper,
   Checkbox,
   CircularProgress,
   TextField,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Chip,
   Pagination,
 } from "@mui/material";
 import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import type { AssessmentSubjectiveQuestionListItem } from "@/lib/services/admin/admin-assessment.service";
+import { DifficultyChip, StatusChip } from "@/components/admin/assessment/shared";
 import {
   FacetBar,
   FacetState,
@@ -32,6 +25,63 @@ import {
   PreviewButton,
   PreviewDialog,
 } from "./questionBankFacets";
+
+/** Redesign card recipe (create-wizard style contract). */
+const CARD_SX = {
+  borderRadius: "16px",
+  border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+  bgcolor: "var(--card-bg)",
+} as const;
+
+/** Uppercase section kicker label. */
+const KICKER_SX = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  color: "var(--font-tertiary)",
+} as const;
+
+/** Token-accented checkbox (replaces the MUI default blue). */
+const CHECKBOX_SX = {
+  color: "var(--font-tertiary)",
+  "&.Mui-checked": { color: "var(--ai-violet)" },
+  "&.MuiCheckbox-indeterminate": { color: "var(--ai-violet)" },
+} as const;
+
+/** Search field with token focus accents instead of the default blue. */
+const SEARCH_FIELD_SX = {
+  "& .MuiOutlinedInput-root": {
+    borderRadius: "10px",
+    "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+      borderColor: "var(--ai-violet)",
+    },
+  },
+  "& .MuiInputLabel-root.Mui-focused": { color: "var(--ai-violet)" },
+} as const;
+
+/** Soft result-row card; selected = violet ring + tint (style contract). */
+const rowCardSx = (selected: boolean) => ({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 1,
+  px: 1.5,
+  py: 1.5,
+  borderRadius: "12px",
+  bgcolor: selected
+    ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
+    : "var(--card-bg)",
+  border: selected
+    ? "1.5px solid var(--ai-violet)"
+    : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+  transition: "border-color 0.15s ease, background-color 0.15s ease",
+  "&:hover": {
+    borderColor: selected
+      ? "var(--ai-violet)"
+      : "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+  },
+});
 
 interface SubjectiveQuestionSelectionSectionProps {
   selectedIds: number[];
@@ -100,106 +150,198 @@ export function SubjectiveQuestionSelectionSection({
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
-        <CircularProgress />
+        <CircularProgress sx={{ color: "var(--ai-violet)" }} />
       </Box>
     );
   }
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Paper sx={{ p: 1.5, bgcolor: "var(--surface)" }}>
-        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-          Selected: {selectedIds.length} | Showing: {filtered.length} of {questions.length}
-        </Typography>
-      </Paper>
-      <TextField
-        label="Search"
-        value={searchTerm}
-        onChange={(e) => {
-          setSearchTerm(e.target.value);
-          setPage(1);
-        }}
-        fullWidth
-        size="small"
-        InputProps={{
-          startAdornment: (
-            <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
-          ),
-        }}
-      />
-      <FacetBar
-        facets={facets}
-        options={facetOptions}
-        onChange={(next) => {
-          setFacets(next);
-          setPage(1);
-        }}
-      />
+      {/* Selection summary band */}
+      <Box sx={{ ...CARD_SX, p: 2, display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: 2,
+            flexShrink: 0,
+            display: "grid",
+            placeItems: "center",
+            bgcolor:
+              "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+          }}
+        >
+          <IconWrapper
+            icon="mdi:text-box-check-outline"
+            size={21}
+            color="var(--warning-500)"
+          />
+        </Box>
+        <Box>
+          <Typography sx={KICKER_SX}>Question bank</Typography>
+          <Typography
+            variant="body2"
+            sx={{ fontWeight: 600, color: "var(--font-primary)" }}
+          >
+            Selected: {selectedIds.length} | Showing: {filtered.length} of {questions.length}
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Search + facet filters grouped in one card */}
+      <Box sx={{ ...CARD_SX, p: { xs: 2, sm: 2.5 } }}>
+        <Typography sx={{ ...KICKER_SX, mb: 1.5 }}>Search & filters</Typography>
+        <TextField
+          label="Search"
+          value={searchTerm}
+          onChange={(e) => {
+            setSearchTerm(e.target.value);
+            setPage(1);
+          }}
+          fullWidth
+          size="small"
+          InputProps={{
+            startAdornment: (
+              <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
+            ),
+          }}
+          sx={SEARCH_FIELD_SX}
+        />
+        <Box sx={{ mt: 2 }}>
+          <FacetBar
+            facets={facets}
+            options={facetOptions}
+            onChange={(next) => {
+              setFacets(next);
+              setPage(1);
+            }}
+          />
+        </Box>
+      </Box>
+
       {filtered.length === 0 ? (
-        <Paper sx={{ p: 3, textAlign: "center", bgcolor: "var(--surface)" }}>
-          <Typography variant="body2" color="text.secondary">
+        <Box sx={{ ...CARD_SX, p: 4, textAlign: "center" }}>
+          <Box
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              mx: "auto",
+              mb: 1.5,
+              bgcolor:
+                "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+            }}
+          >
+            <IconWrapper icon="mdi:magnify" size={22} color="var(--warning-500)" />
+          </Box>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
             {searchTerm ? "No matches" : "No written questions yet. Use Manual Entry or create some in Django admin."}
           </Typography>
-        </Paper>
+        </Box>
       ) : (
-        <Paper sx={{ borderRadius: 2, border: "1px solid var(--border-default)", overflow: "hidden" }}>
-          <TableContainer>
-            <Table size="small">
-              <TableHead>
-                <TableRow sx={{ bgcolor: "var(--surface)" }}>
-                  <TableCell padding="checkbox">
-                    <Checkbox checked={pageAllSelected} onChange={handleSelectAll} />
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>ID</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Question</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Mode</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Marks</TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>Reuse</TableCell>
-                  <TableCell padding="checkbox" />
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {paginated.map((q) => (
-                  <TableRow
-                    key={q.id}
-                    hover
-                    selected={selectedIds.includes(q.id)}
-                    sx={{
-                      bgcolor: selectedIds.includes(q.id)
-                        ? "color-mix(in srgb, var(--warning-500) 10%, var(--card-bg))"
-                        : undefined,
-                    }}
-                  >
-                    <TableCell padding="checkbox">
-                      <Checkbox
-                        checked={selectedIds.includes(q.id)}
-                        onChange={() => toggle(q.id)}
-                      />
-                    </TableCell>
-                    <TableCell sx={{ fontFamily: "monospace" }}>#{q.id}</TableCell>
-                    <TableCell sx={{ maxWidth: 420 }}>
-                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                        {q.question_text.length > 160 ? `${q.question_text.slice(0, 160)}…` : q.question_text}
+        <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
+          {/* Select-all header */}
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.5,
+              px: 2,
+              py: 0.75,
+              borderBottom: "1px solid var(--border-default)",
+              bgcolor: "var(--surface)",
+            }}
+          >
+            <Checkbox
+              checked={pageAllSelected}
+              onChange={handleSelectAll}
+              sx={CHECKBOX_SX}
+            />
+            <Typography sx={KICKER_SX}>Select all on page</Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <Typography
+              variant="caption"
+              sx={{
+                fontFamily: "var(--font-mono)",
+                fontWeight: 700,
+                color: "var(--font-secondary)",
+              }}
+            >
+              {filtered.length} result{filtered.length === 1 ? "" : "s"}
+            </Typography>
+          </Box>
+
+          {/* Result rows as soft cards */}
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 1.25,
+              p: { xs: 1.5, sm: 2 },
+            }}
+          >
+            {paginated.map((q) => {
+              const selected = selectedIds.includes(q.id);
+              return (
+                <Box key={q.id} sx={rowCardSx(selected)}>
+                  <Checkbox
+                    checked={selectedIds.includes(q.id)}
+                    onChange={() => toggle(q.id)}
+                    sx={{ ...CHECKBOX_SX, p: 0.5 }}
+                  />
+                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 0.75,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          color: "var(--font-tertiary)",
+                          fontFamily: "var(--font-mono)",
+                          fontWeight: 600,
+                        }}
+                      >
+                        #{q.id}
                       </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Chip size="small" label={(q.answer_mode || "text").replace(/_/g, " ")} />
-                    </TableCell>
-                    <TableCell>{q.max_marks}</TableCell>
-                    <TableCell>
-                      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, alignItems: "flex-start" }}>
-                        <UsageChip count={q.usage_count} />
-                        <SourceChip source={q.source} />
-                      </Box>
-                    </TableCell>
-                    <TableCell padding="checkbox">
+                      <StatusChip
+                        label={(q.answer_mode || "text").replace(/_/g, " ")}
+                        tone="info"
+                        icon="mdi:pencil-box-outline"
+                      />
+                      <StatusChip
+                        label={`${q.max_marks} marks`}
+                        tone="neutral"
+                        icon="mdi:star-four-points-outline"
+                      />
+                      <UsageChip count={q.usage_count} />
+                      <SourceChip source={q.source} />
+                      <Box sx={{ flexGrow: 1 }} />
                       <PreviewButton onClick={() => setPreview(q)} />
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+                    </Box>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 600,
+                        color: "var(--font-primary)",
+                        mt: 0.75,
+                      }}
+                    >
+                      {q.question_text.length > 160 ? `${q.question_text.slice(0, 160)}…` : q.question_text}
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+
+          {/* Pagination */}
           <Box
             sx={{
               display: "flex",
@@ -220,7 +362,7 @@ export function SubjectiveQuestionSelectionSection({
               size="small"
             />
           </Box>
-        </Paper>
+        </Box>
       )}
 
       <PreviewDialog
@@ -233,10 +375,18 @@ export function SubjectiveQuestionSelectionSection({
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
               <SourceChip source={preview.source} />
               <UsageChip count={preview.usage_count} />
-              <Chip size="small" label={(preview.answer_mode || "text").replace(/_/g, " ")} sx={{ height: 22 }} />
-              <Chip size="small" label={`${preview.max_marks} marks`} sx={{ height: 22 }} />
+              <StatusChip
+                label={(preview.answer_mode || "text").replace(/_/g, " ")}
+                tone="info"
+                icon="mdi:pencil-box-outline"
+              />
+              <StatusChip
+                label={`${preview.max_marks} marks`}
+                tone="neutral"
+                icon="mdi:star-four-points-outline"
+              />
               {preview.difficulty_level && (
-                <Chip size="small" label={preview.difficulty_level} sx={{ height: 22 }} />
+                <DifficultyChip level={preview.difficulty_level} />
               )}
             </Box>
             <Typography variant="body1" sx={{ fontWeight: 600, whiteSpace: "pre-wrap" }}>

--- a/components/admin/assessment/SubjectiveQuestionsFormSection.tsx
+++ b/components/admin/assessment/SubjectiveQuestionsFormSection.tsx
@@ -27,6 +27,41 @@ const emptyQuestion = (): SubjectiveQuestionDraft => ({
   answer_mode: "text",
 });
 
+/** Section kicker label (design contract): tiny, heavy, tracked-out uppercase. */
+const kickerSx = {
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase" as const,
+  color: "var(--font-tertiary)",
+};
+
+function FieldGroup({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box>
+      <Typography component="h4" variant="subtitle2" sx={{ ...kickerSx, mb: 0.25 }}>
+        {title}
+      </Typography>
+      {hint ? (
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.25 }}>
+          {hint}
+        </Typography>
+      ) : (
+        <Box sx={{ mb: 1 }} />
+      )}
+      {children}
+    </Box>
+  );
+}
+
 interface SubjectiveQuestionsFormSectionProps {
   questions: SubjectiveQuestionDraft[];
   onQuestionsChange: (rows: SubjectiveQuestionDraft[]) => void;
@@ -67,102 +102,150 @@ export function SubjectiveQuestionsFormSection({
           key={index}
           elevation={0}
           sx={{
-            p: 2,
-            border: "1px solid var(--border-default)",
-            borderRadius: 2,
+            p: { xs: 2, sm: 2.5 },
+            borderRadius: "16px",
+            border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+            boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
             bgcolor: "var(--card-bg)",
           }}
         >
-          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1.5 }}>
-            <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-              Question {index + 1}
-            </Typography>
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              {/* Ordinal tile: mono number on an indigo-tinted rounded square */}
+              <Box
+                sx={{
+                  minWidth: 28,
+                  height: 28,
+                  borderRadius: 1,
+                  display: "grid",
+                  placeItems: "center",
+                  fontFamily: "var(--font-mono)",
+                  fontWeight: 700,
+                  fontSize: "0.8125rem",
+                  color: "var(--accent-indigo)",
+                  bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+                }}
+              >
+                {index + 1}
+              </Box>
+              <Typography component="h4" variant="subtitle2" sx={kickerSx}>
+                Written question
+              </Typography>
+            </Box>
             {(questions.length > 0 ? questions.length > 1 : rows.length > 1) && (
               <Button
                 size="small"
-                color="error"
                 onClick={() => removeRow(index)}
                 startIcon={<IconWrapper icon="mdi:delete-outline" size={18} />}
+                sx={{
+                  textTransform: "none",
+                  fontWeight: 700,
+                  borderRadius: 2,
+                  color: "var(--error-500)",
+                  "&:hover": {
+                    bgcolor: "color-mix(in srgb, var(--error-500) 8%, transparent)",
+                  },
+                }}
               >
                 Remove
               </Button>
             )}
           </Box>
-          <TextField
-            label="Question text"
-            value={q.question_text}
-            onChange={(e) => updateRow(index, { question_text: e.target.value })}
-            fullWidth
-            required
-            multiline
-            minRows={2}
-            sx={{ mb: 2 }}
-          />
-          <TextField
-            label="Evaluation prompt (rubric for AI / admins)"
-            value={q.evaluation_prompt}
-            onChange={(e) => updateRow(index, { evaluation_prompt: e.target.value })}
-            fullWidth
-            required
-            multiline
-            minRows={2}
-            sx={{ mb: 2 }}
-          />
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr 1fr" },
-              gap: 2,
-            }}
-          >
-            <TextField
-              label="Max marks"
-              type="number"
-              value={q.max_marks}
-              onChange={(e) =>
-                updateRow(index, { max_marks: Math.max(1, Number(e.target.value) || 1) })
-              }
-              inputProps={{ min: 1 }}
-            />
-            <TextField
-              label="Type label (optional)"
-              value={q.question_type ?? ""}
-              onChange={(e) => updateRow(index, { question_type: e.target.value })}
-            />
-            <FormControl fullWidth>
-              <InputLabel id={`answer-mode-${index}`}>Answer mode</InputLabel>
-              <Select
-                labelId={`answer-mode-${index}`}
-                label="Answer mode"
-                value={q.answer_mode ?? "text"}
-                onChange={(e) =>
-                  updateRow(index, { answer_mode: String(e.target.value) })
-                }
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+            <FieldGroup title="Prompt & rubric">
+              <TextField
+                label="Question text"
+                value={q.question_text}
+                onChange={(e) => updateRow(index, { question_text: e.target.value })}
+                fullWidth
+                required
+                multiline
+                minRows={2}
+                sx={{ mb: 2 }}
+              />
+              <TextField
+                label="Evaluation prompt (rubric for AI / admins)"
+                value={q.evaluation_prompt}
+                onChange={(e) => updateRow(index, { evaluation_prompt: e.target.value })}
+                fullWidth
+                required
+                multiline
+                minRows={2}
+              />
+            </FieldGroup>
+            <FieldGroup title="Grading & answer mode">
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr 1fr" },
+                  gap: 2,
+                }}
               >
-                <MenuItem value="text">Text only</MenuItem>
-                <MenuItem value="text_image">Text + image</MenuItem>
-                <MenuItem value="file_upload" disabled={evaluationMode === "auto"}>
-                  File upload (manual eval)
-                </MenuItem>
-                <MenuItem value="video" disabled={evaluationMode === "auto"}>
-                  Video (manual eval)
-                </MenuItem>
-              </Select>
-            </FormControl>
+                <TextField
+                  label="Max marks"
+                  type="number"
+                  value={q.max_marks}
+                  onChange={(e) =>
+                    updateRow(index, { max_marks: Math.max(1, Number(e.target.value) || 1) })
+                  }
+                  inputProps={{ min: 1 }}
+                  sx={{ "& input": { fontFamily: "var(--font-mono)" } }}
+                />
+                <TextField
+                  label="Type label (optional)"
+                  value={q.question_type ?? ""}
+                  onChange={(e) => updateRow(index, { question_type: e.target.value })}
+                />
+                <FormControl fullWidth>
+                  <InputLabel id={`answer-mode-${index}`}>Answer mode</InputLabel>
+                  <Select
+                    labelId={`answer-mode-${index}`}
+                    label="Answer mode"
+                    value={q.answer_mode ?? "text"}
+                    onChange={(e) =>
+                      updateRow(index, { answer_mode: String(e.target.value) })
+                    }
+                  >
+                    <MenuItem value="text">Text only</MenuItem>
+                    <MenuItem value="text_image">Text + image</MenuItem>
+                    <MenuItem value="file_upload" disabled={evaluationMode === "auto"}>
+                      File upload (manual eval)
+                    </MenuItem>
+                    <MenuItem value="video" disabled={evaluationMode === "auto"}>
+                      Video (manual eval)
+                    </MenuItem>
+                  </Select>
+                </FormControl>
+              </Box>
+            </FieldGroup>
           </Box>
           {evaluationMode === "auto" ? (
             <Typography variant="caption" sx={{ display: "block", mt: 1.5, color: "var(--font-secondary)" }}>
               File upload and video require manual evaluation — switch evaluation mode on step 1 or choose text modes.
             </Typography>
           ) : null}
-          {index < rows.length - 1 ? <Divider sx={{ mt: 2 }} /> : null}
+          {index < rows.length - 1 ? (
+            <Divider sx={{ mt: 2, borderColor: "var(--border-default)" }} />
+          ) : null}
         </Paper>
       ))}
       <Button
         variant="outlined"
         onClick={addRow}
         startIcon={<IconWrapper icon="mdi:plus" size={18} />}
-        sx={{ alignSelf: "flex-start" }}
+        sx={{
+          alignSelf: "flex-start",
+          textTransform: "none",
+          fontWeight: 700,
+          borderRadius: 2,
+          px: 2.25,
+          color: "var(--font-primary)",
+          borderColor: "var(--border-default)",
+          "&:hover": {
+            borderColor: "var(--accent-indigo)",
+            bgcolor: "color-mix(in srgb, var(--accent-indigo) 6%, transparent)",
+          },
+        }}
       >
         Add another question
       </Button>


### PR DESCRIPTION
Full redesign of **/admin/assessment/create** to the shipped assessment-management language — every step, component, and modal (user directive).

### Page chrome
- **Horizontal 3-step progress band** (green ✓ done / gradient active / connector fills).
- **Live outline** card (gradient header, icon-tile section rows, live mono counts) left on steps 1 & 3; **step 2 runs full-width** — its inner section outline is the left column, killing the old double-sidebar squeeze that crushed the content.
- Step content as cards on the canvas; white **Back** pill, gradient **Continue / Create**.

### All 13 components restyled (presentation-only, logic verbatim)
Sidenav → "Live outline" card (clipped blue panel gone) · MCQ form (kicker-label cards, A–D violet tiles, gradient Add) · sections builder (type-tile cards + dashed add-card) · step-3 review (identity card + 6 KPI tiles) · 3 bank pickers (violet-ring rows, facet chips) · 2 CSV dropzones · AI coding generator + raw form · Basics card · written-question rows.

### Verification (full chain, per the standing rule)
Combined **tsc 0 errors** · per-file **eslint delta 0** (23=23 pre-existing) · real **`next build` compiled** ✓. Built by an 8-agent restyle fleet on disjoint files, each self-verified tsc=0, plus manual chrome work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)