### PR TITLE
fix(coding): assessment IDE falls back to default languages when template_code is empty

### DIFF
--- a/components/assessment/AssessmentCodingLayout.tsx
+++ b/components/assessment/AssessmentCodingLayout.tsx
@@ -12,7 +12,7 @@ import { AssessmentCodeEditorPanel } from "./AssessmentCodeEditorPanel";
 import { CodingQuestionList } from "./CodingQuestionList";
 import { assessmentService } from "@/lib/services/assessment.service";
 import {
-  getAvailableLanguages,
+  getAvailableLanguagesOrDefault,
   getLanguageId,
 } from "@/components/coding/utils/languageUtils";
 
@@ -63,8 +63,11 @@ export function AssessmentCodingLayout({
   const { showToast } = useToast();
   const { t } = useTranslation("common");
 
-  // Get available languages from problem data
-  const availableLanguages = getAvailableLanguages(
+  // Get available languages from problem data. Falls back to the common languages when the
+  // problem ships no template_code (AI-generated problems can arrive with an empty {}), so the
+  // dropdown is never empty and a language always gets selected — otherwise the editor is
+  // unusable (no selection, no syntax mode, Run/Check disabled).
+  const availableLanguages = getAvailableLanguagesOrDefault(
     problemData?.details?.template_code
   );
 

--- a/components/coding/utils/languageUtils.ts
+++ b/components/coding/utils/languageUtils.ts
@@ -80,8 +80,26 @@ export function getAllLanguages(): LanguageOption[] {
 // Get languages available for a problem based on template_code
 export function getAvailableLanguages(templateCode: Record<string, string> | undefined) {
   if (!templateCode) return [];
-  
+
   return Object.keys(templateCode).map(lang => ({
+    value: lang,
+    label: LANGUAGE_DISPLAY_NAMES[lang] || lang.charAt(0).toUpperCase() + lang.slice(1),
+    monacoLanguage: MONACO_LANGUAGE_MAPPING[lang] || lang,
+  }));
+}
+
+/** Curated fallback languages when a problem ships no template_code — the common
+ * interview/competitive languages. An AI-generated problem can arrive with an empty
+ * template_code ({}), which would otherwise leave the editor with no selectable language
+ * and no way to type. This keeps the IDE usable (Judge0 + Monaco both key off the value). */
+const DEFAULT_FALLBACK_LANGUAGE_KEYS = ["python", "java", "cpp", "c", "javascript"];
+
+export function getAvailableLanguagesOrDefault(
+  templateCode: Record<string, string> | undefined
+): LanguageOption[] {
+  const fromTemplate = getAvailableLanguages(templateCode);
+  if (fromTemplate.length > 0) return fromTemplate;
+  return DEFAULT_FALLBACK_LANGUAGE_KEYS.map((lang) => ({
     value: lang,
     label: LANGUAGE_DISPLAY_NAMES[lang] || lang.charAt(0).toUpperCase() + lang.slice(1),
     monacoLanguage: MONACO_LANGUAGE_MAPPING[lang] || lang,


### PR DESCRIPTION
## Why (urgent — student-facing)

Taking an AI-generated coding question, the **Language dropdown was empty** (no options, nothing selected) and the **editor was blank/unusable**. The IDE derives its language list from the problem's `template_code`, and AI-generated problems can arrive with an empty `{}`.

## What

`getAvailableLanguagesOrDefault(template_code)` (new, in `languageUtils`) returns the common languages (Python, Java, C++, C, JavaScript) when `template_code` is empty; `AssessmentCodingLayout` uses it. A language is then always selected → Monaco syntax mode + Judge0 Run/Check work. Starter code degrades cleanly to empty (student types from scratch).

This unblocks **already-generated** broken problems immediately; BE PR #344 stops new problems arriving with an empty template_code.

## Verification

- tsc --noEmit: 0
- eslint delta vs stashed baseline: 0/0
- real `next build`: compiled clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)