### PR TITLE
feat(assessments): student assessment experience revamp (hub/instructions/device-check/result + AI readiness)

### DIFF
--- a/app/assessments/[slug]/device-check/page.tsx
+++ b/app/assessments/[slug]/device-check/page.tsx
@@ -12,7 +12,6 @@ import {
   Alert,
   CircularProgress,
   LinearProgress,
-  Chip,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
@@ -24,13 +23,25 @@ import {
 import { isCurrentDeviceAllowedForAssessment } from "@/lib/utils/assessment-device";
 import { AssessmentDeviceStatusPanel } from "@/components/assessment/AssessmentDeviceStatusPanel";
 import { useProctoring } from "@/lib/hooks/useProctoring";
-import { CheckCircle, XCircle, AlertCircle } from "lucide-react";
+import { StatusChip, type ChipTone } from "@/components/admin/assessment/shared";
+import { stripHtmlTags } from "@/lib/utils/html-utils";
 
 interface DeviceStatus {
   camera: boolean;
   microphone: boolean;
   browserSupported: boolean;
 }
+
+/** Maps a StatusChip tone to its token-backed foreground color (icon-tile tint + icon). */
+const ROW_TONE_COLOR: Record<ChipTone, string> = {
+  success: "var(--success-500)",
+  warning: "var(--warning-500)",
+  error: "var(--error-500)",
+  info: "var(--accent-indigo)",
+  neutral: "var(--font-secondary)",
+  ai: "var(--ai-pink)",
+  proctored: "var(--tone-proctored)",
+};
 
 export default function DeviceCheckPage({
   params,
@@ -45,6 +56,8 @@ export default function DeviceCheckPage({
   const [deviceAccessDenied, setDeviceAccessDenied] = useState(false);
   const [deniedAssessment, setDeniedAssessment] =
     useState<AssessmentDetail | null>(null);
+  // Loaded detail — used only for the header subtitle (title). Does not gate flow.
+  const [assessment, setAssessment] = useState<AssessmentDetail | null>(null);
   const [deviceStatus, setDeviceStatus] = useState<DeviceStatus>({
     camera: false,
     microphone: false,
@@ -443,6 +456,7 @@ export default function DeviceCheckPage({
     const loadAssessment = async () => {
       try {
         const data = await assessmentService.getAssessmentDetail(slug);
+        setAssessment(data);
 
         if (!isCurrentDeviceAllowedForAssessment(data)) {
           setDeniedAssessment(data);
@@ -630,555 +644,653 @@ export default function DeviceCheckPage({
     );
   }
 
+  // ---- Derived, render-only readiness descriptors (no flow gating) ----
+  const cameraReady = deviceStatus.camera;
+  const micReady = deviceStatus.microphone;
+
+  const cameraTone: ChipTone = cameraReady ? "success" : "error";
+  const micTone: ChipTone = micReady ? "success" : "error";
+  const netTone: ChipTone =
+    networkStatus === "testing" || networkStatus === null
+      ? "neutral"
+      : !networkAllowsProceed
+      ? "error"
+      : networkStatus === "poor"
+      ? "warning"
+      : "success";
+  const fsTone: ChipTone = deviceStatus.browserSupported ? "success" : "error";
+
+  const netSub =
+    networkStatus === "testing"
+      ? "Checking connection..."
+      : networkSpeed !== null
+      ? `${networkSpeed.toFixed(1)} Mbps — ${
+          networkStatus === "good"
+            ? "stable"
+            : networkStatus === "moderate"
+            ? "usable"
+            : "slow"
+        }`
+      : "Connection check required";
+
+  const netChip =
+    netTone === "neutral"
+      ? "Checking"
+      : netTone === "success"
+      ? "Ready"
+      : netTone === "warning"
+      ? "Slow"
+      : "Too slow";
+
+  const checklistRows: {
+    key: string;
+    icon: string;
+    name: string;
+    sub: string;
+    tone: ChipTone;
+    chip: string;
+  }[] = [
+    {
+      key: "camera",
+      icon: "mdi:camera-outline",
+      name: "Camera",
+      sub: cameraReady
+        ? "Camera is working properly"
+        : cameraError || "Camera check required",
+      tone: cameraTone,
+      chip: cameraReady ? "Ready" : "Pending",
+    },
+    {
+      key: "microphone",
+      icon: "mdi:microphone-outline",
+      name: "Microphone",
+      sub: micReady
+        ? "Microphone is working properly"
+        : micError || "Microphone check required",
+      tone: micTone,
+      chip: micReady ? "Ready" : "Pending",
+    },
+    {
+      key: "internet",
+      icon: "mdi:wifi",
+      name: "Internet connection",
+      sub: netSub,
+      tone: netTone,
+      chip: netChip,
+    },
+    {
+      key: "fullscreen",
+      icon: "mdi:fullscreen",
+      name: "Fullscreen support",
+      sub: deviceStatus.browserSupported
+        ? "Browser compatible"
+        : "Browser not supported",
+      tone: fsTone,
+      chip: deviceStatus.browserSupported ? "Ready" : "Unsupported",
+    },
+  ];
+
+  const assessmentTitle = stripHtmlTags(assessment?.title || "").trim();
+
   return (
     <MainLayout>
-      <Container maxWidth="md" sx={{ py: 4 }}>
-        {/* Header */}
-        <Box sx={{ textAlign: "center", mb: 4 }}>
+      <Box
+        sx={{
+          backgroundColor: "var(--canvas)",
+          minHeight: { xs: "calc(100vh - 56px)", sm: "calc(100vh - 64px)" },
+        }}
+      >
+        <Container maxWidth="md" sx={{ py: { xs: 3, md: 5 } }}>
+          {/* Eyebrow + title + subtitle */}
           <Box
             sx={{
-              width: 80,
-              height: 80,
-              borderRadius: "50%",
-              backgroundColor: "var(--accent-indigo)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
+              textAlign: "center",
+              mb: { xs: 3, md: 4 },
+              maxWidth: 640,
               mx: "auto",
-              mb: 2,
             }}
           >
-            <IconWrapper icon="mdi:camera" size={40} color="var(--font-light)" />
-          </Box>
-          <Typography
-            variant="h4"
-            sx={{
-              fontWeight: 700,
-              mb: 1,
-              fontSize: { xs: "1.5rem", md: "2rem" },
-            }}
-          >
-            Device Check
-          </Typography>
-          <Typography
-            variant="body1"
-            sx={{ color: "var(--font-secondary)", maxWidth: 500, mx: "auto" }}
-          >
-            Before starting your assessment, we need to verify that your camera
-            and microphone are working properly. This ensures a smooth
-            assessment experience.
-          </Typography>
-        </Box>
-
-        {!deviceStatus.browserSupported && (
-          <Alert severity="error" sx={{ mb: 3 }}>
-            <Typography variant="body2" fontWeight={600} gutterBottom>
-              Browser Not Supported
-            </Typography>
-            <Typography variant="body2">
-              Your browser does not support camera/microphone access. Please use
-              a modern browser like Chrome, Firefox, Safari, or Edge.
-            </Typography>
-          </Alert>
-        )}
-
-        {/* Device Status Cards */}
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(2, 1fr)",
-            gap: 3,
-            mb: 4,
-          }}
-        >
-          {/* Camera Status */}
-          <Paper
-            elevation={0}
-            sx={{
-              p: 3,
-              borderRadius: 3,
-              border: "1px solid var(--border-default)",
-              backgroundColor: deviceStatus.camera ? "color-mix(in srgb, var(--course-cta) 10%, var(--card-bg))" : "color-mix(in srgb, var(--error-500) 10%, var(--card-bg))",
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2 }}>
-              {deviceStatus.camera ? (
-                <CheckCircle size={32} color="var(--course-cta)" />
-              ) : (
-                <XCircle size={32} color="var(--error-500)" />
-              )}
-              <Box sx={{ flex: 1 }}>
-                <Typography variant="h6" sx={{ fontWeight: 600, mb: 0.5 }}>
-                  Camera
-                </Typography>
-                <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                  {deviceStatus.camera
-                    ? "Camera is working properly"
-                    : "Camera check required"}
-                </Typography>
-              </Box>
-            </Box>
-
-            {cameraError && (
-              <Alert severity="error" sx={{ mt: 2 }}>
-                {cameraError}
-              </Alert>
-            )}
-
-            {/* Video Preview - Always render, show when camera is working */}
-            <Box
+            <Typography
               sx={{
-                mt: 2,
-                borderRadius: 2,
-                overflow: "hidden",
-                border: deviceStatus.camera
-                  ? faceValidationPassed
-                    ? "2px solid var(--course-cta)"
-                    : "2px solid var(--warning-500)"
-                  : "2px solid var(--border-default)",
-                backgroundColor: "var(--assessment-video-letterbox-bg)",
-                minHeight: deviceStatus.camera ? "auto" : "200px",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                position: "relative",
+                fontSize: "0.72rem",
+                fontWeight: 700,
+                letterSpacing: "0.16em",
+                textTransform: "uppercase",
+                color: "var(--ai-pink)",
+                mb: 1.25,
               }}
             >
-              {!deviceStatus.camera && (
-                <Box
-                  sx={{
-                    position: "absolute",
-                    inset: 0,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: "color-mix(in srgb, var(--font-dark) 72%, transparent)",
-                    zIndex: 1,
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-light)" }}>
-                    Camera preview will appear here
-                  </Typography>
-                </Box>
-              )}
-              {(isFaceDetectionInitializing || isNavigatingToAssessment) && (
-                <Box
-                  sx={{
-                    position: "absolute",
-                    inset: 0,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: "color-mix(in srgb, var(--font-dark) 86%, transparent)",
-                    zIndex: 1,
-                  }}
-                >
-                  <Typography variant="body2" sx={{ color: "var(--font-light)" }}>
-                    {isNavigatingToAssessment
-                      ? "Starting assessment..."
-                      : "Initializing face detection..."}
-                  </Typography>
-                </Box>
-              )}
-              <Box
-                component="video"
-                ref={videoRef}
-                autoPlay
-                playsInline
-                muted
-                sx={{
-                  width: "100%",
-                  height: "auto",
-                  display: "block",
-                  maxHeight: "300px",
-                  minHeight: "200px",
-                  objectFit: "cover",
-                  backgroundColor: "var(--assessment-video-letterbox-bg)",
-                }}
-                onLoadedMetadata={() => {
-                  if (videoRef.current) {
-                    videoRef.current.play().catch(() => {
-                      // Handle play error
-                    });
-                  }
-                }}
-              />
-              
-              {/* Face Detection Status Overlay */}
-              {deviceStatus.camera && !isNavigatingToAssessment && (
-                <Box
-                  sx={{
-                    position: "absolute",
-                    top: 8,
-                    right: 8,
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 1,
-                    zIndex: 2,
-                  }}
-                >
-                  {isFaceDetectionInitializing && (
-                    <Chip
-                      icon={<CircularProgress size={16} />}
-                      label="Initializing face detection..."
-                      size="small"
-                      sx={{ backgroundColor: "var(--accent-indigo)", color: "var(--font-light)" }}
-                    />
-                  )}
-                  {!isFaceDetectionInitializing && (
-                    <>
-                      <Chip
-                        icon={
-                          faceValidationPassed ? (
-                            <CheckCircle size={16} />
-                          ) : (
-                            <XCircle size={16} />
-                          )
-                        }
-                        label={
-                          faceCount === 0
-                            ? "No face"
-                            : faceCount > 1
-                            ? `${faceCount} faces`
-                            : faceValidationPassed
-                            ? "Face OK"
-                            : "Adjust position"
-                        }
-                        size="small"
-                        sx={{
-                          backgroundColor: faceValidationPassed
-                            ? "var(--course-cta)"
-                            : "var(--error-500)",
-                          color: "var(--font-light)",
-                        }}
-                      />
-                      {faceStatus !== "NORMAL" && latestViolation && (
-                        <Chip
-                          icon={<AlertCircle size={14} />}
-                          label={latestViolation.message}
-                          size="small"
-                          sx={{
-                            backgroundColor: "var(--warning-500)",
-                            color: "var(--font-light)",
-                            fontSize: "0.7rem",
-                            maxWidth: "200px",
-                          }}
-                        />
-                      )}
-                    </>
-                  )}
-                </Box>
-              )}
-            </Box>
+              Before you begin
+            </Typography>
+            <Typography
+              variant="h4"
+              sx={{
+                fontWeight: 800,
+                mb: 1.25,
+                fontSize: { xs: "1.55rem", md: "2.05rem" },
+                color: "var(--font-primary-dark)",
+                lineHeight: 1.2,
+              }}
+            >
+              Let&apos;s make sure everything works
+            </Typography>
+            <Typography
+              sx={{
+                color: "var(--font-secondary)",
+                maxWidth: 540,
+                mx: "auto",
+                fontSize: "0.95rem",
+                lineHeight: 1.6,
+              }}
+            >
+              {assessmentTitle || "This assessment"} is proctored — a quick
+              systems check keeps your attempt from being interrupted.
+            </Typography>
+          </Box>
 
-            {/* Face Validation Message */}
-            {deviceStatus.camera && !isFaceDetectionInitializing && !isNavigatingToAssessment && (
-              <Box sx={{ mt: 2 }}>
-                {faceValidationPassed ? (
-                  <Alert severity="success" sx={{ mt: 1 }}>
-                    <Typography variant="body2">
-                      ✓ Face detected and positioned correctly. You can proceed.
-                    </Typography>
-                  </Alert>
-                ) : (
-                  <Alert severity="warning" sx={{ mt: 1 }}>
-                    <Typography variant="body2">
-                      {faceValidationMessage ||
-                        "Please position your face in front of the camera. Make sure you're looking at the screen, not too close or too far, and only one person is visible."}
-                    </Typography>
-                  </Alert>
-                )}
-              </Box>
-            )}
-          </Paper>
+          {!deviceStatus.browserSupported && (
+            <Alert
+              severity="error"
+              sx={{ mb: 3, borderRadius: "var(--radius-card)" }}
+            >
+              <Typography variant="body2" fontWeight={600} gutterBottom>
+                Browser not supported
+              </Typography>
+              <Typography variant="body2">
+                Your browser does not support camera/microphone access. Please
+                use a modern browser like Chrome, Firefox, Safari, or Edge.
+              </Typography>
+            </Alert>
+          )}
 
-          {/* Microphone Status */}
-          <Paper
-            elevation={0}
+          {/* Two columns: camera preview + readiness checklist */}
+          <Box
             sx={{
-              p: 3,
-              borderRadius: 3,
-              border: "1px solid var(--border-default)",
-              backgroundColor: deviceStatus.microphone ? "color-mix(in srgb, var(--course-cta) 10%, var(--card-bg))" : "color-mix(in srgb, var(--error-500) 10%, var(--card-bg))",
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", md: "1.05fr 1fr" },
+              gap: { xs: 2.5, md: 3 },
+              alignItems: "start",
             }}
           >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 2 }}>
-              {deviceStatus.microphone ? (
-                <CheckCircle size={32} color="var(--course-cta)" />
-              ) : (
-                <XCircle size={32} color="var(--error-500)" />
-              )}
-              <Box sx={{ flex: 1 }}>
-                <Typography variant="h6" sx={{ fontWeight: 600, mb: 0.5 }}>
-                  Microphone
-                </Typography>
-                <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-                  {deviceStatus.microphone
-                    ? "Microphone is working properly"
-                    : "Microphone check required"}
+            {/* LEFT — camera preview */}
+            <Paper
+              elevation={0}
+              sx={{
+                p: { xs: 2, sm: 2.5 },
+                borderRadius: "var(--radius-card)",
+                border: "1px solid var(--border-default)",
+                backgroundColor: "var(--card-bg)",
+              }}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  mb: 1.5,
+                }}
+              >
+                <IconWrapper
+                  icon="mdi:camera-outline"
+                  size={18}
+                  color="var(--font-secondary)"
+                />
+                <Typography
+                  sx={{
+                    fontWeight: 700,
+                    fontSize: "0.95rem",
+                    color: "var(--font-primary-dark)",
+                  }}
+                >
+                  Camera preview
                 </Typography>
               </Box>
-            </Box>
 
-            {micError && (
-              <Alert severity="error" sx={{ mt: 2 }}>
-                {micError}
-              </Alert>
-            )}
+              <Box
+                sx={{
+                  position: "relative",
+                  borderRadius: 14,
+                  overflow: "hidden",
+                  border: "1px solid var(--border-default)",
+                  backgroundColor: "var(--assessment-video-letterbox-bg)",
+                  aspectRatio: "4 / 3",
+                }}
+              >
+                {!deviceStatus.camera && (
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      inset: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor:
+                        "color-mix(in srgb, var(--font-dark) 72%, transparent)",
+                      zIndex: 1,
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "var(--font-light)" }}
+                    >
+                      Camera preview will appear here
+                    </Typography>
+                  </Box>
+                )}
 
-            {deviceStatus.microphone && (
-              <Box sx={{ mt: 2 }}>
-                <Typography
-                  variant="caption"
-                  sx={{ color: "var(--font-secondary)", display: "block", mb: 1 }}
+                {(isFaceDetectionInitializing || isNavigatingToAssessment) && (
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      inset: 0,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 1.5,
+                      alignItems: "center",
+                      justifyContent: "center",
+                      backgroundColor:
+                        "color-mix(in srgb, var(--font-dark) 86%, transparent)",
+                      zIndex: 3,
+                    }}
+                  >
+                    <CircularProgress
+                      size={26}
+                      sx={{ color: "var(--font-light)" }}
+                    />
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "var(--font-light)" }}
+                    >
+                      {isNavigatingToAssessment
+                        ? "Starting assessment..."
+                        : "Initializing face detection..."}
+                    </Typography>
+                  </Box>
+                )}
+
+                <Box
+                  component="video"
+                  ref={videoRef}
+                  autoPlay
+                  playsInline
+                  muted
+                  sx={{
+                    width: "100%",
+                    height: "100%",
+                    display: "block",
+                    objectFit: "cover",
+                    backgroundColor: "var(--assessment-video-letterbox-bg)",
+                  }}
+                  onLoadedMetadata={() => {
+                    if (videoRef.current) {
+                      videoRef.current.play().catch(() => {
+                        // Handle play error
+                      });
+                    }
+                  }}
+                />
+
+                {faceValidationPassed && !isNavigatingToAssessment && (
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      top: 10,
+                      left: 10,
+                      zIndex: 2,
+                      borderRadius: 999,
+                      boxShadow:
+                        "0 4px 14px -4px color-mix(in srgb, var(--font-dark) 55%, transparent)",
+                    }}
+                  >
+                    <StatusChip
+                      label="Face detected"
+                      tone="success"
+                      icon="mdi:check"
+                    />
+                  </Box>
+                )}
+              </Box>
+
+              {deviceStatus.camera &&
+                !isFaceDetectionInitializing &&
+                !isNavigatingToAssessment &&
+                !faceValidationPassed && (
+                  <Box
+                    sx={{
+                      mt: 1.25,
+                      display: "flex",
+                      gap: 0.75,
+                      alignItems: "flex-start",
+                      color: "var(--warning-500)",
+                    }}
+                  >
+                    <IconWrapper
+                      icon="mdi:alert-circle-outline"
+                      size={16}
+                      color="var(--warning-500)"
+                    />
+                    <Typography sx={{ fontSize: "0.78rem", lineHeight: 1.5 }}>
+                      {faceValidationMessage ||
+                        "Position your face in the frame — look at the screen, one person only."}
+                    </Typography>
+                  </Box>
+                )}
+
+              {/* Mic level */}
+              <Box sx={{ mt: 2.5 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    mb: 0.75,
+                  }}
                 >
-                  Audio Level
-                </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "0.78rem",
+                      fontWeight: 600,
+                      color: "var(--font-primary-dark)",
+                    }}
+                  >
+                    Mic level
+                  </Typography>
+                  <Typography
+                    sx={{
+                      fontSize: "0.72rem",
+                      color: "var(--font-secondary)",
+                    }}
+                  >
+                    {audioLevel > 0.1 ? "Sounds good" : "Speak to test your mic"}
+                  </Typography>
+                </Box>
                 <LinearProgress
                   variant="determinate"
                   value={audioLevel * 100}
                   sx={{
                     height: 8,
-                    borderRadius: 1,
+                    borderRadius: 999,
                     backgroundColor: "var(--border-default)",
                     "& .MuiLinearProgress-bar": {
-                      backgroundColor: "var(--course-cta)",
-                      borderRadius: 1,
+                      backgroundColor: "var(--success-500)",
+                      borderRadius: 999,
                     },
                   }}
                 />
-                <Typography
-                  variant="caption"
-                  sx={{ color: "var(--font-secondary)", display: "block", mt: 0.5 }}
-                >
-                  {audioLevel > 0.1
-                    ? "Speak to test your microphone"
-                    : "Microphone is ready"}
-                </Typography>
               </Box>
-            )}
-          </Paper>
+            </Paper>
 
-          <Paper
-            elevation={0}
+            {/* RIGHT — readiness checklist */}
+            <Paper
+              elevation={0}
+              sx={{
+                p: { xs: 2, sm: 2.5 },
+                borderRadius: "var(--radius-card)",
+                border: "1px solid var(--border-default)",
+                backgroundColor: "var(--card-bg)",
+              }}
+            >
+              <Typography
+                sx={{
+                  fontWeight: 700,
+                  fontSize: "0.95rem",
+                  color: "var(--font-primary-dark)",
+                  mb: 2,
+                }}
+              >
+                System readiness
+              </Typography>
+              <Box
+                sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}
+              >
+                {checklistRows.map((row) => {
+                  const toneColor = ROW_TONE_COLOR[row.tone];
+                  return (
+                    <Box
+                      key={row.key}
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1.5,
+                        p: 1.25,
+                        borderRadius: 12,
+                        border: "1px solid var(--border-default)",
+                        backgroundColor: "var(--surface)",
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          width: 40,
+                          height: 40,
+                          borderRadius: 10,
+                          flexShrink: 0,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          backgroundColor: `color-mix(in srgb, ${toneColor} 14%, var(--surface) 86%)`,
+                        }}
+                      >
+                        <IconWrapper
+                          icon={row.icon}
+                          size={20}
+                          color={toneColor}
+                        />
+                      </Box>
+                      <Box sx={{ minWidth: 0, flex: 1 }}>
+                        <Typography
+                          sx={{
+                            fontWeight: 600,
+                            fontSize: "0.9rem",
+                            color: "var(--font-primary-dark)",
+                          }}
+                        >
+                          {row.name}
+                        </Typography>
+                        <Typography
+                          sx={{
+                            fontSize: "0.78rem",
+                            color: "var(--font-secondary)",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {row.sub}
+                        </Typography>
+                      </Box>
+                      <StatusChip label={row.chip} tone={row.tone} />
+                    </Box>
+                  );
+                })}
+              </Box>
+            </Paper>
+          </Box>
+
+          {/* Amber tip banner */}
+          <Box
             sx={{
-              p: 3,
-              borderRadius: 3,
-              border: "1px solid var(--border-default)",
+              mt: 3,
+              display: "flex",
+              gap: 1.5,
+              alignItems: "flex-start",
+              p: 2,
+              borderRadius: "var(--radius-card)",
               backgroundColor:
-                networkStatus === "good"
-                  ? "color-mix(in srgb, var(--course-cta) 10%, var(--card-bg))"
-                  : networkStatus === "moderate"
-                  ? "color-mix(in srgb, var(--warning-500) 12%, var(--card-bg))"
-                  : networkStatus === "poor"
-                  ? "color-mix(in srgb, var(--error-500) 10%, var(--card-bg))"
-                  : "var(--surface)",
+                "color-mix(in srgb, var(--warning-500) 10%, var(--card-bg))",
+              border:
+                "1px solid color-mix(in srgb, var(--warning-500) 30%, transparent)",
             }}
           >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-              {networkStatus === "good" ? (
-                <CheckCircle size={32} color="var(--course-cta)" />
-              ) : networkStatus === "moderate" ? (
-                <AlertCircle size={32} color="var(--warning-500)" />
-              ) : networkStatus === "poor" ? (
-                <XCircle size={32} color="var(--error-500)" />
-              ) : (
-                <CircularProgress size={32} />
-              )}
-
-              <Box>
-                <Typography variant="h6">Internet</Typography>
-                <Typography variant="body2">
-                  {networkStatus === "testing"
-                    ? "Checking connection..."
-                    : networkSpeed
-                    ? `${networkSpeed.toFixed(2)} Mbps`
-                    : "Connection check required"}
-                </Typography>
-              </Box>
-            </Box>
-
-            {networkStatus === "poor" && (
-              <Alert severity="warning" sx={{ mt: 2 }}>
-                Your connection is slow — you may start, but video may buffer.
-              </Alert>
-            )}
-            {networkStatus === "moderate" && (
-              <Alert severity="warning" sx={{ mt: 2 }}>
-                {t("assessments.deviceCheck.networkModerateHint")}
-              </Alert>
-            )}
-            {networkStatus === "good" && (
-              <Alert severity="success" sx={{ mt: 2 }}>
-                Internet connection is stable.
-              </Alert>
-            )}
-          </Paper>
-        </Box>
-
-        {devicesAndBrowserReady &&
-          faceValidationPassed &&
-          !networkAllowsProceed && (
-            <Alert
-              severity={
-                networkStatus === "poor" ? "error" : "info"
-              }
-              sx={{ mb: 3, maxWidth: 640, mx: "auto" }}
+            <IconWrapper
+              icon="mdi:lightbulb-on-outline"
+              size={20}
+              color="var(--warning-500)"
+            />
+            <Typography
+              sx={{
+                fontSize: "0.85rem",
+                color: "var(--font-primary-dark)",
+                lineHeight: 1.6,
+              }}
             >
-              <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {networkStatus === "testing" || networkStatus === null
-                  ? t("assessments.deviceCheck.networkWaitTest")
-                  : t("assessments.deviceCheck.networkPoorCannotStart")}
-              </Typography>
-            </Alert>
-          )}
+              <Box component="span" sx={{ fontWeight: 700 }}>
+                Tip:
+              </Box>{" "}
+              find a quiet, well-lit spot. Once you start, leaving fullscreen or
+              switching tabs will be flagged and may pause your timer.
+            </Typography>
+          </Box>
 
-        {/* Action Buttons */}
-        <Box
-          sx={{
-            display: "flex",
-            gap: 2,
-            justifyContent: "center",
-            flexWrap: "wrap",
-          }}
-        >
-          {devicesAndBrowserReady &&
-            faceValidationPassed &&
-            !networkAllowsProceed && (
+          {/* Actions */}
+          <Box
+            sx={{
+              mt: 3,
+              mx: "auto",
+              maxWidth: 520,
+              display: "flex",
+              flexDirection: "column",
+              gap: 1.5,
+              alignItems: "stretch",
+            }}
+          >
+            {canProceed ? (
               <Button
-                variant="outlined"
+                fullWidth
                 size="large"
-                onClick={() => void testInternetSpeed()}
-                disabled={networkStatus === "testing"}
+                onClick={handleStartAssessment}
                 startIcon={
-                  networkStatus === "testing" ? (
-                    <CircularProgress size={20} />
-                  ) : (
-                    <IconWrapper icon="mdi:wifi-refresh" size={22} />
-                  )
+                  <IconWrapper
+                    icon="mdi:fullscreen"
+                    size={22}
+                    color="var(--font-light)"
+                  />
                 }
                 sx={{
                   textTransform: "none",
-                  fontWeight: 600,
-                  px: 3,
+                  fontWeight: 700,
+                  fontSize: "1rem",
                   py: 1.5,
-                  borderColor: "var(--accent-indigo)",
-                  color: "var(--accent-indigo-dark)",
+                  borderRadius: "var(--radius-card)",
+                  background: "var(--gradient-ai)",
+                  color: "var(--font-light)",
+                  boxShadow:
+                    "0 14px 30px -12px color-mix(in srgb, var(--ai-pink) 65%, transparent)",
+                  "&:hover": {
+                    background: "var(--gradient-ai)",
+                    filter: "brightness(1.05)",
+                  },
                 }}
               >
-                {t("assessments.deviceCheck.recheckInternet")}
+                Enter fullscreen &amp; begin
               </Button>
+            ) : (
+              <>
+                {devicesAndBrowserReady &&
+                  faceValidationPassed &&
+                  !networkAllowsProceed && (
+                    <Alert
+                      severity={networkStatus === "poor" ? "error" : "info"}
+                      sx={{ borderRadius: "var(--radius-card)" }}
+                    >
+                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                        {networkStatus === "testing" || networkStatus === null
+                          ? t("assessments.deviceCheck.networkWaitTest")
+                          : t("assessments.deviceCheck.networkPoorCannotStart")}
+                      </Typography>
+                    </Alert>
+                  )}
+
+                {devicesAndBrowserReady &&
+                  faceValidationPassed &&
+                  !networkAllowsProceed && (
+                    <Button
+                      fullWidth
+                      variant="outlined"
+                      size="large"
+                      onClick={() => void testInternetSpeed()}
+                      disabled={networkStatus === "testing"}
+                      startIcon={
+                        networkStatus === "testing" ? (
+                          <CircularProgress size={20} />
+                        ) : (
+                          <IconWrapper icon="mdi:wifi-refresh" size={22} />
+                        )
+                      }
+                      sx={{
+                        textTransform: "none",
+                        fontWeight: 600,
+                        py: 1.4,
+                        borderRadius: "var(--radius-card)",
+                        borderColor: "var(--accent-indigo)",
+                        color: "var(--accent-indigo-dark)",
+                      }}
+                    >
+                      {t("assessments.deviceCheck.recheckInternet")}
+                    </Button>
+                  )}
+
+                {(!deviceStatus.camera || !deviceStatus.microphone) && (
+                  <Button
+                    fullWidth
+                    variant="contained"
+                    size="large"
+                    onClick={testDevices}
+                    disabled={checking || !deviceStatus.browserSupported}
+                    startIcon={
+                      checking ? (
+                        <CircularProgress size={20} color="inherit" />
+                      ) : (
+                        <IconWrapper
+                          icon="mdi:camera-retake-outline"
+                          size={22}
+                        />
+                      )
+                    }
+                    sx={{
+                      textTransform: "none",
+                      fontWeight: 700,
+                      py: 1.4,
+                      borderRadius: "var(--radius-card)",
+                      backgroundColor: "var(--accent-indigo)",
+                      "&:hover": {
+                        backgroundColor: "var(--accent-indigo-dark)",
+                      },
+                    }}
+                  >
+                    {checking
+                      ? "Checking devices..."
+                      : "Test camera & microphone"}
+                  </Button>
+                )}
+              </>
             )}
 
-          {!canProceed
-            ? (!deviceStatus.camera || !deviceStatus.microphone) && (
-                <Button
-                  variant="contained"
-                  size="large"
-                  onClick={testDevices}
-                  disabled={checking || !deviceStatus.browserSupported}
-                  startIcon={
-                    checking ? (
-                      <CircularProgress size={20} color="inherit" />
-                    ) : (
-                      <IconWrapper icon="mdi:play-circle" size={24} />
-                    )
-                  }
-                  sx={{
-                    textTransform: "none",
-                    fontWeight: 600,
-                    px: 4,
-                    py: 1.5,
-                    backgroundColor: "var(--accent-indigo)",
-                    "&:hover": {
-                      backgroundColor: "var(--accent-indigo-dark)",
-                    },
-                  }}
-                >
-                  {checking
-                    ? "Checking Devices..."
-                    : "Test Camera & Microphone"}
-                </Button>
-              )
-            : null}
-
-          {canProceed && (
             <Button
-              variant="contained"
-              size="large"
-              onClick={handleStartAssessment}
-              endIcon={<IconWrapper icon="mdi:arrow-right" size={24} />}
+              variant="text"
+              onClick={() => router.push(`/assessments/${slug}`)}
+              startIcon={
+                <IconWrapper
+                  icon="mdi:arrow-left"
+                  size={18}
+                  color="var(--font-secondary)"
+                />
+              }
               sx={{
                 textTransform: "none",
                 fontWeight: 600,
-                px: 4,
-                py: 1.5,
-                backgroundColor: "var(--course-cta)",
+                color: "var(--font-secondary)",
+                alignSelf: "center",
                 "&:hover": {
-                  backgroundColor: "var(--assessment-success-strong)",
+                  backgroundColor: "transparent",
+                  color: "var(--font-primary-dark)",
                 },
               }}
             >
-              {t("assessments.startAssessment")}
+              Back to assessment
             </Button>
-          )}
-
-          <Button
-            variant="outlined"
-            size="large"
-            onClick={() => router.push(`/assessments/${slug}`)}
-            sx={{
-              textTransform: "none",
-              fontWeight: 600,
-              px: 4,
-              py: 1.5,
-              borderColor: "var(--border-default)",
-              color: "var(--font-secondary)",
-              "&:hover": {
-                borderColor: "var(--border-light)",
-                backgroundColor: "var(--surface)",
-              },
-            }}
-          >
-            Cancel
-          </Button>
-        </Box>
-
-        {/* Info Box */}
-        <Paper
-          elevation={0}
-          sx={{
-            mt: 4,
-            p: 3,
-            backgroundColor: "color-mix(in srgb, var(--surface-blue-light) 90%, var(--card-bg))",
-            border: "1px solid color-mix(in srgb, var(--accent-blue-light) 35%, transparent)",
-            borderRadius: 2,
-          }}
-        >
-          <Box sx={{ display: "flex", gap: 2, alignItems: "flex-start" }}>
-            <IconWrapper icon="mdi:information" size={24} color="var(--accent-blue-light)" />
-            <Box>
-              <Typography
-                variant="subtitle2"
-                sx={{ fontWeight: 600, color: "color-mix(in srgb, var(--accent-blue) 82%, var(--font-dark))", mb: 0.5 }}
-              >
-                Why do we need this?
-              </Typography>
-              <Typography
-                variant="body2"
-                sx={{ color: "color-mix(in srgb, var(--accent-blue) 82%, var(--font-dark))", fontSize: "0.875rem", lineHeight: 1.7 }}
-              >
-                Your camera and microphone are essential for the assessment
-                process. We use your camera to monitor the assessment session
-                and ensure a fair evaluation. Your microphone is used to record
-                your answers and analyze your speech using Text-to-Speech (TTS)
-                technology for accurate evaluation. Both devices must be working
-                properly before you can proceed.
-              </Typography>
-            </Box>
           </Box>
-        </Paper>
-      </Container>
+        </Container>
+      </Box>
     </MainLayout>
   );
 }

--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -10,8 +10,8 @@ import {
   Paper,
   Alert,
   CircularProgress,
-  Tooltip,
-  Chip,
+  Checkbox,
+  FormControlLabel,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
@@ -24,6 +24,9 @@ import { AssessmentDesktopOnlyDialog } from "@/components/assessment/AssessmentD
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { isCurrentDeviceAllowedForAssessment, allowedDeviceLabels } from "@/lib/utils/assessment-device";
 import { AssessmentDeviceStatusPanel } from "@/components/assessment/AssessmentDeviceStatusPanel";
+import { AssessmentReadinessPanel } from "@/components/assessment/AssessmentReadinessPanel";
+import { StatusChip, StatStrip } from "@/components/admin/assessment/shared";
+import { stripHtmlTags } from "@/lib/utils/html-utils";
 
 function parseAssessmentStartTime(
   s: string | undefined | null
@@ -31,6 +34,13 @@ function parseAssessmentStartTime(
   if (!s || typeof s !== "string" || !s.trim()) return null;
   const d = new Date(s);
   return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** One rule row on the "Rules for this attempt" card. */
+interface AttemptRule {
+  icon: string;
+  title: string;
+  description: string;
 }
 
 export default function AssessmentDetailPage({
@@ -46,6 +56,7 @@ export default function AssessmentDetailPage({
   const [desktopOnlyOpen, setDesktopOnlyOpen] = useState(false);
   const { showToast } = useToast();
   const [startTimeTick, setStartTimeTick] = useState(0);
+  const [consented, setConsented] = useState(false);
 
   const assessmentStartAt = useMemo(
     () => parseAssessmentStartTime(assessment?.start_time),
@@ -189,6 +200,101 @@ export default function AssessmentDetailPage({
 
   const deviceAllowed = isCurrentDeviceAllowedForAssessment(assessment);
 
+  // ── Derived, display-only view data (no behavior change) ────────────────
+  const proctored = assessment.proctoring_enabled === true;
+  const eyebrow =
+    assessment.course_title ||
+    assessment.courseTitle ||
+    assessment.certificate_course_name ||
+    "";
+  const sectionsCount =
+    assessment.sections?.length || assessment.number_of_sections || 0;
+  const instructionsText = stripHtmlTags(assessment.instructions || "").trim();
+  const descriptionText = (assessment.description || "").trim();
+  const passingPercent = assessment.pass_band_lower_min_percent ?? null;
+  const closesOnLabel = assessmentEndAt
+    ? assessmentEndAt.toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })
+    : "";
+
+  const statItems = [
+    { label: "Questions", value: assessment.number_of_questions ?? 0, icon: "mdi:help-circle-outline", tone: "var(--ai-violet)" },
+    { label: "Duration", value: `${assessment.duration_minutes}m`, icon: "mdi:clock-outline", tone: "var(--accent-indigo)" },
+    { label: "Sections", value: sectionsCount, icon: "mdi:view-dashboard-outline", tone: "var(--accent-blue-light)" },
+    { label: "Attempts", value: canReattempt ? "1 / 2" : "1", icon: "mdi:replay", tone: "var(--ai-pink)" },
+  ];
+
+  // Rules built from the assessment's real settings.
+  const rules: AttemptRule[] = [];
+  if (proctored) {
+    rules.push({
+      icon: "mdi:webcam",
+      title: "Webcam & periodic snapshots",
+      description:
+        "Your camera stays on for the attempt. We run a quick face check before you start and capture periodic snapshots as proof.",
+    });
+    rules.push({
+      icon: "mdi:fullscreen",
+      title: "Fullscreen required",
+      description:
+        "The attempt runs in fullscreen. Leaving fullscreen is recorded — you'll be prompted to return or submit.",
+    });
+  }
+  if (assessment.tab_switch_limit_enabled || proctored) {
+    rules.push({
+      icon: "mdi:cursor-move",
+      title: "No tab-switching or copy-paste",
+      description:
+        assessment.tab_switch_limit_enabled && assessment.tab_switch_limit_count
+          ? `Switching tabs or windows is flagged (limit: ${assessment.tab_switch_limit_count}). Copy and paste are disabled during the attempt.`
+          : "Switching tabs or windows is flagged. Copy and paste are disabled during the attempt.",
+    });
+  }
+  if (assessment.allow_movement === false) {
+    rules.push({
+      icon: "mdi:routes",
+      title: "Fixed section order",
+      description:
+        "Sections are locked to a set order — you can't jump freely between them once you move on.",
+    });
+  }
+  rules.push({
+    icon: "mdi:calculator-variant-outline",
+    title: "On-screen calculator provided",
+    description:
+      "A calculator is available inside the attempt when you need it — no external tools required.",
+  });
+  rules.push({
+    icon: "mdi:flag-outline",
+    title: "Flag questions for review",
+    description:
+      "Mark any question to revisit later, then jump back to your flagged items before you submit.",
+  });
+
+  const ctaLabel = isExpired
+    ? t("assessments.expired")
+    : canReattempt && isAlreadySubmitted
+    ? t("assessments.reattempt", { defaultValue: "Re-attempt" })
+    : isAlreadySubmitted
+    ? t("assessments.alreadySubmitted", { defaultValue: "Already submitted" })
+    : "Continue to device check →";
+
+  const ctaIcon = isExpired
+    ? "mdi:clock-alert-outline"
+    : canReattempt && isAlreadySubmitted
+    ? "mdi:replay"
+    : isAlreadySubmitted
+    ? "mdi:check-circle-outline"
+    : "mdi:play-circle-outline";
+
+  const ctaDisabled =
+    isExpired ||
+    (isAlreadySubmitted && !canReattempt) ||
+    !canStartAssessment ||
+    (proctored && !consented);
+
   return (
     <MainLayout>
       <AssessmentDesktopOnlyDialog
@@ -205,15 +311,16 @@ export default function AssessmentDetailPage({
           mx: "auto",
         }}
       >
-        {/* Back Button */}
+        {/* Back link */}
         <LoadingButton
           startIcon={<IconWrapper icon="mdi:arrow-left" size={20} />}
           onClick={() => router.push("/assessments")}
           sx={{
-            mb: 3,
+            mb: 2.5,
             color: "var(--font-secondary)",
             textTransform: "none",
             fontWeight: 600,
+            px: 1,
             "&:hover": {
               backgroundColor:
                 "color-mix(in srgb, var(--accent-indigo) 10%, transparent)",
@@ -221,525 +328,440 @@ export default function AssessmentDetailPage({
             },
           }}
         >
-          Back to Assessments
+          Back to assessments
         </LoadingButton>
 
-        {/* Assessment Info */}
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)" },
-            gap: 2,
-            mb: 3,
-          }}
-        >
-          <Box
-            sx={{
-              p: 2,
-              backgroundColor: "var(--surface)",
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              display: "flex",
-              alignItems: "center",
-              gap: 1.5,
-            }}
-          >
-            <IconWrapper
-              icon="mdi:clock-outline"
-              size={24}
-              color="var(--accent-indigo)"
-            />
-            <Box>
-              <Typography
-                variant="caption"
-                sx={{
-                  color: "var(--font-tertiary)",
-                  fontSize: "0.75rem",
-                  fontWeight: 500,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.5px",
-                  display: "block",
-                }}
-              >
-                Duration
-              </Typography>
-              <Typography
-                variant="body1"
-                sx={{
-                  color: "var(--font-primary)",
-                  fontWeight: 600,
-                }}
-              >
-                {assessment.duration_minutes} minutes
-              </Typography>
-            </Box>
-          </Box>
-
-          <Box
-            sx={{
-              p: 2,
-              backgroundColor: "var(--surface)",
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              display: "flex",
-              alignItems: "center",
-              gap: 1.5,
-            }}
-          >
-            <IconWrapper
-              icon="mdi:help-circle-outline"
-              size={24}
-              color="var(--accent-indigo)"
-            />
-            <Box>
-              <Typography
-                variant="caption"
-                sx={{
-                  color: "var(--font-tertiary)",
-                  fontSize: "0.75rem",
-                  fontWeight: 500,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.5px",
-                  display: "block",
-                }}
-              >
-                Questions
-              </Typography>
-              <Typography
-                variant="body1"
-                sx={{
-                  color: "var(--font-primary)",
-                  fontWeight: 600,
-                }}
-              >
-                {assessment.number_of_questions}
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
-
-        <AssessmentDeviceStatusPanel assessment={assessment} />
-
-        <Paper
-          elevation={0}
-          sx={{
-            p: 4,
-            border: "1px solid var(--border-default)",
-            borderRadius: 3,
-            backgroundColor: "var(--card-bg)",
-          }}
-        >
+        {/* Header */}
+        <Box sx={{ mb: 3 }}>
+          {eyebrow && (
+            <Typography
+              sx={{
+                fontSize: "0.75rem",
+                fontWeight: 700,
+                letterSpacing: "0.6px",
+                textTransform: "uppercase",
+                color: "var(--ai-violet)",
+                mb: 0.75,
+              }}
+            >
+              {eyebrow}
+            </Typography>
+          )}
           <Typography
             variant="h4"
             sx={{
-              fontWeight: 700,
+              fontWeight: 800,
               color: "var(--font-primary)",
-              mb: 2,
+              lineHeight: 1.2,
+              fontSize: { xs: "1.6rem", sm: "2rem" },
             }}
           >
             {assessment.title}
           </Typography>
-          <Typography
-            variant="body1"
-            sx={{
-              color: "var(--font-secondary)",
-              mb: 3,
-              lineHeight: 1.6,
-            }}
-          >
-            {assessment.description}
-          </Typography>
-
-          {assessment.instructions && (
-            <Alert
-              severity="info"
+          {descriptionText && (
+            <Typography
               sx={{
-                mb: 3,
-                borderRadius: 2,
+                color: "var(--font-secondary)",
+                mt: 1,
+                lineHeight: 1.6,
+                maxWidth: 720,
               }}
             >
-              {assessment.instructions}
-            </Alert>
+              {descriptionText}
+            </Typography>
           )}
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1.75 }}>
+            {proctored && (
+              <StatusChip label="Proctored" tone="proctored" icon="mdi:shield-check" />
+            )}
+            <StatusChip label="Non-adaptive · same for all" tone="neutral" />
+          </Box>
+        </Box>
 
-          {/* Proctoring & Exam Instructions */}
-          {assessment.proctoring_enabled && (
+        {/* Metric strip */}
+        <Box sx={{ mb: 3 }}>
+          <StatStrip items={statItems} />
+        </Box>
+
+        {/* Two-column: main + sidebar */}
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", md: "minmax(0, 1fr) 352px" },
+            gap: { xs: 2.5, md: 3 },
+            alignItems: "start",
+          }}
+        >
+          {/* MAIN column */}
+          <Box sx={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 2.5 }}>
+            {/* Rules for this attempt */}
             <Paper
               elevation={0}
               sx={{
-                p: 3,
-                mb: 3,
-                borderRadius: 2,
-                border: "2px solid var(--warning-500)",
-                backgroundColor: "color-mix(in srgb, var(--warning-100) 95%, var(--card-bg))",
+                p: { xs: 2.5, sm: 3 },
+                borderRadius: "var(--radius-card)",
+                border: "1px solid var(--border-default)",
+                bgcolor: "var(--card-bg)",
               }}
             >
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 1.5,
-                  mb: 2,
-                }}
-              >
-                <IconWrapper
-                  icon="mdi:shield-account"
-                  size={28}
-                  style={{ color: "var(--warning-500)" }}
-                />
-                <Typography
-                  variant="h6"
-                  sx={{
-                    fontWeight: 700,
-                    color: "color-mix(in srgb, var(--accent-orange) 55%, var(--font-dark))",
-                  }}
-                >
-                  Proctored Assessment - Important Instructions
-                </Typography>
-              </Box>
-
-              <Typography
-                variant="body2"
-                sx={{
-                  color: "color-mix(in srgb, var(--warning-500) 55%, var(--font-dark))",
-                  mb: 2,
-                  fontWeight: 600,
-                }}
-              >
-                This is a proctored examination. Please read the following
-                instructions carefully before starting:
-              </Typography>
-
-              <Box
-                component="ul"
-                sx={{
-                  m: 0,
-                  pl: 3,
-                  mb: 2,
-                  "& li": {
-                    mb: 1.5,
-                    color: "color-mix(in srgb, var(--accent-orange) 55%, var(--font-dark))",
-                    lineHeight: 1.7,
-                  },
-                }}
-              >
-                <li>
-                  <strong>Camera & Microphone Required:</strong> You must have a
-                  working camera and microphone. Your device will be tested before
-                  the exam begins. Position your face clearly in frame and look at
-                  the screen—you’ll need to pass a quick face check before starting.
-                </li>
-                <li>
-                  <strong>AI Proctoring Active:</strong> This exam is monitored by
-                  AI proctoring software that tracks:
-                  <Box
-                    component="ul"
-                    sx={{
-                      mt: 0.5,
-                      mb: 0,
-                      pl: 2.5,
-                      "& li": {
-                        mb: 0.5,
-                      },
-                    }}
-                  >
-                    <li>Face detection and visibility</li>
-                    <li>Looking away from screen</li>
-                    <li>Multiple people in the frame</li>
-                    <li>Tab switches and browser window changes</li>
-                    <li>Fullscreen mode violations</li>
-                  </Box>
-                </li>
-                <li>
-                  <strong>Exam Environment:</strong> Ensure you are in a quiet,
-                  well-lit room with no distractions. Remove any unauthorized
-                  materials from your workspace.
-                </li>
-                <li>
-                  <strong>During the Exam:</strong>
-                  <Box
-                    component="ul"
-                    sx={{
-                      mt: 0.5,
-                      mb: 0,
-                      pl: 2.5,
-                      "& li": {
-                        mb: 0.5,
-                      },
-                    }}
-                  >
-                    <li>Do not switch browser tabs or minimize the window</li>
-                    <li>
-                      Do not exit fullscreen mode during the exam — if you do,
-                      you will be prompted to either submit or return to
-                      fullscreen to continue
-                    </li>
-                    <li>Keep your face visible to the camera at all times</li>
-                    <li>Do not use any unauthorized aids or assistance</li>
-                    <li>Do not communicate with anyone during the exam</li>
-                  </Box>
-                </li>
-                <li>
-                  <strong>Violation Policy:</strong> Violations of exam rules will
-                  be recorded and may result in exam disqualification. Multiple
-                  violations will result in automatic submission of your
-                  assessment.
-                </li>
-                <li>
-                  <strong>Time Limit:</strong> The exam has a strict time limit.
-                  Once started, the timer cannot be paused. Ensure you have
-                  adequate time to complete the assessment.
-                </li>
-              </Box>
-
-              <Alert
-                severity="warning"
-                icon={<IconWrapper icon="mdi:alert-circle" size={20} />}
-                sx={{
-                  mt: 2,
-                  backgroundColor: "color-mix(in srgb, var(--warning-500) 18%, transparent)",
-                  border: "1px solid var(--warning-500)",
-                  "& .MuiAlert-icon": {
-                    color: "var(--ats-warning-muted)",
-                  },
-                }}
-              >
-                <Typography
-                  variant="body2"
-                  fontWeight={600}
-                  sx={{ color: "color-mix(in srgb, var(--accent-orange) 55%, var(--font-dark))" }}
-                >
-                  {t("assessments.startAcknowledgment")}
-                </Typography>
-              </Alert>
-            </Paper>
-          )}
-
-          {assessment.sections && assessment.sections.length > 0 && (
-            <Box sx={{ mb: 3 }}>
-              <Typography
-                variant="h6"
-                sx={{
-                  fontWeight: 700,
-                  color: "var(--font-primary)",
-                  mb: 2,
-                }}
-              >
-                Assessment Sections
-              </Typography>
-              {assessment.sections.map((section: any, index: number) => (
-                <Paper
-                  key={index}
-                  elevation={0}
-                  sx={{
-                    p: 2,
-                    mb: 2,
-                    backgroundColor: "var(--surface)",
-                    border: "1px solid var(--border-default)",
-                    borderRadius: 2,
-                  }}
-                >
-                  <Typography
-                    variant="subtitle1"
-                    sx={{
-                      fontWeight: 600,
-                      color: "var(--font-primary)",
-                    }}
-                  >
-                    {section.title || `Section ${index + 1}`}
-                  </Typography>
-                  {section.description && (
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        color: "var(--font-secondary)",
-                        mt: 0.5,
-                      }}
-                    >
-                      {section.description}
-                    </Typography>
-                  )}
-                </Paper>
-              ))}
-            </Box>
-          )}
-
-          {assessment.allow_movement === false && (
-            <Paper
-              elevation={0}
-              sx={{
-                mb: 3,
-                p: 2.5,
-                borderRadius: 2,
-                border: "2px solid var(--accent-indigo)",
-                background: "linear-gradient(135deg, var(--surface-indigo-light) 0%, color-mix(in srgb, var(--surface-indigo-light) 85%, var(--accent-indigo)) 100%)",
-                boxShadow: "0 4px 20px color-mix(in srgb, var(--accent-indigo) 18%, transparent)",
-              }}
-            >
-              <Box
-                sx={{
-                  display: "flex",
-                  alignItems: "flex-start",
-                  gap: 2,
-                  mb: 1.5,
-                }}
-              >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2.5 }}>
                 <Box
                   sx={{
-                    flexShrink: 0,
-                    width: 44,
-                    height: 44,
+                    width: 40,
+                    height: 40,
                     borderRadius: 2,
-                    bgcolor: "var(--accent-indigo-dark)",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
+                    flexShrink: 0,
+                    display: "grid",
+                    placeItems: "center",
+                    background: "var(--gradient-ai-soft)",
+                    color: "var(--ai-violet)",
                   }}
                 >
-                  <IconWrapper icon="mdi:routes" size={26} color="var(--font-light)" />
+                  <IconWrapper icon="mdi:shield-check" size={22} />
                 </Box>
-                <Box sx={{ minWidth: 0 }}>
-                  <Chip
-                    label={t("assessments.take.strictNavImportantBadge")}
-                    size="small"
-                    sx={{
-                      mb: 1,
-                      fontWeight: 700,
-                      bgcolor: "var(--accent-indigo-dark)",
-                      color: "var(--font-light)",
-                      "& .MuiChip-label": { px: 1.25 },
-                    }}
-                  />
-                  <Typography
-                    variant="h6"
-                    sx={{
-                      fontWeight: 800,
-                      color: "var(--accent-indigo-dark)",
-                      lineHeight: 1.3,
-                    }}
-                  >
-                    {t("assessments.take.strictNavTitle")}
+                <Box>
+                  <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
+                    Rules for this attempt
+                  </Typography>
+                  <Typography sx={{ fontSize: "0.8rem", color: "var(--font-secondary)" }}>
+                    Read these before you start — some are enforced automatically.
                   </Typography>
                 </Box>
               </Box>
-              <Typography
-                variant="subtitle2"
-                sx={{
-                  color: "var(--accent-indigo-dark)",
-                  fontWeight: 700,
-                  mb: 1.5,
-                  lineHeight: 1.5,
-                }}
-              >
-                {t("assessments.take.strictNavReadBeforeStart")}
-              </Typography>
-              <Typography
-                variant="body2"
-                component="div"
-                sx={{
-                  color: "color-mix(in srgb, var(--accent-indigo-dark) 88%, var(--font-dark))",
-                  whiteSpace: "pre-line",
-                  lineHeight: 1.75,
-                  fontWeight: 500,
-                }}
-              >
-                {t("assessments.take.strictNavInstructions")}
-              </Typography>
+
+              <Box sx={{ display: "flex", flexDirection: "column" }}>
+                {rules.map((rule, i) => (
+                  <Box
+                    key={rule.title}
+                    sx={{
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: 1.5,
+                      py: 1.75,
+                      borderTop: i === 0 ? "none" : "1px solid var(--border-default)",
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        width: 34,
+                        height: 34,
+                        borderRadius: 1.5,
+                        flexShrink: 0,
+                        display: "grid",
+                        placeItems: "center",
+                        bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, var(--surface))",
+                        color: "var(--accent-indigo)",
+                      }}
+                    >
+                      <IconWrapper icon={rule.icon} size={18} />
+                    </Box>
+                    <Box sx={{ minWidth: 0 }}>
+                      <Typography sx={{ fontWeight: 600, color: "var(--font-primary)", fontSize: "0.925rem" }}>
+                        {rule.title}
+                      </Typography>
+                      <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", lineHeight: 1.55, mt: 0.25 }}>
+                        {rule.description}
+                      </Typography>
+                    </Box>
+                  </Box>
+                ))}
+              </Box>
             </Paper>
-          )}
 
-          {isExpired && (
-            <Alert
-              severity="error"
-              icon={<IconWrapper icon="mdi:clock-alert-outline" size={22} />}
-              sx={{ mb: 3, borderRadius: 2, fontWeight: 500 }}
-            >
-              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
-                {t("assessments.expiredHeading", {
-                  defaultValue: "This assessment has expired",
-                })}
-              </Typography>
-              <Typography variant="body2">
-                {expiredOnLabel
-                  ? t("assessments.expiredOn", {
-                      defaultValue: "The submission window closed on {{date}}.",
-                      date: expiredOnLabel,
-                    })
-                  : t("assessments.expiredGeneric", {
-                      defaultValue: "The submission window for this assessment has closed.",
-                    })}
-              </Typography>
-            </Alert>
-          )}
+            {/* What you'll cover */}
+            {(instructionsText || (assessment.sections && assessment.sections.length > 0)) && (
+              <Paper
+                elevation={0}
+                sx={{
+                  p: { xs: 2.5, sm: 3 },
+                  borderRadius: "var(--radius-card)",
+                  border: "1px solid var(--border-default)",
+                  bgcolor: "var(--card-bg)",
+                }}
+              >
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2 }}>
+                  <IconWrapper icon="mdi:book-open-page-variant-outline" size={22} color="var(--ai-violet)" />
+                  <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
+                    What you&apos;ll cover
+                  </Typography>
+                </Box>
 
-          {canReattempt && isAlreadySubmitted && !isExpired && (
-            <Alert
-              severity="info"
-              icon={<IconWrapper icon="mdi:replay" size={22} />}
-              sx={{ mb: 3, borderRadius: 2 }}
-            >
-              <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
-                {t("assessments.reattemptHeading", {
-                  defaultValue: "Re-attempt available",
-                })}
-              </Typography>
-              <Typography variant="body2">
-                {t("assessments.reattemptHelp", {
-                  defaultValue:
-                    "An admin has granted you a re-attempt for this assessment. Starting again will replace your previous score with the new attempt's score.",
-                })}
-              </Typography>
-            </Alert>
-          )}
+                {instructionsText && (
+                  <Typography
+                    sx={{
+                      color: "var(--font-secondary)",
+                      lineHeight: 1.7,
+                      mb: assessment.sections && assessment.sections.length > 0 ? 2.5 : 0,
+                      whiteSpace: "pre-line",
+                    }}
+                  >
+                    {instructionsText}
+                  </Typography>
+                )}
 
-          <LoadingButton
-            variant="contained"
-            size="large"
-            fullWidth
-            startIcon={
-              <IconWrapper
-                icon={
-                  isExpired
-                    ? "mdi:clock-alert-outline"
-                    : canReattempt && isAlreadySubmitted
-                    ? "mdi:replay"
-                    : isAlreadySubmitted
-                    ? "mdi:check-circle-outline"
-                    : "mdi:play-circle-outline"
-                }
-                size={24}
-              />
-            }
-            onClick={handleStart}
-            disabled={
-              isExpired ||
-              (isAlreadySubmitted && !canReattempt) ||
-              !canStartAssessment
-            }
+                {assessment.sections && assessment.sections.length > 0 && (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+                    {assessment.sections.map((section: any, index: number) => (
+                      <Box
+                        key={index}
+                        sx={{
+                          p: 2,
+                          borderRadius: 2,
+                          bgcolor: "var(--surface)",
+                          border: "1px solid var(--border-default)",
+                        }}
+                      >
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                          <Box
+                            sx={{
+                              width: 22,
+                              height: 22,
+                              borderRadius: "50%",
+                              flexShrink: 0,
+                              display: "grid",
+                              placeItems: "center",
+                              fontFamily: "var(--font-mono)",
+                              fontSize: "0.72rem",
+                              fontWeight: 700,
+                              bgcolor: "color-mix(in srgb, var(--ai-violet) 14%, var(--surface))",
+                              color: "var(--ai-violet)",
+                            }}
+                          >
+                            {index + 1}
+                          </Box>
+                          <Typography sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
+                            {section.title || `Section ${index + 1}`}
+                          </Typography>
+                        </Box>
+                        {section.description && (
+                          <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mt: 0.75, lineHeight: 1.55 }}>
+                            {section.description}
+                          </Typography>
+                        )}
+                      </Box>
+                    ))}
+                  </Box>
+                )}
+              </Paper>
+            )}
+
+            {/* Expired / re-attempt alerts (preserved) */}
+            {isExpired && (
+              <Alert
+                severity="error"
+                icon={<IconWrapper icon="mdi:clock-alert-outline" size={22} />}
+                sx={{ borderRadius: "var(--radius-card)", fontWeight: 500 }}
+              >
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                  {t("assessments.expiredHeading", {
+                    defaultValue: "This assessment has expired",
+                  })}
+                </Typography>
+                <Typography variant="body2">
+                  {expiredOnLabel
+                    ? t("assessments.expiredOn", {
+                        defaultValue: "The submission window closed on {{date}}.",
+                        date: expiredOnLabel,
+                      })
+                    : t("assessments.expiredGeneric", {
+                        defaultValue: "The submission window for this assessment has closed.",
+                      })}
+                </Typography>
+              </Alert>
+            )}
+
+            {canReattempt && isAlreadySubmitted && !isExpired && (
+              <Alert
+                severity="info"
+                icon={<IconWrapper icon="mdi:replay" size={22} />}
+                sx={{ borderRadius: "var(--radius-card)" }}
+              >
+                <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.5 }}>
+                  {t("assessments.reattemptHeading", {
+                    defaultValue: "Re-attempt available",
+                  })}
+                </Typography>
+                <Typography variant="body2">
+                  {t("assessments.reattemptHelp", {
+                    defaultValue:
+                      "An admin has granted you a re-attempt for this assessment. Starting again will replace your previous score with the new attempt's score.",
+                  })}
+                </Typography>
+              </Alert>
+            )}
+          </Box>
+
+          {/* RIGHT sidebar */}
+          <Box
             sx={{
-              backgroundColor: "var(--accent-indigo)",
-              color: "var(--font-light)",
-              fontWeight: 600,
-              py: 1.5,
-              borderRadius: 2,
-              textTransform: "none",
-              fontSize: "1rem",
-              boxShadow: "var(--assessment-catalog-cta-auto-shadow)",
-              "&:hover": {
-                backgroundColor: "var(--accent-indigo-dark)",
-                boxShadow: "var(--assessment-catalog-cta-auto-shadow-hover)",
-              },
+              display: "flex",
+              flexDirection: "column",
+              gap: 2.5,
+              position: { md: "sticky" },
+              top: { md: 16 },
+              alignSelf: "start",
             }}
           >
-            {isExpired
-              ? t("assessments.expired")
-              : canReattempt && isAlreadySubmitted
-              ? t("assessments.reattempt", { defaultValue: "Re-attempt" })
-              : isAlreadySubmitted
-              ? t("assessments.alreadySubmitted", { defaultValue: "Already submitted" })
-              : t("assessments.startAssessment")}
-          </LoadingButton>
-        </Paper>
+            {/* AI Readiness Check */}
+            <AssessmentReadinessPanel slug={slug} />
+
+            {/* Scoring & policy */}
+            <Paper
+              elevation={0}
+              sx={{
+                p: { xs: 2.5, sm: 3 },
+                borderRadius: "var(--radius-card)",
+                border: "1px solid var(--border-default)",
+                bgcolor: "var(--card-bg)",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.75 }}>
+                <IconWrapper icon="mdi:scale-balance" size={20} color="var(--accent-indigo)" />
+                <Typography sx={{ fontWeight: 700, fontSize: "1rem", color: "var(--font-primary)" }}>
+                  Scoring & policy
+                </Typography>
+              </Box>
+
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+                  <IconWrapper icon="mdi:equalizer-outline" size={17} color="var(--font-tertiary)" />
+                  <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", lineHeight: 1.55 }}>
+                    Questions are fixed and non-adaptive — everyone gets the same set. Your score is the total of marks earned.
+                  </Typography>
+                </Box>
+
+                {passingPercent != null && (
+                  <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+                    <IconWrapper icon="mdi:trophy-outline" size={17} color="var(--font-tertiary)" />
+                    <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", lineHeight: 1.55 }}>
+                      Passing score:{" "}
+                      <Box component="span" sx={{ fontWeight: 700, color: "var(--font-primary)", fontFamily: "var(--font-mono)" }}>
+                        {passingPercent}%
+                      </Box>
+                    </Typography>
+                  </Box>
+                )}
+
+                <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.25 }}>
+                  <IconWrapper icon="mdi:calendar-clock" size={17} color="var(--font-tertiary)" />
+                  <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", lineHeight: 1.55 }}>
+                    {closesOnLabel
+                      ? `Submissions close on ${closesOnLabel}. Anything submitted after the window is not accepted — there's no late-submission grace.`
+                      : "Once you start, the timer runs continuously and can't be paused. Submit before it reaches zero."}
+                  </Typography>
+                </Box>
+              </Box>
+            </Paper>
+
+            {/* Device readiness (preserved) */}
+            <AssessmentDeviceStatusPanel assessment={assessment} sx={{ mb: 0 }} />
+
+            {/* Consent + CTA action card */}
+            <Paper
+              elevation={0}
+              sx={{
+                p: { xs: 2.5, sm: 3 },
+                borderRadius: "var(--radius-card)",
+                border: "1px solid var(--border-default)",
+                bgcolor: "var(--card-bg)",
+              }}
+            >
+              {proctored && (
+                <FormControlLabel
+                  sx={{
+                    alignItems: "flex-start",
+                    m: 0,
+                    mb: 2,
+                    "& .MuiFormControlLabel-label": {
+                      fontSize: "0.82rem",
+                      color: "var(--font-secondary)",
+                      lineHeight: 1.5,
+                      mt: 0.25,
+                    },
+                  }}
+                  control={
+                    <Checkbox
+                      checked={consented}
+                      onChange={(e) => setConsented(e.target.checked)}
+                      sx={{
+                        p: 0.5,
+                        mr: 1,
+                        color: "var(--border-strong, var(--font-tertiary))",
+                        "&.Mui-checked": { color: "var(--ai-violet)" },
+                      }}
+                    />
+                  }
+                  label="I understand this attempt is proctored and timed, and that leaving fullscreen or switching tabs may be flagged."
+                />
+              )}
+
+              <LoadingButton
+                variant="contained"
+                size="large"
+                fullWidth
+                startIcon={<IconWrapper icon={ctaIcon} size={24} />}
+                onClick={handleStart}
+                disabled={ctaDisabled}
+                sx={{
+                  background: "var(--gradient-ai)",
+                  color: "#fff",
+                  fontWeight: 700,
+                  py: 1.5,
+                  borderRadius: 2,
+                  textTransform: "none",
+                  fontSize: "1rem",
+                  boxShadow: "0 14px 30px -14px color-mix(in srgb, var(--ai-pink) 70%, transparent)",
+                  "&:hover": {
+                    background: "var(--gradient-ai)",
+                    filter: "brightness(1.05)",
+                    boxShadow: "0 16px 34px -12px color-mix(in srgb, var(--ai-pink) 78%, transparent)",
+                  },
+                  "&.Mui-disabled": {
+                    background: "var(--surface)",
+                    color: "var(--font-tertiary)",
+                    boxShadow: "none",
+                  },
+                }}
+              >
+                {ctaLabel}
+              </LoadingButton>
+
+              {!deviceAllowed && (
+                <Typography
+                  sx={{
+                    mt: 1.25,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    fontSize: "0.75rem",
+                    color: "var(--warning-500)",
+                    fontWeight: 600,
+                  }}
+                >
+                  <IconWrapper icon="mdi:alert-outline" size={15} color="var(--warning-500)" />
+                  This device type isn&apos;t allowed — you&apos;ll be prompted when you continue.
+                </Typography>
+              )}
+
+              {!canStartAssessment && !isExpired && (
+                <Typography
+                  sx={{
+                    mt: 1.25,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    fontSize: "0.75rem",
+                    color: "var(--font-tertiary)",
+                    fontWeight: 500,
+                  }}
+                >
+                  <IconWrapper icon="mdi:clock-outline" size={15} color="var(--font-tertiary)" />
+                  This assessment hasn&apos;t opened yet — the button unlocks at the start time.
+                </Typography>
+              )}
+            </Paper>
+          </Box>
+        </Box>
       </Box>
     </MainLayout>
   );

--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -1,23 +1,9 @@
 "use client";
 
 import { useEffect, useState, useRef, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
-import {
-  Box,
-  Typography,
-  TextField,
-  InputAdornment,
-  Pagination,
-  Button,
-  Paper,
-  Tabs,
-  Tab,
-  Select,
-  MenuItem,
-  FormControl,
-  Chip,
-  Skeleton,
-} from "@mui/material";
+import { Box, Typography, Skeleton, TextField, MenuItem } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
   assessmentService,
@@ -26,818 +12,345 @@ import {
 import { useToast } from "@/components/common/Toast";
 import { AssessmentsGrid } from "@/components/assessment/AssessmentsGrid";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { LoadingButton } from "@/components/common/LoadingButton";
 import { isPsychometricAssessment } from "@/lib/utils/psychometric-utils";
+import { stripHtmlTags } from "@/lib/utils/html-utils";
 import {
   canViewLearnerAssessmentResults,
-  isLearnerAssessmentSubmissionComplete,
   isLearnerAssessmentSubmittedForCatalog,
   isLearnerAssessmentSubmittedUnderReview,
+  normalizeLearnerAssessmentStatus,
 } from "@/lib/utils/assessment-learner-status";
+import {
+  AssessmentSectionHero,
+  StatStrip,
+  SegmentedTabs,
+  AssessmentEmptyState,
+  AssessmentFilterBar,
+} from "@/components/admin/assessment/shared";
 
 const ITEMS_PER_PAGE = 12;
 
 type FilterType = "all" | "available" | "under_review" | "completed" | "expired";
+type SortType = "recent" | "oldest" | "title";
 
 /** Assessment is past its end_time and the learner did not submit before it ended. */
 function isLearnerAssessmentExpired(a: Assessment): boolean {
   if (!a.end_time) return false;
   if (new Date(a.end_time).getTime() > Date.now()) return false;
-  // Don't surface submitted assessments under "expired" — they belong in completed/review.
   return !isLearnerAssessmentSubmittedForCatalog(a);
 }
-type SortType = "recent" | "oldest" | "title";
+
+/** Available = still takeable (not submitted, not expired, and within the open window). */
+function isLearnerAssessmentAvailable(a: Assessment): boolean {
+  if (isLearnerAssessmentSubmittedForCatalog(a)) return false;
+  if (isLearnerAssessmentExpired(a)) return false;
+  if (a.start_time && new Date(a.start_time).getTime() > Date.now()) return false;
+  if (a.status === "not_started" || a.status === "in_progress") return true;
+  if (a.status === undefined || a.status === null) {
+    return !a.is_attempted && !a.has_attempted;
+  }
+  return false;
+}
 
 export default function AssessmentsPage() {
   const { t } = useTranslation("common");
+  const router = useRouter();
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(ITEMS_PER_PAGE);
   const [filter, setFilter] = useState<FilterType>("all");
   const [sortBy, setSortBy] = useState<SortType>("recent");
+  const [nextLoading, setNextLoading] = useState(false);
   const { showToast } = useToast();
   const hasLoadedRef = useRef(false);
 
   useEffect(() => {
     if (hasLoadedRef.current) return;
     hasLoadedRef.current = true;
-    loadAssessments();
-  }, []);
-
-  const loadAssessments = async () => {
-    try {
-      setLoading(true);
-      const data = await assessmentService.getActiveAssessments();
-      setAssessments(data);
-    } catch (error: any) {
-      showToast(t("assessments.failedToLoad"), "error");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // Separate psychometric and regular assessments
-  const psychometricAssessments = assessments.filter((a) =>
-    isPsychometricAssessment(a)
-  );
-  const regularAssessments = assessments.filter(
-    (a) => !isPsychometricAssessment(a)
-  );
-
-  const manualCount = useMemo(
-    () => assessments.filter((a) => a.evaluation_mode === "manual").length,
-    [assessments],
-  );
-
-  // Calculate counts based on status
-  const totalCount = assessments.length;
-  const psychometricCount = psychometricAssessments.length;
-  const regularCount = regularAssessments.length;
-  
-  /** Submitted and learner can open results (excludes pending manual / hidden results). */
-  const completedCount = assessments.filter((a) =>
-    canViewLearnerAssessmentResults(a),
-  ).length;
-
-  const underReviewCount = assessments.filter((a) =>
-    isLearnerAssessmentSubmittedUnderReview(a),
-  ).length;
-
-  const expiredCount = assessments.filter((a) => isLearnerAssessmentExpired(a)).length;
-  
-  // Available: status is "not_started" or "in_progress"
-  // If status is undefined/null, fallback to !is_attempted && !has_attempted for backward compatibility
-  const availableCount = assessments.filter(
-    (a) => {
-      if (isLearnerAssessmentSubmittedForCatalog(a)) return false;
-      if (a.status === "not_started" || a.status === "in_progress") return true;
-      // Fallback for backward compatibility
-      if (a.status === undefined || a.status === null) {
-        return !a.is_attempted && !a.has_attempted;
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await assessmentService.getActiveAssessments();
+        setAssessments(data);
+      } catch {
+        showToast(t("assessments.failedToLoad"), "error");
+      } finally {
+        setLoading(false);
       }
-      return false;
-    }
-  ).length;
-  
-  // Combine all assessments (psychometric + regular)
-  const allAssessments = useMemo(() => {
-    return [...psychometricAssessments, ...regularAssessments];
-  }, [psychometricAssessments, regularAssessments]);
+    })();
+  }, [showToast, t]);
 
-  // Filter and search logic for all assessments
-  const filteredAssessments = useMemo(() => {
-    let result = allAssessments.filter(
-      (assessment) =>
-        assessment.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        assessment.description?.toLowerCase().includes(searchQuery.toLowerCase())
+  // ---- Counts (real learner-status derivation, preserved from the prior hub) ----
+  const counts = useMemo(() => {
+    const totalCount = assessments.length;
+    const availableCount = assessments.filter(isLearnerAssessmentAvailable).length;
+    const completedCount = assessments.filter(canViewLearnerAssessmentResults).length;
+    const underReviewCount = assessments.filter(isLearnerAssessmentSubmittedUnderReview).length;
+    const expiredCount = assessments.filter(isLearnerAssessmentExpired).length;
+    return { totalCount, availableCount, completedCount, underReviewCount, expiredCount };
+  }, [assessments]);
+
+  // ---- Smart band: the single most-urgent thing to do right now (REAL data) ----
+  // Prefer an in-progress attempt, else the soonest-closing available assessment.
+  const nextUp = useMemo(() => {
+    const inProgress = assessments.find(
+      (a) => normalizeLearnerAssessmentStatus(a) === "in_progress" && !isLearnerAssessmentExpired(a),
     );
-
-    if (filter === "completed") {
-      result = result.filter((a) => canViewLearnerAssessmentResults(a));
-    } else if (filter === "under_review") {
-      result = result.filter((a) => isLearnerAssessmentSubmittedUnderReview(a));
-    } else if (filter === "expired") {
-      result = result.filter((a) => isLearnerAssessmentExpired(a));
-    } else if (filter === "available") {
-      // Available: status is "not_started" or "in_progress"
-      // Fallback to !is_attempted && !has_attempted for backward compatibility
-      result = result.filter((a) => {
-        if (isLearnerAssessmentSubmittedForCatalog(a)) return false;
-        if (a.status === "not_started" || a.status === "in_progress") return true;
-        // Fallback for backward compatibility
-        if (a.status === undefined || a.status === null) {
-          return !a.is_attempted && !a.has_attempted;
-        }
-        return false;
+    if (inProgress) return { assessment: inProgress, mode: "resume" as const };
+    const available = assessments
+      .filter(isLearnerAssessmentAvailable)
+      .sort((a, b) => {
+        const ea = a.end_time ? new Date(a.end_time).getTime() : Infinity;
+        const eb = b.end_time ? new Date(b.end_time).getTime() : Infinity;
+        return ea - eb;
       });
-    }
+    return available[0] ? { assessment: available[0], mode: "start" as const } : null;
+  }, [assessments]);
 
-    // Sort
+  const nextHint = useMemo(() => {
+    if (!nextUp) return "";
+    if (nextUp.mode === "resume") return t("assessments.resumeHint", { defaultValue: "You have an attempt in progress — pick up where you left off." });
+    const end = nextUp.assessment.end_time ? new Date(nextUp.assessment.end_time) : null;
+    if (end) {
+      const days = Math.ceil((end.getTime() - Date.now()) / 86400000);
+      if (days <= 0) return t("assessments.dueToday", { defaultValue: "Due today — don't miss it." });
+      if (days <= 2) return t("assessments.dueSoonHint", { count: days, defaultValue: `Due in ${days} day(s) — worth starting soon.` });
+      return t("assessments.openNowHint", { count: days, defaultValue: `Open now · ${days} days left to submit.` });
+    }
+    return t("assessments.readyWhenYouAre", { defaultValue: "Ready whenever you are." });
+  }, [nextUp, t]);
+
+  // ---- Filter + search + sort ----
+  const filteredAssessments = useMemo(() => {
+    const q = searchQuery.toLowerCase();
+    let result = assessments.filter(
+      (a) =>
+        a.title.toLowerCase().includes(q) ||
+        (a.description || "").toLowerCase().includes(q),
+    );
+    if (filter === "completed") result = result.filter(canViewLearnerAssessmentResults);
+    else if (filter === "under_review") result = result.filter(isLearnerAssessmentSubmittedUnderReview);
+    else if (filter === "expired") result = result.filter(isLearnerAssessmentExpired);
+    else if (filter === "available") result = result.filter(isLearnerAssessmentAvailable);
+
     return result.sort((a, b) => {
-      if (sortBy === "recent") {
-        return (
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-        );
-      } else if (sortBy === "oldest") {
-        return (
-          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-        );
-      } else if (sortBy === "title") {
-        return a.title.localeCompare(b.title);
-      }
+      if (sortBy === "recent") return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+      if (sortBy === "oldest") return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      if (sortBy === "title") return a.title.localeCompare(b.title);
       return 0;
     });
-  }, [allAssessments, searchQuery, filter, sortBy]);
+  }, [assessments, searchQuery, filter, sortBy]);
 
-  // Pagination for all assessments
+  const totalPages = Math.max(1, Math.ceil(filteredAssessments.length / ITEMS_PER_PAGE));
   const paginatedAssessments = useMemo(() => {
-    const start = (page - 1) * pageSize;
-    return filteredAssessments.slice(start, start + pageSize);
-  }, [filteredAssessments, page, pageSize]);
+    const start = (page - 1) * ITEMS_PER_PAGE;
+    return filteredAssessments.slice(start, start + ITEMS_PER_PAGE);
+  }, [filteredAssessments, page]);
 
-  const handlePageChange = (newPage: number) => {
-    setPage(newPage);
-    window.scrollTo({ top: 0, behavior: "smooth" });
+  const goToNext = () => {
+    if (!nextUp) return;
+    setNextLoading(true);
+    router.push(`/assessments/${nextUp.assessment.slug}`);
   };
 
-  const totalPages = Math.ceil(filteredAssessments.length / pageSize);
-  const pageStart =
-    filteredAssessments.length === 0 ? 0 : (page - 1) * pageSize + 1;
-  const pageEnd = Math.min(
-    page * pageSize,
-    filteredAssessments.length,
-  );
+  const statItems = [
+    { label: t("assessments.available", { defaultValue: "Available now" }), value: counts.availableCount, icon: "mdi:lightning-bolt", tone: "var(--success-500)" },
+    { label: t("assessments.submittedUnderReview", { defaultValue: "Under review" }), value: counts.underReviewCount, icon: "mdi:progress-clock", tone: "var(--warning-500)" },
+    { label: t("assessments.completed", { defaultValue: "Completed" }), value: counts.completedCount, icon: "mdi:check-circle", tone: "var(--accent-indigo)" },
+    { label: t("assessments.totalAssessments", { defaultValue: "Total" }), value: counts.totalCount, icon: "mdi:clipboard-text", tone: "var(--ai-violet)" },
+  ];
+
+  const tabs = [
+    { value: "all" as FilterType, label: t("assessments.all", { defaultValue: "All" }), count: counts.totalCount },
+    { value: "available" as FilterType, label: t("assessments.available", { defaultValue: "Available" }), count: counts.availableCount },
+    { value: "under_review" as FilterType, label: t("assessments.submittedUnderReview", { defaultValue: "Under review" }), count: counts.underReviewCount },
+    { value: "completed" as FilterType, label: t("assessments.completed", { defaultValue: "Completed" }), count: counts.completedCount },
+    { value: "expired" as FilterType, label: t("assessments.expired", { defaultValue: "Expired" }), count: counts.expiredCount },
+  ];
 
   return (
     <MainLayout>
-      <Box sx={{ width: "100%", maxWidth: "100%", overflow: "visible" }}>
-        {/* Header with Icon */}
-        <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 1.5, sm: 2 }, mb: 1, flexWrap: { xs: "wrap", sm: "nowrap" } }}>
+      <Box sx={{ width: "100%", maxWidth: "100%" }}>
+        <AssessmentSectionHero
+          chapter={t("assessments.center", { defaultValue: "Assessment center" })}
+          title={t("assessments.title", { defaultValue: "Your assessments" })}
+          subtitle={t("assessments.subtitle", { defaultValue: "Everything scheduled across your courses, in one place." })}
+          accent="violet"
+        />
+
+        {/* Smart band — the most-urgent next action, real data, no fabricated metrics. */}
+        {!loading && nextUp && (
           <Box
             sx={{
-              width: { xs: 48, sm: 56 },
-              height: { xs: 48, sm: 56 },
-              borderRadius: 2,
-              background: "var(--assessment-page-header-gradient)",
+              mt: 2.5,
+              borderRadius: "var(--radius-card)",
+              p: { xs: 2.5, sm: 3 },
               display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
-            }}
-          >
-            <IconWrapper icon="mdi:clipboard-text" size={28} color="var(--font-light)" />
-          </Box>
-          <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography 
-              variant="h4" 
-              fontWeight={700}
-              sx={{ fontSize: { xs: "1.5rem", sm: "2rem" } }}
-            >
-              {t("assessments.title")}
-            </Typography>
-            <Typography 
-              variant="body2" 
-              color="text.secondary"
-              sx={{ fontSize: { xs: "0.75rem", sm: "0.875rem" }, display: { xs: "none", sm: "block" } }}
-            >
-              {t("assessments.subtitle")}
-            </Typography>
-          </Box>
-        </Box>
-
-        {/* Stats Cards */}
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: {
-              xs: "1fr",
-              sm: "repeat(2, 1fr)",
-              md: "repeat(3, 1fr)",
-              lg: "repeat(5, 1fr)",
-            },
-            gap: { xs: 1.5, sm: 2 },
-            mb: { xs: 2, sm: 3 },
-            mt: { xs: 1.5, sm: 2 },
-          }}
-        >
-          <Paper
-            elevation={0}
-            sx={{
-              p: { xs: 2, sm: 2.5 },
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              backgroundColor: "var(--card-bg)",
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 1.5, sm: 2 } }}>
-              <Box
-                sx={{
-                  width: { xs: 40, sm: 48 },
-                  height: { xs: 40, sm: 48 },
-                  borderRadius: 2,
-                  backgroundColor: "color-mix(in srgb, var(--accent-indigo) 16%, transparent)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  flexShrink: 0,
-                }}
-              >
-                <IconWrapper
-                  icon="mdi:clipboard-text"
-                  size={24}
-                  color="var(--accent-indigo)"
-                />
-              </Box>
-              <Box sx={{ minWidth: 0 }}>
-                <Typography 
-                  variant="h4" 
-                  fontWeight={700} 
-                  color="var(--font-primary)"
-                  sx={{ fontSize: { xs: "1.5rem", sm: "2rem" } }}
-                >
-                  {totalCount}
-                </Typography>
-                <Typography 
-                  variant="body2" 
-                  color="text.secondary"
-                  sx={{ fontSize: { xs: "0.7rem", sm: "0.875rem" } }}
-                >
-                  {t("assessments.totalAssessments")}
-                </Typography>
-              </Box>
-            </Box>
-          </Paper>
-          <Paper
-            elevation={0}
-            sx={{
-              p: { xs: 2, sm: 2.5 },
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              backgroundColor: "var(--card-bg)",
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 1.5, sm: 2 } }}>
-              <Box
-                sx={{
-                  width: { xs: 40, sm: 48 },
-                  height: { xs: 40, sm: 48 },
-                  borderRadius: 2,
-                  backgroundColor: "color-mix(in srgb, var(--accent-purple) 16%, transparent)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  flexShrink: 0,
-                }}
-              >
-                <IconWrapper
-                  icon="mdi:brain"
-                  size={24}
-                  color="var(--accent-purple)"
-                />
-              </Box>
-              <Box sx={{ minWidth: 0 }}>
-                <Typography 
-                  variant="h4" 
-                  fontWeight={700} 
-                  color="var(--font-primary)"
-                  sx={{ fontSize: { xs: "1.5rem", sm: "2rem" } }}
-                >
-                  {psychometricCount}
-                </Typography>
-                <Typography 
-                  variant="body2" 
-                  color="text.secondary"
-                  sx={{ fontSize: { xs: "0.7rem", sm: "0.875rem" } }}
-                >
-                  {t("assessments.psychometric")}
-                </Typography>
-              </Box>
-            </Box>
-          </Paper>
-          <Paper
-            elevation={0}
-            sx={{
-              p: { xs: 2, sm: 2.5 },
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              backgroundColor: "var(--card-bg)",
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 1.5, sm: 2 } }}>
-              <Box
-                sx={{
-                  width: { xs: 40, sm: 48 },
-                  height: { xs: 40, sm: 48 },
-                  borderRadius: 2,
-                  backgroundColor: "var(--assessment-catalog-manual-list-stat-bg)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  flexShrink: 0,
-                }}
-              >
-                <IconWrapper
-                  icon="mdi:clipboard-account-outline"
-                  size={24}
-                  color="var(--assessment-catalog-stat-icon-manual)"
-                />
-              </Box>
-              <Box sx={{ minWidth: 0 }}>
-                <Typography 
-                  variant="h4" 
-                  fontWeight={700} 
-                  color="var(--font-primary)"
-                  sx={{ fontSize: { xs: "1.5rem", sm: "2rem" } }}
-                >
-                  {manualCount}
-                </Typography>
-                <Typography 
-                  variant="body2" 
-                  color="text.secondary"
-                  sx={{ fontSize: { xs: "0.7rem", sm: "0.875rem" }, lineHeight: 1.3 }}
-                >
-                  {t("assessments.manualEvaluationStat")}
-                </Typography>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ fontSize: { xs: "0.65rem", sm: "0.7rem" }, opacity: 0.85 }}
-                >
-                  {t("assessments.manualEvaluationStatHint")}
-                </Typography>
-              </Box>
-            </Box>
-          </Paper>
-          <Paper
-            elevation={0}
-            sx={{
-              p: { xs: 2, sm: 2.5 },
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              backgroundColor: "var(--card-bg)",
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 1.5, sm: 2 } }}>
-              <Box
-                sx={{
-                  width: { xs: 40, sm: 48 },
-                  height: { xs: 40, sm: 48 },
-                  borderRadius: 2,
-                  backgroundColor: "color-mix(in srgb, var(--accent-blue-light) 16%, transparent)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  flexShrink: 0,
-                }}
-              >
-                <IconWrapper
-                  icon="mdi:play-circle"
-                  size={24}
-                  color="var(--accent-blue-light)"
-                />
-              </Box>
-              <Box sx={{ minWidth: 0 }}>
-                <Typography 
-                  variant="h4" 
-                  fontWeight={700} 
-                  color="var(--font-primary)"
-                  sx={{ fontSize: { xs: "1.5rem", sm: "2rem" } }}
-                >
-                  {availableCount}
-                </Typography>
-                <Typography 
-                  variant="body2" 
-                  color="text.secondary"
-                  sx={{ fontSize: { xs: "0.7rem", sm: "0.875rem" } }}
-                >
-                  {t("assessments.available")}
-                </Typography>
-              </Box>
-            </Box>
-          </Paper>
-          <Paper
-            elevation={0}
-            sx={{
-              p: { xs: 2, sm: 2.5 },
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              backgroundColor: "var(--card-bg)",
-            }}
-          >
-            <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 1.5, sm: 2 } }}>
-              <Box
-                sx={{
-                  width: { xs: 40, sm: 48 },
-                  height: { xs: 40, sm: 48 },
-                  borderRadius: 2,
-                  backgroundColor: "color-mix(in srgb, var(--success-500) 16%, transparent)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  flexShrink: 0,
-                }}
-              >
-                <IconWrapper
-                  icon="mdi:check-circle"
-                  size={24}
-                  color="var(--success-500)"
-                />
-              </Box>
-              <Box sx={{ minWidth: 0 }}>
-                <Typography 
-                  variant="h4" 
-                  fontWeight={700} 
-                  color="var(--font-primary)"
-                  sx={{ fontSize: { xs: "1.5rem", sm: "2rem" } }}
-                >
-                  {completedCount}
-                </Typography>
-                <Typography 
-                  variant="body2" 
-                  color="text.secondary"
-                  sx={{ fontSize: { xs: "0.7rem", sm: "0.875rem" } }}
-                >
-                  {t("assessments.completed")}
-                </Typography>
-              </Box>
-            </Box>
-          </Paper>
-        </Box>
-
-        {/* Filters and Search */}
-        <Paper
-          elevation={0}
-          sx={{
-            border: "1px solid var(--border-default)",
-            borderRadius: 2,
-            mb: 3,
-            overflow: "hidden",
-            backgroundColor: "var(--card-bg)",
-          }}
-        >
-          {/* Tabs */}
-          <Tabs
-            value={filter}
-            onChange={(_, newValue) => {
-              setFilter(newValue);
-              setPage(1);
-            }}
-            variant="scrollable"
-            scrollButtons="auto"
-            allowScrollButtonsMobile
-            sx={{
-              borderBottom: "1px solid var(--border-default)",
-              px: 2,
-              "& .MuiTab-root": {
-                textTransform: "none",
-                fontWeight: 600,
-                fontSize: "0.9375rem",
-                color: "var(--font-secondary)",
-                "&.Mui-selected": {
-                  color: "var(--accent-indigo)",
-                },
-              },
-              "& .MuiTabs-indicator": {
-                backgroundColor: "var(--accent-indigo)",
-                height: 3,
-              },
-            }}
-          >
-            <Tab
-              label={`${t("assessments.all")} (${totalCount})`}
-              value="all"
-            />
-            <Tab
-              label={`${t("assessments.available")} (${availableCount})`}
-              value="available"
-            />
-            <Tab
-              label={`${t("assessments.submittedUnderReview")} (${underReviewCount})`}
-              value="under_review"
-            />
-            <Tab
-              label={`${t("assessments.completed")} (${completedCount})`}
-              value="completed"
-            />
-            <Tab
-              label={`${t("assessments.expired")} (${expiredCount})`}
-              value="expired"
-            />
-          </Tabs>
-
-          {/* Search and Sort */}
-          <Box
-            sx={{
-              p: 2,
-              display: "flex",
-              gap: 2,
               flexDirection: { xs: "column", sm: "row" },
-              alignItems: { xs: "stretch", sm: "center" },
-            }}
-          >
-            <TextField
-              fullWidth
-              placeholder={t("assessments.searchPlaceholder")}
-              value={searchQuery}
-              onChange={(e) => {
-                setSearchQuery(e.target.value);
-                setPage(1);
-              }}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <IconWrapper icon="mdi:magnify" size={20} color="var(--font-secondary)" />
-                  </InputAdornment>
-                ),
-              }}
-              sx={{
-                "& .MuiOutlinedInput-root": {
-                  backgroundColor: "var(--surface)",
-                  color: "var(--font-primary)",
-                  borderRadius: 2,
-                  "& fieldset": {
-                    borderColor: "var(--border-default)",
-                  },
-                  "&:hover fieldset": {
-                    borderColor: "var(--border-default)",
-                  },
-                  "&.Mui-focused fieldset": {
-                    borderColor: "var(--accent-indigo)",
-                  },
-                },
-                "& .MuiInputBase-input::placeholder": {
-                  color: "var(--font-secondary)",
-                  opacity: 1,
-                },
-              }}
-            />
-            <FormControl sx={{ minWidth: 200 }}>
-              <Select
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value as SortType)}
-                displayEmpty
-                sx={{
-                  backgroundColor: "var(--surface)",
-                  color: "var(--font-primary)",
-                  borderRadius: 2,
-                  "& .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "var(--border-default)",
-                  },
-                  "&:hover .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "var(--border-default)",
-                  },
-                  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-                    borderColor: "var(--accent-indigo)",
-                  },
-                  "& .MuiSelect-icon": {
-                    color: "var(--font-secondary)",
-                  },
-                }}
-              >
-                <MenuItem value="recent">
-                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                    <Typography variant="body2" color="text.secondary">
-                      {t("courses.sortBy")}
-                    </Typography>
-                    <Typography variant="body2" fontWeight={600}>
-                      {t("courses.mostRecent")}
-                    </Typography>
-                  </Box>
-                </MenuItem>
-                <MenuItem value="oldest">{t("courses.oldestFirst")}</MenuItem>
-                <MenuItem value="title">{t("courses.titleAZ")}</MenuItem>
-              </Select>
-            </FormControl>
-          </Box>
-        </Paper>
-
-        {/* All Assessments Grid */}
-        {loading ? (
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: {
-                xs: "1fr",
-                sm: "repeat(2, 1fr)",
-                lg: "repeat(3, 1fr)",
-              },
-              gap: { xs: 2, sm: 3 },
-              width: "100%",
-            }}
-          >
-            {Array.from({ length: Math.min(pageSize, 9) }).map((_, i) => (
-              <Skeleton
-                key={i}
-                variant="rounded"
-                height={336}
-                sx={{
-                  borderRadius: 3,
-                  bgcolor: "color-mix(in srgb, var(--surface) 92%, var(--accent-indigo) 8%)",
-                }}
-              />
-            ))}
-          </Box>
-        ) : filteredAssessments.length > 0 ? (
-          <AssessmentsGrid
-            assessments={paginatedAssessments}
-            searchQuery={searchQuery}
-          />
-        ) : (
-          <Paper
-            elevation={0}
-            sx={{
-              p: 8,
-              textAlign: "center",
-              border: "1px dashed var(--border-default)",
-              borderRadius: 3,
-              backgroundColor: "var(--card-bg)",
+              alignItems: { xs: "flex-start", sm: "center" },
+              gap: 2,
+              background: "linear-gradient(115deg, #2b1244 0%, #4a1d5e 55%, #7d2058 100%)",
+              color: "var(--font-light)",
+              overflow: "hidden",
+              position: "relative",
             }}
           >
             <Box
               sx={{
-                width: 80,
-                height: 80,
-                borderRadius: "50%",
-                backgroundColor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                mx: "auto",
-                mb: 3,
+                width: 52, height: 52, borderRadius: 2, flexShrink: 0,
+                background: "var(--gradient-ai)",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                boxShadow: "0 8px 20px -8px color-mix(in srgb, var(--ai-pink) 60%, transparent)",
               }}
             >
-              <IconWrapper
-                icon={
-                  searchQuery
-                    ? "mdi:file-search-outline"
-                    : "mdi:clipboard-text-outline"
-                }
-                size={40}
-                color="var(--accent-indigo)"
-              />
+              <IconWrapper icon="mdi:star-four-points" size={26} color="#fff" />
             </Box>
-            <Typography
-              variant="h6"
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography sx={{ fontWeight: 700, fontSize: { xs: "1rem", sm: "1.125rem" }, lineHeight: 1.3 }}>
+                {nextUp.mode === "resume"
+                  ? t("assessments.pickUpWhereYouLeftOff", { defaultValue: "Pick up where you left off" })
+                  : t("assessments.nextUpBanner", { defaultValue: "Next up" })}
+                {": "}
+                {stripHtmlTags(nextUp.assessment.title || "").trim() || nextUp.assessment.title}
+              </Typography>
+              <Typography sx={{ fontSize: "0.8125rem", opacity: 0.82, mt: 0.5 }}>
+                {nextHint}
+              </Typography>
+            </Box>
+            <LoadingButton
+              onClick={goToNext}
+              loading={nextLoading}
+              endIcon={<IconWrapper icon="mdi:arrow-right" size={18} color="currentColor" />}
               sx={{
-                color: "var(--font-muted)",
-                fontWeight: 600,
-                mb: 1,
+                flexShrink: 0,
+                bgcolor: "#fff",
+                color: "#2b1244",
+                fontWeight: 700,
+                textTransform: "none",
+                px: 3, py: 1.1,
+                borderRadius: 2,
+                "&:hover": { bgcolor: "#fff", transform: "translateY(-1px)" },
               }}
             >
-              {searchQuery ? t("assessments.noAssessmentsFound") : t("assessments.noAssessmentsFound")}
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{
-                color: "var(--font-secondary)",
-                maxWidth: 400,
-                mx: "auto",
-              }}
-            >
-              {searchQuery
-                ? t("assessments.adjustSearchFilter")
-                : t("assessments.checkBackLater")}
-            </Typography>
-          </Paper>
+              {nextUp.mode === "resume"
+                ? t("assessments.resume", { defaultValue: "Resume" })
+                : t("assessments.takeItNow", { defaultValue: "Take it now" })}
+            </LoadingButton>
+          </Box>
         )}
 
-        {/* Pagination */}
-        {filteredAssessments.length > 0 && (
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: { xs: "column", sm: "row" },
-              justifyContent: { xs: "center", sm: "space-between" },
-              alignItems: "center",
-              mt: 4,
-              px: 2,
-              gap: { xs: 2, sm: 0 },
+        {/* Stat strip */}
+        <Box sx={{ mt: 3 }}>
+          <StatStrip items={statItems} />
+        </Box>
+
+        {/* Tabs */}
+        <Box sx={{ mt: 3 }}>
+          <SegmentedTabs
+            tabs={tabs}
+            value={filter}
+            onChange={(v) => {
+              setFilter(v as FilterType);
+              setPage(1);
             }}
-          >
-            <Typography
-              variant="body2"
-              color="text.secondary"
+          />
+        </Box>
+
+        {/* Search + sort */}
+        <Box sx={{ mt: 2 }}>
+          <AssessmentFilterBar
+            search={searchQuery}
+            onSearchChange={(v) => {
+              setSearchQuery(v);
+              setPage(1);
+            }}
+            searchPlaceholder={t("assessments.searchPlaceholder", { defaultValue: "Search assessments…" })}
+            rightSlot={
+              <TextField
+                select
+                size="small"
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as SortType)}
+                label={t("courses.sortBy", { defaultValue: "Sort" })}
+                sx={{
+                  width: { xs: "100%", sm: 180 },
+                  "& .MuiOutlinedInput-root": { borderRadius: 2, bgcolor: "var(--surface)" },
+                }}
+              >
+                <MenuItem value="recent">{t("courses.mostRecent", { defaultValue: "Most recent" })}</MenuItem>
+                <MenuItem value="oldest">{t("courses.oldestFirst", { defaultValue: "Oldest first" })}</MenuItem>
+                <MenuItem value="title">{t("courses.titleAZ", { defaultValue: "Title A–Z" })}</MenuItem>
+              </TextField>
+            }
+          />
+        </Box>
+
+        {/* Grid / loading / empty */}
+        <Box sx={{ mt: 3 }}>
+          {loading ? (
+            <Box
               sx={{
-                fontSize: { xs: "0.75rem", sm: "0.875rem" },
-                textAlign: { xs: "center", sm: "start" },
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+                gap: { xs: 2, sm: 2.5 },
               }}
             >
-              {totalPages > 1
-                ? t("assessments.pageRange", {
-                    start: pageStart,
-                    end: pageEnd,
-                    total: filteredAssessments.length,
-                  })
-                : t("assessments.showingTotal", {
-                    count: filteredAssessments.length,
-                  })}
-            </Typography>
-            {totalPages > 1 && (
-            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
-              <Button
-                variant="outlined"
-                size="small"
-                disabled={page === 1}
-                onClick={() => handlePageChange(page - 1)}
-                startIcon={<IconWrapper icon="mdi:chevron-left" size={16} />}
-                sx={{
-                  borderColor: "var(--border-light)",
-                  color: "var(--font-muted)",
-                  textTransform: "none",
-                  minWidth: { xs: "auto", sm: "auto" },
-                  px: { xs: 1, sm: 2 },
-                  "& .MuiButton-startIcon": {
-                    mr: { xs: 0, sm: 0.5 },
-                  },
-                  "&:hover": {
-                    borderColor: "var(--font-tertiary)",
-                    backgroundColor: "var(--surface)",
-                  },
-                  "&:disabled": {
-                    borderColor: "var(--border-default)",
-                    color: "var(--font-tertiary)",
-                  },
-                }}
-              >
-                <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
-                  {t("assessments.previous")}
-                </Box>
-              </Button>
-              <Pagination
-                count={totalPages}
-                page={page}
-                onChange={(_, value) => handlePageChange(value)}
-                siblingCount={0}
-                boundaryCount={1}
-                size="small"
-                sx={{
-                  "& .MuiPaginationItem-root": {
-                    color: "var(--font-muted)",
-                    minWidth: { xs: "32px", sm: "36px" },
-                    height: { xs: "32px", sm: "36px" },
-                    fontSize: { xs: "0.8125rem", sm: "0.875rem" },
-                    "&.Mui-selected": {
-                      backgroundColor: "var(--font-muted)",
-                      color: "var(--font-light)",
-                      "&:hover": {
-                        backgroundColor: "var(--font-primary-dark)",
-                      },
-                    },
-                  },
-                }}
-              />
-              <Button
-                variant="outlined"
-                size="small"
-                disabled={page === totalPages}
-                onClick={() => handlePageChange(page + 1)}
-                endIcon={<IconWrapper icon="mdi:chevron-right" size={16} />}
-                sx={{
-                  borderColor: "var(--border-light)",
-                  color: "var(--font-muted)",
-                  textTransform: "none",
-                  minWidth: { xs: "auto", sm: "auto" },
-                  px: { xs: 1, sm: 2 },
-                  "& .MuiButton-endIcon": {
-                    ml: { xs: 0, sm: 0.5 },
-                  },
-                  "&:hover": {
-                    borderColor: "var(--font-tertiary)",
-                    backgroundColor: "var(--surface)",
-                  },
-                  "&:disabled": {
-                    borderColor: "var(--border-default)",
-                    color: "var(--font-tertiary)",
-                  },
-                }}
-              >
-                <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
-                  {t("assessments.next")}
-                </Box>
-              </Button>
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton
+                  key={i}
+                  variant="rounded"
+                  height={300}
+                  sx={{ borderRadius: "var(--radius-card)", bgcolor: "color-mix(in srgb, var(--surface) 88%, var(--ai-violet) 12%)" }}
+                />
+              ))}
             </Box>
-            )}
+          ) : filteredAssessments.length > 0 ? (
+            <AssessmentsGrid assessments={paginatedAssessments} searchQuery={searchQuery} />
+          ) : (
+            <AssessmentEmptyState
+              icon={searchQuery ? "mdi:file-search-outline" : "mdi:clipboard-text-outline"}
+              title={t("assessments.noAssessmentsFound", { defaultValue: "No assessments found" })}
+              description={
+                searchQuery
+                  ? t("assessments.adjustSearchFilter", { defaultValue: "Try adjusting your search or filter." })
+                  : t("assessments.checkBackLater", { defaultValue: "Nothing here yet — check back later." })
+              }
+            />
+          )}
+        </Box>
+
+        {/* Pagination */}
+        {!loading && filteredAssessments.length > ITEMS_PER_PAGE && (
+          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mt: 4, flexWrap: "wrap", gap: 2 }}>
+            <Typography sx={{ fontSize: "0.8125rem", color: "var(--font-secondary)" }}>
+              {t("assessments.pageRange", {
+                start: (page - 1) * ITEMS_PER_PAGE + 1,
+                end: Math.min(page * ITEMS_PER_PAGE, filteredAssessments.length),
+                total: filteredAssessments.length,
+                defaultValue: `${(page - 1) * ITEMS_PER_PAGE + 1}–${Math.min(page * ITEMS_PER_PAGE, filteredAssessments.length)} of ${filteredAssessments.length}`,
+              })}
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+              <LoadingButton
+                onClick={() => { setPage((p) => Math.max(1, p - 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
+                disabled={page === 1}
+                sx={{ minWidth: 0, px: 2, py: 0.75, borderRadius: 2, border: "1px solid var(--border-default)", color: "var(--font-secondary)", textTransform: "none" }}
+              >
+                {t("assessments.previous", { defaultValue: "Previous" })}
+              </LoadingButton>
+              <Typography sx={{ fontSize: "0.8125rem", color: "var(--font-secondary)", px: 1, fontFamily: "var(--font-mono)" }}>
+                {page} / {totalPages}
+              </Typography>
+              <LoadingButton
+                onClick={() => { setPage((p) => Math.min(totalPages, p + 1)); window.scrollTo({ top: 0, behavior: "smooth" }); }}
+                disabled={page >= totalPages}
+                sx={{ minWidth: 0, px: 2, py: 0.75, borderRadius: 2, border: "1px solid var(--border-default)", color: "var(--font-secondary)", textTransform: "none" }}
+              >
+                {t("assessments.next", { defaultValue: "Next" })}
+              </LoadingButton>
+            </Box>
           </Box>
         )}
       </Box>

--- a/app/assessments/result/[slug]/page.tsx
+++ b/app/assessments/result/[slug]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { Box, Button, Paper,Alert, Typography, CircularProgress, Chip } from "@mui/material";
+import { Box, Button, Paper, Alert, Typography, CircularProgress } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import {
   assessmentService,
@@ -13,8 +13,12 @@ import {
 import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { AssessmentResultHeader } from "@/components/assessment/result/AssessmentResultHeader";
-import { ScoreDisplay } from "@/components/assessment/result/ScoreDisplay";
 import { EnhancedStatsBar } from "@/components/assessment/result/EnhancedStatsBar";
+import {
+  GradientRing,
+  StatStrip,
+  StatusChip,
+} from "@/components/admin/assessment/shared";
 import { TopicWiseBreakdown } from "@/components/assessment/result/TopicWiseBreakdown";
 import { EnhancedSkillsTags } from "@/components/assessment/result/EnhancedSkillsTags";
 import { OverallFeedback } from "@/components/assessment/result/OverallFeedback";
@@ -80,6 +84,31 @@ function asNumber(v: unknown): number | null {
 
 function looksLikeImageUrl(url: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg)(\?.*)?$/i.test(url);
+}
+
+/**
+ * Performance band — mirrors ScoreDisplay's thresholds exactly
+ * (>=80 Excellent / >=60 Good / >=40 Average / else Needs Improvement) so the
+ * ring hero stays consistent with the retired gradient-bar card.
+ */
+function getPerformanceBand(pct: number): {
+  label: string;
+  tone: "success" | "info" | "warning" | "error";
+  icon: string;
+} {
+  if (pct >= 80) return { label: "Excellent", tone: "success", icon: "mdi:trophy" };
+  if (pct >= 60) return { label: "Good", tone: "info", icon: "mdi:medal" };
+  if (pct >= 40) return { label: "Average", tone: "warning", icon: "mdi:chart-line" };
+  return { label: "Needs Improvement", tone: "error", icon: "mdi:alert-circle" };
+}
+
+/** Minutes → "45 min" / "1h 20m" (mirrors EnhancedStatsBar's formatter). */
+function formatResultMinutes(minutes: number): string {
+  const m = Number.isFinite(minutes) ? minutes : 0;
+  if (m < 60) return `${Math.round(m)} min`;
+  const hours = Math.floor(m / 60);
+  const mins = Math.round(m % 60);
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }
 
 function pickCertificateCourseDisplayName(
@@ -417,6 +446,17 @@ export default function AssessmentResultPage() {
   const hasCoding = codingResponses.length > 0;
   const hasSubjective = subjectiveResponses.length > 0;
 
+  // Score hero — same pct the retired ScoreDisplay used (score / maximum_marks * 100).
+  const heroScore = Number(stats.score) || 0;
+  const heroMax = Number(stats.maximum_marks) || 0;
+  const heroPct = heroMax > 0 ? (heroScore / heroMax) * 100 : 0;
+  const heroBand = getPerformanceBand(heroPct);
+  const heroScoreText = heroMax > 0 ? `${heroScore} / ${heroMax}` : `${heroScore}`;
+  const heroSummary =
+    heroMax > 0
+      ? `You scored ${heroScore} out of ${heroMax} (${Math.round(heroPct)}%) — ${heroBand.label.toLowerCase()} performance.`
+      : "Your submission has been evaluated.";
+
   const handleDownloadResultPdf = () => {
     if (!assessmentResult || pdfExporting) return;
 
@@ -511,11 +551,12 @@ export default function AssessmentResultPage() {
 
   return (
     <MainLayout>
+      <Box sx={{ bgcolor: "var(--canvas)", minHeight: "100%" }}>
       <Box
         sx={{
           maxWidth: "1200px",
           mx: "auto",
-          px: 3,
+          px: { xs: 2, md: 3 },
           py: 3,
         }}
       >
@@ -558,39 +599,46 @@ export default function AssessmentResultPage() {
             retake that was consumed and finalized. Clicking an attempt
             refetches the full result payload for that submission. */}
         {assessmentResult?.attempts && assessmentResult.attempts.length > 1 && (
-          <Paper
-            elevation={0}
-            sx={{
-              mb: 3,
-              border: "1px solid var(--border-default)",
-              borderRadius: 2,
-              bgcolor: "var(--card-bg)",
-              overflow: "hidden",
-            }}
-          >
+          <Box sx={{ mb: 3 }}>
             <Box
               sx={{
-                px: 2,
-                py: 1.25,
-                borderBottom: "1px solid var(--border-default)",
                 display: "flex",
                 alignItems: "center",
                 gap: 1,
-                bgcolor:
-                  "color-mix(in srgb, var(--accent-indigo) 5%, var(--card-bg))",
+                mb: 1.5,
               }}
             >
-              <IconWrapper icon="mdi:history" size={18} color="var(--accent-indigo)" />
-              <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+              <IconWrapper icon="mdi:history" size={18} color="var(--ai-violet)" />
+              <Typography
+                variant="subtitle2"
+                sx={{ fontWeight: 700, color: "var(--font-primary)" }}
+              >
                 Attempt history
               </Typography>
-              <Chip
-                size="small"
-                label={`${assessmentResult.attempts.length} attempts`}
-                sx={{ ml: "auto", bgcolor: "var(--surface)", fontWeight: 600 }}
-              />
+              <Box sx={{ ml: "auto" }}>
+                <StatusChip
+                  label={`${assessmentResult.attempts.length} attempts`}
+                  tone="info"
+                />
+              </Box>
             </Box>
-            <Box sx={{ p: 1, display: "flex", flexWrap: "wrap", gap: 1 }}>
+            {/* SegmentedTabs-like pill track — same handleAttemptChange contract. */}
+            <Box
+              role="tablist"
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 0.75,
+                p: 0.75,
+                borderRadius: "var(--radius-card)",
+                border:
+                  "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+                bgcolor: "var(--card-bg)",
+                boxShadow:
+                  "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+                maxWidth: "100%",
+              }}
+            >
               {assessmentResult.attempts.map((att) => {
                 const isCurrent = att.id === assessmentResult.current_attempt_id;
                 const dateLabel = att.submitted_at
@@ -601,63 +649,75 @@ export default function AssessmentResultPage() {
                   : "—";
                 const scoreLabel = att.score != null ? `${att.score}` : "—";
                 return (
-                  <Button
+                  <Box
                     key={att.id}
-                    size="small"
-                    variant={isCurrent ? "contained" : "outlined"}
-                    onClick={() => handleAttemptChange(att.id)}
-                    disabled={loading}
+                    role="tab"
+                    aria-selected={isCurrent}
+                    tabIndex={0}
+                    onClick={() => {
+                      if (!loading) handleAttemptChange(att.id);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        if (!loading) handleAttemptChange(att.id);
+                      }
+                    }}
                     sx={{
-                      textTransform: "none",
-                      borderRadius: 1.5,
-                      fontWeight: 600,
-                      px: 1.5,
-                      ...(isCurrent
-                        ? {
-                            background:
-                              "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-indigo-dark) 100%)",
-                            color: "var(--font-light)",
-                            "&:hover": {
-                              background:
-                                "linear-gradient(135deg, var(--accent-indigo-dark) 0%, var(--accent-indigo) 100%)",
-                            },
-                          }
+                      cursor: loading ? "default" : "pointer",
+                      opacity: loading && !isCurrent ? 0.55 : 1,
+                      minWidth: 132,
+                      px: 2,
+                      py: 1,
+                      borderRadius: 999,
+                      transition:
+                        "background-color 0.15s ease, color 0.15s ease",
+                      color: isCurrent
+                        ? "var(--font-light)"
+                        : "var(--font-secondary)",
+                      bgcolor: isCurrent ? "var(--ai-violet)" : "transparent",
+                      boxShadow: isCurrent
+                        ? "0 6px 14px -8px color-mix(in srgb, var(--ai-violet) 70%, transparent)"
+                        : "none",
+                      "&:hover": isCurrent
+                        ? {}
                         : {
-                            borderColor: "var(--border-default)",
-                            color: "var(--font-primary)",
-                          }),
+                            bgcolor:
+                              "color-mix(in srgb, var(--ai-violet) 10%, var(--surface) 90%)",
+                            color: "var(--ai-violet)",
+                          },
                     }}
                   >
-                    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1.2 }}>
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          fontSize: "0.7rem",
-                          fontWeight: 700,
-                          opacity: isCurrent ? 0.9 : 0.7,
-                        }}
-                      >
-                        Attempt {att.attempt_number}
-                        {isCurrent ? " · current" : ""}
-                      </Typography>
-                      <Typography variant="body2" sx={{ fontWeight: 700 }}>
-                        Score: {scoreLabel}
-                      </Typography>
-                      <Typography
-                        variant="caption"
-                        sx={{
-                          fontSize: "0.65rem",
-                          opacity: isCurrent ? 0.85 : 0.65,
-                        }}
-                      >
-                        {dateLabel}
-                      </Typography>
-                    </Box>
-                  </Button>
+                    <Typography
+                      sx={{
+                        fontSize: "0.7rem",
+                        fontWeight: 700,
+                        lineHeight: 1.35,
+                        opacity: isCurrent ? 0.9 : 0.75,
+                      }}
+                    >
+                      Attempt {att.attempt_number}
+                      {isCurrent ? " · current" : ""}
+                    </Typography>
+                    <Typography
+                      sx={{ fontWeight: 700, fontSize: "0.9rem", lineHeight: 1.35 }}
+                    >
+                      Score: {scoreLabel}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: "0.65rem",
+                        lineHeight: 1.35,
+                        opacity: isCurrent ? 0.85 : 0.65,
+                      }}
+                    >
+                      {dateLabel}
+                    </Typography>
+                  </Box>
                 );
               })}
             </Box>
-          </Paper>
+          </Box>
         )}
 
         {resultHidden && (
@@ -682,13 +742,113 @@ export default function AssessmentResultPage() {
         {!resultHidden && (
           <>
 
-        {/* Score */}
-        <ScoreDisplay
-          score={stats.score}
-          maximumMarks={stats.maximum_marks}
-          accuracy={stats?.accuracy_percent||0}
-          percentile={stats.percentile}
-        />
+        {/* Score hero — gradient percentage ring + performance band */}
+        <Paper
+          elevation={0}
+          sx={{
+            mb: 3,
+            p: { xs: 3, md: 4 },
+            borderRadius: "var(--radius-card)",
+            bgcolor: "var(--card-bg)",
+            border: "1px solid var(--border-default)",
+            display: "flex",
+            flexDirection: { xs: "column", sm: "row" },
+            alignItems: "center",
+            gap: { xs: 2.5, sm: 4 },
+          }}
+        >
+          <Box sx={{ flexShrink: 0 }}>
+            <GradientRing
+              value={heroPct}
+              size={184}
+              strokeWidth={14}
+              caption="Score"
+              valueFontSize={46}
+            />
+          </Box>
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              textAlign: { xs: "center", sm: "left" },
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: 1.5,
+                mb: 1.5,
+                justifyContent: { xs: "center", sm: "flex-start" },
+              }}
+            >
+              <StatusChip
+                label={heroBand.label}
+                tone={heroBand.tone}
+                icon={heroBand.icon}
+              />
+              <Typography
+                sx={{
+                  fontFamily: "var(--font-mono)",
+                  fontWeight: 700,
+                  fontSize: "1.15rem",
+                  color: "var(--font-primary)",
+                }}
+              >
+                {heroScoreText}
+              </Typography>
+            </Box>
+            <Typography
+              variant="body1"
+              sx={{
+                color: "var(--font-secondary)",
+                maxWidth: 560,
+                lineHeight: 1.6,
+              }}
+            >
+              {heroSummary}
+            </Typography>
+          </Box>
+        </Paper>
+
+        {/* Headline stats */}
+        <Box sx={{ mb: 3 }}>
+          <StatStrip
+            items={[
+              {
+                label: "Accuracy",
+                value: `${(Number(stats.accuracy_percent) || 0).toFixed(1)}%`,
+                icon: "mdi:target-variant",
+                tone: "var(--accent-blue-light)",
+              },
+              {
+                label: "Percentile",
+                value: `${(Number(stats.percentile) || 0).toFixed(1)}%`,
+                icon: "mdi:chart-bell-curve-cumulative",
+                tone: "var(--assessment-chart-violet)",
+              },
+              {
+                label: "Attempted",
+                value: `${Number(stats.attempted_questions) || 0}/${Number(stats.total_questions) || 0}`,
+                icon: "mdi:help-circle",
+                tone: "var(--accent-indigo)",
+              },
+              {
+                label: "Correct",
+                value: Number(stats.correct_answers) || 0,
+                icon: "mdi:check-circle",
+                tone: "var(--course-cta)",
+              },
+              {
+                label: "Time",
+                value: formatResultMinutes(Number(stats.time_taken_minutes) || 0),
+                icon: "mdi:clock-time-four",
+                tone: "var(--accent-purple)",
+              },
+            ]}
+          />
+        </Box>
         {resultCertificateContent && user ? (
           <Paper
             className="exclude-from-pdf"
@@ -878,6 +1038,7 @@ export default function AssessmentResultPage() {
         />
           </>
         )}
+      </Box>
       </Box>
     </MainLayout>
   );

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -28,6 +28,7 @@ import {
   isLearnerAssessmentSubmissionComplete,
   normalizeLearnerAssessmentStatus,
 } from "@/lib/utils/assessment-learner-status";
+import { StatusChip, type ChipTone } from "@/components/admin/assessment/shared";
 
 interface AssessmentCardProps {
   assessment: Assessment;
@@ -322,473 +323,338 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
 
   return (
     <>
-    <AssessmentDesktopOnlyDialog
-      open={desktopOnlyOpen}
-      onClose={() => setDesktopOnlyOpen(false)}
-      allowedTypes={allowedDeviceLabels(assessment)}
-    />
-    <Card
-      sx={{
-        height: "100%",
-        minHeight: isPsychometric ? 360 : isManual ? 336 : 320,
-        display: "flex",
-        flexDirection: "column",
-        border: "1px solid",
-        borderTop: isManual
-          ? "3px solid var(--assessment-catalog-manual-stripe)"
-          : undefined,
-        borderColor: isPsychometric
-          ? showResults
-            ? "var(--assessment-catalog-psychometric-border-done)"
-            : "var(--assessment-catalog-psychometric-border-active)"
-          : isManual
-            ? showResults
-              ? "var(--assessment-catalog-manual-border-done)"
-              : "var(--assessment-catalog-manual-border-active)"
-            : showResults
-              ? "var(--assessment-catalog-card-border-auto-done)"
-              : "var(--assessment-catalog-card-border-neutral)",
-        borderRadius: 3,
-        overflow: "hidden",
-        transition: "all 0.3s ease",
-        position: "relative",
-        cursor: isClickable ? "pointer" : "default",
-        boxShadow: isPsychometric
-          ? "var(--assessment-catalog-psychometric-shadow)"
-          : isManual
-            ? showResults
-              ? "var(--assessment-catalog-manual-shadow-done)"
-              : "var(--assessment-catalog-manual-shadow-active)"
-            : "var(--assessment-catalog-card-shadow-neutral)",
-        "&:hover": isClickable
-          ? {
-              boxShadow: isPsychometric
-                ? "var(--assessment-catalog-psychometric-shadow-hover)"
-                : isManual
-                  ? showResults
-                    ? "var(--assessment-catalog-manual-shadow-hover-done)"
-                    : "var(--assessment-catalog-manual-shadow-hover-active)"
-                  : "var(--assessment-catalog-card-shadow-hover-neutral)",
-              transform: "translateY(-4px)",
-              borderColor: isPsychometric
-                ? showResults
-                  ? "var(--assessment-catalog-psychometric-border-hover-done)"
-                  : "var(--assessment-catalog-psychometric-border-hover-active)"
-                : isManual
-                  ? showResults
-                    ? "var(--assessment-catalog-manual-border-hover-done)"
-                    : "var(--assessment-catalog-manual-border-hover-active)"
-                  : showResults
-                    ? "var(--assessment-catalog-card-border-hover-done)"
-                    : "var(--assessment-catalog-card-border-hover-auto)",
-            }
-          : {},
-      }}
-      role={isClickable ? "button" : undefined}
-      tabIndex={isClickable ? 0 : undefined}
-      onClick={handleClick}
-      onKeyDown={
-        isClickable
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                handleClick();
-              }
-            }
-          : undefined
-      }
-      aria-label={
-        isClickable
-          ? `${stripHtmlTags(assessment.title || "").trim() || assessment.title} - ${buttonLabel}`
-          : undefined
-      }
-    >
-      {/* Header Section - Title and tags in clear rows to avoid overlap */}
-      <Box
+      <AssessmentDesktopOnlyDialog
+        open={desktopOnlyOpen}
+        onClose={() => setDesktopOnlyOpen(false)}
+        allowedTypes={allowedDeviceLabels(assessment)}
+      />
+      <Card
         sx={{
-          background: isPsychometric
-            ? showResults
-              ? "var(--assessment-catalog-psychometric-header-done)"
-              : `url(/images/psychometric-test.png) center/cover no-repeat, var(--assessment-catalog-psychometric-overlay)`
-            : isManual
-              ? showResults
-                ? "var(--assessment-catalog-manual-header-done)"
-                : "var(--assessment-catalog-manual-header-active)"
-              : showResults
-                ? "var(--assessment-catalog-auto-header-done)"
-                : "var(--assessment-catalog-auto-header-active)",
-          p: 2,
-          pb: 2.5,
-          position: "relative",
-          minHeight: isPsychometric ? 120 : isManual ? 102 : 90,
+          height: "100%",
           display: "flex",
           flexDirection: "column",
+          gap: 1.5,
+          p: 2.5,
+          backgroundColor: "var(--card-bg)",
+          border: "1px solid var(--border-default)",
+          borderRadius: "var(--radius-card)",
+          boxShadow: "none",
           overflow: "hidden",
+          cursor: isClickable ? "pointer" : "default",
+          transition: "box-shadow .2s, transform .2s, border-color .2s",
+          ...(isClickable && {
+            "&:hover": {
+              transform: "translateY(-3px)",
+              boxShadow:
+                "0 12px 30px -12px color-mix(in srgb, var(--ai-violet) 22%, transparent)",
+              borderColor:
+                "color-mix(in srgb, var(--ai-violet) 30%, var(--border-default))",
+            },
+          }),
         }}
+        role={isClickable ? "button" : undefined}
+        tabIndex={isClickable ? 0 : undefined}
+        onClick={handleClick}
+        onKeyDown={
+          isClickable
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleClick();
+                }
+              }
+            : undefined
+        }
+        aria-label={
+          isClickable
+            ? `${stripHtmlTags(assessment.title || "").trim() || assessment.title} - ${buttonLabel}`
+            : undefined
+        }
       >
-        {/* Overlay for psychometric image */}
-        {isPsychometric && !showResults && (
-          <Box
-            sx={{
-              position: "absolute",
-              inset: 0,
-              background: "var(--assessment-catalog-psychometric-overlay)",
-              zIndex: 0,
-            }}
-          />
-        )}
-
+        {/* Row 1 — status pill (left) + attribute chips (right) */}
         <Box
           sx={{
-            position: "relative",
-            zIndex: 1,
             display: "flex",
-            flexDirection: "column",
+            flexDirection: isRtl ? "row-reverse" : "row",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
             gap: 1,
+            flexWrap: "wrap",
           }}
         >
-          {/* Title and tags on one row: title wraps before hitting tags */}
+          {(() => {
+            let label = "Available";
+            let tone: ChipTone = "success";
+            const now = Date.now();
+            const end = parseDateTime(assessment.end_time);
+            if (submissionComplete && showResults) {
+              label = "Completed";
+              tone = "success";
+            } else if (submissionComplete && !showResults) {
+              label = "Under review";
+              tone = "warning";
+            } else if (isExpired) {
+              label = "Expired";
+              tone = "error";
+            } else if (!canStartNow) {
+              label = "Scheduled";
+              tone = "info";
+            } else if (normalizedStatus === "in_progress") {
+              label = "In progress";
+              tone = "warning";
+            } else if (end && end.getTime() - now <= 3 * 86400000) {
+              label = "Due soon";
+              tone = "warning";
+            }
+            return <StatusChip label={label} tone={tone} />;
+          })()}
+
           <Box
             sx={{
               display: "flex",
-              flexDirection: isRtl ? "row-reverse" : "row",
-              alignItems: "flex-start",
-              gap: 1.5,
-              minWidth: 0,
+              gap: "6px",
+              flexWrap: "wrap",
+              justifyContent: isRtl ? "flex-start" : "flex-end",
             }}
           >
-            <Typography
-              variant="h6"
-              sx={{
-                flex: 1,
-                minWidth: 0,
-                color: showResults ? "var(--font-primary)" : "var(--font-light)",
-                fontWeight: 700,
-                fontSize: "1.0625rem",
-                lineHeight: 1.35,
-                wordBreak: "break-word",
-                overflowWrap: "break-word",
-                overflow: "hidden",
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical",
-              }}
-            >
-              {stripHtmlTags(assessment.title || "").trim() || assessment.title || "\u00A0"}
-            </Typography>
-            {(assessment.proctoring_enabled || showResults || isManual) && (
-              <Box
-                sx={{
-                  flexShrink: 0,
-                  display: "flex",
-                  flexDirection: isRtl ? "row-reverse" : "row",
-                  gap: 1,
-                  alignItems: "center",
-                  flexWrap: "wrap",
-                  justifyContent: isRtl ? "flex-end" : "flex-start",
-                }}
-              >
-                {isManual && (
-                  <Chip
-                    icon={<IconWrapper icon="mdi:account-school-outline" size={14} />}
-                    label={t("assessments.manualEvaluationBadge")}
-                    size="small"
-                    sx={{
-                      backgroundColor: showResults
-                        ? "var(--assessment-catalog-manual-chip-done-bg)"
-                        : "color-mix(in srgb, var(--font-light) 22%, transparent)",
-                      color: showResults
-                        ? "var(--font-primary)"
-                        : "var(--assessment-catalog-manual-chip-light-fg)",
-                      fontWeight: 600,
-                      fontSize: "0.7rem",
-                      height: 24,
-                      flexDirection: isRtl ? "row-reverse" : "row",
-                      border: showResults
-                        ? "1px solid var(--assessment-catalog-manual-chip-done-border)"
-                        : "1px solid var(--assessment-catalog-manual-chip-light-border)",
-                      "& .MuiChip-icon": {
-                        color: "inherit",
-                        marginInlineStart: isRtl ? "4px" : 0,
-                        marginInlineEnd: isRtl ? 0 : "4px",
-                      },
-                    }}
-                  />
-                )}
-                {assessment.proctoring_enabled && (
-                  <Chip
-                    icon={<IconWrapper icon="mdi:shield-account" size={14} />}
-                    label={t("assessments.proctored")}
-                    size="small"
-                    sx={{
-                      backgroundColor: showResults
-                        ? "color-mix(in srgb, var(--warning-500) 18%, transparent)"
-                        : "color-mix(in srgb, var(--font-light) 25%, transparent)",
-                      color: showResults ? "var(--font-primary)" : "var(--font-light)",
-                      fontWeight: 600,
-                      fontSize: "0.7rem",
-                      height: 24,
-                      flexDirection: isRtl ? "row-reverse" : "row",
-                      border: showResults
-                        ? "1px solid color-mix(in srgb, var(--warning-500) 36%, transparent)"
-                        : "1px solid color-mix(in srgb, var(--font-light) 42%, transparent)",
-                      "& .MuiChip-icon": {
-                        color: "inherit",
-                        marginInlineStart: isRtl ? "4px" : 0,
-                        marginInlineEnd: isRtl ? 0 : "4px",
-                      },
-                    }}
-                  />
-                )}
-                {showResults && (
-                  <Chip
-                    icon={<IconWrapper icon="mdi:check-circle" size={14} />}
-                    label={t("assessments.completed")}
-                    size="small"
-                    sx={{
-                      backgroundColor: showResults
-                        ? "color-mix(in srgb, var(--success-500) 18%, transparent)"
-                        : "color-mix(in srgb, var(--font-light) 25%, transparent)",
-                      color: showResults ? "var(--font-primary)" : "var(--font-light)",
-                      fontWeight: 600,
-                      fontSize: "0.7rem",
-                      height: 24,
-                      flexDirection: isRtl ? "row-reverse" : "row",
-                      border: showResults
-                        ? "1px solid color-mix(in srgb, var(--success-500) 36%, transparent)"
-                        : "1px solid color-mix(in srgb, var(--font-light) 42%, transparent)",
-                      "& .MuiChip-icon": {
-                        color: "inherit",
-                        marginInlineStart: isRtl ? "4px" : 0,
-                        marginInlineEnd: isRtl ? 0 : "4px",
-                      },
-                    }}
-                  />
-                )}
-              </Box>
+            {assessment.proctoring_enabled && (
+              <StatusChip
+                label="Proctored"
+                tone="proctored"
+                icon="mdi:shield-check"
+              />
             )}
+            {isManual && <StatusChip label="Manual eval" tone="info" />}
+            {isPsychometric && <StatusChip label="Psychometric" tone="ai" />}
+            {assessment.is_paid && <StatusChip label="Paid" tone="neutral" />}
           </Box>
+        </Box>
 
-          {/* Subtitle / instructions */}
+        {/* Title + subtitle */}
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
           <Typography
-            variant="body2"
             sx={{
-              color: showResults ? "var(--font-secondary)" : "color-mix(in srgb, var(--font-light) 90%, transparent)",
-              fontSize: "0.8125rem",
-              minHeight: 18,
+              fontWeight: 700,
+              fontSize: "1.0625rem",
+              lineHeight: 1.35,
+              color: "var(--font-primary)",
               display: "-webkit-box",
-              WebkitLineClamp: 1,
+              WebkitLineClamp: 2,
               WebkitBoxOrient: "vertical",
               overflow: "hidden",
+              wordBreak: "break-word",
             }}
           >
-            {(stripHtmlTags(assessment.instructions || "").trim() || "\u00A0")}
+            {stripHtmlTags(assessment.title || "").trim() ||
+              assessment.title ||
+              " "}
           </Typography>
 
-          {/* Psychometric tags */}
-          {isPsychometric && psychometricTags.length > 0 && (
+          {(() => {
+            const subtitle =
+              isPsychometric && psychometricTags.length > 0
+                ? psychometricTags
+                    .slice(0, 3)
+                    .map((tag) => tag.name)
+                    .join(" · ")
+                : stripHtmlTags(assessment.description || "").trim();
+            if (!subtitle) return null;
+            return (
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.75,
+                  flexDirection: isRtl ? "row-reverse" : "row",
+                  minWidth: 0,
+                }}
+              >
+                <Box
+                  component="span"
+                  sx={{ display: "inline-flex", flexShrink: 0 }}
+                >
+                  <IconWrapper
+                    icon="mdi:book-outline"
+                    size={14}
+                    color="var(--font-secondary)"
+                  />
+                </Box>
+                <Typography
+                  sx={{
+                    color: "var(--font-secondary)",
+                    fontSize: "0.8125rem",
+                    lineHeight: 1.4,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    minWidth: 0,
+                  }}
+                >
+                  {subtitle}
+                </Typography>
+              </Box>
+            );
+          })()}
+        </Box>
+
+        {/* Mini-stats strip */}
+        {(() => {
+          const cells: Array<{ value: string | number; label: string }> = [
+            { value: assessment.number_of_questions, label: "Questions" },
+            { value: `${assessment.duration_minutes}m`, label: "Duration" },
+          ];
+          if (assessment.number_of_sections != null) {
+            cells.push({
+              value: assessment.number_of_sections,
+              label: "Sections",
+            });
+          }
+          return (
             <Box
               sx={{
                 display: "flex",
-                flexWrap: "wrap",
-                gap: 1,
-                mt: 0.5,
+                alignItems: "stretch",
+                backgroundColor: "var(--surface)",
+                border: "1px solid var(--border-default)",
+                borderRadius: "12px",
+                p: 1.25,
               }}
             >
-              {psychometricTags.slice(0, 3).map((tag, index) => (
+              {cells.map((cell, i) => (
                 <Box
-                  key={index}
+                  key={cell.label}
                   sx={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 0.5,
-                    px: 1.5,
-                    py: 0.5,
-                    borderRadius: 2,
-                    backgroundColor: showResults
-                      ? `${tag.color}10`
-                      : "color-mix(in srgb, var(--font-light) 20%, transparent)",
-                    color: showResults ? tag.color : "var(--font-light)",
-                    fontWeight: 600,
-                    fontSize: "0.7rem",
-                    border: showResults
-                      ? `1.5px solid ${tag.color}30`
-                      : "1.5px solid color-mix(in srgb, var(--font-light) 42%, transparent)",
-                    backdropFilter: "blur(8px)",
-                    transition: "all 0.2s ease",
-                    "&:hover": {
-                      backgroundColor: showResults
-                        ? `${tag.color}20`
-                        : "color-mix(in srgb, var(--font-light) 30%, transparent)",
-                      transform: "translateY(-1px)",
-                      boxShadow: showResults
-                        ? `0 2px 8px ${tag.color}25`
-                        : "0 2px 8px color-mix(in srgb, var(--font-light) 22%, transparent)",
-                    },
+                    flex: 1,
+                    minWidth: 0,
+                    textAlign: "center",
+                    px: 1,
+                    ...(i > 0 && {
+                      borderInlineStart: "1px solid var(--border-default)",
+                    }),
                   }}
                 >
-                  <Box
+                  <Typography
                     sx={{
-                      width: 6,
-                      height: 6,
-                      borderRadius: "50%",
-                      backgroundColor: showResults ? tag.color : "var(--font-light)",
-                      boxShadow: showResults
-                        ? `0 0 4px ${tag.color}50`
-                        : "0 0 4px color-mix(in srgb, var(--font-light) 52%, transparent)",
+                      fontFamily: "var(--font-mono)",
+                      fontWeight: 700,
+                      fontSize: "1.05rem",
+                      lineHeight: 1.2,
+                      color: "var(--font-primary)",
                     }}
-                  />
-                  <span>{tag.name}</span>
+                  >
+                    {cell.value}
+                  </Typography>
+                  <Typography
+                    sx={{
+                      mt: 0.25,
+                      fontSize: "0.68rem",
+                      letterSpacing: "0.02em",
+                      color: "var(--font-tertiary)",
+                    }}
+                  >
+                    {cell.label}
+                  </Typography>
                 </Box>
               ))}
             </Box>
-          )}
-        </Box>
-      </Box>
+          );
+        })()}
 
-      <CardContent
-        sx={{
-          flexGrow: 1,
-          p: 2,
-          pt: 1.5,
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        {/* Description - Always same height */}
-        <Typography
-          variant="body2"
-          sx={{
-            color: "var(--font-secondary)",
-            fontSize: "0.8125rem",
-            lineHeight: 1.5,
-            mb: 2,
-            minHeight: 38,
-            display: "-webkit-box",
-            WebkitLineClamp: 2,
-            WebkitBoxOrient: "vertical",
-            overflow: "hidden",
-          }}
-        >
-          {(stripHtmlTags(assessment.description || "").trim() || "\u00A0")}
-        </Typography>
+        {/* Due / availability */}
+        {(() => {
+          const now = Date.now();
+          const start = parseDateTime(assessment.start_time);
+          const end = parseDateTime(assessment.end_time);
+          const futureStart =
+            !canStartNow && start !== null && start.getTime() > now;
 
-        {/* Stats Grid - RTL: column order flips (Duration right, Questions left) */}
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "repeat(2, 1fr)",
-            gap: 1.5,
-            mb: 2,
-            minHeight: 60,
-            ...(isRtl && { direction: "rtl" }),
-          }}
-        >
-          {/* Duration - RTL: icon to the left of value */}
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: isRtl ? "row-reverse" : "row",
-              alignItems: "center",
-              gap: 0.75,
-              p: 1.25,
-              backgroundColor: "var(--surface)",
-              border: "1px solid var(--border-default)",
-              ...(isManual && {
-                borderColor: "var(--assessment-catalog-manual-stat-border)",
-                backgroundColor: "var(--assessment-catalog-manual-stat-bg)",
-              }),
-              borderRadius: 1.5,
-            }}
-          >
-            <IconWrapper icon="mdi:clock-outline" size={18} color={statIconColor} />
-            <Box>
-              <Typography
-                variant="caption"
+          let mainText: string;
+          let daysLeft: number | null = null;
+          if (futureStart) {
+            mainText = availabilityLabel;
+          } else if (isExpired) {
+            mainText = "Ended";
+          } else if (end) {
+            daysLeft = Math.ceil((end.getTime() - now) / 86400000);
+            mainText = `Due ${end.toLocaleDateString(undefined, {
+              month: "short",
+              day: "numeric",
+            })} · ${daysLeft} ${daysLeft === 1 ? "day" : "days"} left`;
+          } else {
+            mainText = "No deadline";
+          }
+
+          const dueSoon = daysLeft !== null && daysLeft <= 2 && !isExpired;
+          const lineColor = dueSoon
+            ? "var(--error-500)"
+            : "var(--font-secondary)";
+
+          return (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+              <Box
                 sx={{
-                  color: "var(--font-tertiary)",
-                  fontSize: "0.65rem",
-                  fontWeight: 500,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.5px",
-                  display: "block",
-                  lineHeight: 1.2,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.75,
+                  flexDirection: isRtl ? "row-reverse" : "row",
                 }}
               >
-                Duration
-              </Typography>
-              <Typography
-                variant="body2"
-                sx={{
-                  color: "var(--font-primary)",
-                  fontWeight: 600,
-                  fontSize: "0.8125rem",
-                  lineHeight: 1.2,
-                }}
-              >
-                {assessment.duration_minutes} min
-              </Typography>
+                <Box
+                  component="span"
+                  sx={{ display: "inline-flex", flexShrink: 0 }}
+                >
+                  <IconWrapper
+                    icon="mdi:calendar-outline"
+                    size={16}
+                    color={lineColor}
+                  />
+                </Box>
+                <Typography
+                  sx={{
+                    fontSize: "0.8125rem",
+                    fontWeight: dueSoon ? 600 : 500,
+                    color: lineColor,
+                    minWidth: 0,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {mainText}
+                </Typography>
+              </Box>
+              {dueSoon ? (
+                <Typography
+                  sx={{
+                    ...(isRtl ? { pr: 3 } : { pl: 3 }),
+                    fontSize: "0.7rem",
+                    fontWeight: 600,
+                    color: "var(--error-500)",
+                  }}
+                >
+                  · due soon
+                </Typography>
+              ) : end ? (
+                <Typography
+                  sx={{
+                    ...(isRtl ? { pr: 3 } : { pl: 3 }),
+                    fontSize: "0.7rem",
+                    color: "var(--font-tertiary)",
+                  }}
+                >
+                  ✱ On track
+                </Typography>
+              ) : null}
             </Box>
-          </Box>
+          );
+        })()}
 
-          {/* Questions - RTL: icon to the left of value */}
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: isRtl ? "row-reverse" : "row",
-              alignItems: "center",
-              gap: 0.75,
-              p: 1.25,
-              backgroundColor: "var(--surface)",
-              border: "1px solid var(--border-default)",
-              ...(isManual && {
-                borderColor: "var(--assessment-catalog-manual-stat-border)",
-                backgroundColor: "var(--assessment-catalog-manual-stat-bg)",
-              }),
-              borderRadius: 1.5,
-            }}
-          >
-            <IconWrapper
-              icon="mdi:help-circle-outline"
-              size={18}
-              color={statIconColor}
-            />
-            <Box>
-              <Typography
-                variant="caption"
-                sx={{
-                  color: "var(--font-tertiary)",
-                  fontSize: "0.65rem",
-                  fontWeight: 500,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.5px",
-                  display: "block",
-                  lineHeight: 1.2,
-                }}
-              >
-                {t("assessments.questions")}
-              </Typography>
-              <Typography
-                variant="body2"
-                sx={{
-                  color: "var(--font-primary)",
-                  fontWeight: 600,
-                  fontSize: "0.8125rem",
-                  lineHeight: 1.2,
-                }}
-              >
-                {assessment.number_of_questions}
-              </Typography>
-            </Box>
-          </Box>
-        </Box>
+        {/* Spacer pins the CTAs to the bottom */}
+        <Box sx={{ flexGrow: 1 }} />
 
-        {/* Re-attempt CTA (admin-granted, shown above primary CTA).
-            Styled to match the primary CTA's height/font/radius so the two
-            buttons read as a paired action stack; outlined variant
-            differentiates "secondary action" without breaking alignment. */}
-        {submissionComplete && assessment.can_reattempt && (
-          <Box sx={{ mt: 1 }}>
+        {/* Actions */}
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          {submissionComplete && assessment.can_reattempt && (
             <LoadingButton
               fullWidth
               variant="outlined"
@@ -803,79 +669,122 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
                 router.push(`/assessments/${assessment.slug}`);
               }}
               endIcon={
-                loadingAction === "reattempt"
-                  ? undefined
-                  : <IconWrapper icon="mdi:replay" size={18} color="currentColor" />
+                loadingAction === "reattempt" ? undefined : (
+                  <IconWrapper icon="mdi:replay" size={18} color="currentColor" />
+                )
               }
               sx={{
                 flexDirection: isRtl ? "row-reverse" : "row",
-                mb: 1,
-                py: 1,
-                borderRadius: 2,
-                fontWeight: 600,
-                fontSize: "0.875rem",
+                width: "100%",
+                py: 1.1,
+                borderRadius: "12px",
+                fontWeight: 700,
+                fontSize: "0.9rem",
                 textTransform: "none",
-                // Cyan-filled, contained: matches View Results' solid look so
-                // the two CTAs read as a paired stack; cyan vs green
-                // differentiates the action (re-take vs view).
                 background: "var(--assessment-catalog-reattempt-cta-gradient)",
                 color: "var(--font-light)",
                 border: "none",
                 boxShadow: "var(--assessment-catalog-reattempt-cta-shadow)",
                 WebkitTapHighlightColor: "transparent",
-                transition: "box-shadow 0.22s ease, transform 0.2s ease, background 0.2s ease",
+                transition: "box-shadow .2s ease, transform .2s ease",
                 "& .MuiButton-endIcon": { color: "inherit" },
                 "&&:hover": {
-                  background: "var(--assessment-catalog-reattempt-cta-hover-gradient)",
+                  background:
+                    "var(--assessment-catalog-reattempt-cta-hover-gradient)",
                   color: "var(--font-light)",
-                  boxShadow: "var(--assessment-catalog-reattempt-cta-shadow-hover)",
+                  boxShadow:
+                    "var(--assessment-catalog-reattempt-cta-shadow-hover)",
                   transform: "translateY(-2px)",
                   border: "none",
                 },
                 "&&:active": {
                   transform: "translateY(0)",
-                  background: "var(--assessment-catalog-reattempt-cta-hover-gradient)",
+                  background:
+                    "var(--assessment-catalog-reattempt-cta-hover-gradient)",
                 },
               }}
             >
               {t("assessments.reattempt", { defaultValue: "Re-attempt" })}
             </LoadingButton>
-          </Box>
-        )}
+          )}
 
-        {/* CTA Button */}
-        <Box sx={{ mt: "1" }}>
           {(() => {
-            const primaryLoading = loadingAction === "primary";
-            const primaryEndIcon = primaryLoading ? undefined : (
-              <IconWrapper
-                icon={
-                  submissionComplete && showResults
-                    ? "mdi:eye-outline"
-                    : submissionComplete && !showResults
-                      ? "mdi:check-circle-outline"
-                      : !isClickable
-                        ? "mdi:clock-outline"
-                        : "mdi:play-circle-outline"
-                }
-                size={18}
-                color="currentColor"
-              />
-            );
+            const disabledLook =
+              (submissionComplete && !showResults) || !isClickable;
+            const bg = showResults
+              ? "var(--success-500)"
+              : disabledLook
+                ? "var(--surface)"
+                : "var(--gradient-ai)";
+            const textColor = disabledLook
+              ? "var(--font-tertiary)"
+              : "var(--font-light)";
+            const idleShadow =
+              !showResults && !disabledLook
+                ? "0 10px 24px -10px color-mix(in srgb, var(--ai-violet) 45%, transparent)"
+                : "none";
+            const hoverShadow = showResults
+              ? "0 12px 26px -10px color-mix(in srgb, var(--success-500) 50%, transparent)"
+              : "0 14px 30px -10px color-mix(in srgb, var(--ai-violet) 60%, transparent)";
+
             const primaryButton = (
               <LoadingButton
                 fullWidth
                 variant="contained"
                 size="large"
-                loading={primaryLoading}
-                disabled={!isClickable || (loadingAction !== null && !primaryLoading)}
                 disableRipple
-                endIcon={primaryEndIcon}
-                sx={ctaButtonSx}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleClick();
+                }}
+                loading={loadingAction === "primary"}
+                disabled={
+                  !isClickable ||
+                  (loadingAction !== null && loadingAction !== "primary")
+                }
+                endIcon={
+                  isClickable ? (
+                    <IconWrapper
+                      icon="mdi:arrow-right"
+                      size={18}
+                      color="currentColor"
+                    />
+                  ) : undefined
+                }
+                sx={{
+                  flexDirection: isRtl ? "row-reverse" : "row",
+                  width: "100%",
+                  py: 1.1,
+                  borderRadius: "12px",
+                  fontWeight: 700,
+                  fontSize: "0.9rem",
+                  textTransform: "none",
+                  color: textColor,
+                  background: bg,
+                  boxShadow: idleShadow,
+                  WebkitTapHighlightColor: "transparent",
+                  transition: "box-shadow .2s ease, transform .2s ease",
+                  "& .MuiButton-endIcon": { color: "inherit" },
+                  ...(isClickable && {
+                    "&&:hover": {
+                      background: bg,
+                      color: textColor,
+                      boxShadow: hoverShadow,
+                      transform: "translateY(-2px)",
+                    },
+                    "&&:active": { transform: "translateY(0)" },
+                  }),
+                  "&.Mui-disabled": {
+                    background: "var(--surface)",
+                    color: "var(--font-tertiary)",
+                    boxShadow: "none",
+                  },
+                }}
               >
                 {buttonLabel}
               </LoadingButton>
             );
+
             if (!isClickable && startDate && remainingTime && !showResults) {
               return (
                 <Tooltip
@@ -892,8 +801,7 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             return primaryButton;
           })()}
         </Box>
-      </CardContent>
-    </Card>
+      </Card>
     </>
   );
 };

--- a/components/assessment/AssessmentReadinessPanel.tsx
+++ b/components/assessment/AssessmentReadinessPanel.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Typography, Skeleton } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  assessmentService,
+  AssessmentReadiness,
+} from "@/lib/services/assessment.service";
+
+interface AssessmentReadinessPanelProps {
+  slug: string;
+}
+
+/** Clamp a possibly-null metric into the 0–100 progress-bar range. */
+function clampPercent(value: number | null | undefined): number {
+  if (typeof value !== "number" || Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}
+
+/**
+ * A single labeled progress bar rendered on the dark readiness card. Track and
+ * label sit in translucent white so they read cleanly over the violet→pink
+ * gradient; the fill is solid white.
+ */
+function ReadinessBar({
+  label,
+  value,
+}: {
+  label: string;
+  value: number | null;
+}) {
+  const pct = clampPercent(value);
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "space-between",
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: "0.78rem",
+            fontWeight: 600,
+            color: "color-mix(in srgb, #fff 88%, transparent)",
+          }}
+        >
+          {label}
+        </Typography>
+        <Typography
+          sx={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+            fontWeight: 700,
+            color: "#fff",
+          }}
+        >
+          {typeof value === "number" ? `${Math.round(pct)}%` : "—"}
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          height: 7,
+          borderRadius: 999,
+          backgroundColor: "color-mix(in srgb, #fff 22%, transparent)",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          sx={{
+            height: "100%",
+            width: `${pct}%`,
+            borderRadius: 999,
+            backgroundColor: "#fff",
+            transition: "width 0.5s ease",
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * AssessmentReadinessPanel — the pre-attempt "AI Readiness Check" sidebar card.
+ *
+ * Fetches a readiness snapshot for the assessment and renders one of three
+ * states: a subtle skeleton while loading; a dark violet→pink card with the
+ * predicted score band, three metric bars, and a softest-topic tip when the
+ * snapshot is available; or a gentle muted card carrying the backend's reason
+ * when it is not. Fetch errors are caught here (never on the service) and
+ * treated as unavailable so the page can never break on this panel.
+ */
+export function AssessmentReadinessPanel({
+  slug,
+}: AssessmentReadinessPanelProps) {
+  const [readiness, setReadiness] = useState<AssessmentReadiness | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await assessmentService.getAssessmentReadiness(slug);
+        if (!cancelled) setReadiness(data);
+      } catch {
+        // Never break the page on a readiness fetch error — degrade to the
+        // "not available" state with no fabricated numbers.
+        if (!cancelled) {
+          setReadiness({
+            available: false,
+            overall_band: null,
+            practice_accuracy: null,
+            topic_coverage: null,
+            confidence: null,
+            softest_topic: null,
+            skills: [],
+            reason: null,
+          });
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  // ── Loading: a subtle skeleton that hints at the card shape ──────────────
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          p: 3,
+          borderRadius: "var(--radius-card)",
+          border: "1px solid var(--border-default)",
+          bgcolor: "var(--card-bg)",
+        }}
+      >
+        <Skeleton
+          variant="rounded"
+          width="60%"
+          height={16}
+          sx={{ mb: 2, bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--surface))" }}
+        />
+        <Skeleton
+          variant="rounded"
+          width="85%"
+          height={24}
+          sx={{ mb: 3, bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--surface))" }}
+        />
+        {[0, 1, 2].map((i) => (
+          <Skeleton
+            key={i}
+            variant="rounded"
+            height={14}
+            sx={{ mb: 1.5, bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--surface))" }}
+          />
+        ))}
+      </Box>
+    );
+  }
+
+  const available = readiness?.available === true;
+
+  // ── Not available: gentle muted card, reason only, no fabricated numbers ──
+  if (!available) {
+    return (
+      <Box
+        sx={{
+          p: 3,
+          borderRadius: "var(--radius-card)",
+          border: "1px solid var(--border-default)",
+          bgcolor: "var(--surface)",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
+          <IconWrapper
+            icon="mdi:star-four-points-outline"
+            size={18}
+            color="var(--ai-violet)"
+          />
+          <Typography
+            sx={{
+              fontSize: "0.72rem",
+              fontWeight: 700,
+              letterSpacing: "0.4px",
+              textTransform: "uppercase",
+              color: "var(--font-tertiary)",
+            }}
+          >
+            AI Readiness Check
+          </Typography>
+        </Box>
+        <Typography
+          sx={{ fontSize: "0.875rem", color: "var(--font-secondary)", lineHeight: 1.6 }}
+        >
+          {readiness?.reason ||
+            "We don't have enough practice history to estimate your readiness for this assessment yet."}
+        </Typography>
+      </Box>
+    );
+  }
+
+  const softest = readiness?.softest_topic ?? null;
+
+  // ── Available: dark violet→pink card with band + metric bars + tip ───────
+  return (
+    <Box
+      sx={{
+        p: 3,
+        borderRadius: "var(--radius-card)",
+        background: "var(--gradient-ai)",
+        color: "#fff",
+        overflow: "hidden",
+        boxShadow:
+          "0 18px 40px -22px color-mix(in srgb, var(--ai-pink) 70%, transparent)",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+        <IconWrapper icon="mdi:star-four-points" size={18} color="#fff" />
+        <Typography
+          sx={{
+            fontSize: "0.72rem",
+            fontWeight: 700,
+            letterSpacing: "0.5px",
+            textTransform: "uppercase",
+            color: "color-mix(in srgb, #fff 86%, transparent)",
+          }}
+        >
+          AI Readiness Check
+        </Typography>
+      </Box>
+
+      <Typography
+        sx={{
+          fontSize: "1.05rem",
+          fontWeight: 700,
+          lineHeight: 1.35,
+          mb: 2.5,
+        }}
+      >
+        You&apos;re likely to score:{" "}
+        <Box component="span" sx={{ fontFamily: "var(--font-mono)", fontWeight: 800 }}>
+          {readiness?.overall_band ?? "—"}
+        </Box>
+      </Typography>
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1.75 }}>
+        <ReadinessBar label="Practice accuracy" value={readiness?.practice_accuracy ?? null} />
+        <ReadinessBar label="Topic coverage" value={readiness?.topic_coverage ?? null} />
+        <ReadinessBar label="Confidence" value={readiness?.confidence ?? null} />
+      </Box>
+
+      {softest && (
+        <Box
+          sx={{
+            mt: 2.5,
+            p: 1.5,
+            borderRadius: 2,
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 1,
+            backgroundColor: "color-mix(in srgb, #fff 14%, transparent)",
+          }}
+        >
+          <IconWrapper icon="mdi:lightbulb-on-outline" size={16} color="#fff" />
+          <Typography
+            sx={{
+              fontSize: "0.8rem",
+              lineHeight: 1.55,
+              color: "color-mix(in srgb, #fff 92%, transparent)",
+            }}
+          >
+            <Box component="span" sx={{ fontWeight: 700 }}>
+              {softest.name}
+            </Box>{" "}
+            is your softest topic here ({Math.round(clampPercent(softest.accuracy))}% practice
+            accuracy) — worth a quick skim.
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/lib/services/assessment.service.ts
+++ b/lib/services/assessment.service.ts
@@ -70,6 +70,22 @@ export interface AssessmentDetail extends Assessment {
   courseTitle?: string | null;
 }
 
+/**
+ * AI readiness snapshot for the pre-attempt instructions page. When
+ * `available` is false the panel shows `reason` only (no fabricated numbers);
+ * when true it renders the score band + practice/coverage/confidence bars.
+ */
+export interface AssessmentReadiness {
+  available: boolean;
+  overall_band: string | null;
+  practice_accuracy: number | null;
+  topic_coverage: number | null;
+  confidence: number | null;
+  softest_topic: { name: string; accuracy: number } | null;
+  skills: { name: string; proficiency: number; attempts: number }[];
+  reason: string | null;
+}
+
 /** Lockdown policy for the assessment take flow (aligned with `evaluateLockdownGate`). */
 export interface AssessmentTakeFlags {
   require_lockdown_browser?: boolean;
@@ -408,6 +424,14 @@ export const assessmentService = {
   getAssessmentDetail: async (slug: string): Promise<AssessmentDetail> => {
     const response = await apiClient.get<AssessmentDetail>(
       `/assessment/api/client/${config.clientId}/assessment-details/${slug}/`,
+    );
+    return response.data;
+  },
+
+  // Get AI readiness snapshot for the pre-attempt instructions page.
+  getAssessmentReadiness: async (slug: string): Promise<AssessmentReadiness> => {
+    const response = await apiClient.get<AssessmentReadiness>(
+      `/assessment/api/client/${config.clientId}/assessment-readiness/${slug}/`,
     );
     return response.data;
   },

--- a/lib/services/assessment.service.ts
+++ b/lib/services/assessment.service.ts
@@ -20,6 +20,8 @@ export interface Assessment {
   amount?: number;
   is_active: boolean;
   number_of_questions: number;
+  /** Number of sections in the assessment (added to the catalog list for the hub card mini-stats). */
+  number_of_sections?: number;
   created_at: string;
   is_attempted: boolean;
   start_time?: string | null;


### PR DESCRIPTION
Student assessment experience revamp — all four pages in the shared design language used by the admin redesign, plus a real AI Readiness Check. Behaviour, navigation and security-visibility gates preserved throughout; verified with `tsc` + a full `next build` + preserved-logic spot-checks.

## Pages
- **Hub `/assessments`** — `AssessmentSectionHero`, `StatStrip`, `SegmentedTabs` (real learner filters + counts), search/sort, redesigned catalog cards (status pill + Proctored/Manual/Psychometric chips, mono mini-stats, gradient CTA), an honest **"Next up" smart band** (real most-urgent assessment; no fabricated metrics), skeletons + empty state.
- **Instructions `/assessments/[slug]`** — two-column: rules card from the assessment's *real* settings, "what you'll cover", a **consent checkbox** gating the CTA (proctored only), and the **AI Readiness Check** side panel. `handleStart` navigation preserved byte-for-byte.
- **Device-check** — camera-preview + system-readiness checklist + "Enter fullscreen & begin". All device logic preserved, incl. the `window.__assessmentStream` handoff that must survive navigation to `/take`.
- **Result** — `GradientRing` score hero + `StatStrip` + restyled attempt selector. The `show_result===false` hidden gate, multi-attempt, certificate, psychometric branch, and both `.exclude-from-pdf` regions preserved.

## AI Readiness Check
Real estimate from the learner's prior practice (backed by a new BE endpoint reusing the Skill Scorecard). Shows the band + practice-accuracy/coverage/confidence bars **only when the backend has real data**; otherwise a gentle "practice to unlock" message — never fabricated numbers.

## Verification
`tsc --noEmit` clean project-wide · `next build` ✓ compiled (all /assessments routes) · critical logic (stream handoff, all nav branches, result-hidden gate, PDF exclusions) grep-confirmed preserved. Score integrity was already server-authoritative (audit #346–#359), so no scoring changes. Paired backend PR adds the readiness endpoint + `number_of_sections`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
