### PR TITLE
feat(adaptive): content-lock toggle in the course builder (BE #337)

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -195,6 +195,23 @@ export default function AdminAdaptiveCourseDetailPage() {
     });
   }
 
+  async function handleToggleContentLock() {
+    if (!course) return;
+    const next = !course.content_locked;
+    try {
+      const res = await adminAdaptiveCourseService.updateCourse(course.id, { content_locked: next });
+      setCourse({ ...course, content_locked: res.content_locked });
+      showToast(
+        res.content_locked
+          ? "Content locked: weeks unlock on the cohort schedule and late work loses points."
+          : "Content unlocked: students can open any week now and always earn full XP.",
+        "success"
+      );
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't update the content lock", "error");
+    }
+  }
+
   async function handlePublish() {
     if (!course) return;
     try {
@@ -344,6 +361,18 @@ export default function AdminAdaptiveCourseDetailPage() {
                     >
                       <Icon icon="mdi:plus" width={16} />
                       Add module (AI)
+                    </ButtonBase>
+                    <ButtonBase
+                      onClick={() => void handleToggleContentLock()}
+                      sx={pillBtnSx("outline")}
+                      title={
+                        course.content_locked
+                          ? "Weeks unlock on the cohort schedule; late completions lose points. Click to unlock everything."
+                          : "All weeks are open and every completion earns full XP. Click to restore the weekly lock."
+                      }
+                    >
+                      <Icon icon={course.content_locked ? "mdi:lock-outline" : "mdi:lock-open-variant-outline"} width={16} />
+                      {course.content_locked ? "Content locked" : "Content unlocked"}
                     </ButtonBase>
                     <ButtonBase onClick={() => void handlePublish()} sx={pillBtnSx(course.is_published ? "outline" : "solid")}>
                       <Icon icon={course.is_published ? "mdi:eye-off-outline" : "mdi:earth"} width={16} />

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -284,6 +284,8 @@ export interface AdminAdaptiveCourseListItem {
   duration_weeks: number;
   difficulty_levels: string[];
   is_published: boolean;
+  /** Weekly cohort gate. False = every week open + full XP (admin toggle). */
+  content_locked: boolean;
   module_count: number;
   submodule_count: number;
   quiz_count: number;
@@ -539,10 +541,10 @@ export const adminAdaptiveCourseService = {
     return data;
   },
 
-  /** Edit the course title and/or description. Returns the updated course detail. */
+  /** Edit course fields (title/description/content lock). Returns the updated detail. */
   async updateCourse(
     courseId: number,
-    payload: { title?: string; description?: string },
+    payload: { title?: string; description?: string; content_locked?: boolean },
   ): Promise<AdminAdaptiveCourseDetail> {
     const { data } = await apiClient.patch<AdminAdaptiveCourseDetail>(
       `${BASE}/courses/${courseId}/`,


### PR DESCRIPTION
**Content locked / Content unlocked** pill beside Publish on the adaptive course manage page. Locked (default) = weekly cohort gate + late penalties; unlocked = every week open now + **full XP**. Toast + hover copy state the consequences; round-trips via `updateCourse` PATCH.

**Verified:** tsc 0 · eslint 0=0 · real `next build` ✓ · BE #337 (367-test sweep, 0 new failures) merged; deploy-verify running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)