### PR TITLE
feat(assessment): company-prep picker in the hub hero

### DIFF
--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -21,6 +21,7 @@ import {
   IconButton,
   Divider,
   Tooltip,
+  CircularProgress,
 } from "@mui/material";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -60,7 +61,9 @@ import {
 } from "@/components/admin/assessment/shared";
 import {
   startAssessmentComposer,
+  getAssessmentCompanyCatalog,
   type ComposerPreset,
+  type CompanyPrepEntry,
 } from "@/lib/services/admin/admin-assessment-composer.service";
 
 const COMPOSER_EXAMPLES = [
@@ -144,6 +147,34 @@ export default function AssessmentPage() {
       ["content manager", "content_manager"].includes(
         user.role.toLowerCase().replace(/\s+/g, " ")
       ));
+  // Company-prep picker: curated real hiring-round blueprints (BE catalog).
+  const [companyCatalog, setCompanyCatalog] = useState<CompanyPrepEntry[]>([]);
+  const [companyOpen, setCompanyOpen] = useState<string>("");
+  const [companyStarting, setCompanyStarting] = useState<string>("");
+  useEffect(() => {
+    if (composerBlocked) return;
+    let cancelled = false;
+    getAssessmentCompanyCatalog(config.clientId)
+      .then((c) => { if (!cancelled) setCompanyCatalog(c); })
+      .catch(() => { /* picker simply stays hidden */ });
+    return () => { cancelled = true; };
+  }, [composerBlocked]);
+
+  const handleCompanyGenerate = async (companyId: string, roundKey: string) => {
+    if (companyStarting) return;
+    try {
+      setCompanyStarting(`${companyId}:${roundKey}`);
+      const job = await startAssessmentComposer(config.clientId, {
+        company: companyId,
+        round_key: roundKey,
+      });
+      router.push(`/admin/assessment/compose/${job.job_id}`);
+    } catch (e: unknown) {
+      showToast((e as { message?: string })?.message || "Couldn't start the company prep", "error");
+      setCompanyStarting("");
+    }
+  };
+
   const handleComposerGenerate = async () => {
     if (!composerBrief.trim() || composerSubmitting) return;
     try {
@@ -1016,6 +1047,95 @@ export default function AssessmentPage() {
                     );
                   })}
                 </Box>
+
+                {/* Company prep: curated real hiring-round blueprints (TCS, Infosys, …) */}
+                {companyCatalog.length > 0 ? (
+                  <>
+                    <Typography
+                      sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: "0.1em", opacity: 0.75, mt: 2.5, mb: 1.25 }}
+                    >
+                      PREP FOR A COMPANY
+                    </Typography>
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
+                      {companyCatalog.map((co) => {
+                        const active = companyOpen === co.id;
+                        return (
+                          <Box
+                            key={co.id}
+                            onClick={() => setCompanyOpen(active ? "" : co.id)}
+                            sx={{
+                              px: 1.5,
+                              py: 0.6,
+                              borderRadius: 999,
+                              cursor: "pointer",
+                              fontSize: "0.82rem",
+                              fontWeight: 700,
+                              userSelect: "none",
+                              bgcolor: active ? "rgba(255,255,255,0.22)" : "rgba(255,255,255,0.08)",
+                              border: active ? "1px solid rgba(255,255,255,0.6)" : "1px solid rgba(255,255,255,0.18)",
+                              transition: "background-color 0.15s ease, border-color 0.15s ease",
+                              "&:hover": { bgcolor: "rgba(255,255,255,0.18)" },
+                            }}
+                          >
+                            {co.name}
+                          </Box>
+                        );
+                      })}
+                    </Box>
+                    {companyOpen
+                      ? (() => {
+                          const co = companyCatalog.find((c) => c.id === companyOpen);
+                          if (!co) return null;
+                          return (
+                            <Box sx={{ mt: 1.25, display: "flex", flexDirection: "column", gap: 0.75 }}>
+                              {co.rounds.map((r) => {
+                                const starting = companyStarting === `${co.id}:${r.key}`;
+                                return (
+                                  <Box
+                                    key={r.key}
+                                    onClick={() => void handleCompanyGenerate(co.id, r.key)}
+                                    sx={{
+                                      display: "flex",
+                                      alignItems: "center",
+                                      gap: 1,
+                                      px: 1.5,
+                                      py: 1.1,
+                                      borderRadius: 2,
+                                      cursor: "pointer",
+                                      bgcolor: "rgba(255,255,255,0.07)",
+                                      border: "1px solid rgba(255,255,255,0.16)",
+                                      opacity: companyStarting && !starting ? 0.55 : 1,
+                                      transition: "background-color 0.15s ease",
+                                      "&:hover": { bgcolor: "rgba(255,255,255,0.15)" },
+                                    }}
+                                  >
+                                    {starting ? (
+                                      <CircularProgress size={15} sx={{ color: "#fff", flexShrink: 0 }} />
+                                    ) : (
+                                      <IconWrapper
+                                        icon={r.has_coding ? "mdi:code-tags" : "mdi:format-list-checks"}
+                                        size={16}
+                                      />
+                                    )}
+                                    <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+                                      <Typography sx={{ fontWeight: 700, fontSize: "0.85rem", lineHeight: 1.25 }}>
+                                        {r.title}
+                                      </Typography>
+                                      <Typography sx={{ fontSize: "0.72rem", opacity: 0.75 }}>
+                                        {r.question_count} questions · {r.duration_minutes}m
+                                        {r.has_coding ? " · coding" : ""}
+                                      </Typography>
+                                    </Box>
+                                    <IconWrapper icon="mdi:arrow-right" size={16} />
+                                  </Box>
+                                );
+                              })}
+                            </Box>
+                          );
+                        })()
+                      : null}
+                  </>
+                ) : null}
               </Box>
             </Box>
           </Box>

--- a/lib/services/admin/admin-assessment-composer.service.ts
+++ b/lib/services/admin/admin-assessment-composer.service.ts
@@ -60,10 +60,43 @@ export type ComposerPreset =
   | "";
 
 export interface StartAssessmentComposerBody {
-  brief: string;
+  brief?: string;
   preset?: ComposerPreset;
   attach_course_id?: number;
+  /** Company-prep path: curated catalog blueprint (no brief needed). */
+  company?: string;
+  round_key?: string;
 }
+
+/** One company in the curated prep catalog (real hiring-round patterns). */
+export interface CompanyPrepRound {
+  key: string;
+  title: string;
+  summary: string;
+  duration_minutes: number;
+  has_coding: boolean;
+  question_count: number;
+  section_titles: string[];
+}
+
+export interface CompanyPrepEntry {
+  id: string;
+  name: string;
+  category: string;
+  exam_name: string;
+  pattern_year: string;
+  rounds: CompanyPrepRound[];
+}
+
+/** Curated company-prep catalog for the composer's blueprint picker. */
+export const getAssessmentCompanyCatalog = async (
+  clientId: string | number
+): Promise<CompanyPrepEntry[]> => {
+  const response = await apiClient.get(
+    `/admin-dashboard/api/clients/${clientId}/assessment-company-catalog/`
+  );
+  return response.data?.companies ?? [];
+};
 
 /** Start the AI Assessment Composer — one brief → whole draft assessment (background). */
 export const startAssessmentComposer = async (


### PR DESCRIPTION
## What

The assessment hub hero gains a **"Prep for a company"** picker: chips for the 8 curated companies from BE #339's catalog (TCS NQT, Infosys, Wipro, Capgemini, Accenture, Cognizant, product-based, service-based). Selecting a company reveals its real hiring rounds (title, question count, duration, coding marker); picking a round starts the deterministic company-prep composer path and routes straight to the live compose page.

## How

- `admin-assessment-composer.service.ts`: `getAssessmentCompanyCatalog(clientId)` + `CompanyPrepEntry`/`CompanyPrepRound` types; `StartAssessmentComposerBody` widened with `company`/`round_key` (brief now optional).
- `app/admin/assessment/page.tsx`: catalog fetched lazily once composer access is confirmed; chip strip + per-round rows with per-round busy spinner; failures reuse the brief path's error surface. Styling follows the dark-hero language (translucent chips, kicker label, Satoshi stack).

## Verification

- `tsc --noEmit`: 0 errors.
- Per-file eslint delta vs stashed baseline: 6 = 6 (one unused disable directive this branch introduced was caught by the delta and removed).
- Real `next build` (worktree with real `npm ci` node_modules): compiled clean, twice (before and after the lint fix).
- Backend is already live and reverified on prod: catalog returns all 8 companies; a real TCS NQT Advanced job produced 10 MCQ + 2 coding questions and assembled a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
