### PR TITLE
fix(adaptive): learner journey board honors content unlock (locked-icon + due-date)

### DIFF
--- a/components/adaptive-journey/JourneyBoard.tsx
+++ b/components/adaptive-journey/JourneyBoard.tsx
@@ -111,12 +111,18 @@ function NodeRow({ node, courseId, stepNo, dueAt }: { node: JourneyNodeView; cou
   const go = () => { if (navigable && navHref) push(navHref); };
   const warm = () => { if (navigable && navHref) prefetch(navHref); };
 
+  const available = node.status === "available";
   const circle = done ? (
     <Box sx={{ width: 28, height: 28, borderRadius: "50%", display: "grid", placeItems: "center", bgcolor: "#22c55e", color: "white", flexShrink: 0, zIndex: 1 }}>
       <Icon icon="mdi:check" width={16} />
     </Box>
   ) : current ? (
     <Box sx={{ width: 28, height: 28, borderRadius: "50%", display: "grid", placeItems: "center", bgcolor: "#6366f1", color: "white", fontWeight: 800, fontSize: "0.8rem", flexShrink: 0, zIndex: 1, boxShadow: "0 0 0 4px rgba(99,102,241,0.18)" }}>
+      {stepNo}
+    </Box>
+  ) : available ? (
+    // Unlocked-but-not-started: open and actionable — a step number, never a padlock.
+    <Box sx={{ width: 28, height: 28, borderRadius: "50%", display: "grid", placeItems: "center", bgcolor: "#eef2ff", color: "#6366f1", fontWeight: 800, fontSize: "0.8rem", flexShrink: 0, zIndex: 1, border: "1.5px solid #c7d2fe" }}>
       {stepNo}
     </Box>
   ) : (
@@ -444,15 +450,28 @@ export function JourneyBoard({ courseId }: { courseId: number; showHeader?: bool
                 </Typography>
               </Box>
             </Stack>
-            <Chip icon={<Icon icon="mdi:auto-fix" width={15} />} label="Adaptive paths on" size="small" sx={{ fontWeight: 800, color: "#6d28d9", bgcolor: "#ede9fe", border: "1px solid #ddd6fe", "& .MuiChip-icon": { color: "#6d28d9" } }} />
+            {board.contentLocked ? (
+              <Chip icon={<Icon icon="mdi:auto-fix" width={15} />} label="Adaptive paths on" size="small" sx={{ fontWeight: 800, color: "#6d28d9", bgcolor: "#ede9fe", border: "1px solid #ddd6fe", "& .MuiChip-icon": { color: "#6d28d9" } }} />
+            ) : (
+              <Chip icon={<Icon icon="mdi:lock-open-variant-outline" width={15} />} label="Open access" size="small" sx={{ fontWeight: 800, color: "#047857", bgcolor: "#d1fae5", border: "1px solid #a7f3d0", "& .MuiChip-icon": { color: "#047857" } }} />
+            )}
           </Stack>
 
-          <Stack direction="row" spacing={1} alignItems="center" sx={{ p: 1.5, mb: 2, borderRadius: 2.5, backgroundImage: "linear-gradient(135deg, #faf5ff, #fff1f7)", border: "1px solid #f0e7fb" }}>
-            <Icon icon="mdi:calendar-alert" width={17} color="#a855f7" style={{ flexShrink: 0 }} />
-            <Typography sx={{ fontSize: "0.8rem", color: "#475569", lineHeight: 1.4 }}>
-              Each week has its own due date. Late penalties apply to the <b style={{ color: "#7c3aed" }}>points earned</b> for that week — finish before the date to keep 100%.
-            </Typography>
-          </Stack>
+          {board.contentLocked ? (
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ p: 1.5, mb: 2, borderRadius: 2.5, backgroundImage: "linear-gradient(135deg, #faf5ff, #fff1f7)", border: "1px solid #f0e7fb" }}>
+              <Icon icon="mdi:calendar-alert" width={17} color="#a855f7" style={{ flexShrink: 0 }} />
+              <Typography sx={{ fontSize: "0.8rem", color: "#475569", lineHeight: 1.4 }}>
+                Each week has its own due date. Late penalties apply to the <b style={{ color: "#7c3aed" }}>points earned</b> for that week — finish before the date to keep 100%.
+              </Typography>
+            </Stack>
+          ) : (
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ p: 1.5, mb: 2, borderRadius: 2.5, backgroundImage: "linear-gradient(135deg, #ecfdf5, #f0fdfa)", border: "1px solid #bbf7d0" }}>
+              <Icon icon="mdi:lock-open-variant-outline" width={17} color="#059669" style={{ flexShrink: 0 }} />
+              <Typography sx={{ fontSize: "0.8rem", color: "#475569", lineHeight: 1.4 }}>
+                Every step is <b style={{ color: "#047857" }}>open</b> — learn in any order and earn <b style={{ color: "#047857" }}>full points anytime</b>. No due dates, no late penalties.
+              </Typography>
+            </Stack>
+          )}
 
           {board.weeks.map((w, i) => (
             <WeekCard key={w.weekNo} week={w} courseId={courseId} startStep={stepStarts[i] ?? 0} />

--- a/components/adaptive-journey/JourneySidePanels.tsx
+++ b/components/adaptive-journey/JourneySidePanels.tsx
@@ -67,9 +67,13 @@ export function JourneySidePanels({ courseId, board }: { courseId: number; board
 
   const current = board.weeks.flatMap((w) => w.nodes).find((n) => n.status === "current");
   const currentWeek = board.weeks.find((w) => w.nodes.some((n) => n.status === "current"));
-  const due = currentWeek?.schedule?.dueAt;
+  // No deadline framing on an unlocked course (no penalties exist).
+  const due = board.contentLocked ? currentWeek?.schedule?.dueAt : undefined;
+  const stepWord = current?.type === "topic" ? "topic" : "step";
   const momentum = current
-    ? `finish the current ${current.type === "topic" ? "topic" : "step"}${due ? ` by ${fmtDate(due)}` : ""} to stay penalty-free and lock in the next ${current.score.total} pts at full value.`
+    ? board.contentLocked
+      ? `finish the current ${stepWord}${due ? ` by ${fmtDate(due)}` : ""} to stay penalty-free and lock in the next ${current.score.total} pts at full value.`
+      : `every step is open — finish the current ${stepWord} to earn the next ${current.score.total} pts. No deadlines, full credit anytime.`
     : "complete a step today to keep your momentum and your streak alive.";
 
   return (
@@ -107,12 +111,22 @@ export function JourneySidePanels({ courseId, board }: { courseId: number; board
               {pc.pointsEarned}<span style={{ color: "#64748b", fontSize: "0.75rem", fontWeight: 600 }}> / {pc.pointsTotal}</span>
             </Typography>
           </Box>
-          <Box sx={{ flex: 1, p: 1, borderRadius: 2.5, bgcolor: "#f0fdf4", border: "1px solid #dcfce7" }}>
-            <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "#15803d" }}>ON-TIME RATE</Typography>
-            <Typography sx={{ fontWeight: 800, color: "#15803d", fontSize: "0.95rem" }}>
-              {pc.onTimeRate != null ? `${Math.round(pc.onTimeRate * 100)}%` : "—"}
-            </Typography>
-          </Box>
+          {board.contentLocked ? (
+            <Box sx={{ flex: 1, p: 1, borderRadius: 2.5, bgcolor: "#f0fdf4", border: "1px solid #dcfce7" }}>
+              <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "#15803d" }}>ON-TIME RATE</Typography>
+              <Typography sx={{ fontWeight: 800, color: "#15803d", fontSize: "0.95rem" }}>
+                {pc.onTimeRate != null ? `${Math.round(pc.onTimeRate * 100)}%` : "—"}
+              </Typography>
+            </Box>
+          ) : (
+            // 'On-time' is meaningless with no deadlines — show progress instead.
+            <Box sx={{ flex: 1, p: 1, borderRadius: 2.5, bgcolor: "#f0fdf4", border: "1px solid #dcfce7" }}>
+              <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "#15803d" }}>STEPS DONE</Typography>
+              <Typography sx={{ fontWeight: 800, color: "#15803d", fontSize: "0.95rem" }}>
+                {pc.nodesDone}<span style={{ color: "#64748b", fontSize: "0.75rem", fontWeight: 600 }}> / {pc.nodesTotal}</span>
+              </Typography>
+            </Box>
+          )}
         </Stack>
 
         <Stack direction="row" spacing={0.6} alignItems="flex-start" sx={{ mt: 1.25, p: 1, borderRadius: 2, bgcolor: "#f5f3ff" }}>

--- a/lib/types/adaptive-journey.ts
+++ b/lib/types/adaptive-journey.ts
@@ -6,7 +6,7 @@
 import type { MomentumInfo } from "./momentum";
 
 export type NodeType = "topic" | "checkpoint" | "interview" | "week_final";
-export type NodeStatus = "locked" | "current" | "done";
+export type NodeStatus = "locked" | "available" | "current" | "done";
 export type UnlockRule = "sequential" | "week_open" | "prev_passed" | "always";
 export type FieldTier = "beginner" | "intermediate" | "advanced";
 
@@ -81,6 +81,8 @@ export interface AdminCertificateConfig {
 }
 
 export interface JourneyBoard {
+  /** Admin content-lock. false = every step is open, no deadlines, full XP anytime. */
+  contentLocked: boolean;
   course: {
     id: number;
     title: string;


### PR DESCRIPTION
Phase 3 of the content-lock hardening — the learner-facing journey board. Addresses the original ask (locked icon + due date should update when unlocked) plus the board findings from the audit.

## What (all gated on the board's `contentLocked` flag, now in the type)

- **Locked-icon bug** — the BE marks unlocked-but-unstarted nodes `available`, a value the FE `NodeStatus` union didn't have, so `NodeRow`'s timeline circle fell through to a **padlock**. Added `available` to the union and render it as an open, numbered step (never a padlock); the card stays navigable.
- **Overview banner + chip** — the hardcoded 'Each week has its own due date. Late penalties apply…' banner and 'Adaptive paths on' chip swap, when unlocked, to an **'Open access'** chip + **'Every step is open — full points anytime, no deadlines'** banner.
- **AI momentum** — drops the 'by \<due\> … penalty-free … at full value' wording when unlocked; open-access copy instead.
- **ON-TIME RATE tile → STEPS DONE** when unlocked ('on-time' is meaningless with no deadlines).

The week due chip, node 'before \<date\>' subtitle, and penalty strip already vanish because the BE emits no `schedule`/`penaltyStrip` when unlocked (BE #345).

## Verification
- tsc 0; eslint delta 0; real `next build` compiled clean.

_Follow-up (minor): article/coding/video leaf pages could show the submodule page's 'This step is locked' panel on a 403+locked instead of a generic error. The BE gate (Phase 1) already blocks access; this is polish._

🤖 Generated with [Claude Code](https://claude.com/claude-code)