### PR TITLE
feat(assessment): Basics fields — ✦ Generate-with-AI + lively field groups (phase 2)

### DIFF
--- a/components/admin/assessment/BasicInfoSection.tsx
+++ b/components/admin/assessment/BasicInfoSection.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { memo } from "react";
-import { Box, Typography, TextField, Paper } from "@mui/material";
+import { memo, useState } from "react";
+import { Box, Typography, TextField, Paper, Button, CircularProgress } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { RichTextEditor } from "@/components/common/RichTextEditor";
+import { useToast } from "@/components/common/Toast";
+import { config } from "@/lib/config";
+import { generateAssessmentCopy } from "@/lib/services/admin/admin-assessment-composer.service";
 
 interface BasicInfoSectionProps {
   title: string;
@@ -30,24 +33,36 @@ const groupTitleSx = {
   fontWeight: 800,
   letterSpacing: "0.08em",
   textTransform: "uppercase" as const,
-  color: "var(--font-tertiary)",
-  mb: 0.25,
+  color: "var(--font-secondary)",
 };
 
 function FieldGroup({
   title,
   hint,
+  action,
   children,
 }: {
   title: string;
   hint?: string;
+  /** Right-aligned affordance on the kicker row (e.g. the ✦ AI button). */
+  action?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
-    <Box>
-      <Typography component="h4" variant="subtitle2" sx={groupTitleSx}>
-        {title}
-      </Typography>
+    <Box
+      sx={{
+        p: { xs: 1.75, sm: 2 },
+        borderRadius: "12px",
+        bgcolor: "color-mix(in srgb, var(--accent-indigo) 4%, var(--card-bg) 96%)",
+        border: "1px solid color-mix(in srgb, var(--accent-indigo) 10%, var(--border-default) 90%)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1, mb: 0.25 }}>
+        <Typography component="h4" variant="subtitle2" sx={groupTitleSx}>
+          {title}
+        </Typography>
+        {action ?? null}
+      </Box>
       {hint ? (
         <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.25 }}>
           {hint}
@@ -60,6 +75,52 @@ function FieldGroup({
   );
 }
 
+/** Small gradient "✦ Generate with AI" pill for a copy field. */
+function AiAssistButton({
+  label,
+  loading,
+  onClick,
+}: {
+  label: string;
+  loading: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      size="small"
+      onClick={onClick}
+      disabled={loading}
+      startIcon={
+        loading ? (
+          <CircularProgress size={13} sx={{ color: "#fff" }} />
+        ) : (
+          <IconWrapper icon="mdi:auto-fix" size={14} />
+        )
+      }
+      sx={{
+        flexShrink: 0,
+        px: 1.5,
+        py: 0.4,
+        borderRadius: 999,
+        textTransform: "none",
+        fontWeight: 700,
+        fontSize: "0.75rem",
+        color: "#fff",
+        background: "var(--gradient-ai)",
+        boxShadow: "0 6px 14px -8px color-mix(in srgb, var(--ai-violet) 70%, transparent)",
+        "&:hover": { filter: "brightness(1.05)" },
+        "&.Mui-disabled": {
+          color: "#fff",
+          opacity: 0.7,
+          background: "var(--gradient-ai)",
+        },
+      }}
+    >
+      {loading ? "Writing…" : label}
+    </Button>
+  );
+}
+
 function BasicInfoSectionInner({
   title,
   instructions,
@@ -69,6 +130,31 @@ function BasicInfoSectionInner({
   onDescriptionChange,
   readOnly = false,
 }: BasicInfoSectionProps) {
+  const { showToast } = useToast();
+  const [assisting, setAssisting] = useState<"instructions" | "description" | null>(null);
+
+  const handleAssist = async (field: "instructions" | "description") => {
+    if (assisting) return;
+    try {
+      setAssisting(field);
+      const text = await generateAssessmentCopy(config.clientId, {
+        field,
+        title,
+        current_text: field === "instructions" ? instructions : description,
+      });
+      if (field === "instructions") onInstructionsChange(text);
+      else onDescriptionChange(text);
+      showToast("Draft written — edit it to taste", "success");
+    } catch (e: unknown) {
+      showToast(
+        (e as { message?: string })?.message || "The AI assistant couldn't draft that just now",
+        "error"
+      );
+    } finally {
+      setAssisting(null);
+    }
+  };
+
   return (
     <Paper
       elevation={0}
@@ -125,7 +211,7 @@ function BasicInfoSectionInner({
         </Box>
       </Box>
 
-      <Box sx={{ px: { xs: 2, sm: 2.5 }, py: 2.5, display: "flex", flexDirection: "column", gap: 3 }}>
+      <Box sx={{ px: { xs: 2, sm: 2.5 }, py: 2.5, display: "flex", flexDirection: "column", gap: 2.5 }}>
         <FieldGroup
           title="Assessment title"
           hint="Shown in lists and at the top of the attempt. Keep it specific and concise."
@@ -158,38 +244,61 @@ function BasicInfoSectionInner({
             FormHelperTextProps={{ ...helperFormProps, component: "div" }}
             inputProps={{ maxLength: 255 }}
             disabled={readOnly}
+            sx={{ "& .MuiInputBase-root": { bgcolor: "var(--card-bg)" } }}
           />
         </FieldGroup>
 
         <FieldGroup
           title="Instructions for students"
           hint="Required. Tell students how to complete the assessment, time expectations, and any materials allowed."
+          action={
+            !readOnly ? (
+              <AiAssistButton
+                label={instructions.trim() ? "Improve with AI" : "Generate with AI"}
+                loading={assisting === "instructions"}
+                onClick={() => void handleAssist("instructions")}
+              />
+            ) : undefined
+          }
         >
-          <RichTextEditor
-            label="Instructions"
-            value={instructions}
-            onChange={onInstructionsChange}
-            mode="text"
-            required
-            minRows={4}
-            readOnly={readOnly}
-            helperText="Provide clear instructions for students."
-          />
+          <Box sx={{ "& .MuiInputBase-root, & textarea": { bgcolor: "var(--card-bg)" } }}>
+            <RichTextEditor
+              label="Instructions"
+              value={instructions}
+              onChange={onInstructionsChange}
+              mode="text"
+              required
+              minRows={4}
+              readOnly={readOnly}
+              helperText="Provide clear instructions for students."
+            />
+          </Box>
         </FieldGroup>
 
         <FieldGroup
           title="Description (optional)"
           hint="Optional context for the catalog or course page—goals, topics covered, or prerequisites."
+          action={
+            !readOnly ? (
+              <AiAssistButton
+                label={description.trim() ? "Improve with AI" : "Generate with AI"}
+                loading={assisting === "description"}
+                onClick={() => void handleAssist("description")}
+              />
+            ) : undefined
+          }
         >
-          <RichTextEditor
-            label="Description"
-            value={description}
-            onChange={onDescriptionChange}
-            mode="text"
-            minRows={2}
-            readOnly={readOnly}
-            helperText="Optional description of the assessment."
-          />
+          <Box sx={{ "& .MuiInputBase-root, & textarea": { bgcolor: "var(--card-bg)" } }}>
+            <RichTextEditor
+              label="Description"
+              value={description}
+              onChange={onDescriptionChange}
+              mode="text"
+              minRows={2}
+              readOnly={readOnly}
+              helperText="Optional description of the assessment."
+            />
+          </Box>
         </FieldGroup>
       </Box>
     </Paper>

--- a/lib/services/admin/admin-assessment-composer.service.ts
+++ b/lib/services/admin/admin-assessment-composer.service.ts
@@ -88,6 +88,23 @@ export const getAssessmentComposerJob = async (
   return response.data;
 };
 
+/** One-shot AI helper for the builder's Instructions/Description fields (BE #336). */
+export const generateAssessmentCopy = async (
+  clientId: string | number,
+  body: {
+    field: "instructions" | "description";
+    title?: string;
+    current_text?: string;
+    duration_minutes?: number;
+  }
+): Promise<string> => {
+  const response = await apiClient.post(
+    `/admin-dashboard/api/clients/${clientId}/assessment-copy-assist/`,
+    body
+  );
+  return String(response.data?.text ?? "");
+};
+
 /** Latest human-readable reason from a composer job's error_log (or ""). */
 export function composerErrorMessage(job: Pick<ComposerJobResponse, "error_log">): string {
   const entries = job.error_log || [];


### PR DESCRIPTION
Phase 2: the builder's **Instructions / Description** fields get a working **✦ Generate with AI** pill (BE #336, verified live — real copy returned on prod) + livelier tinted field groups per the user directive. Draft fills the editor and stays editable; 'Improve with AI' when text exists; hidden in readOnly.

**Verified:** tsc 0 · eslint 0 on both files · real `next build` ✓ · BE endpoint live-tested (200 + real text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)