### PR TITLE
feat(assessment): brand the student PDF report (logo + cursive + gradient) — pass 1

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -75,6 +75,7 @@ import type { EmailNotificationEditorHandle } from "@/components/admin/assessmen
 import { buildAssessmentNotificationEmailHtml } from "@/lib/utils/email-template";
 import { extractSavedEmailAttachment } from "@/lib/utils/assessment-email-attachment";
 import { generateAssessmentResultPdfVector } from "@/lib/utils/assessment-result-pdf.utils";
+import { preloadPdfBrandAssets } from "@/lib/utils/assessment-pdf-assets";
 import { generateAssessmentAnalyticsPdfVector } from "@/lib/utils/assessment-analytics-pdf.utils";
 import { AssessmentAnalyticsCharts } from "@/components/admin/assessment/AssessmentAnalyticsCharts";
 import JSZip from "jszip";
@@ -1369,9 +1370,11 @@ export default function AssessmentEditPage() {
   }, [submissionsData]);
 
   const handleDownloadSubmissionPdf = useCallback(
-    (submission: SubmissionsExportSubmission) => {
+    async (submission: SubmissionsExportSubmission) => {
       if (!submissionsData) return;
       try {
+        // Load the AiLinc logo + cursive font once so the report renders fully branded.
+        await preloadPdfBrandAssets();
         const result = mapSubmissionsExportRowToAssessmentResult(
           submissionsData,
           submission,
@@ -1398,6 +1401,8 @@ export default function AssessmentEditPage() {
     if (!submissionsData?.submissions?.length) return;
     setDownloadingAllSubmissionPdfs(true);
     try {
+      // Load the AiLinc logo + cursive font once; every report in the zip reuses the cache.
+      await preloadPdfBrandAssets();
       const zip = new JSZip();
       const usedFileNames = new Set<string>();
 

--- a/lib/utils/assessment-pdf-assets.ts
+++ b/lib/utils/assessment-pdf-assets.ts
@@ -1,0 +1,96 @@
+/**
+ * Lazy, cached loaders for the assessment PDF's brand assets — the AiLinc cursive font
+ * (AlexBrush) and the AiLinc logo mark rasterized to PNG. Both are fetched from /public and
+ * memoized, so the first report download pays the cost once and the All-PDFs zip reuses it.
+ *
+ * All of this is browser-only (fetch / Image / canvas). The loaders resolve to null on the
+ * server or on any failure, and the PDF generator degrades gracefully (helvetica, no logo).
+ */
+
+const CURSIVE_FONT_URL = "/assets/fonts/AlexBrush-Regular.ttf";
+const LOGO_SVG_URL = "/logos/ai-linc-mark-color.svg";
+
+export const PDF_CURSIVE_FONT = "AlexBrush";
+export const PDF_CURSIVE_FILE = "AlexBrush-Regular.ttf";
+
+let _fontB64: string | null | undefined;
+let _logoPng: { dataUrl: string; w: number; h: number } | null | undefined;
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + chunk)) as unknown as number[],
+    );
+  }
+  return btoa(binary);
+}
+
+/** Base64 of the AlexBrush TTF for jsPDF `addFileToVFS`, or null if unavailable. */
+export async function loadCursiveFontBase64(): Promise<string | null> {
+  if (_fontB64 !== undefined) return _fontB64;
+  try {
+    if (typeof window === "undefined") return (_fontB64 = null);
+    const res = await fetch(CURSIVE_FONT_URL);
+    if (!res.ok) return (_fontB64 = null);
+    _fontB64 = arrayBufferToBase64(await res.arrayBuffer());
+  } catch {
+    _fontB64 = null;
+  }
+  return _fontB64;
+}
+
+/** The AiLinc logo mark rasterized to a PNG data URL (retina-scaled), or null if unavailable. */
+export async function loadLogoPng(): Promise<{ dataUrl: string; w: number; h: number } | null> {
+  if (_logoPng !== undefined) return _logoPng;
+  try {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return (_logoPng = null);
+    }
+    const res = await fetch(LOGO_SVG_URL);
+    if (!res.ok) return (_logoPng = null);
+    const svgText = await res.text();
+    const blob = new Blob([svgText], { type: "image/svg+xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    try {
+      const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+        const im = new Image();
+        im.onload = () => resolve(im);
+        im.onerror = () => reject(new Error("logo decode failed"));
+        im.src = url;
+      });
+      // The mark viewBox is 400×240 (5:3). Rasterize at 4× for crisp print.
+      const scale = 4;
+      const w = 400;
+      const h = 240;
+      const canvas = document.createElement("canvas");
+      canvas.width = w * scale;
+      canvas.height = h * scale;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return (_logoPng = null);
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      _logoPng = { dataUrl: canvas.toDataURL("image/png"), w, h };
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  } catch {
+    _logoPng = null;
+  }
+  return _logoPng;
+}
+
+/** Preload both assets (call before a bulk export so each item reuses the cache). */
+export async function preloadPdfBrandAssets(): Promise<void> {
+  await Promise.all([loadCursiveFontBase64(), loadLogoPng()]);
+}
+
+/** Synchronous cache reads for the (sync) PDF generator — null until preloaded. */
+export function getCachedCursiveFontBase64(): string | null {
+  return _fontB64 ?? null;
+}
+export function getCachedLogoPng(): { dataUrl: string; w: number; h: number } | null {
+  return _logoPng ?? null;
+}

--- a/lib/utils/assessment-result-pdf.utils.ts
+++ b/lib/utils/assessment-result-pdf.utils.ts
@@ -1,4 +1,10 @@
 import jsPDF from "jspdf";
+import {
+  getCachedCursiveFontBase64,
+  getCachedLogoPng,
+  PDF_CURSIVE_FILE,
+  PDF_CURSIVE_FONT,
+} from "@/lib/utils/assessment-pdf-assets";
 import type {
   AssessmentResult,
   CodingProblemResponseItem,
@@ -28,10 +34,13 @@ import {
   parseSubjectiveAnswerPayload,
 } from "@/utils/assessment.utils";
 
-/** Design tokens */
-const SKY = { r: 2, g: 132, b: 199 };
-const SKY_LIGHT = { r: 224, g: 242, b: 254 };
-const SKY_DEEP = { r: 3, g: 105, b: 161 };
+/** Design tokens — aligned to the assessment-management UI (violet→pink gradient + semantics). */
+const SKY = { r: 124, g: 58, b: 237 };        // violet-600 (primary accent)
+const SKY_LIGHT = { r: 237, g: 233, b: 254 }; // violet-100
+const SKY_DEEP = { r: 109, g: 40, b: 217 };   // violet-700
+/** Signature gradient used for the report header band (matches --gradient-ai). */
+const GRADIENT_START = { r: 124, g: 58, b: 237 }; // #7c3aed
+const GRADIENT_END = { r: 236, g: 72, b: 153 };   // #ec4899
 const SLATE = { r: 15, g: 23, b: 42 };
 const SLATE_MUTED = { r: 71, g: 85, b: 105 };
 const INK = { r: 15, g: 23, b: 42 };
@@ -641,6 +650,99 @@ function drawTopAccentBar(pdf: jsPDF, pageW: number) {
   pdf.rect(0, 0, pageW, 1.1, "F");
 }
 
+/** Register the AlexBrush cursive font on this jsPDF instance if it's been preloaded.
+ * Returns true when the font is available for `pdf.setFont(PDF_CURSIVE_FONT, "normal")`. */
+function registerCursiveFont(pdf: jsPDF): boolean {
+  const b64 = getCachedCursiveFontBase64();
+  if (!b64) return false;
+  try {
+    pdf.addFileToVFS(PDF_CURSIVE_FILE, b64);
+    pdf.addFont(PDF_CURSIVE_FILE, PDF_CURSIVE_FONT, "normal");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** jsPDF has no native gradient — paint a smooth left→right gradient as thin vertical strips. */
+function drawHorizontalGradient(
+  pdf: jsPDF,
+  x: number,
+  yTop: number,
+  w: number,
+  h: number,
+  c1: { r: number; g: number; b: number },
+  c2: { r: number; g: number; b: number },
+) {
+  const steps = Math.max(24, Math.min(160, Math.round(w * 3)));
+  const stripW = w / steps;
+  for (let i = 0; i < steps; i++) {
+    const t = i / (steps - 1);
+    const r = Math.round(c1.r + (c2.r - c1.r) * t);
+    const g = Math.round(c1.g + (c2.g - c1.g) * t);
+    const b = Math.round(c1.b + (c2.b - c1.b) * t);
+    pdf.setFillColor(r, g, b);
+    // +0.4 overlap kills hairline seams between strips.
+    pdf.rect(x + i * stripW, yTop, stripW + 0.4, h, "F");
+  }
+}
+
+/**
+ * Signature brand header band on page 1: the violet→pink gradient, the AiLinc logo mark, a
+ * cursive "Assessment Report" wordmark, and the assessment name. Returns the y just below it.
+ */
+function drawBrandHeader(
+  pdf: jsPDF,
+  pageW: number,
+  margin: number,
+  assessmentName: string,
+  hasCursive: boolean,
+): number {
+  const bandH = 34;
+  drawHorizontalGradient(pdf, 0, 0, pageW, bandH, GRADIENT_START, GRADIENT_END);
+
+  // Logo mark (rasterized) top-left, on a soft translucent chip for contrast.
+  const logo = getCachedLogoPng();
+  let textX = margin;
+  if (logo) {
+    const logoH = 12;
+    const logoW = (logo.w / logo.h) * logoH;
+    // White rounded plate behind the mark so the blue→cyan logo reads on the violet gradient.
+    pdf.setFillColor(255, 255, 255);
+    pdf.roundedRect(margin - 1.5, 8, logoW + 3, logoH + 2, 2, 2, "F");
+    try {
+      pdf.addImage(logo.dataUrl, "PNG", margin, 9, logoW, logoH);
+    } catch {
+      /* logo optional */
+    }
+    textX = margin + logoW + 5;
+  }
+
+  // "AiLinc" wordmark + cursive report title
+  pdf.setTextColor(255, 255, 255);
+  pdf.setFont(PDF_FONT, "bold");
+  pdf.setFontSize(9);
+  pdf.text("AILINC", textX, 13, { charSpace: 0.6 });
+
+  if (hasCursive) {
+    pdf.setFont(PDF_CURSIVE_FONT, "normal");
+    pdf.setFontSize(26);
+  } else {
+    pdf.setFont(PDF_FONT, "bold");
+    pdf.setFontSize(18);
+  }
+  pdf.text("Assessment Report", textX, 25);
+
+  // Assessment name, right-aligned, muted white
+  pdf.setFont(PDF_FONT, "normal");
+  pdf.setFontSize(8.5);
+  pdf.setTextColor(255, 255, 255);
+  const nameLines = pdf.splitTextToSize(assessmentName || "Assessment", pageW / 2 - margin);
+  pdf.text(nameLines.slice(0, 2), pageW - margin, 12, { align: "right" });
+
+  return bandH + 6;
+}
+
 function drawFootersOnAllPages(
   pdf: jsPDF,
   pageW: number,
@@ -696,9 +798,11 @@ export function generateAssessmentResultPdfVector(
   const footerReserve = 14;
   const contentBottom = pageH - margin - footerReserve;
 
-  let y = margin + 1;
+  const hasCursive = registerCursiveFont(pdf);
 
-  drawTopAccentBar(pdf, pageW);
+  // Page 1 opens with the signature brand band (gradient + logo + cursive title); the body
+  // starts below it. Later pages keep a slim accent bar so content has the full height.
+  let y = drawBrandHeader(pdf, pageW, margin, data.assessment_name, hasCursive) + 1;
 
   const newPage = () => {
     pdf.addPage();


### PR DESCRIPTION
First pass of the downloaded assessment-report redesign, toward the assessment-management look. **Please review on staging and I'll restyle the body cards next per your feedback.**

## What (pass 1)
- **Signature header band**: violet→pink gradient (matches `--gradient-ai`) with the **AiLinc logo mark** and a **cursive 'Assessment Report' title** (AlexBrush), plus the assessment name.
- **Brand palette**: shifted from sky-blue to violet/pink across accents, panels, footer.
- **Assets**: AlexBrush TTF + logo mark (rasterized to PNG) are fetched from `/public` once and memoized (`assessment-pdf-assets.ts`); the generator reads a sync cache and **degrades gracefully** (helvetica, no logo) if unavailable, so a report always renders. The submissions handlers preload before generating, so single + All-PDFs-zip downloads are branded.
- **No crop**: pagination unchanged — the existing `fitEntireBlock`/`ensureSpace` logic already starts blocks on a fresh page, so content isn't cropped as questions grow.

## Next passes (after your review)
- Restyle the score summary, per-question, and proctoring cards to the new card language.
- Then the PDF/CSV download loophole audit you queued.

## Verification
- tsc 0; eslint delta 0; real `next build` compiled clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)