### PR TITLE
fix(assessment): visible prompt text + width cap; human captions; em-dash sweep (phase 4)

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -507,7 +507,7 @@ export default function AssessmentEditPage() {
   const defaultEmailBody = useMemo(() => {
     return [
       "<p>Dear {name},</p>",
-      "<p>All set! Your assessment details are below — good luck 👍.</p>",
+      "<p>All set! Your assessment details are below. Good luck 👍.</p>",
       `<p><strong>Assessment:</strong> ${title.trim() || "New Assessment"}</p>`,
     ].join("");
   }, [title]);

--- a/app/admin/assessment/compose/[jobId]/page.tsx
+++ b/app/admin/assessment/compose/[jobId]/page.tsx
@@ -23,7 +23,7 @@ import {
 const STAGE_LABEL: Record<string, string> = {
   pending: "Starting…",
   generating_blueprint: "Designing the blueprint…",
-  blueprint_ready: "Blueprint ready — generating questions…",
+  blueprint_ready: "Blueprint ready, generating questions…",
   generating_questions: "Writing & calibrating questions…",
   assembling: "Assembling your draft…",
   completed: "Draft ready",
@@ -341,7 +341,7 @@ export default function ComposerJobPage() {
                             <Box sx={{ mt: 1.5, p: 1.5, borderRadius: 2, display: "flex", gap: 1, alignItems: "flex-start", bgcolor: "color-mix(in srgb, var(--success-500) 10%, var(--card-bg) 90%)" }}>
                               <IconWrapper icon="mdi:check" size={15} color="var(--success-500)" />
                               <Typography variant="caption" sx={{ color: "var(--success-500)", fontWeight: 600, lineHeight: 1.4 }}>
-                                Every planned batch generated — no gaps in the blueprint&apos;s coverage.
+                                Every planned batch generated. No gaps in the blueprint&apos;s coverage.
                               </Typography>
                             </Box>
                           ) : null}

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -174,7 +174,7 @@ function CreateAssessmentPageContent() {
   const defaultEmailBody = useMemo(() => {
     return [
       "<p>Dear {name},</p>",
-      "<p>All set! Your assessment details are below — good luck 👍.</p>",
+      "<p>All set! Your assessment details are below. Good luck 👍.</p>",
       `<p><strong>Assessment:</strong> ${title.trim() || "New Assessment"}</p>`,
     ].join("");
   }, [title]);
@@ -1566,7 +1566,7 @@ function CreateAssessmentPageContent() {
         title={
           editingAssessmentId
             ? "Updates your draft on the server. Learners still cannot see it until you publish."
-            : "Saves progress as a draft (title, settings, and any sections you’ve started). You can leave and continue later—learners never see drafts until you publish."
+            : "Saves progress as a draft (title, settings, and any sections you’ve started). You can leave and continue later. Learners never see drafts until you publish."
         }
         placement="bottom"
         arrow
@@ -2104,7 +2104,7 @@ function CreateAssessmentPageContent() {
                   </Box>
                   {outlineSections.length === 0 ? (
                     <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
-                      Add sections below — they&apos;ll appear here with live question counts.
+                      Add sections below. They&apos;ll appear here with live question counts.
                     </Typography>
                   ) : (
                     outlineSections.map((s) => {

--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -79,7 +79,7 @@ const COMPOSER_BLUEPRINTS: {
     preset: "proctored_screening",
     label: "Proctored screening",
     icon: "mdi:shield-check-outline",
-    starter: "45-min proctored screening — 10 medium MCQs + 2 hard coding problems",
+    starter: "45-min proctored screening: 10 medium MCQs + 2 hard coding problems",
   },
   {
     preset: "final_exam",
@@ -91,7 +91,7 @@ const COMPOSER_BLUEPRINTS: {
     preset: "coding_challenge",
     label: "Coding challenge",
     icon: "mdi:code-tags",
-    starter: "Coding challenge — 3 DSA problems, 90 minutes, auto-graded",
+    starter: "Coding challenge: 3 DSA problems, 90 minutes, auto-graded",
   },
 ];
 
@@ -580,7 +580,7 @@ export default function AssessmentPage() {
     return `
       <p>Dear {name},</p>
 
-      <p>All set! Your assessment details are below—good luck 👍.</p>
+      <p>All set! Your assessment details are below. Good luck 👍.</p>
 
       <p>
         ${lines.join("<br>\n        ")}
@@ -874,7 +874,7 @@ export default function AssessmentPage() {
           <AssessmentSectionHero
             chapter="ASSESSMENT MANAGEMENT"
             title="Assessments"
-            subtitle="Create, schedule, and monitor every assessment — in one place."
+            subtitle="Create, schedule, and monitor every assessment in one place."
             accent="violet"
             icon=""
             rightSlot={
@@ -948,19 +948,21 @@ export default function AssessmentPage() {
                     mb: 1,
                   }}
                 >
-                  Describe it — we&apos;ll build the whole thing.
+                  Describe it. We&apos;ll build the whole thing.
                 </Typography>
                 <Typography sx={{ opacity: 0.9, maxWidth: 620, mb: 2.5 }}>
                   Type a plain-English brief. AI drafts sections, questions, difficulty balance,
-                  timing, and proctoring — you just review and publish. No forms to fight.
+                  timing, and proctoring. You just review and publish. No forms to fight.
                 </Typography>
-                <AiPromptField
-                  value={composerBrief}
-                  onChange={setComposerBrief}
-                  onSubmit={handleComposerGenerate}
-                  submitting={composerSubmitting}
-                  examples={COMPOSER_EXAMPLES}
-                />
+                <Box sx={{ maxWidth: 860 }}>
+                  <AiPromptField
+                    value={composerBrief}
+                    onChange={setComposerBrief}
+                    onSubmit={handleComposerGenerate}
+                    submitting={composerSubmitting}
+                    examples={COMPOSER_EXAMPLES}
+                  />
+                </Box>
               </Box>
 
               {/* Right: blueprints inside the band (mockup) */}
@@ -1382,7 +1384,7 @@ export default function AssessmentPage() {
             {assessmentToTriggerEmail && (
               <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
                 <DialogContentText>
-                  Send notification emails to students for this assessment. Review the full template below — this is what each recipient will receive.
+                  Send notification emails to students for this assessment. Review the full template below. This is what each recipient will receive.
                 </DialogContentText>
                 <Box>
                   <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontWeight: 600 }}>

--- a/components/admin/assessment/AIGeneratedCodingSection.tsx
+++ b/components/admin/assessment/AIGeneratedCodingSection.tsx
@@ -161,7 +161,7 @@ export function AIGeneratedCodingSection({
         showToast(
           reason ||
             (produced
-              ? `Generation finished with errors — ${produced} problem(s) produced.`
+              ? `Generation finished with errors: ${produced} problem(s) produced.`
               : "Coding problem generation failed. Please try again shortly."),
           "error"
         );
@@ -325,7 +325,7 @@ export function AIGeneratedCodingSection({
             <IconWrapper icon="mdi:lightning-bolt-outline" size={15} color="var(--ai-violet)" />
             <Typography variant="caption" sx={{ color: "var(--font-tertiary)", lineHeight: 1.45 }}>
               Generated problems are saved to your coding bank and selected for this
-              assessment automatically — preview or remove any of them below.
+              assessment automatically. Preview or remove any of them below.
             </Typography>
           </Box>
         </Box>

--- a/components/admin/assessment/AIGeneratedSection.tsx
+++ b/components/admin/assessment/AIGeneratedSection.tsx
@@ -126,7 +126,7 @@ export function AIGeneratedSection({
         showToast(
           reason ||
             (job.questions.length
-              ? `Generation finished with errors — ${job.questions.length} question(s) produced.`
+              ? `Generation finished with errors: ${job.questions.length} question(s) produced.`
               : "Question generation failed. Please try again shortly."),
           "error"
         );
@@ -259,7 +259,7 @@ export function AIGeneratedSection({
             <IconWrapper icon="mdi:lightning-bolt-outline" size={15} color="var(--ai-violet)" />
             <Typography variant="caption" sx={{ color: "var(--font-tertiary)", lineHeight: 1.45 }}>
               Generated questions land in a review list with quality checks and duplicate
-              detection — nothing is added until you approve it.
+              detection. Nothing is added until you approve it.
             </Typography>
           </Box>
         </Box>
@@ -482,7 +482,7 @@ export function AIGeneratedSection({
                 <CircularProgress size={16} sx={{ color: "var(--ai-violet)" }} />
                 <Typography sx={{ fontWeight: 600, color: "var(--ai-violet)" }}>
                   Writing question {mcqs.length + 1}
-                  {progress?.total ? ` — batch ${Math.min(progress.done + 1, progress.total)}/${progress.total}` : ""}…
+                  {progress?.total ? ` (batch ${Math.min(progress.done + 1, progress.total)}/${progress.total})` : ""}…
                 </Typography>
               </Box>
             ) : null}

--- a/components/admin/assessment/AssessmentAnalyticsCharts.tsx
+++ b/components/admin/assessment/AssessmentAnalyticsCharts.tsx
@@ -331,7 +331,7 @@ function AnalyticsChartEmptyState() {
           }}
         >
           There isn&apos;t enough data for this visualization right now. As activity picks up, you&apos;ll see
-          distributions and trends here—no extra setup required.
+          distributions and trends here. No extra setup required.
         </Typography>
 
         <Stack
@@ -1464,7 +1464,7 @@ export function AssessmentAnalyticsCharts({ data, toolbar }: Props) {
       {/* {codingQuestions.length > 0 && (
         <Paper variant="outlined" sx={{ ...tablePaperSx, borderRadius: 2 }}>
           <SectionTableTitle
-            title="Coding exercises — how students did"
+            title="Coding exercises: how students did"
             count={codingQuestions.length}
             subtitle="For each coding task: how many students saw it, solved it fully, partly, did not pass, or skipped it."
           />
@@ -1544,7 +1544,7 @@ export function AssessmentAnalyticsCharts({ data, toolbar }: Props) {
       {/* {mcqQuestions.length > 0 && (
         <Paper variant="outlined" sx={{ ...tablePaperSx, borderRadius: 2 }}>
           <SectionTableTitle
-            title="Multiple choice — details per question"
+            title="Multiple choice: details per question"
             count={mcqQuestions.length}
             subtitle="Technical detail view (for staff who need the raw numbers)."
           />
@@ -1609,7 +1609,7 @@ export function AssessmentAnalyticsCharts({ data, toolbar }: Props) {
       {subjectiveQuestions.length > 0 && (
         <Paper variant="outlined" sx={{ ...tablePaperSx, borderRadius: 2 }}>
           <SectionTableTitle
-            title="Written answers — details per question"
+            title="Written answers: details per question"
             count={subjectiveQuestions.length}
             subtitle="Technical detail view (for staff who need the raw numbers)."
           />

--- a/components/admin/assessment/BasicInfoSection.tsx
+++ b/components/admin/assessment/BasicInfoSection.tsx
@@ -144,7 +144,7 @@ function BasicInfoSectionInner({
       });
       if (field === "instructions") onInstructionsChange(text);
       else onDescriptionChange(text);
-      showToast("Draft written — edit it to taste", "success");
+      showToast("Draft written. Edit it to taste.", "success");
     } catch (e: unknown) {
       showToast(
         (e as { message?: string })?.message || "The AI assistant couldn't draft that just now",
@@ -277,7 +277,7 @@ function BasicInfoSectionInner({
 
         <FieldGroup
           title="Description (optional)"
-          hint="Optional context for the catalog or course page—goals, topics covered, or prerequisites."
+          hint="Optional context for the catalog or course page: goals, topics covered, or prerequisites."
           action={
             !readOnly ? (
               <AiAssistButton

--- a/components/admin/assessment/CodingCSVUploadSection.tsx
+++ b/components/admin/assessment/CodingCSVUploadSection.tsx
@@ -305,7 +305,7 @@ export function CodingCSVUploadSection({
       setParsedProblems((prev) => prev.slice(processedUpTo));
       showToast(
         allIds.length > 0
-          ? `${msg} — ${allIds.length} problem(s) were created and kept; retry the rest.`
+          ? `${msg}: ${allIds.length} problem(s) were created and kept; retry the rest.`
           : msg,
         "error"
       );
@@ -371,7 +371,7 @@ export function CodingCSVUploadSection({
       <Box>
         <Typography sx={KICKER_SX}>Bulk upload (CSV)</Typography>
         <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 1 }}>
-          Use plain text in cells—no HTML. Put multi-line text, code, and indented blocks inside double-quoted
+          Use plain text in cells, no HTML. Put multi-line text, code, and indented blocks inside double-quoted
           fields; line breaks and spaces inside quotes are kept. Either use one{" "}
           <Typography component="span" variant="body2" sx={{ fontFamily: "var(--font-mono)" }}>
             raw_problem
@@ -439,7 +439,7 @@ export function CodingCSVUploadSection({
                 lineHeight: 1.5,
               }}
             >
-              Download a template, fill it in plain text, and upload the CSV — quoted cells keep
+              Download a template, fill it in plain text, and upload the CSV. Quoted cells keep
               line breaks and indentation.
             </Typography>
           </Box>

--- a/components/admin/assessment/MCQFormSection.tsx
+++ b/components/admin/assessment/MCQFormSection.tsx
@@ -751,7 +751,7 @@ export function MCQFormSection({ mcqs, onMCQsChange }: MCQFormSectionProps) {
               </Stack>
               {mcq.question_style === "multiple" && (
                 <Typography variant="caption" sx={{ color: "var(--font-secondary)", mt: 1, display: "block" }}>
-                  Multiple select — exact set: {(mcq.correct_options || []).join(", ")}
+                  Multiple select, exact set: {(mcq.correct_options || []).join(", ")}
                 </Typography>
               )}
               {mcq.difficulty_level && (

--- a/components/admin/assessment/MultipleSectionsSection.tsx
+++ b/components/admin/assessment/MultipleSectionsSection.tsx
@@ -505,7 +505,7 @@ export function MultipleSectionsSection({
                 fullWidth
                 inputProps={{ min: 0, step: 0.5 }}
                 FormHelperTextProps={helperFormProps}
-                helperText="easy_score"
+                helperText="Points for each easy question"
               />
               <TextField
                 label="Medium"
@@ -521,7 +521,7 @@ export function MultipleSectionsSection({
                 fullWidth
                 inputProps={{ min: 0, step: 0.5 }}
                 FormHelperTextProps={helperFormProps}
-                helperText="medium_score"
+                helperText="Points for each medium question"
               />
               <TextField
                 label="Hard"
@@ -537,7 +537,7 @@ export function MultipleSectionsSection({
                 fullWidth
                 inputProps={{ min: 0, step: 0.5 }}
                 FormHelperTextProps={helperFormProps}
-                helperText="hard_score"
+                helperText="Points for each hard question"
               />
             </Box>
           </FieldGroup>
@@ -559,7 +559,7 @@ export function MultipleSectionsSection({
               required
               inputProps={{ maxLength: 255 }}
               FormHelperTextProps={helperFormProps}
-              helperText="Required. Maps to title in the payload."
+              helperText="Required. Learners see this as the section heading."
             />
             <TextField
               label="Section description"
@@ -603,7 +603,7 @@ export function MultipleSectionsSection({
 
           <FieldGroup
             title="Time & cutoff"
-            hint="Optional limits sent as time_limit_minutes and section_cutoff_marks."
+            hint="Optionally cap this section's time and set a minimum score to clear it."
           >
             <Box
               sx={{
@@ -977,7 +977,7 @@ function SectionCard({
                 fullWidth
                 inputProps={{ min: 0, step: 0.5 }}
                 FormHelperTextProps={helperFormProps}
-                helperText="easy_score"
+                helperText="Points for each easy question"
               />
               <TextField
                 label="Medium"
@@ -993,7 +993,7 @@ function SectionCard({
                 fullWidth
                 inputProps={{ min: 0, step: 0.5 }}
                 FormHelperTextProps={helperFormProps}
-                helperText="medium_score"
+                helperText="Points for each medium question"
               />
               <TextField
                 label="Hard"
@@ -1009,7 +1009,7 @@ function SectionCard({
                 fullWidth
                 inputProps={{ min: 0, step: 0.5 }}
                 FormHelperTextProps={helperFormProps}
-                helperText="hard_score"
+                helperText="Points for each hard question"
               />
             </Box>
           </FieldGroup>

--- a/components/admin/assessment/QuestionsInputSection.tsx
+++ b/components/admin/assessment/QuestionsInputSection.tsx
@@ -89,7 +89,7 @@ export function QuestionsInputSection({
       {hasInlineData && (
         <Alert severity="info">
           Switching the input method keeps the questions you already added or
-          generated — they carry over to the new method.
+          generated. They carry over to the new method.
         </Alert>
       )}
 

--- a/components/admin/assessment/SectionBasedQuestionsInput.tsx
+++ b/components/admin/assessment/SectionBasedQuestionsInput.tsx
@@ -452,7 +452,7 @@ export function SectionBasedQuestionsInput({
               <Box component="span" sx={{ color: "var(--ai-violet)" }}>{currentSection.title}</Box>
             </Typography>
             <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-              Pick how you want to add them — mix and match anytime.
+              Pick how you want to add them. Mix and match anytime.
             </Typography>
             {currentSection.number_of_questions_to_show && (
               <Typography variant="body2" sx={{ color: "var(--ai-violet)", mt: 1, fontWeight: 600 }}>
@@ -480,7 +480,7 @@ export function SectionBasedQuestionsInput({
               }
             }}
             options={[
-              { value: "ai", title: "AI Generated", subtitle: "Describe a topic — get questions", icon: "mdi:auto-fix", ai: true },
+              { value: "ai", title: "AI Generated", subtitle: "Describe a topic, get questions", icon: "mdi:auto-fix", ai: true },
               { value: "existing", title: "From question bank", subtitle: "Reuse verified items", icon: "mdi:content-copy" },
               { value: "manual", title: "Write manually", subtitle: "Type one at a time", icon: "mdi:pencil-outline" },
               { value: "csv", title: "Bulk upload (CSV)", subtitle: "Import a spreadsheet", icon: "mdi:download-outline" },
@@ -657,7 +657,7 @@ export function SectionBasedQuestionsInput({
                     }
                   }}
                   options={[
-                    { value: "ai", title: "AI Generated", subtitle: "Describe a topic — get problems", icon: "mdi:auto-fix", ai: true },
+                    { value: "ai", title: "AI Generated", subtitle: "Describe a topic, get problems", icon: "mdi:auto-fix", ai: true },
                     { value: "existing", title: "From problem bank", subtitle: "Reuse verified problems", icon: "mdi:content-copy" },
                     { value: "raw", title: "Write your own", subtitle: "Author a problem from scratch", icon: "mdi:pencil-outline" },
                     { value: "csv", title: "Bulk upload (CSV)", subtitle: "Import a spreadsheet", icon: "mdi:download-outline" },

--- a/components/admin/assessment/SubjectiveQuestionsFormSection.tsx
+++ b/components/admin/assessment/SubjectiveQuestionsFormSection.tsx
@@ -221,7 +221,7 @@ export function SubjectiveQuestionsFormSection({
           </Box>
           {evaluationMode === "auto" ? (
             <Typography variant="caption" sx={{ display: "block", mt: 1.5, color: "var(--font-secondary)" }}>
-              File upload and video require manual evaluation — switch evaluation mode on step 1 or choose text modes.
+              File upload and video require manual evaluation. Switch evaluation mode on step 1 or choose text modes.
             </Typography>
           ) : null}
           {index < rows.length - 1 ? (

--- a/components/admin/assessment/shared/AiPromptField.tsx
+++ b/components/admin/assessment/shared/AiPromptField.tsx
@@ -77,8 +77,15 @@ export function AiPromptField({
               fontFamily: "var(--font-jakarta)",
               fontSize: "1.02rem",
               color: "#fff",
-              "& textarea": { color: "#fff" },
-              "& textarea::placeholder": { color: "rgba(255,255,255,0.62)", opacity: 1 },
+              caretColor: "#fff",
+              // Class-based selector: MUI's .MuiInputBase-input theme color outranks a bare
+              // element selector, which left typed text invisible on the dark band.
+              "& .MuiInputBase-input": {
+                color: "#fff",
+                WebkitTextFillColor: "#fff",
+                caretColor: "#fff",
+              },
+              "& .MuiInputBase-input::placeholder": { color: "rgba(255,255,255,0.62)", opacity: 1 },
             },
           }}
         />

--- a/components/admin/assessment/shared/AssessmentCard.tsx
+++ b/components/admin/assessment/shared/AssessmentCard.tsx
@@ -197,7 +197,7 @@ export function AssessmentCard({
           >
             <IconWrapper icon="mdi:pencil-outline" size={16} />
             <Typography sx={{ fontSize: "0.9rem", fontWeight: 700, flexGrow: 1 }}>
-              Draft — continue setup
+              Draft: continue setup
             </Typography>
             <IconWrapper icon="mdi:arrow-right" size={17} />
           </Box>


### PR DESCRIPTION
Phase 4:

- **HOTFIX — invisible typed text** in the composer prompt pill (MUI input class outranked the element selector; now class-targeted with `WebkitTextFillColor`/caret white). Pill capped at 860px per user.
- **Sections builder captions humanized** (`easy_score` → *Points for each easy question*, payload jargon removed) in add form + edit panel.
- **Em-dash sweep**: 34 user-visible em dashes replaced across hub/composer/wizard/cards/analytics/CSV/toasts (data placeholders kept).

**Verified:** tsc 0 · eslint delta 0 (80=80, 16 files) · real `next build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)