### PR TITLE
feat(assessment): hub+builder polish phase 1 — glass prompt, contrast, live outline

### DIFF
--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/lib/services/admin/admin-assessment.service";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
 import { config } from "@/lib/config";
-import { AssessmentSectionHero, AssessmentBreadcrumb } from "@/components/admin/assessment/shared";
+import { AssessmentSectionHero, AssessmentBreadcrumb, StatusChip, DifficultyBalanceMeter } from "@/components/admin/assessment/shared";
 import { BasicInfoSection } from "@/components/admin/assessment/BasicInfoSection";
 import { AssessmentSettingsSection } from "@/components/admin/assessment/AssessmentSettingsSection";
 import type { EmailNotificationEditorHandle } from "@/components/admin/assessment/EmailNotificationEditor";
@@ -1839,6 +1839,70 @@ function CreateAssessmentPageContent() {
       : getTotalMCQCountForSection(s.id);
   const outlineSections = [...sections].sort((a, b) => a.order - b.order);
   const totalOutlineQuestions = sections.reduce((sum, s) => sum + sectionQuestionCount(s), 0);
+  // Real difficulty roll-up + max score across every authored/selected question, mirroring
+  // the per-section count conventions (all MCQ sources combined; subjective by method).
+  const outlineStats = (() => {
+    const balance = { easy: 0, medium: 0, hard: 0 };
+    let maxScore = 0;
+    const bucket = (d: unknown): "easy" | "medium" | "hard" => {
+      const x = String(d ?? "").toLowerCase();
+      return x.startsWith("e") ? "easy" : x.startsWith("h") ? "hard" : "medium";
+    };
+    for (const s of sections) {
+      if (s.type === "quiz") {
+        const picked = new Set(sectionMcqIds[s.id] ?? []);
+        const qs = [
+          ...(manualMCQs[s.id] ?? []),
+          ...(csvMCQs[s.id] ?? []),
+          ...(aiMCQs[s.id] ?? []),
+          ...existingMCQs.filter((m) => picked.has(m.id)),
+        ];
+        for (const q of qs) {
+          const k = bucket(q.difficulty_level);
+          balance[k] += 1;
+          maxScore += k === "easy" ? (s.easyScore ?? 1) : k === "hard" ? (s.hardScore ?? 3) : (s.mediumScore ?? 2);
+        }
+      } else if (s.type === "coding") {
+        const picked = new Set(sectionCodingProblemIds[s.id] ?? []);
+        const seen = new Set<number>();
+        const probs = [
+          ...(aiCodingProblems[s.id] ?? []),
+          ...existingCodingProblems.filter((p) => picked.has(p.id)),
+        ].filter((p) => {
+          if (p.id == null) return true;
+          if (seen.has(p.id)) return false;
+          seen.add(p.id);
+          return true;
+        });
+        for (const q of probs) {
+          const k = bucket(q.difficulty_level);
+          balance[k] += 1;
+          maxScore += k === "easy" ? (s.easyScore ?? 10) : k === "hard" ? (s.hardScore ?? 30) : (s.mediumScore ?? 20);
+        }
+      } else {
+        const method = subjectiveInputMethodBySection[s.id] ?? "manual";
+        if (method === "existing") {
+          const picked = new Set(sectionSubjectiveQuestionIds[s.id] ?? []);
+          for (const q of existingSubjectiveQuestions.filter((x) => picked.has(x.id))) {
+            maxScore += Number(q.max_marks ?? 0) || 0;
+          }
+        } else {
+          for (const r of manualSubjectiveQuestions[s.id] ?? []) {
+            maxScore += Number(r.max_marks ?? 0) || 0;
+          }
+        }
+      }
+    }
+    const hasBalance = balance.easy + balance.medium + balance.hard > 0;
+    return { balance, maxScore, hasBalance };
+  })();
+  const handleOutlineAddSection = () => {
+    if (activeStep !== 0) setActiveStep(0);
+    // let step 0 mount, then bring the sections builder into view
+    setTimeout(() => {
+      document.getElementById("sections-builder")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 120);
+  };
   const sectionTypeMeta = (t: string) =>
     t === "coding"
       ? { icon: "mdi:code-tags", label: "Coding" }
@@ -2031,11 +2095,12 @@ function CreateAssessmentPageContent() {
                   >
                     {title.trim() || "Untitled assessment"}
                   </Typography>
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 1.5 }}>
-                    <IconWrapper icon="mdi:clock-outline" size={14} color="var(--font-tertiary)" />
-                    <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-                      {durationMinutes} min · {sections.length} section{sections.length === 1 ? "" : "s"}
-                    </Typography>
+                  <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, mb: 1.5 }}>
+                    {proctoringEnabled ? (
+                      <StatusChip label="Proctored" tone="proctored" icon="mdi:shield-check-outline" />
+                    ) : null}
+                    <StatusChip label={`${durationMinutes}m`} tone="info" icon="mdi:clock-outline" />
+                    <StatusChip label={`${sections.length} section${sections.length === 1 ? "" : "s"}`} tone="neutral" />
                   </Box>
                   {outlineSections.length === 0 ? (
                     <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
@@ -2045,26 +2110,83 @@ function CreateAssessmentPageContent() {
                     outlineSections.map((s) => {
                       const meta = sectionTypeMeta(s.type);
                       return (
-                        <Box key={s.id} sx={{ display: "flex", alignItems: "center", gap: 1, py: 0.8, borderTop: "1px solid var(--border-default)" }}>
-                          <Box sx={{ width: 30, height: 30, borderRadius: 1.5, display: "grid", placeItems: "center", flexShrink: 0, color: "var(--accent-indigo)", bgcolor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--card-bg) 90%)" }}>
-                            <IconWrapper icon={meta.icon} size={16} />
+                        <Box
+                          key={s.id}
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 1.25,
+                            px: 1.5,
+                            py: 1.25,
+                            mb: 1,
+                            borderRadius: "12px",
+                            bgcolor: "color-mix(in srgb, var(--ai-violet) 6%, var(--card-bg) 94%)",
+                            border: "1px solid color-mix(in srgb, var(--ai-violet) 14%, var(--border-default) 86%)",
+                          }}
+                        >
+                          <Box sx={{ width: 36, height: 36, borderRadius: 2, display: "grid", placeItems: "center", flexShrink: 0, color: "var(--ai-violet)", bgcolor: "var(--card-bg)", border: "1px solid color-mix(in srgb, var(--ai-violet) 20%, var(--border-default) 80%)" }}>
+                            <IconWrapper icon={meta.icon} size={18} />
                           </Box>
-                          <Typography sx={{ flexGrow: 1, minWidth: 0, fontSize: "0.85rem", fontWeight: 600, color: "var(--font-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                            {s.title?.trim() || meta.label}
-                          </Typography>
-                          <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "0.85rem", color: "var(--font-primary)" }}>
-                            {sectionQuestionCount(s)}
+                          <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+                            <Typography sx={{ fontSize: "0.92rem", fontWeight: 700, fontFamily: "var(--font-jakarta)", color: "var(--font-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                              {s.title?.trim() || meta.label}
+                            </Typography>
+                            <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                              {meta.label} · {sectionQuestionCount(s)} question{sectionQuestionCount(s) === 1 ? "" : "s"}
+                            </Typography>
                           </Box>
                         </Box>
                       );
                     })
                   )}
+                  <Box
+                    onClick={handleOutlineAddSection}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleOutlineAddSection(); } }}
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      gap: 0.75,
+                      py: 1.4,
+                      mt: 0.5,
+                      borderRadius: "12px",
+                      border: "1.5px dashed color-mix(in srgb, var(--font-tertiary) 55%, transparent)",
+                      color: "var(--font-secondary)",
+                      fontWeight: 700,
+                      fontSize: "0.9rem",
+                      cursor: "pointer",
+                      userSelect: "none",
+                      transition: "border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease",
+                      "&:hover": {
+                        borderColor: "var(--ai-violet)",
+                        color: "var(--ai-violet)",
+                        bgcolor: "color-mix(in srgb, var(--ai-violet) 5%, transparent)",
+                      },
+                    }}
+                  >
+                    <IconWrapper icon="mdi:plus" size={18} /> Add section
+                  </Box>
                   <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mt: 1.5, pt: 1.5, borderTop: "1px solid var(--border-default)" }}>
-                    <Typography sx={{ fontSize: "0.8rem", fontWeight: 600, color: "var(--font-secondary)" }}>Total questions</Typography>
-                    <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 800, fontSize: "1.1rem", color: "var(--ai-violet)" }}>
+                    <Typography sx={{ fontSize: "0.85rem", fontWeight: 700, color: "var(--font-primary)" }}>Total questions</Typography>
+                    <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 800, fontSize: "1.1rem", color: "var(--font-primary)" }}>
                       {totalOutlineQuestions}
                     </Box>
                   </Box>
+                  {outlineStats.maxScore > 0 ? (
+                    <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mt: 0.75 }}>
+                      <Typography sx={{ fontSize: "0.85rem", fontWeight: 700, color: "var(--font-primary)" }}>Max score</Typography>
+                      <Box sx={{ fontFamily: "var(--font-mono)", fontWeight: 800, fontSize: "1.1rem", color: "var(--font-primary)" }}>
+                        {outlineStats.maxScore} pts
+                      </Box>
+                    </Box>
+                  ) : null}
+                  {outlineStats.hasBalance ? (
+                    <Box sx={{ mt: 1.25 }}>
+                      <DifficultyBalanceMeter balance={outlineStats.balance} legend={false} height={8} />
+                    </Box>
+                  ) : null}
                 </Box>
               </Box>
             </Box>

--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -56,7 +56,6 @@ import {
   type SegmentedTab,
   AssessmentCard,
   deriveAssessmentStatus,
-  AssessmentBreadcrumb,
   AiPromptField,
 } from "@/components/admin/assessment/shared";
 import {
@@ -870,15 +869,14 @@ export default function AssessmentPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ p: { xs: 2, sm: 3, md: 4 } }}>
-        <AssessmentBreadcrumb segments={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Assessments" }]} />
         {/* Header — adaptive-course design language (Phase 1 revamp) */}
         <Box sx={{ mb: 4 }}>
           <AssessmentSectionHero
-            chapter="ASSESSMENTS"
-            title={t("admin.assessment.title")}
-            subtitle={t("admin.assessment.subtitle")}
-            accent="indigo"
-            icon="mdi:clipboard-text-outline"
+            chapter="ASSESSMENT MANAGEMENT"
+            title="Assessments"
+            subtitle="Create, schedule, and monitor every assessment — in one place."
+            accent="violet"
+            icon=""
             rightSlot={
               /* Mockup: the ONLY header action is "Build manually" — the AI composer
                  lives inline in the hero band below. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -73,7 +73,9 @@
 
   /* Warning Colors */
   --warning-100: #fff8e6;
-  --warning-500: #ffb800;
+  --warning-500: #f59e0b;
+  /* darker amber for TEXT on amber tints (draft chips/panels) — #ffb800 text was unreadable */
+  --warning-600: #b45309;
 
   /* Error Colors */
   --error-100: #ffe6e6;
@@ -81,9 +83,11 @@
   --error-600: #ae0606;
 
   /* Font Colors */
-  --font-primary: #333333;
-  --font-secondary: #6b7280;
-  --font-tertiary: #9ca3af;
+  /* Contrast pass (user directive): darker text scale so labels/captions stay readable
+     on the warm canvas — primary near-black, secondary slate-600, tertiary gray-500. */
+  --font-primary: #1f2430;
+  --font-secondary: #4b5563;
+  --font-tertiary: #6b7280;
   --font-light: #ffffff;
   --font-dark: #000000;
   --font-primary-dark: #1f2937;

--- a/components/admin/assessment/shared/AiPromptField.tsx
+++ b/components/admin/assessment/shared/AiPromptField.tsx
@@ -34,14 +34,28 @@ export function AiPromptField({
   const canSubmit = value.trim().length > 0 && !submitting && !disabled;
   return (
     <Box sx={{ width: "100%" }}>
+      {/* One translucent glass pill wrapping the input AND the white Generate button (mockup) */}
       <Box
         sx={{
           display: "flex",
-          gap: 1.5,
-          flexDirection: { xs: "column", sm: "row" },
-          alignItems: { xs: "stretch", sm: "flex-start" },
+          alignItems: "center",
+          gap: 1,
+          pl: 2.25,
+          pr: 1,
+          py: 1,
+          borderRadius: "18px",
+          bgcolor: "rgba(255,255,255,0.08)",
+          border: "1px solid rgba(255,255,255,0.18)",
+          transition: "border-color 0.15s ease, background-color 0.15s ease",
+          "&:focus-within": {
+            bgcolor: "rgba(255,255,255,0.11)",
+            borderColor: "rgba(255,255,255,0.35)",
+          },
         }}
       >
+        <Box sx={{ display: "inline-flex", flexShrink: 0, color: "#c4b5fd" }}>
+          <IconWrapper icon="mdi:auto-fix" size={20} />
+        </Box>
         <TextField
           value={value}
           onChange={(e) => onChange(e.target.value)}
@@ -56,20 +70,15 @@ export function AiPromptField({
           minRows={1}
           maxRows={5}
           fullWidth
+          variant="standard"
           InputProps={{
-            startAdornment: (
-              <Box sx={{ display: "inline-flex", mr: 1, mt: 0.25, color: "var(--ai-violet)" }}>
-                <IconWrapper icon="mdi:auto-fix" size={20} />
-              </Box>
-            ),
+            disableUnderline: true,
             sx: {
-              alignItems: "flex-start",
-              borderRadius: "14px",
-              bgcolor: "rgba(255,255,255,0.97)",
               fontFamily: "var(--font-jakarta)",
-              "& fieldset": { border: "none" },
-              "& textarea": { color: "#1f1a2e" },
-              "& textarea::placeholder": { color: "#6f6a80", opacity: 1 },
+              fontSize: "1.02rem",
+              color: "#fff",
+              "& textarea": { color: "#fff" },
+              "& textarea::placeholder": { color: "rgba(255,255,255,0.62)", opacity: 1 },
             },
           }}
         />
@@ -78,22 +87,22 @@ export function AiPromptField({
           disabled={!canSubmit}
           sx={{
             flexShrink: 0,
-            px: 3,
-            py: 1.25,
-            minWidth: 132,
-            borderRadius: "12px",
+            alignSelf: "flex-end",
+            px: 2.75,
+            py: 1.1,
+            minWidth: 128,
+            borderRadius: "14px",
             textTransform: "none",
             fontWeight: 700,
             fontSize: "0.95rem",
             color: "var(--ai-violet)",
             bgcolor: "#fff",
-            boxShadow: "0 10px 24px -12px rgba(0,0,0,0.45)",
-            "&:hover": { bgcolor: "#fff", filter: "brightness(0.97)" },
-            "&.Mui-disabled": { bgcolor: "rgba(255,255,255,0.55)", color: "rgba(90,80,120,0.55)" },
+            "&:hover": { bgcolor: "#fff", filter: "brightness(0.96)" },
+            "&.Mui-disabled": { bgcolor: "rgba(255,255,255,0.85)", color: "rgba(124,58,237,0.45)" },
           }}
           endIcon={
             submitting ? (
-              <CircularProgress size={16} sx={{ color: "#fff" }} />
+              <CircularProgress size={16} sx={{ color: "var(--ai-violet)" }} />
             ) : (
               <IconWrapper icon="mdi:arrow-right" size={18} />
             )

--- a/components/admin/assessment/shared/AssessmentCard.tsx
+++ b/components/admin/assessment/shared/AssessmentCard.tsx
@@ -109,6 +109,21 @@ export function AssessmentCard({
           : {},
       }}
     >
+      {/* status top accent bar (mockup): AI gradient for active, indigo→violet scheduled,
+          amber draft, gray closed */}
+      <Box
+        sx={{
+          height: 5,
+          background:
+            status.key === "active"
+              ? "var(--gradient-ai)"
+              : status.key === "scheduled"
+              ? "linear-gradient(90deg, var(--accent-indigo), var(--ai-violet))"
+              : status.key === "draft"
+              ? "linear-gradient(90deg, var(--warning-500), color-mix(in srgb, var(--warning-500) 45%, #fff))"
+              : "color-mix(in srgb, var(--font-tertiary) 45%, transparent)",
+        }}
+      />
       {/* header: status + badges + title + course (mockup) */}
       <Box sx={{ px: 2.5, pt: 2.25, pb: isDraft ? 0.5 : 2 }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mb: 1.5, flexWrap: "wrap" }}>

--- a/components/admin/assessment/shared/AssessmentSectionHero.tsx
+++ b/components/admin/assessment/shared/AssessmentSectionHero.tsx
@@ -37,11 +37,16 @@ export function AssessmentSectionHero({
       subtitle={subtitle}
       accentTop={tone.top}
       accentBottom={tone.bottom}
-      iconBadge={{
-        icon,
-        gradient: `linear-gradient(135deg, ${tone.top} 0%, ${tone.bottom} 100%)`,
-        shadow: `0 18px 32px -16px color-mix(in srgb, ${tone.top} 60%, transparent)`,
-      }}
+      // Empty icon = badge-less header (mockup hub header is kicker/title/subtitle only).
+      iconBadge={
+        icon
+          ? {
+              icon,
+              gradient: `linear-gradient(135deg, ${tone.top} 0%, ${tone.bottom} 100%)`,
+              shadow: `0 18px 32px -16px color-mix(in srgb, ${tone.top} 60%, transparent)`,
+            }
+          : undefined
+      }
       rightSlot={rightSlot}
     />
   );

--- a/components/admin/assessment/shared/AssessmentSectionShell.tsx
+++ b/components/admin/assessment/shared/AssessmentSectionShell.tsx
@@ -36,6 +36,7 @@ export function AssessmentSectionShell({
 /** Per-surface accent gradients, matching the scorecard/adaptive convention. */
 export const ASSESSMENT_ACCENTS = {
   indigo: { top: "#6366f1", bottom: "#4338ca" },
+  violet: { top: "#7c3aed", bottom: "#6d28d9" },
   sky: { top: "#0ea5e9", bottom: "#0369a1" },
   teal: { top: "#14b8a6", bottom: "#0f766e" },
   amber: { top: "#f59e0b", bottom: "#b45309" },

--- a/components/admin/assessment/shared/SegmentedTabs.tsx
+++ b/components/admin/assessment/shared/SegmentedTabs.tsx
@@ -38,8 +38,9 @@ export function SegmentedTabs<T extends string>({
         gap: 0.5,
         p: 0.5,
         borderRadius: 999,
-        border: "1px solid var(--border-default)",
-        bgcolor: "var(--surface)",
+        border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+        bgcolor: "var(--card-bg)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
         maxWidth: "100%",
         overflowX: "auto",
         ...(fullWidth ? { display: "flex", width: "100%" } : {}),
@@ -74,16 +75,16 @@ export function SegmentedTabs<T extends string>({
               fontSize: "0.85rem",
               fontWeight: active ? 700 : 500,
               color: active ? "var(--font-light)" : "var(--font-secondary)",
-              bgcolor: active ? "var(--accent-indigo)" : "transparent",
+              bgcolor: active ? "var(--ai-violet)" : "transparent",
               boxShadow: active
-                ? "0 6px 14px -8px color-mix(in srgb, var(--accent-indigo) 70%, transparent)"
+                ? "0 6px 14px -8px color-mix(in srgb, var(--ai-violet) 70%, transparent)"
                 : "none",
               transition: "background-color 0.15s ease, color 0.15s ease",
               "&:hover": active
                 ? {}
                 : {
-                    bgcolor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--surface) 90%)",
-                    color: "var(--accent-indigo-dark)",
+                    bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--surface) 90%)",
+                    color: "var(--ai-violet)",
                   },
             }}
           >
@@ -101,8 +102,8 @@ export function SegmentedTabs<T extends string>({
                   fontWeight: 700,
                   bgcolor: active
                     ? "color-mix(in srgb, var(--font-light) 26%, transparent)"
-                    : "color-mix(in srgb, var(--accent-indigo) 14%, var(--surface) 86%)",
-                  color: active ? "var(--font-light)" : "var(--accent-indigo-dark)",
+                    : "color-mix(in srgb, var(--ai-violet) 14%, var(--surface) 86%)",
+                  color: active ? "var(--font-light)" : "var(--ai-violet)",
                 }}
               >
                 {tab.count}


### PR DESCRIPTION
Phase 1 of the sequential polish plan (all user-reported):

- **Glass prompt pill** — input + white Generate inside one translucent pill (mockup).
- **Hub header** — breadcrumb removed on the hub, badge-less hero, violet accent, mockup kicker/title/subtitle.
- **Violet segmented tabs** on a white soft-shadow track.
- **Contrast pass (platform-wide tokens)** — darker text scale (#1f2430/#4b5563/#6b7280), `--warning-500`→#f59e0b + new `--warning-600` #b45309 so amber text is readable.
- **Card status top bars** restored per mockup (gradient/indigo/amber/gray by status).
- **Live outline card detailed** — chips, violet-tinted section rows, working **+ Add section**, Total questions + **real Max score** (difficulty roll-up × section scores) + balance bar.

**Verified:** tsc 0 · eslint delta 0 (16=16) · real `next build` ✓. (BE #336 copy-assist verified live separately — powers Phase 2.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)