### PR TITLE
feat(assessment): batch 6 — placeholders, declutter, add-section e2e, settings accordion

### DIFF
--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -13,7 +13,6 @@ import {
   Button,
   CircularProgress,
   Tooltip,
-  Chip,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
@@ -1727,6 +1726,7 @@ function CreateAssessmentPageContent() {
         return (
           <SectionBasedQuestionsInput
             evaluationMode={evaluationMode}
+            onAddSection={handleOutlineAddSection}
             sections={sections}
             mcqInputMethodBySection={mcqInputMethodBySection}
             onMcqInputMethodChange={(sectionId, method) => {
@@ -1934,29 +1934,9 @@ function CreateAssessmentPageContent() {
             accent="indigo"
             icon="mdi:clipboard-plus-outline"
             rightSlot={
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: { xs: "stretch", sm: "flex-end" },
-                  gap: 0.75,
-                }}
-              >
-                {(Boolean(editingAssessmentId) || savingDraft) && (
-                  <Chip
-                    size="small"
-                    label={savingDraft ? "Saving draft…" : "Draft"}
-                    sx={{
-                      fontWeight: 600,
-                      height: 24,
-                      bgcolor: "color-mix(in srgb, var(--font-secondary) 12%, var(--surface) 88%)",
-                      color: "var(--font-secondary)",
-                      border: "1px solid var(--border-default)",
-                    }}
-                  />
-                )}
-                {renderSaveDraftButton()}
-              </Box>
+              /* One save-draft affordance only (declutter): the button's own label
+                 already reflects the saving state. */
+              renderSaveDraftButton()
             }
           />
         </Box>
@@ -2232,7 +2212,6 @@ function CreateAssessmentPageContent() {
             Back
           </Button>
           <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", justifyContent: "flex-end", alignItems: "center" }}>
-            {renderSaveDraftButton({ compact: true })}
             {activeStep === steps.length - 1 ? (
               <>
                 {editingAssessmentId && loadedIsDraft && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -128,6 +128,18 @@
   --font-jakarta: var(--font-family-primary, "Satoshi"), "Satoshi Variable", system-ui, sans-serif;
   /* cyan = proctored (semantic tone the chip set was missing) */
   --tone-proctored: var(--accent-cyan, #06b6d4);
+}
+
+/* Placeholders must read as hints, not content (user: "placeholder looks like actual
+   text"). Keep them clearly lighter than typed text across MUI inputs. */
+.MuiInputBase-input::placeholder,
+textarea::placeholder,
+input::placeholder {
+  color: var(--font-tertiary);
+  opacity: 0.55;
+}
+
+:root {
 
   /* Chart series colors */
   --chart-articles: #234256;

--- a/components/admin/assessment/AssessmentSettingsSection.tsx
+++ b/components/admin/assessment/AssessmentSettingsSection.tsx
@@ -132,18 +132,19 @@ interface AssessmentSettingsSectionProps {
   readOnly?: boolean;
 }
 
+const softBorder = "color-mix(in srgb, var(--border-default) 55%, transparent)";
+
 const listSubheaderSx = {
-  py: 1,
-  px: 2,
-  lineHeight: 1.5,
-  fontSize: "0.7rem",
-  fontWeight: 700,
+  py: 0.9,
+  px: { xs: 1.5, sm: 1.75 },
+  lineHeight: 1.4,
+  fontSize: "0.72rem",
+  fontWeight: 800,
   letterSpacing: "0.08em",
   textTransform: "uppercase",
-  color: "var(--font-secondary)",
-  bgcolor: "var(--surface)",
-  borderTop: "1px solid",
-  borderColor: "var(--border-default)",
+  color: "var(--font-tertiary)",
+  bgcolor: "transparent",
+  borderTop: `1px solid ${softBorder}`,
   "&:first-of-type": {
     borderTop: "none",
   },
@@ -159,11 +160,11 @@ const helperFormProps = {
 };
 
 const groupTitleSx = {
-  fontSize: "0.7rem",
-  fontWeight: 700,
-  letterSpacing: "0.06em",
+  fontSize: "0.72rem",
+  fontWeight: 800,
+  letterSpacing: "0.08em",
   textTransform: "uppercase" as const,
-  color: "var(--font-secondary)",
+  color: "var(--font-tertiary)",
   mb: 0.25,
 };
 
@@ -205,14 +206,14 @@ function DateTimePartsField({
 
   return (
     <Box>
-      <Typography variant="body2" sx={{ fontWeight: 600, color: "var(--font-primary)", mb: 1 }}>
+      <Typography variant="body2" sx={{ fontWeight: 600, color: "var(--font-primary)", mb: 0.75 }}>
         {label}
       </Typography>
       <Box
         sx={{
           display: "grid",
           gridTemplateColumns: { xs: "1fr", sm: "1.2fr 1fr" },
-          gap: 2,
+          gap: 1.5,
         }}
       >
         <TextField
@@ -355,10 +356,9 @@ function PolicySwitchRow({
         />
       }
       sx={{
-        py: 1.6,
-        px: { xs: 1.5, sm: 2 },
-        borderBottom: "1px solid",
-        borderColor: "var(--border-default)",
+        py: 1.15,
+        px: { xs: 1.5, sm: 1.75 },
+        borderBottom: `1px solid ${softBorder}`,
         transition: "background-color 0.15s ease",
         "&:last-of-type": { borderBottom: "none" },
         "&:hover": {
@@ -366,11 +366,11 @@ function PolicySwitchRow({
         },
       }}
     >
-      <ListItemIcon sx={{ minWidth: 52, mt: 0.15 }}>
+      <ListItemIcon sx={{ minWidth: 46, mt: 0.15 }}>
         <Box
           sx={{
-            width: 42,
-            height: 42,
+            width: 36,
+            height: 36,
             borderRadius: 2,
             display: "flex",
             alignItems: "center",
@@ -378,7 +378,7 @@ function PolicySwitchRow({
             bgcolor: `color-mix(in srgb, ${accent} 12%, var(--card-bg) 88%)`,
           }}
         >
-          <IconWrapper icon={icon} size={22} color={accent} />
+          <IconWrapper icon={icon} size={19} color={accent} />
         </Box>
       </ListItemIcon>
       <ListItemText
@@ -386,20 +386,142 @@ function PolicySwitchRow({
         secondary={subtitle}
         primaryTypographyProps={{
           variant: "body2",
-          sx: { fontWeight: 700, color: "var(--font-primary)", pr: 1, fontSize: "0.95rem" },
+          sx: { fontWeight: 700, color: "var(--font-primary)", pr: 1, fontSize: "0.9rem" },
         }}
         secondaryTypographyProps={{
           variant: "caption",
           sx: {
             display: "block",
-            mt: 0.35,
+            mt: 0.25,
             color: "text.secondary",
-            lineHeight: 1.45,
+            lineHeight: 1.4,
             maxWidth: "min(100%, 36rem)",
           },
         }}
       />
     </ListItem>
+  );
+}
+
+/**
+ * Accordion card matching the "Live outline" design language: 16px-radius
+ * white card, icon tile + bold Jakarta title, live one-line summary of the
+ * group's current values, chevron toggle. Children stay MOUNTED when closed
+ * (Collapse hides via style, no unmountOnExit) so nothing inside — notably
+ * the email editor — is ever torn down by expanding/collapsing.
+ */
+function SettingsGroupCard({
+  id,
+  icon,
+  accent,
+  title,
+  summary,
+  open,
+  onToggle,
+  children,
+}: {
+  id: string;
+  icon: string;
+  accent: string;
+  title: string;
+  summary: string;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        borderRadius: "16px",
+        border: `1px solid ${softBorder}`,
+        boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+        bgcolor: "var(--card-bg)",
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        component="button"
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-controls={`${id}-body`}
+        sx={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 1.25,
+          px: { xs: 1.5, sm: 1.75 },
+          py: 1.3,
+          border: 0,
+          borderBottom: open ? `1px solid ${softBorder}` : "1px solid transparent",
+          background: "none",
+          textAlign: "left",
+          cursor: "pointer",
+          font: "inherit",
+          color: "inherit",
+          transition: "background-color 0.15s ease, border-color 0.15s ease",
+          "&:hover": { bgcolor: `color-mix(in srgb, ${accent} 5%, transparent)` },
+          "&:focus-visible": {
+            outline: "2px solid var(--ai-violet)",
+            outlineOffset: "-2px",
+          },
+        }}
+      >
+        <Box
+          sx={{
+            width: 38,
+            height: 38,
+            borderRadius: 2,
+            display: "grid",
+            placeItems: "center",
+            flexShrink: 0,
+            bgcolor: `color-mix(in srgb, ${accent} 12%, var(--card-bg) 88%)`,
+          }}
+        >
+          <IconWrapper icon={icon} size={20} color={accent} />
+        </Box>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: "0.95rem",
+              lineHeight: 1.3,
+              color: "var(--font-primary)",
+            }}
+          >
+            {title}
+          </Typography>
+          <Typography
+            noWrap
+            sx={{
+              display: "block",
+              fontSize: "0.78rem",
+              lineHeight: 1.4,
+              color: "var(--font-secondary)",
+            }}
+          >
+            {summary}
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            flexShrink: 0,
+            display: "grid",
+            placeItems: "center",
+            transform: open ? "rotate(180deg)" : "rotate(0deg)",
+            transition: "transform 0.2s ease",
+          }}
+        >
+          <IconWrapper icon="mdi:chevron-down" size={20} color="var(--font-tertiary)" />
+        </Box>
+      </Box>
+      {/* No unmountOnExit: closed groups hide via style only, children stay mounted. */}
+      <Collapse in={open} timeout="auto">
+        <Box id={`${id}-body`}>{children}</Box>
+      </Collapse>
+    </Paper>
   );
 }
 
@@ -501,146 +623,209 @@ export function AssessmentSettingsSection({
     const handle = window.setTimeout(() => setEmailEditorMounted(true), 800);
     return () => window.clearTimeout(handle);
   }, [emailEditorMounted]);
+
+  // ---- Accordion open/closed state (presentation only). "Timing & audience"
+  // starts open; everything else starts collapsed since the defaults are
+  // sensible. Notifications auto-opens when the email toggle turns on.
+  const [timingOpen, setTimingOpen] = useState(true);
+  const [billingOpen, setBillingOpen] = useState(false);
+  const [sessionOpen, setSessionOpen] = useState(false);
+  const [resultsOpen, setResultsOpen] = useState(false);
+  const [notificationsOpen, setNotificationsOpen] = useState(
+    Boolean(sendCommunication)
+  );
+  // Auto-open Notifications on the false→true transition of sendCommunication
+  // (render-time prev-props pattern; the admin can still collapse it after).
+  const [prevSendCommunication, setPrevSendCommunication] = useState(
+    Boolean(sendCommunication)
+  );
+  if (Boolean(sendCommunication) !== prevSendCommunication) {
+    setPrevSendCommunication(Boolean(sendCommunication));
+    if (sendCommunication && !notificationsOpen) {
+      setNotificationsOpen(true);
+    }
+  }
+
+  // ---- Live header summaries, computed from props only.
+  const courseCount = courseIds.length;
+  const collegeCount = colleges.length;
+  const timingSummary = [
+    durationMinutes > 0 ? `${durationMinutes} min` : "duration not set",
+    courseCount > 0 ? `${courseCount} course${courseCount === 1 ? "" : "s"}` : "no courses",
+    collegeCount > 0 ? `${collegeCount} college${collegeCount === 1 ? "" : "s"}` : null,
+    startTime || endTime ? "window set" : "window not set",
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const enabledDevices = [
+    allowDesktop ? "desktop" : null,
+    allowMobile ? "mobile" : null,
+    allowTablet ? "tablet" : null,
+  ].filter(Boolean);
+  const deviceSummary =
+    enabledDevices.length === 3
+      ? "all devices"
+      : enabledDevices.length === 0
+        ? "no devices allowed"
+        : enabledDevices.join(" + ");
+  const billingSummary = `${
+    isPaid ? (price ? `Paid · ${price} ${currency}` : `Paid · ${currency}`) : "Free"
+  } · ${deviceSummary}`;
+
+  const sessionSummary = [
+    isActive ? "Active" : "Inactive",
+    proctoringEnabled ? "proctored" : "unproctored",
+    showLiveStreamingToggle && liveStreaming ? "live stream on" : null,
+    allowMovementAcrossSections ? "free section movement" : "sections locked",
+    tabSwitchLimitEnabled
+      ? `${tabSwitchLimitCount > 0 ? tabSwitchLimitCount : "?"} tab-switch limit`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const resultsSummary = [
+    evaluationMode === "auto" ? "Auto-graded" : "Manual evaluation",
+    showResult ? "results shown" : "results hidden",
+    certificateAvailable
+      ? passBandLowerPercent && passBandUpperPercent
+        ? `certificate ${passBandLowerPercent}–${passBandUpperPercent}%`
+        : "certificate on"
+      : "no certificate",
+  ].join(" · ");
+
+  const reminderCount = emailReminderOffsets.length;
+  const notificationsSummary = sendCommunication
+    ? [
+        emailNotificationEnabled ? "Email on publish" : "Email on · content pending",
+        emailRemindersEnabled
+          ? reminderCount > 0
+            ? `${reminderCount} reminder${reminderCount === 1 ? "" : "s"}`
+            : "reminders need times"
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" · ")
+    : "No email will be sent";
+
   return (
-    <Paper
-      elevation={0}
+    <Box
       component="section"
       aria-labelledby="assessment-settings-heading"
       sx={{
-        borderRadius: 2,
-        border: "1px solid",
-        borderColor:
-          "color-mix(in srgb, var(--accent-indigo) 30%, var(--border-default) 70%)",
-        overflow: "hidden",
-        boxShadow:
-          "0 1px 3px color-mix(in srgb, var(--font-primary) 10%, transparent)",
-        background:
-          "linear-gradient(180deg, color-mix(in srgb, var(--accent-indigo) 8%, var(--surface) 92%) 0%, var(--card-bg) 56px)",
+        display: "flex",
+        flexDirection: "column",
+        gap: 1.5,
         opacity: readOnly ? 0.96 : 1,
       }}
     >
-      <Box
+      <Typography
+        id="assessment-settings-heading"
         sx={{
-          px: 2.5,
-          py: 2,
-          display: "flex",
-          alignItems: "flex-start",
-          gap: 1.5,
-          borderBottom: "1px solid",
-          borderColor:
-            "color-mix(in srgb, var(--accent-indigo) 20%, var(--border-default) 80%)",
+          fontSize: "0.72rem",
+          fontWeight: 800,
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+          color: "var(--font-tertiary)",
         }}
+      >
+        Assessment settings
+      </Typography>
+
+      {/* ---- Timing & audience -------------------------------------------- */}
+      <SettingsGroupCard
+        id="settings-timing"
+        icon="mdi:calendar-clock"
+        accent="var(--accent-indigo)"
+        title="Timing & audience"
+        summary={timingSummary}
+        open={timingOpen}
+        onToggle={() => setTimingOpen((v) => !v)}
       >
         <Box
           sx={{
-            width: 44,
-            height: 44,
-            borderRadius: 1.5,
+            p: { xs: 1.5, sm: 2 },
             display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            bgcolor:
-              "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface) 88%)",
-            border:
-              "1px solid color-mix(in srgb, var(--accent-indigo) 30%, var(--border-default) 70%)",
-            flexShrink: 0,
+            flexDirection: "column",
+            gap: 2,
           }}
         >
-          <IconWrapper icon="mdi:tune-vertical" size={24} color="var(--accent-indigo)" />
-        </Box>
-        <Box>
-          <Typography
-            id="assessment-settings-heading"
-            variant="subtitle1"
-            sx={{ fontWeight: 700, color: "var(--font-primary)" }}
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+              gap: 2,
+              alignItems: "start",
+            }}
           >
-            Assessment settings
-          </Typography>
-        </Box>
-      </Box>
-
-      <Box sx={{ px: { xs: 2, sm: 2.5 }, py: 2.5, display: "flex", flexDirection: "column", gap: 3 }}>
-        <FieldGroup
-          title="Overall duration"
-          hint="Total minutes for the full attempt. You can still set per-section time limits separately."
-        > 
-          <TextField
-            label="Duration (minutes)"
-            type="number"
-            value={durationMinutes === 0 ? "" : durationMinutes}
-            onChange={(e) => {
-              const v = e.target.value;
-              onDurationChange(v === "" ? 0 : Number(v));
-            }}
-            fullWidth
-            required
-            inputProps={{ min: 0 }}
-            disabled={readOnly}
-            helperText="Applies to the entire attempt. Section blocks can define their own time limits."
-            FormHelperTextProps={helperFormProps}
-          />
-        </FieldGroup>
-
-        <FieldGroup
-          title="Courses"
-          hint="Link this assessment to one or more courses so it appears in the right catalogs."
-        >
-          <Autocomplete
-            multiple
-            options={courses}
-            getOptionLabel={(option: any) =>
-              option?.title ?? option?.name ?? `Course ${option?.id ?? ""}`
-            }
-            isOptionEqualToValue={(option: any, value: any) =>
-              option?.id === value?.id
-            }
-            value={courseIds
-              .map((id) => courses.find((c: any) => Number(c?.id) === Number(id)))
-              .filter(Boolean)}
-            onChange={(_, newValue: any[]) => {
-              onCourseIdsChange(newValue.map((c) => c.id));
-            }}
-            loading={loadingCourses}
-            disabled={readOnly || loadingCourses}
-            renderOption={(props, option: any) => (
-              <li {...props} key={option?.id != null ? option.id : props.id}>
-                {option?.title ?? option?.name ?? `Course ${option?.id}`}
-              </li>
-            )}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Courses (optional)"
-                placeholder="Search and select courses"
-                helperText="Select multiple courses. Click × on a chip to remove."
-                FormHelperTextProps={helperFormProps}
-              />
-            )}
-            renderTags={(value, getTagProps) =>
-              value.map((option, index) => (
-                <Chip
-                  label={option?.title ?? option?.name ?? `Course ${option?.id}`}
-                  {...getTagProps({ index })}
-                  key={option?.id ?? index}
-                  size="small"
-                  variant="outlined"
-                  sx={{
-                    borderColor:
-                      "color-mix(in srgb, var(--accent-indigo) 35%, var(--border-default) 65%)",
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 8%, var(--surface) 92%)",
-                  }}
-                  onDelete={getTagProps({ index }).onDelete}
+            <TextField
+              label="Duration (minutes)"
+              type="number"
+              value={durationMinutes === 0 ? "" : durationMinutes}
+              onChange={(e) => {
+                const v = e.target.value;
+                onDurationChange(v === "" ? 0 : Number(v));
+              }}
+              fullWidth
+              required
+              inputProps={{ min: 0 }}
+              disabled={readOnly}
+              helperText="Applies to the entire attempt. Section blocks can define their own time limits."
+              FormHelperTextProps={helperFormProps}
+            />
+            <Autocomplete
+              multiple
+              options={courses}
+              getOptionLabel={(option: any) =>
+                option?.title ?? option?.name ?? `Course ${option?.id ?? ""}`
+              }
+              isOptionEqualToValue={(option: any, value: any) =>
+                option?.id === value?.id
+              }
+              value={courseIds
+                .map((id) => courses.find((c: any) => Number(c?.id) === Number(id)))
+                .filter(Boolean)}
+              onChange={(_, newValue: any[]) => {
+                onCourseIdsChange(newValue.map((c) => c.id));
+              }}
+              loading={loadingCourses}
+              disabled={readOnly || loadingCourses}
+              renderOption={(props, option: any) => (
+                <li {...props} key={option?.id != null ? option.id : props.id}>
+                  {option?.title ?? option?.name ?? `Course ${option?.id}`}
+                </li>
+              )}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Courses (optional)"
+                  placeholder="Search and select courses"
+                  helperText="Select multiple courses. Click × on a chip to remove."
+                  FormHelperTextProps={helperFormProps}
                 />
-              ))
-            }
-          />
-        </FieldGroup>
+              )}
+              renderTags={(value, getTagProps) =>
+                value.map((option, index) => (
+                  <Chip
+                    label={option?.title ?? option?.name ?? `Course ${option?.id}`}
+                    {...getTagProps({ index })}
+                    key={option?.id ?? index}
+                    size="small"
+                    variant="outlined"
+                    sx={{
+                      borderColor:
+                        "color-mix(in srgb, var(--accent-indigo) 35%, var(--border-default) 65%)",
+                      bgcolor:
+                        "color-mix(in srgb, var(--accent-indigo) 8%, var(--surface) 92%)",
+                    }}
+                    onDelete={getTagProps({ index }).onDelete}
+                  />
+                ))
+              }
+            />
+          </Box>
 
-        <FieldGroup
-          title="Colleges"
-          hint="Restrict visibility by institution using free-form college names."
-        >
           <Autocomplete
             multiple
             freeSolo
@@ -677,535 +862,543 @@ export function AssessmentSettingsSection({
               ))
             }
           />
-        </FieldGroup>
 
-        <FieldGroup
-          title="Availability window (optional)"
-          hint="When set, learners only see start/end boundaries you define here. All times are interpreted in IST."
-        >
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
-              gap: 2,
-            }}
+          <FieldGroup
+            title="Availability window (optional)"
+            hint="When set, learners only see start/end boundaries you define here. All times are interpreted in IST."
           >
-            <DateTimePartsField
-              label="Start date & time (optional)"
-              value={startTime}
-              onChange={onStartTimeChange}
-              helperText="IST timezone"
-              disabled={readOnly}
-            />
-            <DateTimePartsField
-              label="End date & time (optional)"
-              value={endTime}
-              onChange={onEndTimeChange}
-              helperText="IST timezone"
-              disabled={readOnly}
-            />
-          </Box>
-        </FieldGroup>
-      </Box>
-
-      <Box
-        sx={{
-          borderTop: "1px solid",
-          borderColor:
-            "color-mix(in srgb, var(--accent-indigo) 20%, var(--border-default) 80%)",
-          bgcolor: "color-mix(in srgb, var(--surface) 76%, var(--card-bg) 24%)",
-        }}
-      >
-        <Box
-          sx={{
-            px: 2.25,
-            py: 1.75,
-            borderBottom: "1px solid",
-            borderColor: "var(--border-default)",
-            bgcolor: "var(--card-bg)",
-          }}
-        >
-          <Typography
-            id="assessment-policies-heading"
-            variant="subtitle2"
-            sx={{ fontWeight: 700, color: "var(--font-primary)", letterSpacing: 0.02 }}
-          >
-            Policies & learner experience
-          </Typography>
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ mt: 0.5, display: "block", lineHeight: 1.45 }}
-          >
-            These options apply to every learner for this assessment. Use the switches on the
-            right—each row is one policy.
-          </Typography>
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+                gap: 2,
+              }}
+            >
+              <DateTimePartsField
+                label="Start date & time (optional)"
+                value={startTime}
+                onChange={onStartTimeChange}
+                helperText="IST timezone"
+                disabled={readOnly}
+              />
+              <DateTimePartsField
+                label="End date & time (optional)"
+                value={endTime}
+                onChange={onEndTimeChange}
+                helperText="IST timezone"
+                disabled={readOnly}
+              />
+            </Box>
+          </FieldGroup>
         </Box>
+      </SettingsGroupCard>
 
-        <List dense disablePadding sx={{ py: 0, bgcolor: "color-mix(in srgb, var(--card-bg) 65%, var(--surface) 35%)" }}>
-            <ListSubheader component="div" disableSticky sx={listSubheaderSx}>
-              Billing
-            </ListSubheader>
-            <PolicySwitchRow
-              icon="mdi:cash-multiple"
-              title="Paid assessment"
-              subtitle="Charge learners before they can start. Opens price and currency below."
-              checked={isPaid}
-              onChange={onPaidChange}
-              disabled={readOnly}
-              accent="var(--success-500)"
-            />
-            <Collapse in={isPaid} timeout="auto" unmountOnExit>
-              <ListItem
-                sx={{
-                  display: "block",
-                  px: 2,
-                  py: 2,
-                  bgcolor: "var(--surface)",
-                  borderBottom: "1px solid",
-                  borderColor: "var(--border-default)",
-                }}
-              >
-                <Box
-                  sx={{
-                    display: "grid",
-                    gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
-                    gap: 2,
-                    maxWidth: 520,
-                    ml: { xs: 0, sm: 1 },
-                  }}
-                >
-                  <TextField
-                    label="Price"
-                    type="number"
-                    value={price}
-                    onChange={(e) => onPriceChange(e.target.value)}
-                    fullWidth
-                    required
-                    inputProps={{ min: 0, step: 0.01 }}
-                    helperText="Amount charged for access"
-                    FormHelperTextProps={helperFormProps}
-                    disabled={readOnly}
-                  />
-                  <FormControl fullWidth required>
-                    <InputLabel>Currency</InputLabel>
-                    <Select
-                      value={currency}
-                      onChange={(e) => onCurrencyChange(e.target.value)}
-                      label="Currency"
-                      disabled={readOnly}
-                    >
-                      <MenuItem value="INR">INR (₹)</MenuItem>
-                      <MenuItem value="USD">USD ($)</MenuItem>
-                      <MenuItem value="EUR">EUR (€)</MenuItem>
-                      <MenuItem value="GBP">GBP (£)</MenuItem>
-                      <MenuItem value="SAR">SAR (﷼)</MenuItem>
-                    </Select>
-                  </FormControl>
-                </Box>
-              </ListItem>
-            </Collapse>
-
-            <ListSubheader component="div" disableSticky sx={listSubheaderSx}>
-              {t("assessmentDevice.sectionTitle")}
-            </ListSubheader>
+      {/* ---- Billing & access --------------------------------------------- */}
+      <SettingsGroupCard
+        id="settings-billing"
+        icon="mdi:cash-multiple"
+        accent="var(--success-500)"
+        title="Billing & access"
+        summary={billingSummary}
+        open={billingOpen}
+        onToggle={() => setBillingOpen((v) => !v)}
+      >
+        <List dense disablePadding sx={{ py: 0 }}>
+          <PolicySwitchRow
+            icon="mdi:cash-multiple"
+            title="Paid assessment"
+            subtitle="Charge learners before they can start. Opens price and currency below."
+            checked={isPaid}
+            onChange={onPaidChange}
+            disabled={readOnly}
+            accent="var(--success-500)"
+          />
+          <Collapse in={isPaid} timeout="auto" unmountOnExit>
             <ListItem
               sx={{
                 display: "block",
-                py: 1.35,
                 px: 2,
+                py: 2,
                 bgcolor: "var(--surface)",
                 borderBottom: "1px solid",
                 borderColor: "var(--border-default)",
               }}
             >
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{ display: "block", lineHeight: 1.45 }}
-              >
-                {t("assessmentDevice.sectionIntro")}
-              </Typography>
-              <Typography
-                variant="caption"
-                color="text.secondary"
+              <Box
                 sx={{
-                  display: "block",
-                  mt: 0.75,
-                  fontWeight: 600,
-                  lineHeight: 1.45,
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+                  gap: 2,
+                  maxWidth: 520,
+                  ml: { xs: 0, sm: 1 },
                 }}
               >
-                {t("assessmentDevice.sectionHint")}
-              </Typography>
+                <TextField
+                  label="Price"
+                  type="number"
+                  value={price}
+                  onChange={(e) => onPriceChange(e.target.value)}
+                  fullWidth
+                  required
+                  inputProps={{ min: 0, step: 0.01 }}
+                  helperText="Amount charged for access"
+                  FormHelperTextProps={helperFormProps}
+                  disabled={readOnly}
+                />
+                <FormControl fullWidth required>
+                  <InputLabel>Currency</InputLabel>
+                  <Select
+                    value={currency}
+                    onChange={(e) => onCurrencyChange(e.target.value)}
+                    label="Currency"
+                    disabled={readOnly}
+                  >
+                    <MenuItem value="INR">INR (₹)</MenuItem>
+                    <MenuItem value="USD">USD ($)</MenuItem>
+                    <MenuItem value="EUR">EUR (€)</MenuItem>
+                    <MenuItem value="GBP">GBP (£)</MenuItem>
+                    <MenuItem value="SAR">SAR (﷼)</MenuItem>
+                  </Select>
+                </FormControl>
+              </Box>
             </ListItem>
-            <PolicySwitchRow
-              icon="mdi:monitor"
-              title={t("assessmentDevice.allowDesktop")}
-              subtitle={t("assessmentDevice.allowDesktopHint")}
-              checked={allowDesktop}
-              onChange={onAllowDesktopChange}
-              disabled={readOnly}
-            />
-            <PolicySwitchRow
-              icon="mdi:cellphone"
-              title={t("assessmentDevice.allowMobile")}
-              subtitle={t("assessmentDevice.allowMobileHint")}
-              checked={allowMobile}
-              onChange={onAllowMobileChange}
-              disabled={readOnly}
-            />
-            <PolicySwitchRow
-              icon="mdi:tablet"
-              title={t("assessmentDevice.allowTablet")}
-              subtitle={t("assessmentDevice.allowTabletHint")}
-              checked={allowTablet}
-              onChange={onAllowTabletChange}
-              disabled={readOnly}
-            />
+          </Collapse>
 
-            <ListSubheader component="div" disableSticky sx={listSubheaderSx}>
-              Session & integrity
-            </ListSubheader>
+          <ListSubheader component="div" disableSticky sx={listSubheaderSx}>
+            {t("assessmentDevice.sectionTitle")}
+          </ListSubheader>
+          <ListItem
+            sx={{
+              display: "block",
+              py: 1.1,
+              px: { xs: 1.5, sm: 1.75 },
+              bgcolor: "var(--surface)",
+              borderBottom: `1px solid ${softBorder}`,
+            }}
+          >
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "block", lineHeight: 1.45 }}
+            >
+              {t("assessmentDevice.sectionIntro")}
+            </Typography>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{
+                display: "block",
+                mt: 0.5,
+                fontWeight: 600,
+                lineHeight: 1.45,
+              }}
+            >
+              {t("assessmentDevice.sectionHint")}
+            </Typography>
+          </ListItem>
+          <PolicySwitchRow
+            icon="mdi:monitor"
+            title={t("assessmentDevice.allowDesktop")}
+            subtitle={t("assessmentDevice.allowDesktopHint")}
+            checked={allowDesktop}
+            onChange={onAllowDesktopChange}
+            disabled={readOnly}
+          />
+          <PolicySwitchRow
+            icon="mdi:cellphone"
+            title={t("assessmentDevice.allowMobile")}
+            subtitle={t("assessmentDevice.allowMobileHint")}
+            checked={allowMobile}
+            onChange={onAllowMobileChange}
+            disabled={readOnly}
+          />
+          <PolicySwitchRow
+            icon="mdi:tablet"
+            title={t("assessmentDevice.allowTablet")}
+            subtitle={t("assessmentDevice.allowTabletHint")}
+            checked={allowTablet}
+            onChange={onAllowTabletChange}
+            disabled={readOnly}
+          />
+        </List>
+      </SettingsGroupCard>
+
+      {/* ---- Session & integrity ------------------------------------------ */}
+      <SettingsGroupCard
+        id="settings-session"
+        icon="mdi:shield-check-outline"
+        accent="var(--tone-proctored)"
+        title="Session & integrity"
+        summary={sessionSummary}
+        open={sessionOpen}
+        onToggle={() => setSessionOpen((v) => !v)}
+      >
+        <List dense disablePadding sx={{ py: 0 }}>
+          <PolicySwitchRow
+            icon="mdi:calendar-check"
+            title="Active"
+            subtitle="Inactive assessments stay out of the catalog."
+            checked={isActive}
+            onChange={onActiveChange}
+            disabled={readOnly}
+          />
+          <PolicySwitchRow
+            icon="mdi:cctv"
+            title="Proctoring enabled"
+            subtitle="Camera and integrity checks during the attempt."
+            checked={proctoringEnabled ?? true}
+            onChange={onProctoringEnabledChange}
+            disabled={readOnly}
+            accent="var(--tone-proctored)"
+          />
+          {showLiveStreamingToggle && (
             <PolicySwitchRow
-              icon="mdi:calendar-check"
-              title="Active"
-              subtitle="Inactive assessments stay out of the catalog."
-              checked={isActive}
-              onChange={onActiveChange}
-              disabled={readOnly}
-            />
-            <PolicySwitchRow
-              icon="mdi:cctv"
-              title="Proctoring enabled"
-              subtitle="Camera and integrity checks during the attempt."
-              checked={proctoringEnabled ?? true}
-              onChange={onProctoringEnabledChange}
+              icon="mdi:video-wireless"
+              title="Live streaming"
+              subtitle="Allow live monitoring for this assessment."
+              checked={liveStreaming}
+              onChange={onLiveStreamingChange}
               disabled={readOnly}
               accent="var(--tone-proctored)"
             />
-            {showLiveStreamingToggle && (
-              <PolicySwitchRow
-                icon="mdi:video-wireless"
-                title="Live streaming"
-                subtitle="Allow live monitoring for this assessment."
-                checked={liveStreaming}
-                onChange={onLiveStreamingChange}
-                disabled={readOnly}
-                accent="var(--tone-proctored)"
-              />
-            )}
-
-            <ListSubheader component="div" disableSticky sx={listSubheaderSx}>
-              Notifications & results
-            </ListSubheader>
-            <PolicySwitchRow
-              icon="mdi:email-outline"
-              title="Send notification email to students"
-              subtitle="Email when this assessment is created."
-              checked={sendCommunication}
-              onChange={onSendCommunicationChange}
-              disabled={readOnly}
-              accent="var(--warning-500)"
-            />
-            {emailEditorMounted ? (
-              <Box
-                sx={{
-                  display: emailNotificationEnabled ? "block" : "none",
-                }}
-              >
-                <EmailNotificationEditor
-                  ref={emailEditorRef}
-                  initialSubject={defaultEmailSubject}
-                  initialBody={defaultEmailBody}
-                  initialAttachmentUrl={existingEmailAttachmentUrl}
-                  initialAttachmentName={existingEmailAttachmentName}
-                  schedule={emailSchedule}
-                  readOnly={readOnly}
-                  onEnabledChange={onEmailEnabledChange}
-                />
-
-                {/* Scheduled reminders — additive to the on-publish send. */}
-                <Box
-                  sx={{
-                    mt: 1.5,
-                    p: 1.75,
-                    borderRadius: 2,
-                    border: "1px solid var(--border-default)",
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 4%, var(--surface) 96%)",
-                  }}
-                >
-                  <FormControlLabel
-                    control={
-                      <Checkbox
-                        size="small"
-                        checked={emailRemindersEnabled}
-                        disabled={readOnly}
-                        onChange={(e) =>
-                          onEmailRemindersEnabledChange?.(e.target.checked)
-                        }
-                      />
-                    }
-                    label={
-                      <Box>
-                        <Typography
-                          sx={{ fontWeight: 700, fontSize: "0.9rem", color: "var(--font-primary)" }}
-                        >
-                          Send reminder emails before it starts
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          Automatically re-sends this email at the times you pick before the start
-                          time. The announcement on publish is still sent.
-                        </Typography>
-                      </Box>
-                    }
-                  />
-
-                  {emailRemindersEnabled ? (
-                    <Box
-                      sx={{
-                        mt: 1,
-                        pl: 3.5,
-                        display: "flex",
-                        flexWrap: "wrap",
-                        gap: 0.5,
-                      }}
-                    >
-                      {REMINDER_OFFSET_OPTIONS.map((opt) => {
-                        const checked = emailReminderOffsets.includes(opt.minutes);
-                        return (
-                          <FormControlLabel
-                            key={opt.minutes}
-                            sx={{ minWidth: 150 }}
-                            control={
-                              <Checkbox
-                                size="small"
-                                checked={checked}
-                                disabled={readOnly}
-                                onChange={(e) => {
-                                  const next = e.target.checked
-                                    ? [...emailReminderOffsets, opt.minutes]
-                                    : emailReminderOffsets.filter((m) => m !== opt.minutes);
-                                  // keep sorted + de-duped so the payload is stable
-                                  onEmailReminderOffsetsChange?.(
-                                    Array.from(new Set(next)).sort((a, b) => a - b)
-                                  );
-                                }}
-                              />
-                            }
-                            label={
-                              <Typography sx={{ fontSize: "0.85rem" }}>{opt.label}</Typography>
-                            }
-                          />
-                        );
-                      })}
-                      {emailReminderOffsets.length === 0 ? (
-                        <Typography
-                          variant="caption"
-                          sx={{ display: "block", width: "100%", color: "var(--warning-500)", pl: 0.5 }}
-                        >
-                          Pick at least one time, or no reminder will be sent.
-                        </Typography>
-                      ) : null}
-                    </Box>
-                  ) : null}
-                </Box>
-              </Box>
-            ) : null}
+          )}
+          <PolicySwitchRow
+            icon="mdi:swap-horizontal"
+            title="Allow movement across sections"
+            subtitle="Learners can revisit other blocks (e.g. quiz ↔ coding) when on."
+            checked={allowMovementAcrossSections}
+            onChange={onAllowMovementAcrossSectionsChange}
+            disabled={readOnly}
+            accent="var(--ai-violet)"
+          />
+          <PolicySwitchRow
+            icon="mdi:tab"
+            title="Auto-submit on tab switches"
+            subtitle="When enabled, attempt is auto-submitted once tab switch count reaches the configured limit."
+            checked={tabSwitchLimitEnabled}
+            onChange={onTabSwitchLimitEnabledChange}
+            disabled={readOnly}
+            accent="var(--warning-500)"
+          />
+          <Collapse in={tabSwitchLimitEnabled} timeout="auto" unmountOnExit>
             <ListItem
               sx={{
-                py: 1.35,
+                display: "block",
                 px: 2,
+                py: 2,
+                bgcolor: "var(--surface)",
                 borderBottom: "1px solid",
                 borderColor: "var(--border-default)",
               }}
             >
-              <ListItemIcon sx={{ minWidth: 48, mt: 0.15 }}>
-                <Box
-                  sx={{
-                    width: 40,
-                    height: 40,
-                    borderRadius: 1.5,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    bgcolor:
-                      "color-mix(in srgb, var(--accent-indigo) 10%, var(--surface) 90%)",
-                    border:
-                      "1px solid color-mix(in srgb, var(--accent-indigo) 24%, var(--border-default) 76%)",
-                  }}
-                >
-                  <IconWrapper icon="mdi:clipboard-check-outline" size={22} color="var(--accent-indigo)" />
-                </Box>
-              </ListItemIcon>
-              <ListItemText
-                primary="Evaluation mode"
-                secondary="Manual mode requires admins to evaluate and publish results."
-                primaryTypographyProps={{ variant: "body2", sx: { fontWeight: 600, color: "var(--font-primary)", pr: 1 } }}
-                secondaryTypographyProps={{ variant: "caption", sx: { display: "block", mt: 0.35, color: "text.secondary", lineHeight: 1.45 } }}
+              <TextField
+                label="Allowed tab switches"
+                type="number"
+                value={tabSwitchLimitCount > 0 ? tabSwitchLimitCount : ""}
+                onChange={(e) => onTabSwitchLimitCountChange(Number(e.target.value || 0))}
+                fullWidth
+                required
+                inputProps={{ min: 1 }}
+                helperText="Attempt auto-submits immediately when this count is reached."
+                FormHelperTextProps={helperFormProps}
+                disabled={readOnly}
               />
-              <FormControl size="small" sx={{ minWidth: 140 }}>
-                <Select
-                  value={evaluationMode}
-                  disabled={readOnly}
-                  onChange={(e) => onEvaluationModeChange(e.target.value as "auto" | "manual")}
-                >
-                  <MenuItem value="auto">Auto (AI)</MenuItem>
-                  <MenuItem value="manual">Manual</MenuItem>
-                </Select>
-              </FormControl>
             </ListItem>
-            <PolicySwitchRow
-              icon="mdi:chart-box-outline"
-              title="Show results to students"
-              subtitle="When off, learners see an evaluation-in-progress message instead of scores."
-              checked={showResult}
-              onChange={onShowResultChange}
-              disabled={readOnly || evaluationMode === "manual"}
-            />
-            <PolicySwitchRow
-              icon="mdi:swap-horizontal"
-              title="Allow movement across sections"
-              subtitle="Learners can revisit other blocks (e.g. quiz ↔ coding) when on."
-              checked={allowMovementAcrossSections}
-              onChange={onAllowMovementAcrossSectionsChange}
-              disabled={readOnly}
-              accent="var(--ai-violet)"
-            />
-            <PolicySwitchRow
-              icon="mdi:tab"
-              title="Auto-submit on tab switches"
-              subtitle="When enabled, attempt is auto-submitted once tab switch count reaches the configured limit."
-              checked={tabSwitchLimitEnabled}
-              onChange={onTabSwitchLimitEnabledChange}
-              disabled={readOnly}
-              accent="var(--warning-500)"
-            />
-            <Collapse in={tabSwitchLimitEnabled} timeout="auto" unmountOnExit>
-              <ListItem
+          </Collapse>
+        </List>
+      </SettingsGroupCard>
+
+      {/* ---- Results & certificates --------------------------------------- */}
+      <SettingsGroupCard
+        id="settings-results"
+        icon="mdi:certificate"
+        accent="var(--ai-violet)"
+        title="Results & certificates"
+        summary={resultsSummary}
+        open={resultsOpen}
+        onToggle={() => setResultsOpen((v) => !v)}
+      >
+        <List dense disablePadding sx={{ py: 0 }}>
+          <ListItem
+            sx={{
+              py: 1.15,
+              px: { xs: 1.5, sm: 1.75 },
+              borderBottom: `1px solid ${softBorder}`,
+            }}
+          >
+            <ListItemIcon sx={{ minWidth: 46, mt: 0.15 }}>
+              <Box
                 sx={{
-                  display: "block",
-                  px: 2,
-                  py: 2,
-                  bgcolor: "var(--surface)",
-                  borderBottom: "1px solid",
-                  borderColor: "var(--border-default)",
+                  width: 36,
+                  height: 36,
+                  borderRadius: 2,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  bgcolor:
+                    "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+                }}
+              >
+                <IconWrapper icon="mdi:clipboard-check-outline" size={19} color="var(--accent-indigo)" />
+              </Box>
+            </ListItemIcon>
+            <ListItemText
+              primary="Evaluation mode"
+              secondary="Manual mode requires admins to evaluate and publish results."
+              primaryTypographyProps={{
+                variant: "body2",
+                sx: { fontWeight: 700, color: "var(--font-primary)", pr: 1, fontSize: "0.9rem" },
+              }}
+              secondaryTypographyProps={{
+                variant: "caption",
+                sx: { display: "block", mt: 0.25, color: "text.secondary", lineHeight: 1.4 },
+              }}
+            />
+            <FormControl size="small" sx={{ minWidth: 140 }}>
+              <Select
+                value={evaluationMode}
+                disabled={readOnly}
+                onChange={(e) => onEvaluationModeChange(e.target.value as "auto" | "manual")}
+              >
+                <MenuItem value="auto">Auto (AI)</MenuItem>
+                <MenuItem value="manual">Manual</MenuItem>
+              </Select>
+            </FormControl>
+          </ListItem>
+          <PolicySwitchRow
+            icon="mdi:chart-box-outline"
+            title="Show results to students"
+            subtitle="When off, learners see an evaluation-in-progress message instead of scores."
+            checked={showResult}
+            onChange={onShowResultChange}
+            disabled={readOnly || evaluationMode === "manual"}
+          />
+          <PolicySwitchRow
+            icon="mdi:certificate"
+            title="Certificate available"
+            subtitle="When on, set pass-band thresholds below for tiered certificates."
+            checked={certificateAvailable}
+            onChange={onCertificateAvailableChange}
+            disabled={readOnly}
+            accent="var(--ai-violet)"
+          />
+          <Collapse in={certificateAvailable} timeout="auto" unmountOnExit>
+            <ListItem
+              sx={{
+                display: "block",
+                alignItems: "stretch",
+                py: 2,
+                px: 2,
+                bgcolor:
+                  "color-mix(in srgb, var(--accent-indigo) 8%, var(--surface) 92%)",
+                borderTop: "1px solid",
+                borderColor:
+                  "color-mix(in srgb, var(--accent-indigo) 20%, var(--border-default) 80%)",
+              }}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  mb: 1.5,
+                }}
+              >
+                <IconWrapper icon="mdi:percent" size={20} color="var(--accent-indigo-dark)" />
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontWeight: 700, color: "var(--font-primary)" }}
+                >
+                  Pass band thresholds
+                </Typography>
+              </Box>
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ display: "block", mb: 2, lineHeight: 1.45 }}
+              >
+                Overall score percentages (0–100). Lower must be less than or equal
+                to upper.
+              </Typography>
+              <Box
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+                  gap: 2,
                 }}
               >
                 <TextField
-                  label="Allowed tab switches"
-                  type="number"
-                  value={tabSwitchLimitCount > 0 ? tabSwitchLimitCount : ""}
-                  onChange={(e) => onTabSwitchLimitCountChange(Number(e.target.value || 0))}
+                  label="Lower threshold (%)"
+                  value={passBandLowerPercent}
+                  onChange={(e) => onPassBandLowerPercentChange(e.target.value)}
                   fullWidth
-                  required
-                  inputProps={{ min: 1 }}
-                  helperText="Attempt auto-submits immediately when this count is reached."
-                  FormHelperTextProps={helperFormProps}
                   disabled={readOnly}
+                  required
+                  placeholder="e.g. 50"
+                  error={Boolean(passBandLowerError)}
+                  helperText={passBandLowerError || " "}
+                  FormHelperTextProps={
+                    passBandLowerError
+                      ? { sx: { fontSize: "0.8125rem", lineHeight: 1.45, mt: 0.5 } }
+                      : helperFormProps
+                  }
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ bgcolor: "background.paper" }}
                 />
-              </ListItem>
-            </Collapse>
+                <TextField
+                  label="Upper threshold (%)"
+                  value={passBandUpperPercent}
+                  onChange={(e) => onPassBandUpperPercentChange(e.target.value)}
+                  fullWidth
+                  disabled={readOnly}
+                  required
+                  placeholder="e.g. 80"
+                  error={Boolean(passBandUpperError)}
+                  helperText={passBandUpperError || " "}
+                  FormHelperTextProps={
+                    passBandUpperError
+                      ? { sx: { fontSize: "0.8125rem", lineHeight: 1.45, mt: 0.5 } }
+                      : helperFormProps
+                  }
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ bgcolor: "background.paper" }}
+                />
+              </Box>
+            </ListItem>
+          </Collapse>
+        </List>
+      </SettingsGroupCard>
 
-            <ListSubheader component="div" disableSticky sx={listSubheaderSx}>
-              Certificates
-            </ListSubheader>
-            <PolicySwitchRow
-              icon="mdi:certificate"
-              title="Certificate available"
-              subtitle="When on, set pass-band thresholds below for tiered certificates."
-              checked={certificateAvailable}
-              onChange={onCertificateAvailableChange}
-              disabled={readOnly}
-              accent="var(--ai-violet)"
+      {/* ---- Notifications ------------------------------------------------ */}
+      <SettingsGroupCard
+        id="settings-notifications"
+        icon="mdi:email-outline"
+        accent="var(--warning-500)"
+        title="Notifications"
+        summary={notificationsSummary}
+        open={notificationsOpen}
+        onToggle={() => setNotificationsOpen((v) => !v)}
+      >
+        <List dense disablePadding sx={{ py: 0 }}>
+          <PolicySwitchRow
+            icon="mdi:email-outline"
+            title="Send notification email to students"
+            subtitle="Email when this assessment is created."
+            checked={sendCommunication}
+            onChange={onSendCommunicationChange}
+            disabled={readOnly}
+            accent="var(--warning-500)"
+          />
+        </List>
+        {emailEditorMounted ? (
+          <Box
+            sx={{
+              display: emailNotificationEnabled ? "block" : "none",
+              px: { xs: 1.5, sm: 2 },
+              pt: 1,
+              pb: 2,
+            }}
+          >
+            <EmailNotificationEditor
+              ref={emailEditorRef}
+              initialSubject={defaultEmailSubject}
+              initialBody={defaultEmailBody}
+              initialAttachmentUrl={existingEmailAttachmentUrl}
+              initialAttachmentName={existingEmailAttachmentName}
+              schedule={emailSchedule}
+              readOnly={readOnly}
+              onEnabledChange={onEmailEnabledChange}
             />
-            <Collapse in={certificateAvailable} timeout="auto" unmountOnExit>
-              <ListItem
-                sx={{
-                  display: "block",
-                  alignItems: "stretch",
-                  py: 2,
-                  px: 2,
-                  bgcolor:
-                    "color-mix(in srgb, var(--accent-indigo) 8%, var(--surface) 92%)",
-                  borderTop: "1px solid",
-                  borderColor:
-                    "color-mix(in srgb, var(--accent-indigo) 20%, var(--border-default) 80%)",
-                }}
-              >
+
+            {/* Scheduled reminders — additive to the on-publish send. */}
+            <Box
+              sx={{
+                mt: 1.5,
+                p: 1.75,
+                borderRadius: 2,
+                border: "1px solid var(--border-default)",
+                bgcolor:
+                  "color-mix(in srgb, var(--accent-indigo) 4%, var(--surface) 96%)",
+              }}
+            >
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    size="small"
+                    checked={emailRemindersEnabled}
+                    disabled={readOnly}
+                    onChange={(e) =>
+                      onEmailRemindersEnabledChange?.(e.target.checked)
+                    }
+                  />
+                }
+                label={
+                  <Box>
+                    <Typography
+                      sx={{ fontWeight: 700, fontSize: "0.9rem", color: "var(--font-primary)" }}
+                    >
+                      Send reminder emails before it starts
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Automatically re-sends this email at the times you pick before the start
+                      time. The announcement on publish is still sent.
+                    </Typography>
+                  </Box>
+                }
+              />
+
+              {emailRemindersEnabled ? (
                 <Box
                   sx={{
+                    mt: 1,
+                    pl: 3.5,
                     display: "flex",
-                    alignItems: "center",
-                    gap: 1,
-                    mb: 1.5,
+                    flexWrap: "wrap",
+                    gap: 0.5,
                   }}
                 >
-                  <IconWrapper icon="mdi:percent" size={20} color="var(--accent-indigo-dark)" />
-                  <Typography
-                    variant="subtitle2"
-                    sx={{ fontWeight: 700, color: "var(--font-primary)" }}
-                  >
-                    Pass band thresholds
-                  </Typography>
+                  {REMINDER_OFFSET_OPTIONS.map((opt) => {
+                    const checked = emailReminderOffsets.includes(opt.minutes);
+                    return (
+                      <FormControlLabel
+                        key={opt.minutes}
+                        sx={{ minWidth: 150 }}
+                        control={
+                          <Checkbox
+                            size="small"
+                            checked={checked}
+                            disabled={readOnly}
+                            onChange={(e) => {
+                              const next = e.target.checked
+                                ? [...emailReminderOffsets, opt.minutes]
+                                : emailReminderOffsets.filter((m) => m !== opt.minutes);
+                              // keep sorted + de-duped so the payload is stable
+                              onEmailReminderOffsetsChange?.(
+                                Array.from(new Set(next)).sort((a, b) => a - b)
+                              );
+                            }}
+                          />
+                        }
+                        label={
+                          <Typography sx={{ fontSize: "0.85rem" }}>{opt.label}</Typography>
+                        }
+                      />
+                    );
+                  })}
+                  {emailReminderOffsets.length === 0 ? (
+                    <Typography
+                      variant="caption"
+                      sx={{ display: "block", width: "100%", color: "var(--warning-500)", pl: 0.5 }}
+                    >
+                      Pick at least one time, or no reminder will be sent.
+                    </Typography>
+                  ) : null}
                 </Box>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ display: "block", mb: 2, lineHeight: 1.45 }}
-                >
-                  Overall score percentages (0–100). Lower must be less than or equal
-                  to upper.
-                </Typography>
-                <Box
-                  sx={{
-                    display: "grid",
-                    gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
-                    gap: 2,
-                  }}
-                >
-                  <TextField
-                    label="Lower threshold (%)"
-                    value={passBandLowerPercent}
-                    onChange={(e) => onPassBandLowerPercentChange(e.target.value)}
-                    fullWidth
-                    disabled={readOnly}
-                    required
-                    placeholder="e.g. 50"
-                    error={Boolean(passBandLowerError)}
-                    helperText={passBandLowerError || " "}
-                    FormHelperTextProps={
-                      passBandLowerError
-                        ? { sx: { fontSize: "0.8125rem", lineHeight: 1.45, mt: 0.5 } }
-                        : helperFormProps
-                    }
-                    InputLabelProps={{ shrink: true }}
-                    sx={{ bgcolor: "background.paper" }}
-                  />
-                  <TextField
-                    label="Upper threshold (%)"
-                    value={passBandUpperPercent}
-                    onChange={(e) => onPassBandUpperPercentChange(e.target.value)}
-                    fullWidth
-                    disabled={readOnly}
-                    required
-                    placeholder="e.g. 80"
-                    error={Boolean(passBandUpperError)}
-                    helperText={passBandUpperError || " "}
-                    FormHelperTextProps={
-                      passBandUpperError
-                        ? { sx: { fontSize: "0.8125rem", lineHeight: 1.45, mt: 0.5 } }
-                        : helperFormProps
-                    }
-                    InputLabelProps={{ shrink: true }}
-                    sx={{ bgcolor: "background.paper" }}
-                  />
-                </Box>
-              </ListItem>
-            </Collapse>
-          </List>
-      </Box>
-    </Paper>
+              ) : null}
+            </Box>
+          </Box>
+        ) : null}
+      </SettingsGroupCard>
+    </Box>
   );
 }

--- a/components/admin/assessment/CodingProblemSelectionSection.tsx
+++ b/components/admin/assessment/CodingProblemSelectionSection.tsx
@@ -7,8 +7,12 @@ import {
   Checkbox,
   CircularProgress,
   TextField,
+  Chip,
   Pagination,
+  Select,
+  MenuItem,
   IconButton,
+  Button,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -19,11 +23,12 @@ import { CodingProblemListItem } from "@/lib/services/admin/admin-assessment.ser
 import { ProblemDescription } from "@/components/coding/ProblemDescription";
 import { DifficultyChip } from "@/components/admin/assessment/shared";
 import {
-  FacetBar,
   FacetState,
   EMPTY_FACETS,
   applyFacets,
   deriveFacetOptions,
+  hasActiveFacets,
+  SOURCE_LABELS,
   SourceChip,
   UsageChip,
   TagChips,
@@ -64,27 +69,235 @@ const SEARCH_FIELD_SX = {
   "& .MuiInputLabel-root.Mui-focused": { color: "var(--ai-violet)" },
 } as const;
 
-/** Soft result-row card; selected = violet ring + tint (style contract). */
-const rowCardSx = (selected: boolean) => ({
-  display: "flex",
-  alignItems: "flex-start",
-  gap: 1,
-  px: 1.5,
-  py: 1.5,
-  borderRadius: "12px",
+/** Hairline separator between rows (no heavy borders). */
+const HAIRLINE = "1px solid color-mix(in srgb, var(--border-default) 45%, transparent)";
+
+/** Compact toolbar dropdown: token border, violet focus, no floating label. */
+const TOOLBAR_SELECT_SX = {
+  borderRadius: "10px",
+  fontSize: "0.8rem",
+  bgcolor: "var(--card-bg)",
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderColor: "color-mix(in srgb, var(--border-default) 70%, transparent)",
+  },
+  "&:hover .MuiOutlinedInput-notchedOutline": {
+    borderColor: "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+  },
+  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    borderColor: "var(--ai-violet)",
+  },
+} as const;
+
+/** Active-facet chip — wraps below the toolbar only when a filter is active. */
+const ACTIVE_CHIP_SX = {
+  height: 24,
+  fontSize: "0.72rem",
+  fontWeight: 600,
+  bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+  color: "var(--accent-indigo)",
+  "& .MuiChip-deleteIcon": {
+    color: "color-mix(in srgb, var(--accent-indigo) 70%, transparent)",
+    "&:hover": { color: "var(--accent-indigo)" },
+  },
+} as const;
+
+/** Token pagination (replaces the MUI default blue). */
+const PAGINATION_SX = {
+  "& .MuiPaginationItem-root": {
+    fontSize: { xs: "0.75rem", sm: "0.875rem" },
+    "&.Mui-selected": {
+      bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
+      color: "var(--ai-violet)",
+      fontWeight: 700,
+      "&:hover": {
+        bgcolor: "color-mix(in srgb, var(--ai-violet) 18%, var(--card-bg) 82%)",
+      },
+    },
+  },
+} as const;
+
+/** Flat result row: hairline separators; selected = soft violet tint + inset ring. */
+const rowShellSx = (selected: boolean) => ({
   bgcolor: selected
-    ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
-    : "var(--card-bg)",
-  border: selected
-    ? "1.5px solid var(--ai-violet)"
-    : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
-  transition: "border-color 0.15s ease, background-color 0.15s ease",
+    ? "color-mix(in srgb, var(--ai-violet) 6%, var(--card-bg) 94%)"
+    : "transparent",
+  boxShadow: selected
+    ? "inset 0 0 0 1.5px color-mix(in srgb, var(--ai-violet) 40%, transparent)"
+    : "none",
+  transition: "background-color 0.15s ease, box-shadow 0.15s ease",
+  "&:not(:last-child)": { borderBottom: HAIRLINE },
   "&:hover": {
-    borderColor: selected
-      ? "var(--ai-violet)"
-      : "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+    bgcolor: selected
+      ? "color-mix(in srgb, var(--ai-violet) 9%, var(--card-bg) 91%)"
+      : "color-mix(in srgb, var(--surface) 65%, var(--card-bg) 35%)",
   },
 });
+
+const DIFFICULTY_OPTIONS = ["Easy", "Medium", "Hard"] as const;
+const SOURCE_OPTIONS = ["manual", "ai_generated", "csv_import", "course_builder"] as const;
+
+/** Compact single-value facet dropdown for the toolbar row. */
+function FacetSelect({
+  placeholder,
+  allLabel,
+  value,
+  options,
+  onChange,
+  getLabel,
+}: {
+  placeholder: string;
+  allLabel: string;
+  value: string;
+  options: readonly string[];
+  onChange: (next: string) => void;
+  getLabel?: (v: string) => string;
+}) {
+  const label = getLabel ?? ((v: string) => v);
+  return (
+    <Select
+      size="small"
+      displayEmpty
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      renderValue={(v) =>
+        v ? (
+          <span style={{ fontWeight: 600 }}>{label(v)}</span>
+        ) : (
+          <span style={{ color: "var(--font-tertiary)" }}>{placeholder}</span>
+        )
+      }
+      sx={TOOLBAR_SELECT_SX}
+      MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+    >
+      <MenuItem value="" sx={{ fontSize: "0.85rem" }}>
+        {allLabel}
+      </MenuItem>
+      {options.map((o) => (
+        <MenuItem key={o} value={o} sx={{ fontSize: "0.85rem" }}>
+          {label(o)}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+/** Compact multi-value facet dropdown (Topic/Skill/Tag); hidden when no options. */
+function FacetMultiSelect({
+  placeholder,
+  value,
+  options,
+  onChange,
+}: {
+  placeholder: string;
+  value: string[];
+  options: string[];
+  onChange: (next: string[]) => void;
+}) {
+  if (options.length === 0) return null;
+  return (
+    <Select
+      multiple
+      size="small"
+      displayEmpty
+      value={value}
+      onChange={(e) => {
+        const next = e.target.value;
+        onChange(typeof next === "string" ? next.split(",") : next);
+      }}
+      renderValue={(v) =>
+        v.length ? (
+          <span style={{ fontWeight: 600 }}>{`${placeholder} · ${v.length}`}</span>
+        ) : (
+          <span style={{ color: "var(--font-tertiary)" }}>{placeholder}</span>
+        )
+      }
+      sx={TOOLBAR_SELECT_SX}
+      MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+    >
+      {options.map((o) => (
+        <MenuItem key={o} value={o} sx={{ fontSize: "0.85rem", gap: 1 }}>
+          <Checkbox size="small" checked={value.includes(o)} sx={{ ...CHECKBOX_SX, p: 0 }} />
+          {o}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+/** Active filters as deletable chips — rendered below the toolbar only when active. */
+function ActiveFacetChips({
+  facets,
+  onChange,
+}: {
+  facets: FacetState;
+  onChange: (next: FacetState) => void;
+}) {
+  if (!hasActiveFacets(facets)) return null;
+  const chips: { key: string; label: string; clear: () => void }[] = [];
+  if (facets.difficulty) {
+    chips.push({
+      key: "difficulty",
+      label: facets.difficulty,
+      clear: () => onChange({ ...facets, difficulty: "" }),
+    });
+  }
+  if (facets.source) {
+    chips.push({
+      key: "source",
+      label: SOURCE_LABELS[facets.source] || facets.source,
+      clear: () => onChange({ ...facets, source: "" }),
+    });
+  }
+  if (facets.reusedOnly) {
+    chips.push({
+      key: "reused",
+      label: "Reused only",
+      clear: () => onChange({ ...facets, reusedOnly: false }),
+    });
+  }
+  for (const t of facets.topics) {
+    chips.push({
+      key: `topic:${t}`,
+      label: t,
+      clear: () => onChange({ ...facets, topics: facets.topics.filter((x) => x !== t) }),
+    });
+  }
+  for (const s of facets.skills) {
+    chips.push({
+      key: `skill:${s}`,
+      label: s,
+      clear: () => onChange({ ...facets, skills: facets.skills.filter((x) => x !== s) }),
+    });
+  }
+  for (const g of facets.tags) {
+    chips.push({
+      key: `tag:${g}`,
+      label: g,
+      clear: () => onChange({ ...facets, tags: facets.tags.filter((x) => x !== g) }),
+    });
+  }
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 0.75, px: 2, pb: 1.5 }}>
+      {chips.map((c) => (
+        <Chip key={c.key} label={c.label} size="small" onDelete={c.clear} sx={ACTIVE_CHIP_SX} />
+      ))}
+      <Button
+        size="small"
+        variant="text"
+        startIcon={<IconWrapper icon="mdi:filter-remove-outline" size={15} />}
+        onClick={() => onChange(EMPTY_FACETS)}
+        sx={{
+          fontSize: "0.72rem",
+          fontWeight: 600,
+          textTransform: "none",
+          color: "var(--font-secondary)",
+        }}
+      >
+        Clear all
+      </Button>
+    </Box>
+  );
+}
 
 interface CodingProblemSelectionSectionProps {
   selectedIds: number[];
@@ -104,6 +317,7 @@ export function CodingProblemSelectionSection({
   const [limit, setLimit] = useState(10);
   const [facets, setFacets] = useState<FacetState>(EMPTY_FACETS);
   const [previewProblem, setPreviewProblem] = useState<CodingProblemListItem | null>(null);
+  const [expandedIds, setExpandedIds] = useState<number[]>([]);
   const facetOptions = useMemo(() => deriveFacetOptions(codingProblems), [codingProblems]);
 
   const problemDataForPreview = (problem: CodingProblemListItem) => {
@@ -167,6 +381,17 @@ export function CodingProblemSelectionSection({
 
   const isAllSelected = paginatedProblems.length > 0 && paginatedProblems.every((problem) => selectedIds.includes(problem.id));
 
+  /** Facet changes always reset to page 1 (same behavior as the old FacetBar wiring). */
+  const updateFacets = (next: FacetState) => {
+    setFacets(next);
+    setPage(1);
+  };
+
+  const toggleExpanded = (id: number) =>
+    setExpandedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
@@ -177,277 +402,338 @@ export function CodingProblemSelectionSection({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          flexWrap: "wrap",
-          gap: 2,
-        }}
-      >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-          <Box
-            sx={{
-              width: 40,
-              height: 40,
-              borderRadius: 2,
-              flexShrink: 0,
-              display: "grid",
-              placeItems: "center",
-              bgcolor:
-                "color-mix(in srgb, var(--success-500) 12%, var(--card-bg) 88%)",
-            }}
-          >
-            <IconWrapper
-              icon="mdi:code-braces"
-              size={21}
-              color="var(--success-500)"
-            />
-          </Box>
-          <Box>
-            <Typography sx={KICKER_SX}>Problem bank</Typography>
-            <Typography
-              sx={{
-                fontFamily: "var(--font-jakarta)",
-                fontWeight: 800,
-                fontSize: "1.05rem",
-                color: "var(--font-primary)",
-                lineHeight: 1.3,
-              }}
-            >
-              Select from Existing Coding Problems
-            </Typography>
-          </Box>
-        </Box>
-        {selectedIds.length > 0 && (
-          <Box
-            sx={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 0.75,
-              px: 1.5,
-              py: 0.75,
-              borderRadius: 999,
-              bgcolor:
-                "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
-              border:
-                "1px solid color-mix(in srgb, var(--ai-violet) 35%, transparent)",
-            }}
-          >
-            <IconWrapper
-              icon="mdi:check-circle-outline"
-              size={15}
-              color="var(--ai-violet)"
-            />
-            <Typography
-              variant="body2"
-              sx={{ fontWeight: 600, color: "var(--ai-violet)" }}
-            >
-              Selected: {selectedIds.length} Problem(s) | Showing: {filteredProblems.length} of {codingProblems.length} total
-            </Typography>
-          </Box>
-        )}
-      </Box>
-
-      {/* Search + facet filters grouped in one card */}
-      <Box sx={{ ...CARD_SX, p: { xs: 2, sm: 2.5 } }}>
-        <Typography sx={{ ...KICKER_SX, mb: 1.5 }}>Search & filters</Typography>
-        <TextField
-          label="Search Coding Problems"
-          value={searchTerm}
-          onChange={(e) => {
-            setSearchTerm(e.target.value);
-            setPage(1);
+      {/* Slim section header */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Box
+          sx={{
+            width: 36,
+            height: 36,
+            borderRadius: 2,
+            flexShrink: 0,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: "color-mix(in srgb, var(--success-500) 12%, var(--card-bg) 88%)",
           }}
-          fullWidth
-          size="small"
-          InputProps={{
-            startAdornment: (
-              <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
-            ),
-          }}
-          sx={SEARCH_FIELD_SX}
-        />
-        <Box sx={{ mt: 2 }}>
-          <FacetBar
-            facets={facets}
-            options={facetOptions}
-            onChange={(next) => {
-              setFacets(next);
-              setPage(1);
-            }}
-          />
+        >
+          <IconWrapper icon="mdi:code-braces" size={19} color="var(--success-500)" />
         </Box>
-      </Box>
-
-      {filteredProblems.length === 0 ? (
-        <Box sx={{ ...CARD_SX, p: 4, textAlign: "center" }}>
-          <Box
+        <Box>
+          <Typography sx={KICKER_SX}>Problem bank</Typography>
+          <Typography
             sx={{
-              width: 44,
-              height: 44,
-              borderRadius: 2,
-              display: "grid",
-              placeItems: "center",
-              mx: "auto",
-              mb: 1.5,
-              bgcolor:
-                "color-mix(in srgb, var(--success-500) 12%, var(--card-bg) 88%)",
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: "1.02rem",
+              color: "var(--font-primary)",
+              lineHeight: 1.3,
             }}
           >
-            <IconWrapper icon="mdi:magnify" size={22} color="var(--success-500)" />
-          </Box>
-          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-            {searchTerm
-              ? "No coding problems found matching your search"
-              : "No coding problems available. Please add coding problems first."}
+            Select from Existing Coding Problems
           </Typography>
         </Box>
-      ) : (
-        <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
-          {/* Select-all header */}
+      </Box>
+
+      {/* Single results card: compact toolbar header + rows + pagination */}
+      <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
+        {/* One compact toolbar row: search + facet dropdowns + selected-count chip */}
+        <Box sx={{ borderBottom: HAIRLINE }}>
           <Box
             sx={{
               display: "flex",
               alignItems: "center",
-              gap: 0.5,
+              flexWrap: "wrap",
+              gap: 1,
               px: 2,
-              py: 0.75,
-              borderBottom: "1px solid var(--border-default)",
-              bgcolor: "var(--surface)",
+              py: 1.5,
             }}
           >
-            <Checkbox
-              checked={isAllSelected}
-              indeterminate={
-                selectedIds.length > 0 && !isAllSelected
-              }
-              onChange={handleSelectAll}
-              sx={CHECKBOX_SX}
+            <TextField
+              label="Search Coding Problems"
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                setPage(1);
+              }}
+              size="small"
+              InputProps={{
+                startAdornment: (
+                  <IconWrapper icon="mdi:magnify" size={18} style={{ marginRight: 8 }} />
+                ),
+              }}
+              sx={{ ...SEARCH_FIELD_SX, flex: "1 1 220px", minWidth: 200 }}
             />
-            <Typography sx={KICKER_SX}>Select all on page</Typography>
-            <Box sx={{ flexGrow: 1 }} />
-            <Typography
-              variant="caption"
+            <FacetSelect
+              placeholder="Difficulty"
+              allLabel="All difficulties"
+              value={facets.difficulty}
+              options={DIFFICULTY_OPTIONS}
+              onChange={(difficulty) => updateFacets({ ...facets, difficulty })}
+            />
+            <FacetSelect
+              placeholder="Source"
+              allLabel="All sources"
+              value={facets.source}
+              options={SOURCE_OPTIONS}
+              getLabel={(s) => SOURCE_LABELS[s] || s}
+              onChange={(source) => updateFacets({ ...facets, source })}
+            />
+            <FacetMultiSelect
+              placeholder="Topic"
+              value={facets.topics}
+              options={facetOptions.topics}
+              onChange={(topics) => updateFacets({ ...facets, topics })}
+            />
+            <FacetMultiSelect
+              placeholder="Skill"
+              value={facets.skills}
+              options={facetOptions.skills}
+              onChange={(skills) => updateFacets({ ...facets, skills })}
+            />
+            <FacetMultiSelect
+              placeholder="Tag"
+              value={facets.tags}
+              options={facetOptions.tags}
+              onChange={(tags) => updateFacets({ ...facets, tags })}
+            />
+            <Chip
+              icon={<IconWrapper icon="mdi:recycle-variant" size={14} />}
+              label="Reused"
+              size="small"
+              variant={facets.reusedOnly ? "filled" : "outlined"}
+              onClick={() => updateFacets({ ...facets, reusedOnly: !facets.reusedOnly })}
               sx={{
-                fontFamily: "var(--font-mono)",
-                fontWeight: 700,
-                color: "var(--font-secondary)",
+                height: 32,
+                borderRadius: "10px",
+                fontSize: "0.75rem",
+                fontWeight: 600,
+                cursor: "pointer",
+                bgcolor: facets.reusedOnly ? "var(--accent-indigo)" : "transparent",
+                color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)",
+                borderColor: "color-mix(in srgb, var(--border-default) 70%, transparent)",
+                "& .MuiChip-icon": {
+                  color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)",
+                },
+                "&:hover": {
+                  bgcolor: facets.reusedOnly ? "var(--accent-indigo)" : "var(--surface)",
+                },
+              }}
+            />
+            <Box sx={{ flexGrow: 1 }} />
+            {selectedIds.length > 0 && (
+              <Box
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  px: 1.25,
+                  py: 0.5,
+                  borderRadius: 999,
+                  flexShrink: 0,
+                  bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
+                  border: "1px solid color-mix(in srgb, var(--ai-violet) 35%, transparent)",
+                }}
+              >
+                <IconWrapper icon="mdi:check-circle-outline" size={14} color="var(--ai-violet)" />
+                <Typography
+                  sx={{
+                    fontSize: "0.78rem",
+                    fontWeight: 700,
+                    color: "var(--ai-violet)",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  <Box component="span" sx={{ fontFamily: "var(--font-mono)" }}>
+                    {selectedIds.length}
+                  </Box>
+                  {" selected"}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+          <ActiveFacetChips facets={facets} onChange={updateFacets} />
+        </Box>
+
+        {filteredProblems.length === 0 ? (
+          <Box sx={{ p: 4, textAlign: "center" }}>
+            <Box
+              sx={{
+                width: 44,
+                height: 44,
+                borderRadius: 2,
+                display: "grid",
+                placeItems: "center",
+                mx: "auto",
+                mb: 1.5,
+                bgcolor: "color-mix(in srgb, var(--success-500) 12%, var(--card-bg) 88%)",
               }}
             >
-              {filteredProblems.length} result{filteredProblems.length === 1 ? "" : "s"}
+              <IconWrapper icon="mdi:magnify" size={22} color="var(--success-500)" />
+            </Box>
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+              {searchTerm
+                ? "No coding problems found matching your search"
+                : "No coding problems available. Please add coding problems first."}
             </Typography>
           </Box>
+        ) : (
+          <>
+            {/* Select-all header */}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                px: 1.5,
+                py: 0.25,
+                borderBottom: HAIRLINE,
+                bgcolor: "var(--surface)",
+              }}
+            >
+              <Checkbox
+                checked={isAllSelected}
+                indeterminate={selectedIds.length > 0 && !isAllSelected}
+                onChange={handleSelectAll}
+                sx={{ ...CHECKBOX_SX, p: 0.5 }}
+              />
+              <Typography sx={KICKER_SX}>Select all on page</Typography>
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography
+                variant="caption"
+                sx={{
+                  fontFamily: "var(--font-mono)",
+                  fontWeight: 700,
+                  color: "var(--font-secondary)",
+                }}
+              >
+                {filteredProblems.length} result{filteredProblems.length === 1 ? "" : "s"}
+              </Typography>
+            </Box>
 
-          {/* Result rows as soft cards */}
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 1.25,
-              p: { xs: 1.5, sm: 2 },
-            }}
-          >
-            {paginatedProblems.map((problem) => {
-              const selected = selectedIds.includes(problem.id);
-              return (
-                <Box key={problem.id} sx={rowCardSx(selected)}>
-                  <Checkbox
-                    checked={selectedIds.includes(problem.id)}
-                    onChange={() => handleToggle(problem.id)}
-                    sx={{ ...CHECKBOX_SX, p: 0.5 }}
-                  />
-                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.75,
-                        flexWrap: "wrap",
-                      }}
-                    >
+            {/* Single-line-first rows; secondary metadata lives inside the expand */}
+            <Box>
+              {paginatedProblems.map((problem) => {
+                const selected = selectedIds.includes(problem.id);
+                const expanded = expandedIds.includes(problem.id);
+                return (
+                  <Box key={problem.id} sx={rowShellSx(selected)}>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, px: 1.5, minHeight: 48 }}>
+                      <Checkbox
+                        checked={selectedIds.includes(problem.id)}
+                        onChange={() => handleToggle(problem.id)}
+                        sx={{ ...CHECKBOX_SX, p: 0.5 }}
+                      />
                       <Typography
-                        variant="body2"
+                        noWrap
                         sx={{
-                          color: "var(--font-tertiary)",
-                          fontFamily: "var(--font-mono)",
+                          flex: 1,
+                          minWidth: 0,
+                          fontSize: "0.875rem",
                           fontWeight: 600,
+                          color: "var(--font-primary)",
                         }}
                       >
-                        #{problem.id}
+                        {problem.title}
                       </Typography>
-                      {problem.difficulty_level ? (
-                        <DifficultyChip level={problem.difficulty_level} />
-                      ) : (
-                        <Typography variant="body2" sx={{ color: "var(--font-tertiary)" }}>
-                          -
-                        </Typography>
-                      )}
-                      <UsageChip count={problem.usage_count} />
-                      <SourceChip source={problem.source} />
-                      <Box sx={{ flexGrow: 1 }} />
+                      {problem.difficulty_level && <DifficultyChip level={problem.difficulty_level} />}
+                      <Box
+                        sx={{
+                          display: { xs: "none", md: "flex" },
+                          alignItems: "center",
+                          gap: 0.75,
+                          flexShrink: 0,
+                        }}
+                      >
+                        <UsageChip count={problem.usage_count} />
+                        <SourceChip source={problem.source} />
+                      </Box>
                       <IconButton
                         size="small"
                         onClick={() => setPreviewProblem(problem)}
-                        sx={{ color: "var(--accent-indigo)" }}
+                        sx={{ color: "var(--font-secondary)" }}
                         title="Preview"
                       >
                         <IconWrapper icon="mdi:eye-outline" size={18} />
                       </IconButton>
-                    </Box>
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        fontWeight: 600,
-                        color: "var(--font-primary)",
-                        mt: 0.75,
-                      }}
-                    >
-                      {problem.title}
-                    </Typography>
-                    {problem.problem_statement && (
-                      <Typography
-                        variant="caption"
-                        sx={{ color: "var(--font-secondary)", display: "block", mt: 0.5 }}
+                      <IconButton
+                        size="small"
+                        aria-label={expanded ? "Collapse problem details" : "Expand problem details"}
+                        onClick={() => toggleExpanded(problem.id)}
+                        sx={{
+                          color: "var(--font-tertiary)",
+                          transform: expanded ? "rotate(180deg)" : "none",
+                          transition: "transform 0.15s ease",
+                        }}
                       >
-                        {problem.problem_statement.length > 100
-                          ? problem.problem_statement.substring(0, 100) + "..."
-                          : problem.problem_statement}
-                      </Typography>
-                    )}
-                    {problem.tags ? (
-                      <Box sx={{ mt: 1 }}>
-                        <TagChips tags={problem.tags} />
+                        <IconWrapper icon="mdi:chevron-down" size={18} />
+                      </IconButton>
+                    </Box>
+                    {expanded && (
+                      <Box
+                        sx={{
+                          pl: 6.5,
+                          pr: 2,
+                          pb: 1.75,
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 1,
+                        }}
+                      >
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                          <Typography
+                            sx={{
+                              fontFamily: "var(--font-mono)",
+                              fontWeight: 600,
+                              fontSize: "0.75rem",
+                              color: "var(--font-tertiary)",
+                            }}
+                          >
+                            #{problem.id}
+                          </Typography>
+                          {problem.topic && (
+                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                              <IconWrapper
+                                icon="mdi:shape-outline"
+                                size={13}
+                                color="var(--font-tertiary)"
+                              />
+                              <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                                {problem.topic}
+                              </Typography>
+                            </Box>
+                          )}
+                        </Box>
+                        {problem.problem_statement && (
+                          <Typography
+                            variant="body2"
+                            sx={{ color: "var(--font-secondary)" }}
+                          >
+                            {problem.problem_statement.length > 240
+                              ? problem.problem_statement.substring(0, 240) + "..."
+                              : problem.problem_statement}
+                          </Typography>
+                        )}
+                        {problem.tags ? <TagChips tags={problem.tags} /> : null}
                       </Box>
-                    ) : null}
+                    )}
                   </Box>
-                </Box>
-              );
-            })}
-          </Box>
+                );
+              })}
+            </Box>
 
-          {/* Pagination */}
-          {filteredProblems.length > 0 && (
+            {/* Pagination */}
             <Box
               sx={{
-                p: { xs: 1.5, sm: 2 },
-                borderTop: "1px solid var(--border-default)",
+                px: 2,
+                py: 1.5,
+                borderTop: HAIRLINE,
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "center",
-                flexDirection: { xs: "column", sm: "row" },
-                gap: { xs: 1.5, sm: 2 },
+                flexWrap: "wrap",
+                gap: 1.5,
               }}
             >
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1,
-                  flexWrap: "wrap",
-                }}
-              >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
                 <Typography
                   variant="body2"
                   sx={{
@@ -474,23 +760,18 @@ export function CodingProblemSelectionSection({
                 count={totalPages}
                 page={page}
                 onChange={(_, value) => setPage(value)}
-                color="primary"
                 size="small"
                 showFirstButton={false}
                 showLastButton={false}
                 boundaryCount={1}
                 siblingCount={0}
                 disabled={totalPages <= 1}
-                sx={{
-                  "& .MuiPaginationItem-root": {
-                    fontSize: { xs: "0.75rem", sm: "0.875rem" },
-                  },
-                }}
+                sx={PAGINATION_SX}
               />
             </Box>
-          )}
-        </Box>
-      )}
+          </>
+        )}
+      </Box>
 
       <Dialog
         open={!!previewProblem}

--- a/components/admin/assessment/MCQSelectionSection.tsx
+++ b/components/admin/assessment/MCQSelectionSection.tsx
@@ -9,6 +9,10 @@ import {
   TextField,
   Chip,
   Pagination,
+  Select,
+  MenuItem,
+  IconButton,
+  Button,
 } from "@mui/material";
 import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
@@ -16,11 +20,12 @@ import { useToast } from "@/components/common/Toast";
 import { MCQListItem } from "@/lib/services/admin/admin-assessment.service";
 import { DifficultyChip, StatusChip } from "@/components/admin/assessment/shared";
 import {
-  FacetBar,
   FacetState,
   EMPTY_FACETS,
   applyFacets,
   deriveFacetOptions,
+  hasActiveFacets,
+  SOURCE_LABELS,
   SourceChip,
   UsageChip,
   TagChips,
@@ -63,27 +68,235 @@ const SEARCH_FIELD_SX = {
   "& .MuiInputLabel-root.Mui-focused": { color: "var(--ai-violet)" },
 } as const;
 
-/** Soft result-row card; selected = violet ring + tint (style contract). */
-const rowCardSx = (selected: boolean) => ({
-  display: "flex",
-  alignItems: "flex-start",
-  gap: 1,
-  px: 1.5,
-  py: 1.5,
-  borderRadius: "12px",
+/** Hairline separator between rows (no heavy borders). */
+const HAIRLINE = "1px solid color-mix(in srgb, var(--border-default) 45%, transparent)";
+
+/** Compact toolbar dropdown: token border, violet focus, no floating label. */
+const TOOLBAR_SELECT_SX = {
+  borderRadius: "10px",
+  fontSize: "0.8rem",
+  bgcolor: "var(--card-bg)",
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderColor: "color-mix(in srgb, var(--border-default) 70%, transparent)",
+  },
+  "&:hover .MuiOutlinedInput-notchedOutline": {
+    borderColor: "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+  },
+  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    borderColor: "var(--ai-violet)",
+  },
+} as const;
+
+/** Active-facet chip — wraps below the toolbar only when a filter is active. */
+const ACTIVE_CHIP_SX = {
+  height: 24,
+  fontSize: "0.72rem",
+  fontWeight: 600,
+  bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+  color: "var(--accent-indigo)",
+  "& .MuiChip-deleteIcon": {
+    color: "color-mix(in srgb, var(--accent-indigo) 70%, transparent)",
+    "&:hover": { color: "var(--accent-indigo)" },
+  },
+} as const;
+
+/** Token pagination (replaces the MUI default blue). */
+const PAGINATION_SX = {
+  "& .MuiPaginationItem-root": {
+    fontSize: { xs: "0.75rem", sm: "0.875rem" },
+    "&.Mui-selected": {
+      bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
+      color: "var(--ai-violet)",
+      fontWeight: 700,
+      "&:hover": {
+        bgcolor: "color-mix(in srgb, var(--ai-violet) 18%, var(--card-bg) 82%)",
+      },
+    },
+  },
+} as const;
+
+/** Flat result row: hairline separators; selected = soft violet tint + inset ring. */
+const rowShellSx = (selected: boolean) => ({
   bgcolor: selected
-    ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
-    : "var(--card-bg)",
-  border: selected
-    ? "1.5px solid var(--ai-violet)"
-    : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
-  transition: "border-color 0.15s ease, background-color 0.15s ease",
+    ? "color-mix(in srgb, var(--ai-violet) 6%, var(--card-bg) 94%)"
+    : "transparent",
+  boxShadow: selected
+    ? "inset 0 0 0 1.5px color-mix(in srgb, var(--ai-violet) 40%, transparent)"
+    : "none",
+  transition: "background-color 0.15s ease, box-shadow 0.15s ease",
+  "&:not(:last-child)": { borderBottom: HAIRLINE },
   "&:hover": {
-    borderColor: selected
-      ? "var(--ai-violet)"
-      : "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+    bgcolor: selected
+      ? "color-mix(in srgb, var(--ai-violet) 9%, var(--card-bg) 91%)"
+      : "color-mix(in srgb, var(--surface) 65%, var(--card-bg) 35%)",
   },
 });
+
+const DIFFICULTY_OPTIONS = ["Easy", "Medium", "Hard"] as const;
+const SOURCE_OPTIONS = ["manual", "ai_generated", "csv_import", "course_builder"] as const;
+
+/** Compact single-value facet dropdown for the toolbar row. */
+function FacetSelect({
+  placeholder,
+  allLabel,
+  value,
+  options,
+  onChange,
+  getLabel,
+}: {
+  placeholder: string;
+  allLabel: string;
+  value: string;
+  options: readonly string[];
+  onChange: (next: string) => void;
+  getLabel?: (v: string) => string;
+}) {
+  const label = getLabel ?? ((v: string) => v);
+  return (
+    <Select
+      size="small"
+      displayEmpty
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      renderValue={(v) =>
+        v ? (
+          <span style={{ fontWeight: 600 }}>{label(v)}</span>
+        ) : (
+          <span style={{ color: "var(--font-tertiary)" }}>{placeholder}</span>
+        )
+      }
+      sx={TOOLBAR_SELECT_SX}
+      MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+    >
+      <MenuItem value="" sx={{ fontSize: "0.85rem" }}>
+        {allLabel}
+      </MenuItem>
+      {options.map((o) => (
+        <MenuItem key={o} value={o} sx={{ fontSize: "0.85rem" }}>
+          {label(o)}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+/** Compact multi-value facet dropdown (Topic/Skill/Tag); hidden when no options. */
+function FacetMultiSelect({
+  placeholder,
+  value,
+  options,
+  onChange,
+}: {
+  placeholder: string;
+  value: string[];
+  options: string[];
+  onChange: (next: string[]) => void;
+}) {
+  if (options.length === 0) return null;
+  return (
+    <Select
+      multiple
+      size="small"
+      displayEmpty
+      value={value}
+      onChange={(e) => {
+        const next = e.target.value;
+        onChange(typeof next === "string" ? next.split(",") : next);
+      }}
+      renderValue={(v) =>
+        v.length ? (
+          <span style={{ fontWeight: 600 }}>{`${placeholder} · ${v.length}`}</span>
+        ) : (
+          <span style={{ color: "var(--font-tertiary)" }}>{placeholder}</span>
+        )
+      }
+      sx={TOOLBAR_SELECT_SX}
+      MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+    >
+      {options.map((o) => (
+        <MenuItem key={o} value={o} sx={{ fontSize: "0.85rem", gap: 1 }}>
+          <Checkbox size="small" checked={value.includes(o)} sx={{ ...CHECKBOX_SX, p: 0 }} />
+          {o}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+/** Active filters as deletable chips — rendered below the toolbar only when active. */
+function ActiveFacetChips({
+  facets,
+  onChange,
+}: {
+  facets: FacetState;
+  onChange: (next: FacetState) => void;
+}) {
+  if (!hasActiveFacets(facets)) return null;
+  const chips: { key: string; label: string; clear: () => void }[] = [];
+  if (facets.difficulty) {
+    chips.push({
+      key: "difficulty",
+      label: facets.difficulty,
+      clear: () => onChange({ ...facets, difficulty: "" }),
+    });
+  }
+  if (facets.source) {
+    chips.push({
+      key: "source",
+      label: SOURCE_LABELS[facets.source] || facets.source,
+      clear: () => onChange({ ...facets, source: "" }),
+    });
+  }
+  if (facets.reusedOnly) {
+    chips.push({
+      key: "reused",
+      label: "Reused only",
+      clear: () => onChange({ ...facets, reusedOnly: false }),
+    });
+  }
+  for (const t of facets.topics) {
+    chips.push({
+      key: `topic:${t}`,
+      label: t,
+      clear: () => onChange({ ...facets, topics: facets.topics.filter((x) => x !== t) }),
+    });
+  }
+  for (const s of facets.skills) {
+    chips.push({
+      key: `skill:${s}`,
+      label: s,
+      clear: () => onChange({ ...facets, skills: facets.skills.filter((x) => x !== s) }),
+    });
+  }
+  for (const g of facets.tags) {
+    chips.push({
+      key: `tag:${g}`,
+      label: g,
+      clear: () => onChange({ ...facets, tags: facets.tags.filter((x) => x !== g) }),
+    });
+  }
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 0.75, px: 2, pb: 1.5 }}>
+      {chips.map((c) => (
+        <Chip key={c.key} label={c.label} size="small" onDelete={c.clear} sx={ACTIVE_CHIP_SX} />
+      ))}
+      <Button
+        size="small"
+        variant="text"
+        startIcon={<IconWrapper icon="mdi:filter-remove-outline" size={15} />}
+        onClick={() => onChange(EMPTY_FACETS)}
+        sx={{
+          fontSize: "0.72rem",
+          fontWeight: 600,
+          textTransform: "none",
+          color: "var(--font-secondary)",
+        }}
+      >
+        Clear all
+      </Button>
+    </Box>
+  );
+}
 
 interface MCQSelectionSectionProps {
   selectedIds: number[];
@@ -104,6 +317,7 @@ export function MCQSelectionSection({
   const [limit, setLimit] = useState(10);
   const [facets, setFacets] = useState<FacetState>(EMPTY_FACETS);
   const [preview, setPreview] = useState<MCQListItem | null>(null);
+  const [expandedIds, setExpandedIds] = useState<number[]>([]);
   const facetOptions = useMemo(() => deriveFacetOptions(mcqs), [mcqs]);
 
   const filteredMCQs = useMemo(() => {
@@ -151,6 +365,17 @@ export function MCQSelectionSection({
 
   const isAllSelected = paginatedMCQs.length > 0 && paginatedMCQs.every((mcq) => selectedIds.includes(mcq.id));
 
+  /** Facet changes always reset to page 1 (same behavior as the old FacetBar wiring). */
+  const updateFacets = (next: FacetState) => {
+    setFacets(next);
+    setPage(1);
+  };
+
+  const toggleExpanded = (id: number) =>
+    setExpandedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
@@ -161,347 +386,351 @@ export function MCQSelectionSection({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          flexWrap: "wrap",
-          gap: 2,
-        }}
-      >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-          <Box
-            sx={{
-              width: 40,
-              height: 40,
-              borderRadius: 2,
-              flexShrink: 0,
-              display: "grid",
-              placeItems: "center",
-              bgcolor:
-                "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
-            }}
-          >
-            <IconWrapper
-              icon="mdi:format-list-checks"
-              size={21}
-              color="var(--accent-indigo)"
-            />
-          </Box>
-          <Box>
-            <Typography sx={KICKER_SX}>Question bank</Typography>
-            <Typography
-              sx={{
-                fontFamily: "var(--font-jakarta)",
-                fontWeight: 800,
-                fontSize: "1.05rem",
-                color: "var(--font-primary)",
-                lineHeight: 1.3,
-              }}
-            >
-              Select from Existing Questions
-            </Typography>
-          </Box>
-        </Box>
-        {selectedIds.length > 0 && (
-          <Box
-            sx={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 0.75,
-              px: 1.5,
-              py: 0.75,
-              borderRadius: 999,
-              bgcolor:
-                "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
-              border:
-                "1px solid color-mix(in srgb, var(--ai-violet) 35%, transparent)",
-            }}
-          >
-            <IconWrapper
-              icon="mdi:check-circle-outline"
-              size={15}
-              color="var(--ai-violet)"
-            />
-            <Typography
-              variant="body2"
-              sx={{ fontWeight: 600, color: "var(--ai-violet)" }}
-            >
-              Selected: {selectedIds.length} MCQ(s) | Showing: {filteredMCQs.length} of {mcqs.length} total
-            </Typography>
-          </Box>
-        )}
-      </Box>
-
-      {/* Search + facet filters grouped in one card */}
-      <Box sx={{ ...CARD_SX, p: { xs: 2, sm: 2.5 } }}>
-        <Typography sx={{ ...KICKER_SX, mb: 1.5 }}>Search & filters</Typography>
-        <TextField
-          label="Search Questions"
-          value={searchTerm}
-          onChange={(e) => {
-            setSearchTerm(e.target.value);
-            setPage(1);
+      {/* Slim section header */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        <Box
+          sx={{
+            width: 36,
+            height: 36,
+            borderRadius: 2,
+            flexShrink: 0,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
           }}
-          fullWidth
-          size="small"
-          InputProps={{
-            startAdornment: (
-              <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
-            ),
-          }}
-          sx={SEARCH_FIELD_SX}
-        />
-        <Box sx={{ mt: 2 }}>
-          <FacetBar
-            facets={facets}
-            options={facetOptions}
-            onChange={(next) => {
-              setFacets(next);
-              setPage(1);
-            }}
-          />
+        >
+          <IconWrapper icon="mdi:format-list-checks" size={19} color="var(--accent-indigo)" />
         </Box>
-      </Box>
-
-      {filteredMCQs.length === 0 ? (
-        <Box sx={{ ...CARD_SX, p: 4, textAlign: "center" }}>
-          <Box
+        <Box>
+          <Typography sx={KICKER_SX}>Question bank</Typography>
+          <Typography
             sx={{
-              width: 44,
-              height: 44,
-              borderRadius: 2,
-              display: "grid",
-              placeItems: "center",
-              mx: "auto",
-              mb: 1.5,
-              bgcolor:
-                "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: "1.02rem",
+              color: "var(--font-primary)",
+              lineHeight: 1.3,
             }}
           >
-            <IconWrapper icon="mdi:magnify" size={22} color="var(--accent-indigo)" />
-          </Box>
-          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-            {searchTerm
-              ? "No questions found matching your search"
-              : "No questions available. Please add questions first."}
+            Select from Existing Questions
           </Typography>
         </Box>
-      ) : (
-        <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
-          {/* Select-all header */}
+      </Box>
+
+      {/* Single results card: compact toolbar header + rows + pagination */}
+      <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
+        {/* One compact toolbar row: search + facet dropdowns + selected-count chip */}
+        <Box sx={{ borderBottom: HAIRLINE }}>
           <Box
             sx={{
               display: "flex",
               alignItems: "center",
-              gap: 0.5,
+              flexWrap: "wrap",
+              gap: 1,
               px: 2,
-              py: 0.75,
-              borderBottom: "1px solid var(--border-default)",
-              bgcolor: "var(--surface)",
+              py: 1.5,
             }}
           >
-            <Checkbox
-              checked={isAllSelected}
-              indeterminate={
-                selectedIds.length > 0 && !isAllSelected
-              }
-              onChange={handleSelectAll}
-              sx={CHECKBOX_SX}
-            />
-            <Typography sx={KICKER_SX}>Select all on page</Typography>
-            <Box sx={{ flexGrow: 1 }} />
-            <Typography
-              variant="caption"
-              sx={{
-                fontFamily: "var(--font-mono)",
-                fontWeight: 700,
-                color: "var(--font-secondary)",
+            <TextField
+              label="Search Questions"
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                setPage(1);
               }}
-            >
-              {filteredMCQs.length} result{filteredMCQs.length === 1 ? "" : "s"}
-            </Typography>
-          </Box>
-
-          {/* Result rows as soft cards */}
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 1.25,
-              p: { xs: 1.5, sm: 2 },
-            }}
-          >
-            {paginatedMCQs.map((mcq) => {
-              const selected = selectedIds.includes(mcq.id);
-              return (
-                <Box key={mcq.id} sx={rowCardSx(selected)}>
-                  <Checkbox
-                    checked={selectedIds.includes(mcq.id)}
-                    onChange={() => handleToggle(mcq.id)}
-                    sx={{ ...CHECKBOX_SX, p: 0.5 }}
-                  />
-                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.75,
-                        flexWrap: "wrap",
-                      }}
-                    >
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          color: "var(--font-tertiary)",
-                          fontFamily: "var(--font-mono)",
-                          fontWeight: 600,
-                        }}
-                      >
-                        #{mcq.id}
-                      </Typography>
-                      {mcq.difficulty_level ? (
-                        <DifficultyChip level={mcq.difficulty_level} />
-                      ) : (
-                        <Typography variant="body2" sx={{ color: "var(--font-tertiary)" }}>
-                          -
-                        </Typography>
-                      )}
-                      <StatusChip
-                        label={`Correct: ${mcq.correct_option}`}
-                        tone="success"
-                        icon="mdi:check-circle-outline"
-                      />
-                      <UsageChip count={mcq.usage_count} />
-                      <SourceChip source={mcq.source} />
-                      <Box sx={{ flexGrow: 1 }} />
-                      <PreviewButton onClick={() => setPreview(mcq)} />
-                    </Box>
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        fontWeight: 600,
-                        color: "var(--font-primary)",
-                        mt: 0.75,
-                      }}
-                    >
-                      {mcq.question_text}
-                    </Typography>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 0.5 }}>
-                      <IconWrapper
-                        icon="mdi:shape-outline"
-                        size={13}
-                        color="var(--font-tertiary)"
-                      />
-                      <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
-                        {mcq.topic || "-"}
-                      </Typography>
-                    </Box>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        flexWrap: "wrap",
-                        gap: 0.5,
-                        mt: 1,
-                      }}
-                    >
-                      <Chip
-                        label={`A: ${mcq.option_a.length > 30 ? mcq.option_a.substring(0, 30) + "..." : mcq.option_a}`}
-                        size="small"
-                        sx={{
-                          bgcolor:
-                            mcq.correct_option === "A"
-                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                              : "var(--surface)",
-                          color:
-                            mcq.correct_option === "A"
-                              ? "var(--success-500)"
-                              : "var(--font-primary)",
-                          fontWeight: mcq.correct_option === "A" ? 600 : 400,
-                          fontSize: "0.75rem",
-                          height: 24,
-                        }}
-                      />
-                      <Chip
-                        label={`B: ${mcq.option_b.length > 30 ? mcq.option_b.substring(0, 30) + "..." : mcq.option_b}`}
-                        size="small"
-                        sx={{
-                          bgcolor:
-                            mcq.correct_option === "B"
-                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                              : "var(--surface)",
-                          color:
-                            mcq.correct_option === "B"
-                              ? "var(--success-500)"
-                              : "var(--font-primary)",
-                          fontWeight: mcq.correct_option === "B" ? 600 : 400,
-                          fontSize: "0.75rem",
-                          height: 24,
-                        }}
-                      />
-                      <Chip
-                        label={`C: ${mcq.option_c.length > 30 ? mcq.option_c.substring(0, 30) + "..." : mcq.option_c}`}
-                        size="small"
-                        sx={{
-                          bgcolor:
-                            mcq.correct_option === "C"
-                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                              : "var(--surface)",
-                          color:
-                            mcq.correct_option === "C"
-                              ? "var(--success-500)"
-                              : "var(--font-primary)",
-                          fontWeight: mcq.correct_option === "C" ? 600 : 400,
-                          fontSize: "0.75rem",
-                          height: 24,
-                        }}
-                      />
-                      <Chip
-                        label={`D: ${mcq.option_d.length > 30 ? mcq.option_d.substring(0, 30) + "..." : mcq.option_d}`}
-                        size="small"
-                        sx={{
-                          bgcolor:
-                            mcq.correct_option === "D"
-                              ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
-                              : "var(--surface)",
-                          color:
-                            mcq.correct_option === "D"
-                              ? "var(--success-500)"
-                              : "var(--font-primary)",
-                          fontWeight: mcq.correct_option === "D" ? 600 : 400,
-                          fontSize: "0.75rem",
-                          height: 24,
-                        }}
-                      />
-                    </Box>
+              size="small"
+              InputProps={{
+                startAdornment: (
+                  <IconWrapper icon="mdi:magnify" size={18} style={{ marginRight: 8 }} />
+                ),
+              }}
+              sx={{ ...SEARCH_FIELD_SX, flex: "1 1 220px", minWidth: 200 }}
+            />
+            <FacetSelect
+              placeholder="Difficulty"
+              allLabel="All difficulties"
+              value={facets.difficulty}
+              options={DIFFICULTY_OPTIONS}
+              onChange={(difficulty) => updateFacets({ ...facets, difficulty })}
+            />
+            <FacetSelect
+              placeholder="Source"
+              allLabel="All sources"
+              value={facets.source}
+              options={SOURCE_OPTIONS}
+              getLabel={(s) => SOURCE_LABELS[s] || s}
+              onChange={(source) => updateFacets({ ...facets, source })}
+            />
+            <FacetMultiSelect
+              placeholder="Topic"
+              value={facets.topics}
+              options={facetOptions.topics}
+              onChange={(topics) => updateFacets({ ...facets, topics })}
+            />
+            <FacetMultiSelect
+              placeholder="Skill"
+              value={facets.skills}
+              options={facetOptions.skills}
+              onChange={(skills) => updateFacets({ ...facets, skills })}
+            />
+            <FacetMultiSelect
+              placeholder="Tag"
+              value={facets.tags}
+              options={facetOptions.tags}
+              onChange={(tags) => updateFacets({ ...facets, tags })}
+            />
+            <Chip
+              icon={<IconWrapper icon="mdi:recycle-variant" size={14} />}
+              label="Reused"
+              size="small"
+              variant={facets.reusedOnly ? "filled" : "outlined"}
+              onClick={() => updateFacets({ ...facets, reusedOnly: !facets.reusedOnly })}
+              sx={{
+                height: 32,
+                borderRadius: "10px",
+                fontSize: "0.75rem",
+                fontWeight: 600,
+                cursor: "pointer",
+                bgcolor: facets.reusedOnly ? "var(--accent-indigo)" : "transparent",
+                color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)",
+                borderColor: "color-mix(in srgb, var(--border-default) 70%, transparent)",
+                "& .MuiChip-icon": {
+                  color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)",
+                },
+                "&:hover": {
+                  bgcolor: facets.reusedOnly ? "var(--accent-indigo)" : "var(--surface)",
+                },
+              }}
+            />
+            <Box sx={{ flexGrow: 1 }} />
+            {selectedIds.length > 0 && (
+              <Box
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  px: 1.25,
+                  py: 0.5,
+                  borderRadius: 999,
+                  flexShrink: 0,
+                  bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
+                  border: "1px solid color-mix(in srgb, var(--ai-violet) 35%, transparent)",
+                }}
+              >
+                <IconWrapper icon="mdi:check-circle-outline" size={14} color="var(--ai-violet)" />
+                <Typography
+                  sx={{
+                    fontSize: "0.78rem",
+                    fontWeight: 700,
+                    color: "var(--ai-violet)",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  <Box component="span" sx={{ fontFamily: "var(--font-mono)" }}>
+                    {selectedIds.length}
                   </Box>
-                </Box>
-              );
-            })}
+                  {" selected"}
+                </Typography>
+              </Box>
+            )}
           </Box>
+          <ActiveFacetChips facets={facets} onChange={updateFacets} />
+        </Box>
 
-          {/* Pagination */}
-          {filteredMCQs.length > 0 && (
+        {filteredMCQs.length === 0 ? (
+          <Box sx={{ p: 4, textAlign: "center" }}>
             <Box
               sx={{
-                p: { xs: 1.5, sm: 2 },
-                borderTop: "1px solid var(--border-default)",
+                width: 44,
+                height: 44,
+                borderRadius: 2,
+                display: "grid",
+                placeItems: "center",
+                mx: "auto",
+                mb: 1.5,
+                bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+              }}
+            >
+              <IconWrapper icon="mdi:magnify" size={22} color="var(--accent-indigo)" />
+            </Box>
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+              {searchTerm
+                ? "No questions found matching your search"
+                : "No questions available. Please add questions first."}
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            {/* Select-all header */}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                px: 1.5,
+                py: 0.25,
+                borderBottom: HAIRLINE,
+                bgcolor: "var(--surface)",
+              }}
+            >
+              <Checkbox
+                checked={isAllSelected}
+                indeterminate={selectedIds.length > 0 && !isAllSelected}
+                onChange={handleSelectAll}
+                sx={{ ...CHECKBOX_SX, p: 0.5 }}
+              />
+              <Typography sx={KICKER_SX}>Select all on page</Typography>
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography
+                variant="caption"
+                sx={{
+                  fontFamily: "var(--font-mono)",
+                  fontWeight: 700,
+                  color: "var(--font-secondary)",
+                }}
+              >
+                {filteredMCQs.length} result{filteredMCQs.length === 1 ? "" : "s"}
+              </Typography>
+            </Box>
+
+            {/* Single-line-first rows; secondary metadata lives inside the expand */}
+            <Box>
+              {paginatedMCQs.map((mcq) => {
+                const selected = selectedIds.includes(mcq.id);
+                const expanded = expandedIds.includes(mcq.id);
+                return (
+                  <Box key={mcq.id} sx={rowShellSx(selected)}>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, px: 1.5, minHeight: 48 }}>
+                      <Checkbox
+                        checked={selectedIds.includes(mcq.id)}
+                        onChange={() => handleToggle(mcq.id)}
+                        sx={{ ...CHECKBOX_SX, p: 0.5 }}
+                      />
+                      <Typography
+                        noWrap
+                        sx={{
+                          flex: 1,
+                          minWidth: 0,
+                          fontSize: "0.875rem",
+                          fontWeight: 600,
+                          color: "var(--font-primary)",
+                        }}
+                      >
+                        {mcq.question_text}
+                      </Typography>
+                      {mcq.difficulty_level && <DifficultyChip level={mcq.difficulty_level} />}
+                      <Box
+                        sx={{
+                          display: { xs: "none", md: "flex" },
+                          alignItems: "center",
+                          gap: 0.75,
+                          flexShrink: 0,
+                        }}
+                      >
+                        <UsageChip count={mcq.usage_count} />
+                        <SourceChip source={mcq.source} />
+                      </Box>
+                      <PreviewButton onClick={() => setPreview(mcq)} />
+                      <IconButton
+                        size="small"
+                        aria-label={expanded ? "Collapse question details" : "Expand question details"}
+                        onClick={() => toggleExpanded(mcq.id)}
+                        sx={{
+                          color: "var(--font-tertiary)",
+                          transform: expanded ? "rotate(180deg)" : "none",
+                          transition: "transform 0.15s ease",
+                        }}
+                      >
+                        <IconWrapper icon="mdi:chevron-down" size={18} />
+                      </IconButton>
+                    </Box>
+                    {expanded && (
+                      <Box
+                        sx={{
+                          pl: 6.5,
+                          pr: 2,
+                          pb: 1.75,
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 1,
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          sx={{ color: "var(--font-primary)", whiteSpace: "pre-wrap" }}
+                        >
+                          {mcq.question_text}
+                        </Typography>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                          <Typography
+                            sx={{
+                              fontFamily: "var(--font-mono)",
+                              fontWeight: 600,
+                              fontSize: "0.75rem",
+                              color: "var(--font-tertiary)",
+                            }}
+                          >
+                            #{mcq.id}
+                          </Typography>
+                          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                            <IconWrapper
+                              icon="mdi:shape-outline"
+                              size={13}
+                              color="var(--font-tertiary)"
+                            />
+                            <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                              {mcq.topic || "-"}
+                            </Typography>
+                          </Box>
+                          <StatusChip
+                            label={`Correct: ${mcq.correct_option}`}
+                            tone="success"
+                            icon="mdi:check-circle-outline"
+                          />
+                        </Box>
+                        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                          {(["A", "B", "C", "D"] as const).map((opt) => {
+                            const val = mcq[`option_${opt.toLowerCase()}` as "option_a"];
+                            const correct = mcq.correct_option === opt;
+                            return (
+                              <Chip
+                                key={opt}
+                                label={`${opt}: ${val.length > 30 ? val.substring(0, 30) + "..." : val}`}
+                                size="small"
+                                sx={{
+                                  bgcolor: correct
+                                    ? "color-mix(in srgb, var(--success-500) 14%, var(--surface) 86%)"
+                                    : "var(--surface)",
+                                  color: correct ? "var(--success-500)" : "var(--font-primary)",
+                                  fontWeight: correct ? 600 : 400,
+                                  fontSize: "0.75rem",
+                                  height: 24,
+                                }}
+                              />
+                            );
+                          })}
+                        </Box>
+                      </Box>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {/* Pagination */}
+            <Box
+              sx={{
+                px: 2,
+                py: 1.5,
+                borderTop: HAIRLINE,
                 display: "flex",
                 justifyContent: "space-between",
                 alignItems: "center",
-                flexDirection: { xs: "column", sm: "row" },
-                gap: { xs: 1.5, sm: 2 },
+                flexWrap: "wrap",
+                gap: 1.5,
               }}
             >
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1,
-                  flexWrap: "wrap",
-                }}
-              >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
                 <Typography
                   variant="body2"
                   sx={{
@@ -528,23 +757,18 @@ export function MCQSelectionSection({
                 count={totalPages}
                 page={page}
                 onChange={(_, value) => setPage(value)}
-                color="primary"
                 size="small"
                 showFirstButton={false}
                 showLastButton={false}
                 boundaryCount={1}
                 siblingCount={0}
                 disabled={totalPages <= 1}
-                sx={{
-                  "& .MuiPaginationItem-root": {
-                    fontSize: { xs: "0.75rem", sm: "0.875rem" },
-                  },
-                }}
+                sx={PAGINATION_SX}
               />
             </Box>
-          )}
-        </Box>
-      )}
+          </>
+        )}
+      </Box>
 
       <PreviewDialog
         open={!!preview}

--- a/components/admin/assessment/SectionBasedQuestionsInput.tsx
+++ b/components/admin/assessment/SectionBasedQuestionsInput.tsx
@@ -128,6 +128,8 @@ function MethodCardGrid<T extends string>({
 interface SectionBasedQuestionsInputProps {
   sections: Section[];
   evaluationMode: "auto" | "manual";
+  /** Optional: lets the sidenav's "+ Add section" jump back to the sections builder. */
+  onAddSection?: () => void;
   mcqInputMethodBySection: Record<string, MCQInputMethod>;
   onMcqInputMethodChange: (sectionId: string, method: MCQInputMethod) => void;
   // Section-based question assignments
@@ -165,6 +167,7 @@ interface SectionBasedQuestionsInputProps {
 export function SectionBasedQuestionsInput({
   sections,
   evaluationMode,
+  onAddSection,
   mcqInputMethodBySection,
   onMcqInputMethodChange,
   sectionMcqIds,
@@ -419,6 +422,7 @@ export function SectionBasedQuestionsInput({
         >
           <SectionQuestionsSidenav
             sections={sections}
+            onAddSection={onAddSection}
             selectedSectionId={currentSelectedId}
             onSectionSelect={handleSectionSelect}
             sectionQuestionCounts={sectionQuestionCounts}

--- a/components/admin/assessment/SectionQuestionsSidenav.tsx
+++ b/components/admin/assessment/SectionQuestionsSidenav.tsx
@@ -21,6 +21,8 @@ interface SectionQuestionsSidenavProps {
   sections: Section[];
   selectedSectionId: string | "";
   onSectionSelect: (sectionId: string) => void;
+  /** Optional: renders a "+ Add section" row that jumps back to the sections builder. */
+  onAddSection?: () => void;
   sectionQuestionCounts: Record<string, number>;
   sectionCodingCounts: Record<string, number>;
   sectionSubjectiveCounts: Record<string, number>;
@@ -54,6 +56,7 @@ export function SectionQuestionsSidenav({
   sections,
   selectedSectionId,
   onSectionSelect,
+  onAddSection,
   sectionQuestionCounts,
   sectionCodingCounts,
   sectionSubjectiveCounts,
@@ -471,6 +474,44 @@ export function SectionQuestionsSidenav({
           </Typography>
         </Box>
       )}
+
+      {onAddSection ? (
+        <Box sx={{ px: 2, pb: 2, pt: sections.length === 0 ? 0 : 1 }}>
+          <Box
+            onClick={onAddSection}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onAddSection();
+              }
+            }}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 0.75,
+              py: 1.3,
+              borderRadius: "12px",
+              border: "1.5px dashed color-mix(in srgb, var(--font-tertiary) 55%, transparent)",
+              color: "var(--font-secondary)",
+              fontWeight: 700,
+              fontSize: "0.9rem",
+              cursor: "pointer",
+              userSelect: "none",
+              transition: "border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease",
+              "&:hover": {
+                borderColor: "var(--ai-violet)",
+                color: "var(--ai-violet)",
+                bgcolor: "color-mix(in srgb, var(--ai-violet) 5%, transparent)",
+              },
+            }}
+          >
+            <IconWrapper icon="mdi:plus" size={18} /> Add section
+          </Box>
+        </Box>
+      ) : null}
     </Paper>
   );
 }

--- a/components/admin/assessment/SubjectiveQuestionSelectionSection.tsx
+++ b/components/admin/assessment/SubjectiveQuestionSelectionSection.tsx
@@ -7,18 +7,24 @@ import {
   Checkbox,
   CircularProgress,
   TextField,
+  Chip,
   Pagination,
+  Select,
+  MenuItem,
+  IconButton,
+  Button,
 } from "@mui/material";
 import { PerPageSelect } from "@/components/common/PerPageSelect";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import type { AssessmentSubjectiveQuestionListItem } from "@/lib/services/admin/admin-assessment.service";
 import { DifficultyChip, StatusChip } from "@/components/admin/assessment/shared";
 import {
-  FacetBar,
   FacetState,
   EMPTY_FACETS,
   applyFacets,
   deriveFacetOptions,
+  hasActiveFacets,
+  SOURCE_LABELS,
   SourceChip,
   UsageChip,
   TagChips,
@@ -61,27 +67,235 @@ const SEARCH_FIELD_SX = {
   "& .MuiInputLabel-root.Mui-focused": { color: "var(--ai-violet)" },
 } as const;
 
-/** Soft result-row card; selected = violet ring + tint (style contract). */
-const rowCardSx = (selected: boolean) => ({
-  display: "flex",
-  alignItems: "flex-start",
-  gap: 1,
-  px: 1.5,
-  py: 1.5,
-  borderRadius: "12px",
+/** Hairline separator between rows (no heavy borders). */
+const HAIRLINE = "1px solid color-mix(in srgb, var(--border-default) 45%, transparent)";
+
+/** Compact toolbar dropdown: token border, violet focus, no floating label. */
+const TOOLBAR_SELECT_SX = {
+  borderRadius: "10px",
+  fontSize: "0.8rem",
+  bgcolor: "var(--card-bg)",
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderColor: "color-mix(in srgb, var(--border-default) 70%, transparent)",
+  },
+  "&:hover .MuiOutlinedInput-notchedOutline": {
+    borderColor: "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+  },
+  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+    borderColor: "var(--ai-violet)",
+  },
+} as const;
+
+/** Active-facet chip — wraps below the toolbar only when a filter is active. */
+const ACTIVE_CHIP_SX = {
+  height: 24,
+  fontSize: "0.72rem",
+  fontWeight: 600,
+  bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--card-bg) 88%)",
+  color: "var(--accent-indigo)",
+  "& .MuiChip-deleteIcon": {
+    color: "color-mix(in srgb, var(--accent-indigo) 70%, transparent)",
+    "&:hover": { color: "var(--accent-indigo)" },
+  },
+} as const;
+
+/** Token pagination (replaces the MUI default blue). */
+const PAGINATION_SX = {
+  "& .MuiPaginationItem-root": {
+    fontSize: { xs: "0.75rem", sm: "0.875rem" },
+    "&.Mui-selected": {
+      bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--card-bg) 88%)",
+      color: "var(--ai-violet)",
+      fontWeight: 700,
+      "&:hover": {
+        bgcolor: "color-mix(in srgb, var(--ai-violet) 18%, var(--card-bg) 82%)",
+      },
+    },
+  },
+} as const;
+
+/** Flat result row: hairline separators; selected = soft violet tint + inset ring. */
+const rowShellSx = (selected: boolean) => ({
   bgcolor: selected
-    ? "color-mix(in srgb, var(--ai-violet) 7%, var(--card-bg) 93%)"
-    : "var(--card-bg)",
-  border: selected
-    ? "1.5px solid var(--ai-violet)"
-    : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
-  transition: "border-color 0.15s ease, background-color 0.15s ease",
+    ? "color-mix(in srgb, var(--ai-violet) 6%, var(--card-bg) 94%)"
+    : "transparent",
+  boxShadow: selected
+    ? "inset 0 0 0 1.5px color-mix(in srgb, var(--ai-violet) 40%, transparent)"
+    : "none",
+  transition: "background-color 0.15s ease, box-shadow 0.15s ease",
+  "&:not(:last-child)": { borderBottom: HAIRLINE },
   "&:hover": {
-    borderColor: selected
-      ? "var(--ai-violet)"
-      : "color-mix(in srgb, var(--ai-violet) 45%, var(--border-default) 55%)",
+    bgcolor: selected
+      ? "color-mix(in srgb, var(--ai-violet) 9%, var(--card-bg) 91%)"
+      : "color-mix(in srgb, var(--surface) 65%, var(--card-bg) 35%)",
   },
 });
+
+const DIFFICULTY_OPTIONS = ["Easy", "Medium", "Hard"] as const;
+const SOURCE_OPTIONS = ["manual", "ai_generated", "csv_import", "course_builder"] as const;
+
+/** Compact single-value facet dropdown for the toolbar row. */
+function FacetSelect({
+  placeholder,
+  allLabel,
+  value,
+  options,
+  onChange,
+  getLabel,
+}: {
+  placeholder: string;
+  allLabel: string;
+  value: string;
+  options: readonly string[];
+  onChange: (next: string) => void;
+  getLabel?: (v: string) => string;
+}) {
+  const label = getLabel ?? ((v: string) => v);
+  return (
+    <Select
+      size="small"
+      displayEmpty
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      renderValue={(v) =>
+        v ? (
+          <span style={{ fontWeight: 600 }}>{label(v)}</span>
+        ) : (
+          <span style={{ color: "var(--font-tertiary)" }}>{placeholder}</span>
+        )
+      }
+      sx={TOOLBAR_SELECT_SX}
+      MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+    >
+      <MenuItem value="" sx={{ fontSize: "0.85rem" }}>
+        {allLabel}
+      </MenuItem>
+      {options.map((o) => (
+        <MenuItem key={o} value={o} sx={{ fontSize: "0.85rem" }}>
+          {label(o)}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+/** Compact multi-value facet dropdown (Topic/Skill/Tag); hidden when no options. */
+function FacetMultiSelect({
+  placeholder,
+  value,
+  options,
+  onChange,
+}: {
+  placeholder: string;
+  value: string[];
+  options: string[];
+  onChange: (next: string[]) => void;
+}) {
+  if (options.length === 0) return null;
+  return (
+    <Select
+      multiple
+      size="small"
+      displayEmpty
+      value={value}
+      onChange={(e) => {
+        const next = e.target.value;
+        onChange(typeof next === "string" ? next.split(",") : next);
+      }}
+      renderValue={(v) =>
+        v.length ? (
+          <span style={{ fontWeight: 600 }}>{`${placeholder} · ${v.length}`}</span>
+        ) : (
+          <span style={{ color: "var(--font-tertiary)" }}>{placeholder}</span>
+        )
+      }
+      sx={TOOLBAR_SELECT_SX}
+      MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+    >
+      {options.map((o) => (
+        <MenuItem key={o} value={o} sx={{ fontSize: "0.85rem", gap: 1 }}>
+          <Checkbox size="small" checked={value.includes(o)} sx={{ ...CHECKBOX_SX, p: 0 }} />
+          {o}
+        </MenuItem>
+      ))}
+    </Select>
+  );
+}
+
+/** Active filters as deletable chips — rendered below the toolbar only when active. */
+function ActiveFacetChips({
+  facets,
+  onChange,
+}: {
+  facets: FacetState;
+  onChange: (next: FacetState) => void;
+}) {
+  if (!hasActiveFacets(facets)) return null;
+  const chips: { key: string; label: string; clear: () => void }[] = [];
+  if (facets.difficulty) {
+    chips.push({
+      key: "difficulty",
+      label: facets.difficulty,
+      clear: () => onChange({ ...facets, difficulty: "" }),
+    });
+  }
+  if (facets.source) {
+    chips.push({
+      key: "source",
+      label: SOURCE_LABELS[facets.source] || facets.source,
+      clear: () => onChange({ ...facets, source: "" }),
+    });
+  }
+  if (facets.reusedOnly) {
+    chips.push({
+      key: "reused",
+      label: "Reused only",
+      clear: () => onChange({ ...facets, reusedOnly: false }),
+    });
+  }
+  for (const t of facets.topics) {
+    chips.push({
+      key: `topic:${t}`,
+      label: t,
+      clear: () => onChange({ ...facets, topics: facets.topics.filter((x) => x !== t) }),
+    });
+  }
+  for (const s of facets.skills) {
+    chips.push({
+      key: `skill:${s}`,
+      label: s,
+      clear: () => onChange({ ...facets, skills: facets.skills.filter((x) => x !== s) }),
+    });
+  }
+  for (const g of facets.tags) {
+    chips.push({
+      key: `tag:${g}`,
+      label: g,
+      clear: () => onChange({ ...facets, tags: facets.tags.filter((x) => x !== g) }),
+    });
+  }
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 0.75, px: 2, pb: 1.5 }}>
+      {chips.map((c) => (
+        <Chip key={c.key} label={c.label} size="small" onDelete={c.clear} sx={ACTIVE_CHIP_SX} />
+      ))}
+      <Button
+        size="small"
+        variant="text"
+        startIcon={<IconWrapper icon="mdi:filter-remove-outline" size={15} />}
+        onClick={() => onChange(EMPTY_FACETS)}
+        sx={{
+          fontSize: "0.72rem",
+          fontWeight: 600,
+          textTransform: "none",
+          color: "var(--font-secondary)",
+        }}
+      >
+        Clear all
+      </Button>
+    </Box>
+  );
+}
 
 interface SubjectiveQuestionSelectionSectionProps {
   selectedIds: number[];
@@ -101,6 +315,7 @@ export function SubjectiveQuestionSelectionSection({
   const [limit, setLimit] = useState(10);
   const [facets, setFacets] = useState<FacetState>(EMPTY_FACETS);
   const [preview, setPreview] = useState<AssessmentSubjectiveQuestionListItem | null>(null);
+  const [expandedIds, setExpandedIds] = useState<number[]>([]);
   const facetOptions = useMemo(() => deriveFacetOptions(questions), [questions]);
 
   const filtered = useMemo(() => {
@@ -147,6 +362,17 @@ export function SubjectiveQuestionSelectionSection({
   const pageAllSelected =
     paginated.length > 0 && paginated.every((q) => selectedIds.includes(q.id));
 
+  /** Facet changes always reset to page 1 (same behavior as the old FacetBar wiring). */
+  const updateFacets = (next: FacetState) => {
+    setFacets(next);
+    setPage(1);
+  };
+
+  const toggleExpanded = (id: number) =>
+    setExpandedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+
   if (loading) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
@@ -157,213 +383,333 @@ export function SubjectiveQuestionSelectionSection({
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {/* Selection summary band */}
-      <Box sx={{ ...CARD_SX, p: 2, display: "flex", alignItems: "center", gap: 1.5 }}>
+      {/* Slim section header */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
         <Box
           sx={{
-            width: 40,
-            height: 40,
+            width: 36,
+            height: 36,
             borderRadius: 2,
             flexShrink: 0,
             display: "grid",
             placeItems: "center",
-            bgcolor:
-              "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+            bgcolor: "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
           }}
         >
-          <IconWrapper
-            icon="mdi:text-box-check-outline"
-            size={21}
-            color="var(--warning-500)"
-          />
+          <IconWrapper icon="mdi:text-box-check-outline" size={19} color="var(--warning-500)" />
         </Box>
         <Box>
           <Typography sx={KICKER_SX}>Question bank</Typography>
           <Typography
-            variant="body2"
-            sx={{ fontWeight: 600, color: "var(--font-primary)" }}
-          >
-            Selected: {selectedIds.length} | Showing: {filtered.length} of {questions.length}
-          </Typography>
-        </Box>
-      </Box>
-
-      {/* Search + facet filters grouped in one card */}
-      <Box sx={{ ...CARD_SX, p: { xs: 2, sm: 2.5 } }}>
-        <Typography sx={{ ...KICKER_SX, mb: 1.5 }}>Search & filters</Typography>
-        <TextField
-          label="Search"
-          value={searchTerm}
-          onChange={(e) => {
-            setSearchTerm(e.target.value);
-            setPage(1);
-          }}
-          fullWidth
-          size="small"
-          InputProps={{
-            startAdornment: (
-              <IconWrapper icon="mdi:magnify" size={20} style={{ marginRight: 8 }} />
-            ),
-          }}
-          sx={SEARCH_FIELD_SX}
-        />
-        <Box sx={{ mt: 2 }}>
-          <FacetBar
-            facets={facets}
-            options={facetOptions}
-            onChange={(next) => {
-              setFacets(next);
-              setPage(1);
-            }}
-          />
-        </Box>
-      </Box>
-
-      {filtered.length === 0 ? (
-        <Box sx={{ ...CARD_SX, p: 4, textAlign: "center" }}>
-          <Box
             sx={{
-              width: 44,
-              height: 44,
-              borderRadius: 2,
-              display: "grid",
-              placeItems: "center",
-              mx: "auto",
-              mb: 1.5,
-              bgcolor:
-                "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: "1.02rem",
+              color: "var(--font-primary)",
+              lineHeight: 1.3,
             }}
           >
-            <IconWrapper icon="mdi:magnify" size={22} color="var(--warning-500)" />
-          </Box>
-          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-            {searchTerm ? "No matches" : "No written questions yet. Use Manual Entry or create some in Django admin."}
+            Select from Existing Written Questions
           </Typography>
         </Box>
-      ) : (
-        <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
-          {/* Select-all header */}
+      </Box>
+
+      {/* Single results card: compact toolbar header + rows + pagination */}
+      <Box sx={{ ...CARD_SX, overflow: "hidden" }}>
+        {/* One compact toolbar row: search + facet dropdowns + selected-count chip */}
+        <Box sx={{ borderBottom: HAIRLINE }}>
           <Box
             sx={{
               display: "flex",
               alignItems: "center",
-              gap: 0.5,
+              flexWrap: "wrap",
+              gap: 1,
               px: 2,
-              py: 0.75,
-              borderBottom: "1px solid var(--border-default)",
-              bgcolor: "var(--surface)",
+              py: 1.5,
             }}
           >
-            <Checkbox
-              checked={pageAllSelected}
-              onChange={handleSelectAll}
-              sx={CHECKBOX_SX}
+            <TextField
+              label="Search"
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                setPage(1);
+              }}
+              size="small"
+              InputProps={{
+                startAdornment: (
+                  <IconWrapper icon="mdi:magnify" size={18} style={{ marginRight: 8 }} />
+                ),
+              }}
+              sx={{ ...SEARCH_FIELD_SX, flex: "1 1 220px", minWidth: 200 }}
             />
-            <Typography sx={KICKER_SX}>Select all on page</Typography>
-            <Box sx={{ flexGrow: 1 }} />
-            <Typography
-              variant="caption"
+            <FacetSelect
+              placeholder="Difficulty"
+              allLabel="All difficulties"
+              value={facets.difficulty}
+              options={DIFFICULTY_OPTIONS}
+              onChange={(difficulty) => updateFacets({ ...facets, difficulty })}
+            />
+            <FacetSelect
+              placeholder="Source"
+              allLabel="All sources"
+              value={facets.source}
+              options={SOURCE_OPTIONS}
+              getLabel={(s) => SOURCE_LABELS[s] || s}
+              onChange={(source) => updateFacets({ ...facets, source })}
+            />
+            <FacetMultiSelect
+              placeholder="Topic"
+              value={facets.topics}
+              options={facetOptions.topics}
+              onChange={(topics) => updateFacets({ ...facets, topics })}
+            />
+            <FacetMultiSelect
+              placeholder="Skill"
+              value={facets.skills}
+              options={facetOptions.skills}
+              onChange={(skills) => updateFacets({ ...facets, skills })}
+            />
+            <FacetMultiSelect
+              placeholder="Tag"
+              value={facets.tags}
+              options={facetOptions.tags}
+              onChange={(tags) => updateFacets({ ...facets, tags })}
+            />
+            <Chip
+              icon={<IconWrapper icon="mdi:recycle-variant" size={14} />}
+              label="Reused"
+              size="small"
+              variant={facets.reusedOnly ? "filled" : "outlined"}
+              onClick={() => updateFacets({ ...facets, reusedOnly: !facets.reusedOnly })}
               sx={{
-                fontFamily: "var(--font-mono)",
-                fontWeight: 700,
-                color: "var(--font-secondary)",
+                height: 32,
+                borderRadius: "10px",
+                fontSize: "0.75rem",
+                fontWeight: 600,
+                cursor: "pointer",
+                bgcolor: facets.reusedOnly ? "var(--accent-indigo)" : "transparent",
+                color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)",
+                borderColor: "color-mix(in srgb, var(--border-default) 70%, transparent)",
+                "& .MuiChip-icon": {
+                  color: facets.reusedOnly ? "var(--font-light)" : "var(--font-secondary)",
+                },
+                "&:hover": {
+                  bgcolor: facets.reusedOnly ? "var(--accent-indigo)" : "var(--surface)",
+                },
+              }}
+            />
+            <Box sx={{ flexGrow: 1 }} />
+            {selectedIds.length > 0 && (
+              <Box
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  px: 1.25,
+                  py: 0.5,
+                  borderRadius: 999,
+                  flexShrink: 0,
+                  bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--card-bg) 90%)",
+                  border: "1px solid color-mix(in srgb, var(--ai-violet) 35%, transparent)",
+                }}
+              >
+                <IconWrapper icon="mdi:check-circle-outline" size={14} color="var(--ai-violet)" />
+                <Typography
+                  sx={{
+                    fontSize: "0.78rem",
+                    fontWeight: 700,
+                    color: "var(--ai-violet)",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  <Box component="span" sx={{ fontFamily: "var(--font-mono)" }}>
+                    {selectedIds.length}
+                  </Box>
+                  {" selected"}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+          <ActiveFacetChips facets={facets} onChange={updateFacets} />
+        </Box>
+
+        {filtered.length === 0 ? (
+          <Box sx={{ p: 4, textAlign: "center" }}>
+            <Box
+              sx={{
+                width: 44,
+                height: 44,
+                borderRadius: 2,
+                display: "grid",
+                placeItems: "center",
+                mx: "auto",
+                mb: 1.5,
+                bgcolor: "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg) 88%)",
               }}
             >
-              {filtered.length} result{filtered.length === 1 ? "" : "s"}
+              <IconWrapper icon="mdi:magnify" size={22} color="var(--warning-500)" />
+            </Box>
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+              {searchTerm ? "No matches" : "No written questions yet. Use Manual Entry or create some in Django admin."}
             </Typography>
           </Box>
+        ) : (
+          <>
+            {/* Select-all header */}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                px: 1.5,
+                py: 0.25,
+                borderBottom: HAIRLINE,
+                bgcolor: "var(--surface)",
+              }}
+            >
+              <Checkbox
+                checked={pageAllSelected}
+                onChange={handleSelectAll}
+                sx={{ ...CHECKBOX_SX, p: 0.5 }}
+              />
+              <Typography sx={KICKER_SX}>Select all on page</Typography>
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography
+                variant="caption"
+                sx={{
+                  fontFamily: "var(--font-mono)",
+                  fontWeight: 700,
+                  color: "var(--font-secondary)",
+                }}
+              >
+                {filtered.length} result{filtered.length === 1 ? "" : "s"}
+              </Typography>
+            </Box>
 
-          {/* Result rows as soft cards */}
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 1.25,
-              p: { xs: 1.5, sm: 2 },
-            }}
-          >
-            {paginated.map((q) => {
-              const selected = selectedIds.includes(q.id);
-              return (
-                <Box key={q.id} sx={rowCardSx(selected)}>
-                  <Checkbox
-                    checked={selectedIds.includes(q.id)}
-                    onChange={() => toggle(q.id)}
-                    sx={{ ...CHECKBOX_SX, p: 0.5 }}
-                  />
-                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.75,
-                        flexWrap: "wrap",
-                      }}
-                    >
+            {/* Single-line-first rows; secondary metadata lives inside the expand */}
+            <Box>
+              {paginated.map((q) => {
+                const selected = selectedIds.includes(q.id);
+                const expanded = expandedIds.includes(q.id);
+                return (
+                  <Box key={q.id} sx={rowShellSx(selected)}>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, px: 1.5, minHeight: 48 }}>
+                      <Checkbox
+                        checked={selectedIds.includes(q.id)}
+                        onChange={() => toggle(q.id)}
+                        sx={{ ...CHECKBOX_SX, p: 0.5 }}
+                      />
                       <Typography
-                        variant="body2"
+                        noWrap
                         sx={{
-                          color: "var(--font-tertiary)",
-                          fontFamily: "var(--font-mono)",
+                          flex: 1,
+                          minWidth: 0,
+                          fontSize: "0.875rem",
                           fontWeight: 600,
+                          color: "var(--font-primary)",
                         }}
                       >
-                        #{q.id}
+                        {q.question_text}
                       </Typography>
-                      <StatusChip
-                        label={(q.answer_mode || "text").replace(/_/g, " ")}
-                        tone="info"
-                        icon="mdi:pencil-box-outline"
-                      />
-                      <StatusChip
-                        label={`${q.max_marks} marks`}
-                        tone="neutral"
-                        icon="mdi:star-four-points-outline"
-                      />
-                      <UsageChip count={q.usage_count} />
-                      <SourceChip source={q.source} />
-                      <Box sx={{ flexGrow: 1 }} />
+                      {q.difficulty_level && <DifficultyChip level={q.difficulty_level} />}
+                      <Box
+                        sx={{
+                          display: { xs: "none", md: "flex" },
+                          alignItems: "center",
+                          gap: 0.75,
+                          flexShrink: 0,
+                        }}
+                      >
+                        <UsageChip count={q.usage_count} />
+                        <SourceChip source={q.source} />
+                      </Box>
                       <PreviewButton onClick={() => setPreview(q)} />
+                      <IconButton
+                        size="small"
+                        aria-label={expanded ? "Collapse question details" : "Expand question details"}
+                        onClick={() => toggleExpanded(q.id)}
+                        sx={{
+                          color: "var(--font-tertiary)",
+                          transform: expanded ? "rotate(180deg)" : "none",
+                          transition: "transform 0.15s ease",
+                        }}
+                      >
+                        <IconWrapper icon="mdi:chevron-down" size={18} />
+                      </IconButton>
                     </Box>
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        fontWeight: 600,
-                        color: "var(--font-primary)",
-                        mt: 0.75,
-                      }}
-                    >
-                      {q.question_text.length > 160 ? `${q.question_text.slice(0, 160)}…` : q.question_text}
-                    </Typography>
+                    {expanded && (
+                      <Box
+                        sx={{
+                          pl: 6.5,
+                          pr: 2,
+                          pb: 1.75,
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 1,
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          sx={{ color: "var(--font-primary)", whiteSpace: "pre-wrap" }}
+                        >
+                          {q.question_text}
+                        </Typography>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                          <Typography
+                            sx={{
+                              fontFamily: "var(--font-mono)",
+                              fontWeight: 600,
+                              fontSize: "0.75rem",
+                              color: "var(--font-tertiary)",
+                            }}
+                          >
+                            #{q.id}
+                          </Typography>
+                          <StatusChip
+                            label={(q.answer_mode || "text").replace(/_/g, " ")}
+                            tone="info"
+                            icon="mdi:pencil-box-outline"
+                          />
+                          <StatusChip
+                            label={`${q.max_marks} marks`}
+                            tone="neutral"
+                            icon="mdi:star-four-points-outline"
+                          />
+                        </Box>
+                        {q.tags && <TagChips tags={q.tags} />}
+                      </Box>
+                    )}
                   </Box>
-                </Box>
-              );
-            })}
-          </Box>
+                );
+              })}
+            </Box>
 
-          {/* Pagination */}
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 2,
-              flexWrap: "wrap",
-              p: 1.5,
-              borderTop: "1px solid var(--border-default)",
-            }}
-          >
-            <PerPageSelect value={limit} onChange={(n) => { setLimit(n); setPage(1); }} />
-            <Pagination
-              count={totalPages}
-              page={page}
-              onChange={(_, p) => setPage(p)}
-              color="primary"
-              size="small"
-            />
-          </Box>
-        </Box>
-      )}
+            {/* Pagination */}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 2,
+                flexWrap: "wrap",
+                px: 2,
+                py: 1.5,
+                borderTop: HAIRLINE,
+              }}
+            >
+              <PerPageSelect value={limit} onChange={(n) => { setLimit(n); setPage(1); }} />
+              <Pagination
+                count={totalPages}
+                page={page}
+                onChange={(_, p) => setPage(p)}
+                size="small"
+                sx={PAGINATION_SX}
+              />
+            </Box>
+          </>
+        )}
+      </Box>
 
       <PreviewDialog
         open={!!preview}

--- a/components/admin/assessment/shared/AiPromptField.tsx
+++ b/components/admin/assessment/shared/AiPromptField.tsx
@@ -85,7 +85,7 @@ export function AiPromptField({
                 WebkitTextFillColor: "#fff",
                 caretColor: "#fff",
               },
-              "& .MuiInputBase-input::placeholder": { color: "rgba(255,255,255,0.62)", opacity: 1 },
+              "& .MuiInputBase-input::placeholder": { color: "rgba(255,255,255,0.45)", opacity: 1 },
             },
           }}
         />


### PR DESCRIPTION
Five user-reported items, one verified batch:

1. **Placeholders** clearly grey again (pill 0.45 alpha + global MUI placeholder rule at 0.55 opacity).
2. **Select-from-Existing pickers decluttered** (MCQ/coding/subjective): one toolbar row, chips only when active, single-line rows + chevron expand, violet selection. Logic verbatim.
3. **Draft header decluttered**: one save-draft button (chip + nav duplicate removed).
4. **+ Add section works from step 2**: dashed row in the section sidenav → jumps to step 1 & scrolls to the builder (new optional `onAddSection` prop chain).
5. **Settings → accordion cards** with live one-line summaries; obvious defaults collapsed; Notifications auto-opens when email is on; email-editor mount trick preserved.

**Verified:** tsc 0 · eslint delta 0 (23=23, 9 files) · real `next build` ✓. (BE #338 gen-speed verified live separately: 10-question job = 2 parallel batches, completed 10/10.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)