### PR TITLE
fix(assessment): company picker — reposition + select-then-Generate flow

### DIFF
--- a/app/admin/assessment/page.tsx
+++ b/app/admin/assessment/page.tsx
@@ -21,7 +21,6 @@ import {
   IconButton,
   Divider,
   Tooltip,
-  CircularProgress,
 } from "@mui/material";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -150,7 +149,9 @@ export default function AssessmentPage() {
   // Company-prep picker: curated real hiring-round blueprints (BE catalog).
   const [companyCatalog, setCompanyCatalog] = useState<CompanyPrepEntry[]>([]);
   const [companyOpen, setCompanyOpen] = useState<string>("");
-  const [companyStarting, setCompanyStarting] = useState<string>("");
+  // A picked company round fills the brief and arms the deterministic company path;
+  // Generate (not the click) starts it, mirroring the blueprint cards.
+  const [companyRound, setCompanyRound] = useState<{ company: string; roundKey: string } | null>(null);
   useEffect(() => {
     if (composerBlocked) return;
     let cancelled = false;
@@ -160,23 +161,46 @@ export default function AssessmentPage() {
     return () => { cancelled = true; };
   }, [composerBlocked]);
 
-  const handleCompanyGenerate = async (companyId: string, roundKey: string) => {
-    if (companyStarting) return;
-    try {
-      setCompanyStarting(`${companyId}:${roundKey}`);
-      const job = await startAssessmentComposer(config.clientId, {
-        company: companyId,
-        round_key: roundKey,
-      });
-      router.push(`/admin/assessment/compose/${job.job_id}`);
-    } catch (e: unknown) {
-      showToast((e as { message?: string })?.message || "Couldn't start the company prep", "error");
-      setCompanyStarting("");
-    }
+  // Human-readable brief shown in the input when a company round is picked. The company
+  // path is deterministic (the BE builds from the curated catalog, not this text), so this
+  // is a preview of the selection — like a blueprint's starter brief.
+  const briefForCompanyRound = (co: CompanyPrepEntry, r: CompanyPrepEntry["rounds"][number]) =>
+    `${co.name} · ${r.title} — ${r.question_count} questions, ${r.duration_minutes} min` +
+    (r.has_coding ? ", includes a coding round." : ".");
+
+  // Pick a round: fill the input + arm the company path. Does NOT start generation —
+  // the user reviews the input and clicks Generate, same as the blueprint cards.
+  const handleSelectCompanyRound = (co: CompanyPrepEntry, r: CompanyPrepEntry["rounds"][number]) => {
+    setCompanyRound({ company: co.id, roundKey: r.key });
+    setComposerPreset("");
+    setComposerBrief(briefForCompanyRound(co, r));
+  };
+
+  // Typing (or picking a blueprint/example) means the user left the company selection —
+  // fall back to the free-text AI path so Generate uses what's actually in the box.
+  const handleComposerBriefChange = (v: string) => {
+    setComposerBrief(v);
+    if (companyRound) setCompanyRound(null);
   };
 
   const handleComposerGenerate = async () => {
-    if (!composerBrief.trim() || composerSubmitting) return;
+    if (composerSubmitting) return;
+    // A picked company round takes the deterministic catalog path; otherwise the AI brief.
+    if (companyRound) {
+      try {
+        setComposerSubmitting(true);
+        const job = await startAssessmentComposer(config.clientId, {
+          company: companyRound.company,
+          round_key: companyRound.roundKey,
+        });
+        router.push(`/admin/assessment/compose/${job.job_id}`);
+      } catch (e: unknown) {
+        showToast((e as { message?: string })?.message || "Couldn't start the company prep", "error");
+        setComposerSubmitting(false);
+      }
+      return;
+    }
+    if (!composerBrief.trim()) return;
     try {
       setComposerSubmitting(true);
       const job = await startAssessmentComposer(config.clientId, {
@@ -988,12 +1012,129 @@ export default function AssessmentPage() {
                 <Box sx={{ maxWidth: 860 }}>
                   <AiPromptField
                     value={composerBrief}
-                    onChange={setComposerBrief}
+                    onChange={handleComposerBriefChange}
                     onSubmit={handleComposerGenerate}
                     submitting={composerSubmitting}
                     examples={COMPOSER_EXAMPLES}
                   />
                 </Box>
+
+                {/* Company prep: curated real hiring-round blueprints (TCS, Infosys, …).
+                    Lives under the brief on the left so a picked round fills the input and
+                    the left column stays full; Generate (not the click) starts it. */}
+                {companyCatalog.length > 0 ? (
+                  <Box sx={{ maxWidth: 860, mt: 3.5 }}>
+                    <Typography
+                      sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: "0.1em", opacity: 0.75, mb: 0.5 }}
+                    >
+                      PREP FOR A COMPANY
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.82rem", opacity: 0.7, mb: 1.5 }}>
+                      Pick a company and a round — we fill the brief with its real pattern. Then hit Generate.
+                    </Typography>
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
+                      {companyCatalog.map((co) => {
+                        const active = companyOpen === co.id;
+                        return (
+                          <Box
+                            key={co.id}
+                            onClick={() => setCompanyOpen(active ? "" : co.id)}
+                            sx={{
+                              px: 1.5,
+                              height: 34,
+                              display: "inline-flex",
+                              alignItems: "center",
+                              borderRadius: 999,
+                              cursor: "pointer",
+                              fontSize: "0.82rem",
+                              fontWeight: 700,
+                              lineHeight: 1,
+                              whiteSpace: "nowrap",
+                              userSelect: "none",
+                              bgcolor: active ? "rgba(255,255,255,0.22)" : "rgba(255,255,255,0.08)",
+                              border: active ? "1px solid rgba(255,255,255,0.6)" : "1px solid rgba(255,255,255,0.18)",
+                              transition: "background-color 0.15s ease, border-color 0.15s ease",
+                              "&:hover": { bgcolor: "rgba(255,255,255,0.18)" },
+                            }}
+                          >
+                            {co.short_name || co.name}
+                          </Box>
+                        );
+                      })}
+                    </Box>
+                    {companyOpen
+                      ? (() => {
+                          const co = companyCatalog.find((c) => c.id === companyOpen);
+                          if (!co) return null;
+                          return (
+                            <Box
+                              sx={{
+                                mt: 1.5,
+                                display: "grid",
+                                gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+                                gap: 1.25,
+                              }}
+                            >
+                              {co.rounds.map((r) => {
+                                const selected =
+                                  companyRound?.company === co.id && companyRound?.roundKey === r.key;
+                                return (
+                                  <Box
+                                    key={r.key}
+                                    onClick={() => handleSelectCompanyRound(co, r)}
+                                    sx={{
+                                      display: "flex",
+                                      alignItems: "center",
+                                      gap: 1.5,
+                                      p: 1.75,
+                                      borderRadius: 2.5,
+                                      cursor: "pointer",
+                                      bgcolor: selected ? "rgba(255,255,255,0.2)" : "rgba(255,255,255,0.08)",
+                                      border: selected
+                                        ? "1px solid rgba(255,255,255,0.6)"
+                                        : "1px solid rgba(255,255,255,0.16)",
+                                      transition: "background-color 0.15s ease, border-color 0.15s ease",
+                                      "&:hover": { bgcolor: "rgba(255,255,255,0.16)" },
+                                    }}
+                                  >
+                                    <Box
+                                      sx={{
+                                        width: 38,
+                                        height: 38,
+                                        borderRadius: 2,
+                                        flexShrink: 0,
+                                        display: "grid",
+                                        placeItems: "center",
+                                        bgcolor: "rgba(255,255,255,0.14)",
+                                      }}
+                                    >
+                                      <IconWrapper
+                                        icon={r.has_coding ? "mdi:code-tags" : "mdi:format-list-checks"}
+                                        size={19}
+                                      />
+                                    </Box>
+                                    <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+                                      <Typography sx={{ fontWeight: 700, fontSize: "0.95rem", lineHeight: 1.3 }}>
+                                        {r.title}
+                                      </Typography>
+                                      <Typography sx={{ fontSize: "0.78rem", opacity: 0.72, mt: 0.25 }}>
+                                        {r.question_count} questions · {r.duration_minutes}m
+                                        {r.has_coding ? " · coding" : ""}
+                                      </Typography>
+                                    </Box>
+                                    <IconWrapper
+                                      icon={selected ? "mdi:check-circle" : "mdi:chevron-right"}
+                                      size={20}
+                                    />
+                                  </Box>
+                                );
+                              })}
+                            </Box>
+                          );
+                        })()
+                      : null}
+                  </Box>
+                ) : null}
               </Box>
 
               {/* Right: blueprints inside the band (mockup) */}
@@ -1010,6 +1151,7 @@ export default function AssessmentPage() {
                       <Box
                         key={bp.preset}
                         onClick={() => {
+                          setCompanyRound(null);
                           setComposerPreset(bp.preset);
                           setComposerBrief(bp.starter);
                         }}
@@ -1047,112 +1189,6 @@ export default function AssessmentPage() {
                     );
                   })}
                 </Box>
-
-                {/* Company prep: curated real hiring-round blueprints (TCS, Infosys, …) */}
-                {companyCatalog.length > 0 ? (
-                  <>
-                    <Typography
-                      sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: "0.1em", opacity: 0.75, mt: 2.5, mb: 1.25 }}
-                    >
-                      PREP FOR A COMPANY
-                    </Typography>
-                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
-                      {companyCatalog.map((co) => {
-                        const active = companyOpen === co.id;
-                        return (
-                          <Box
-                            key={co.id}
-                            onClick={() => setCompanyOpen(active ? "" : co.id)}
-                            sx={{
-                              px: 1.5,
-                              height: 34,
-                              display: "inline-flex",
-                              alignItems: "center",
-                              borderRadius: 999,
-                              cursor: "pointer",
-                              fontSize: "0.82rem",
-                              fontWeight: 700,
-                              lineHeight: 1,
-                              whiteSpace: "nowrap",
-                              userSelect: "none",
-                              bgcolor: active ? "rgba(255,255,255,0.22)" : "rgba(255,255,255,0.08)",
-                              border: active ? "1px solid rgba(255,255,255,0.6)" : "1px solid rgba(255,255,255,0.18)",
-                              transition: "background-color 0.15s ease, border-color 0.15s ease",
-                              "&:hover": { bgcolor: "rgba(255,255,255,0.18)" },
-                            }}
-                          >
-                            {co.short_name || co.name}
-                          </Box>
-                        );
-                      })}
-                    </Box>
-                    {companyOpen
-                      ? (() => {
-                          const co = companyCatalog.find((c) => c.id === companyOpen);
-                          if (!co) return null;
-                          return (
-                            <Box sx={{ mt: 1.25, display: "flex", flexDirection: "column", gap: 1.25 }}>
-                              {co.rounds.map((r) => {
-                                const starting = companyStarting === `${co.id}:${r.key}`;
-                                return (
-                                  <Box
-                                    key={r.key}
-                                    onClick={() => void handleCompanyGenerate(co.id, r.key)}
-                                    sx={{
-                                      display: "flex",
-                                      alignItems: "center",
-                                      gap: 1.5,
-                                      p: 1.75,
-                                      borderRadius: 2.5,
-                                      cursor: companyStarting ? "default" : "pointer",
-                                      bgcolor: "rgba(255,255,255,0.08)",
-                                      border: "1px solid rgba(255,255,255,0.16)",
-                                      opacity: companyStarting && !starting ? 0.55 : 1,
-                                      transition: "background-color 0.15s ease, border-color 0.15s ease",
-                                      "&:hover": companyStarting
-                                        ? undefined
-                                        : { bgcolor: "rgba(255,255,255,0.16)" },
-                                    }}
-                                  >
-                                    <Box
-                                      sx={{
-                                        width: 38,
-                                        height: 38,
-                                        borderRadius: 2,
-                                        flexShrink: 0,
-                                        display: "grid",
-                                        placeItems: "center",
-                                        bgcolor: "rgba(255,255,255,0.14)",
-                                      }}
-                                    >
-                                      {starting ? (
-                                        <CircularProgress size={17} sx={{ color: "#fff" }} />
-                                      ) : (
-                                        <IconWrapper
-                                          icon={r.has_coding ? "mdi:code-tags" : "mdi:format-list-checks"}
-                                          size={19}
-                                        />
-                                      )}
-                                    </Box>
-                                    <Box sx={{ minWidth: 0, flexGrow: 1 }}>
-                                      <Typography sx={{ fontWeight: 700, fontSize: "0.95rem", lineHeight: 1.3 }}>
-                                        {r.title}
-                                      </Typography>
-                                      <Typography sx={{ fontSize: "0.78rem", opacity: 0.72, mt: 0.25 }}>
-                                        {r.question_count} questions · {r.duration_minutes}m
-                                        {r.has_coding ? " · coding" : ""}
-                                      </Typography>
-                                    </Box>
-                                    <IconWrapper icon="mdi:chevron-right" size={20} />
-                                  </Box>
-                                );
-                              })}
-                            </Box>
-                          );
-                        })()
-                      : null}
-                  </>
-                ) : null}
               </Box>
             </Box>
           </Box>


### PR DESCRIPTION
## Why

Three issues on the company-prep picker (from user feedback with screenshots):
1. **Position / empty left**: the picker lived in the 340px right rail; when a company expanded, its round cards made the rail tall while the wide left column sat empty.
2. **Tall narrow stack**: rounds stacked vertically in the rail.
3. **Instant generate**: clicking a round immediately started a job and navigated away — unlike the blueprint cards, which fill the brief and wait for Generate.

## What

- The entire 'Prep for a company' section moves into the **left column under the brief input**, so a picked round fills the input right above it and the left column stays full.
- Rounds render as a **2-up responsive grid**.
- **Select-then-Generate**: clicking a round fills the brief with the round's real pattern (`Company · Round — N questions, M min, includes coding`) and highlights the card with a check; **Generate** starts it via the deterministic company path. Typing in the box, or picking a blueprint/example, clears the company selection and reverts to the free-text AI path.

## Verification

- tsc --noEmit: 0
- per-file eslint delta vs stashed baseline: 6 = 6 (removed the now-unused `CircularProgress` import)
- real `next build`: compiled clean

Pairs with the live BE company path (no BE change needed — Generate still calls `startAssessmentComposer({company, round_key})`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)