### PR TITLE
style(assessments): banner headers + contrast + font matching the management page

### DIFF
--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -296,7 +296,7 @@ export default function AssessmentDetailPage({
     (proctored && !consented);
 
   return (
-    <MainLayout>
+    <MainLayout fullWidthContent>
       <AssessmentDesktopOnlyDialog
         open={desktopOnlyOpen}
         onClose={() => setDesktopOnlyOpen(false)}
@@ -307,7 +307,7 @@ export default function AssessmentDetailPage({
           width: "100%",
           px: { xs: 2, sm: 3, md: 4 },
           py: { xs: 2, sm: 3 },
-          maxWidth: "1200px",
+          maxWidth: "1400px",
           mx: "auto",
         }}
       >
@@ -331,29 +331,44 @@ export default function AssessmentDetailPage({
           Back to assessments
         </LoadingButton>
 
-        {/* Header */}
-        <Box sx={{ mb: 3 }}>
-          {eyebrow && (
-            <Typography
-              sx={{
-                fontSize: "0.75rem",
-                fontWeight: 700,
-                letterSpacing: "0.6px",
-                textTransform: "uppercase",
-                color: "var(--ai-violet)",
-                mb: 0.75,
-              }}
-            >
-              {eyebrow}
-            </Typography>
-          )}
-          <Typography
-            variant="h4"
+        {/* Banner header — assessment-management design language (dark gradient band) */}
+        <Box
+          sx={{
+            mb: 3,
+            position: "relative",
+            overflow: "hidden",
+            borderRadius: "22px",
+            p: { xs: 3, md: 4 },
+            color: "#fff",
+            background:
+              "linear-gradient(115deg, #2b1244 0%, #3d1663 45%, #6b1a52 82%, #7d2058 100%)",
+            boxShadow: "0 28px 56px -28px rgba(61, 22, 99, 0.55)",
+          }}
+        >
+          <Box
             sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 999,
+              mb: 1.75,
+              background: "var(--gradient-ai)",
+              fontSize: "0.7rem",
               fontWeight: 800,
-              color: "var(--font-primary)",
-              lineHeight: 1.2,
-              fontSize: { xs: "1.6rem", sm: "2rem" },
+              letterSpacing: "0.1em",
+            }}
+          >
+            <IconWrapper icon="mdi:clipboard-text-outline" size={14} color="#fff" />
+            {eyebrow ? String(eyebrow).toUpperCase() : "ASSESSMENT"}
+          </Box>
+          <Typography
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              lineHeight: 1.15,
+              fontSize: { xs: "1.6rem", md: "2.15rem" },
             }}
           >
             {assessment.title}
@@ -361,24 +376,25 @@ export default function AssessmentDetailPage({
           {descriptionText && (
             <Typography
               sx={{
-                color: "var(--font-secondary)",
-                mt: 1,
+                mt: 1.25,
+                color: "color-mix(in srgb, #fff 82%, transparent)",
                 lineHeight: 1.6,
-                maxWidth: 720,
+                maxWidth: 820,
+                fontSize: "0.95rem",
               }}
             >
               {descriptionText}
             </Typography>
           )}
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1.75 }}>
-            {proctored && (
-              <StatusChip label="Proctored" tone="proctored" icon="mdi:shield-check" />
-            )}
-            <StatusChip label="Non-adaptive · same for all" tone="neutral" />
-          </Box>
         </Box>
 
-        {/* Metric strip */}
+        {/* Attribute chips + metric strip on the canvas */}
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 2.5 }}>
+          {proctored && (
+            <StatusChip label="Proctored" tone="proctored" icon="mdi:shield-check" />
+          )}
+          <StatusChip label="Non-adaptive · same for all" tone="neutral" />
+        </Box>
         <Box sx={{ mb: 3 }}>
           <StatStrip items={statItems} />
         </Box>
@@ -655,113 +671,122 @@ export default function AssessmentDetailPage({
 
             {/* Device readiness (preserved) */}
             <AssessmentDeviceStatusPanel assessment={assessment} sx={{ mb: 0 }} />
-
-            {/* Consent + CTA action card */}
-            <Paper
-              elevation={0}
-              sx={{
-                p: { xs: 2.5, sm: 3 },
-                borderRadius: "var(--radius-card)",
-                border: "1px solid var(--border-default)",
-                bgcolor: "var(--card-bg)",
-              }}
-            >
-              {proctored && (
-                <FormControlLabel
-                  sx={{
-                    alignItems: "flex-start",
-                    m: 0,
-                    mb: 2,
-                    "& .MuiFormControlLabel-label": {
-                      fontSize: "0.82rem",
-                      color: "var(--font-secondary)",
-                      lineHeight: 1.5,
-                      mt: 0.25,
-                    },
-                  }}
-                  control={
-                    <Checkbox
-                      checked={consented}
-                      onChange={(e) => setConsented(e.target.checked)}
-                      sx={{
-                        p: 0.5,
-                        mr: 1,
-                        color: "var(--border-strong, var(--font-tertiary))",
-                        "&.Mui-checked": { color: "var(--ai-violet)" },
-                      }}
-                    />
-                  }
-                  label="I understand this attempt is proctored and timed, and that leaving fullscreen or switching tabs may be flagged."
-                />
-              )}
-
-              <LoadingButton
-                variant="contained"
-                size="large"
-                fullWidth
-                startIcon={<IconWrapper icon={ctaIcon} size={24} />}
-                onClick={handleStart}
-                disabled={ctaDisabled}
-                sx={{
-                  background: "var(--gradient-ai)",
-                  color: "#fff",
-                  fontWeight: 700,
-                  py: 1.5,
-                  borderRadius: 2,
-                  textTransform: "none",
-                  fontSize: "1rem",
-                  boxShadow: "0 14px 30px -14px color-mix(in srgb, var(--ai-pink) 70%, transparent)",
-                  "&:hover": {
-                    background: "var(--gradient-ai)",
-                    filter: "brightness(1.05)",
-                    boxShadow: "0 16px 34px -12px color-mix(in srgb, var(--ai-pink) 78%, transparent)",
-                  },
-                  "&.Mui-disabled": {
-                    background: "var(--surface)",
-                    color: "var(--font-tertiary)",
-                    boxShadow: "none",
-                  },
-                }}
-              >
-                {ctaLabel}
-              </LoadingButton>
-
-              {!deviceAllowed && (
-                <Typography
-                  sx={{
-                    mt: 1.25,
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 0.5,
-                    fontSize: "0.75rem",
-                    color: "var(--warning-500)",
-                    fontWeight: 600,
-                  }}
-                >
-                  <IconWrapper icon="mdi:alert-outline" size={15} color="var(--warning-500)" />
-                  This device type isn&apos;t allowed — you&apos;ll be prompted when you continue.
-                </Typography>
-              )}
-
-              {!canStartAssessment && !isExpired && (
-                <Typography
-                  sx={{
-                    mt: 1.25,
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 0.5,
-                    fontSize: "0.75rem",
-                    color: "var(--font-tertiary)",
-                    fontWeight: 500,
-                  }}
-                >
-                  <IconWrapper icon="mdi:clock-outline" size={15} color="var(--font-tertiary)" />
-                  This assessment hasn&apos;t opened yet — the button unlocks at the start time.
-                </Typography>
-              )}
-            </Paper>
           </Box>
         </Box>
+
+        {/* Consent + CTA — full-width action bar below the two columns */}
+        <Paper
+          elevation={0}
+          sx={{
+            mt: 3,
+            p: { xs: 2.5, sm: 3 },
+            borderRadius: "var(--radius-card)",
+            border: "1px solid var(--border-default)",
+            bgcolor: "var(--card-bg)",
+            boxShadow: "0 2px 10px color-mix(in srgb, var(--font-primary) 7%, transparent)",
+            display: "flex",
+            flexDirection: { xs: "column", md: "row" },
+            alignItems: { md: "center" },
+            gap: { xs: 2, md: 3 },
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {proctored && (
+              <FormControlLabel
+                sx={{
+                  alignItems: "flex-start",
+                  m: 0,
+                  "& .MuiFormControlLabel-label": {
+                    fontSize: "0.9rem",
+                    color: "var(--font-secondary)",
+                    lineHeight: 1.55,
+                    mt: 0.25,
+                  },
+                }}
+                control={
+                  <Checkbox
+                    checked={consented}
+                    onChange={(e) => setConsented(e.target.checked)}
+                    sx={{
+                      p: 0.5,
+                      mr: 1,
+                      color: "var(--border-strong, var(--font-tertiary))",
+                      "&.Mui-checked": { color: "var(--ai-violet)" },
+                    }}
+                  />
+                }
+                label="I understand this attempt is proctored and timed, and that leaving fullscreen or switching tabs may be flagged."
+              />
+            )}
+            {!deviceAllowed && (
+              <Typography
+                sx={{
+                  mt: proctored ? 1.25 : 0,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  fontSize: "0.8rem",
+                  color: "var(--warning-500)",
+                  fontWeight: 600,
+                }}
+              >
+                <IconWrapper icon="mdi:alert-outline" size={15} color="var(--warning-500)" />
+                This device type isn&apos;t allowed — you&apos;ll be prompted when you continue.
+              </Typography>
+            )}
+            {!canStartAssessment && !isExpired && (
+              <Typography
+                sx={{
+                  mt: proctored ? 1.25 : 0,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  fontSize: "0.8rem",
+                  color: "var(--font-tertiary)",
+                  fontWeight: 500,
+                }}
+              >
+                <IconWrapper icon="mdi:clock-outline" size={15} color="var(--font-tertiary)" />
+                This assessment hasn&apos;t opened yet — the button unlocks at the start time.
+              </Typography>
+            )}
+          </Box>
+
+          <LoadingButton
+            variant="contained"
+            size="large"
+            startIcon={<IconWrapper icon={ctaIcon} size={24} />}
+            onClick={handleStart}
+            disabled={ctaDisabled}
+            sx={{
+              flexShrink: 0,
+              width: { xs: "100%", md: "auto" },
+              minWidth: { md: 300 },
+              background: "var(--gradient-ai)",
+              color: "#fff",
+              fontWeight: 800,
+              py: 1.5,
+              px: 4,
+              borderRadius: 2.5,
+              textTransform: "none",
+              fontSize: "1.05rem",
+              fontFamily: "var(--font-jakarta)",
+              boxShadow: "0 14px 30px -14px color-mix(in srgb, var(--ai-pink) 70%, transparent)",
+              "&:hover": {
+                background: "var(--gradient-ai)",
+                filter: "brightness(1.05)",
+                boxShadow: "0 16px 34px -12px color-mix(in srgb, var(--ai-pink) 78%, transparent)",
+              },
+              "&.Mui-disabled": {
+                background: "var(--surface)",
+                color: "var(--font-tertiary)",
+                boxShadow: "none",
+              },
+            }}
+          >
+            {ctaLabel}
+          </LoadingButton>
+        </Paper>
       </Box>
     </MainLayout>
   );

--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -171,75 +171,155 @@ export default function AssessmentsPage() {
   ];
 
   return (
-    <MainLayout>
-      <Box sx={{ width: "100%", maxWidth: "100%" }}>
-        <AssessmentSectionHero
-          chapter={t("assessments.center", { defaultValue: "Assessment center" })}
-          title={t("assessments.title", { defaultValue: "Your assessments" })}
-          subtitle={t("assessments.subtitle", { defaultValue: "Everything scheduled across your courses, in one place." })}
-          accent="violet"
-        />
+    <MainLayout fullWidthContent>
+      <Box sx={{ p: { xs: 2, sm: 3, md: 4 } }}>
+        <Box sx={{ mb: 4 }}>
+          <AssessmentSectionHero
+            chapter={t("assessments.center", { defaultValue: "Assessment center" })}
+            title={t("assessments.title", { defaultValue: "Your assessments" })}
+            subtitle={t("assessments.subtitle", { defaultValue: "Everything scheduled across your courses, in one place." })}
+            accent="violet"
+          />
+        </Box>
 
-        {/* Smart band — the most-urgent next action, real data, no fabricated metrics. */}
-        {!loading && nextUp && (
+        {/* Smart band — always shown (matches management's hero band). Real next-up
+            data + a working CTA when there's something to do; a welcoming variant
+            otherwise. No fabricated metrics. */}
+        <Box
+          sx={{
+            mb: 3,
+            position: "relative",
+            overflow: "hidden",
+            borderRadius: "22px",
+            p: { xs: 3, md: 4 },
+            color: "#fff",
+            background: "linear-gradient(115deg, #2b1244 0%, #3d1663 45%, #6b1a52 82%, #7d2058 100%)",
+            boxShadow: "0 28px 56px -28px rgba(61, 22, 99, 0.55)",
+          }}
+        >
+          {/* Decorative glow — presentation only */}
+          <Box
+            aria-hidden
+            sx={{
+              position: "absolute",
+              top: -90,
+              right: -70,
+              width: 300,
+              height: 300,
+              borderRadius: "50%",
+              background: "radial-gradient(circle, rgba(255,255,255,0.14) 0%, rgba(255,255,255,0) 70%)",
+              pointerEvents: "none",
+            }}
+          />
           <Box
             sx={{
-              mt: 2.5,
-              borderRadius: "var(--radius-card)",
-              p: { xs: 2.5, sm: 3 },
-              display: "flex",
-              flexDirection: { xs: "column", sm: "row" },
-              alignItems: { xs: "flex-start", sm: "center" },
-              gap: 2,
-              background: "linear-gradient(115deg, #2b1244 0%, #4a1d5e 55%, #7d2058 100%)",
-              color: "var(--font-light)",
-              overflow: "hidden",
               position: "relative",
+              zIndex: 1,
+              display: "flex",
+              flexDirection: { xs: "column", md: "row" },
+              alignItems: { xs: "flex-start", md: "center" },
+              justifyContent: "space-between",
+              gap: 3,
             }}
           >
-            <Box
-              sx={{
-                width: 52, height: 52, borderRadius: 2, flexShrink: 0,
-                background: "var(--gradient-ai)",
-                display: "flex", alignItems: "center", justifyContent: "center",
-                boxShadow: "0 8px 20px -8px color-mix(in srgb, var(--ai-pink) 60%, transparent)",
-              }}
-            >
-              <IconWrapper icon="mdi:star-four-points" size={26} color="#fff" />
-            </Box>
-            <Box sx={{ minWidth: 0, flex: 1 }}>
-              <Typography sx={{ fontWeight: 700, fontSize: { xs: "1rem", sm: "1.125rem" }, lineHeight: 1.3 }}>
-                {nextUp.mode === "resume"
-                  ? t("assessments.pickUpWhereYouLeftOff", { defaultValue: "Pick up where you left off" })
-                  : t("assessments.nextUpBanner", { defaultValue: "Next up" })}
-                {": "}
-                {stripHtmlTags(nextUp.assessment.title || "").trim() || nextUp.assessment.title}
-              </Typography>
-              <Typography sx={{ fontSize: "0.8125rem", opacity: 0.82, mt: 0.5 }}>
-                {nextHint}
-              </Typography>
-            </Box>
-            <LoadingButton
-              onClick={goToNext}
-              loading={nextLoading}
-              endIcon={<IconWrapper icon="mdi:arrow-right" size={18} color="currentColor" />}
-              sx={{
-                flexShrink: 0,
-                bgcolor: "#fff",
-                color: "#2b1244",
-                fontWeight: 700,
-                textTransform: "none",
-                px: 3, py: 1.1,
-                borderRadius: 2,
-                "&:hover": { bgcolor: "#fff", transform: "translateY(-1px)" },
-              }}
-            >
-              {nextUp.mode === "resume"
-                ? t("assessments.resume", { defaultValue: "Resume" })
-                : t("assessments.takeItNow", { defaultValue: "Take it now" })}
-            </LoadingButton>
+            {nextUp ? (
+              <>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Box
+                    sx={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 0.75,
+                      px: 1.25,
+                      py: 0.5,
+                      borderRadius: 999,
+                      background: "var(--gradient-ai)",
+                      fontSize: "0.7rem",
+                      fontWeight: 800,
+                      letterSpacing: "0.1em",
+                      mb: 1.5,
+                    }}
+                  >
+                    <IconWrapper icon="mdi:star-four-points" size={14} color="#fff" />
+                    {nextUp.mode === "resume"
+                      ? t("assessments.inProgressLabel", { defaultValue: "IN PROGRESS" })
+                      : t("assessments.nextUpLabel", { defaultValue: "NEXT UP" })}
+                  </Box>
+                  <Typography
+                    sx={{
+                      fontFamily: "var(--font-jakarta)",
+                      fontWeight: 800,
+                      fontSize: { xs: "1.5rem", md: "2rem" },
+                      lineHeight: 1.15,
+                      mb: 1,
+                    }}
+                  >
+                    {stripHtmlTags(nextUp.assessment.title || "").trim() || nextUp.assessment.title}
+                  </Typography>
+                  <Typography sx={{ opacity: 0.9, fontSize: { xs: "0.9rem", md: "0.95rem" } }}>
+                    {nextHint}
+                  </Typography>
+                </Box>
+                <LoadingButton
+                  onClick={goToNext}
+                  loading={nextLoading}
+                  endIcon={<IconWrapper icon="mdi:arrow-right" size={18} color="currentColor" />}
+                  sx={{
+                    flexShrink: 0,
+                    bgcolor: "#fff",
+                    color: "#2b1244",
+                    fontWeight: 800,
+                    textTransform: "none",
+                    px: 3,
+                    py: 1.15,
+                    borderRadius: 999,
+                    boxShadow: "0 12px 24px -12px rgba(0,0,0,0.4)",
+                    "&:hover": { bgcolor: "#fff", transform: "translateY(-1px)" },
+                  }}
+                >
+                  {nextUp.mode === "resume"
+                    ? t("assessments.resume", { defaultValue: "Resume" })
+                    : t("assessments.takeItNow", { defaultValue: "Take it now" })}
+                </LoadingButton>
+              </>
+            ) : (
+              <Box sx={{ minWidth: 0, flex: 1 }}>
+                <Box
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 0.75,
+                    px: 1.25,
+                    py: 0.5,
+                    borderRadius: 999,
+                    background: "var(--gradient-ai)",
+                    fontSize: "0.7rem",
+                    fontWeight: 800,
+                    letterSpacing: "0.1em",
+                    mb: 1.5,
+                  }}
+                >
+                  <IconWrapper icon="mdi:star-four-points" size={14} color="#fff" />
+                  {t("assessments.centerLabel", { defaultValue: "ASSESSMENT CENTER" })}
+                </Box>
+                <Typography
+                  sx={{
+                    fontFamily: "var(--font-jakarta)",
+                    fontWeight: 800,
+                    fontSize: { xs: "1.5rem", md: "2rem" },
+                    lineHeight: 1.15,
+                    mb: 1,
+                  }}
+                >
+                  {t("assessments.centerTitle", { defaultValue: "Your assessment center" })}
+                </Typography>
+                <Typography sx={{ opacity: 0.9, fontSize: { xs: "0.9rem", md: "0.95rem" } }}>
+                  {t("assessments.subtitle", { defaultValue: "Everything scheduled across your courses, in one place." })}
+                </Typography>
+              </Box>
+            )}
           </Box>
-        )}
+        </Box>
 
         {/* Stat strip */}
         <Box sx={{ mt: 3 }}>

--- a/app/assessments/result/[slug]/page.tsx
+++ b/app/assessments/result/[slug]/page.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/lib/services/assessment.service";
 import { useToast } from "@/components/common/Toast";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { AssessmentResultHeader } from "@/components/assessment/result/AssessmentResultHeader";
 import { EnhancedStatsBar } from "@/components/assessment/result/EnhancedStatsBar";
 import {
   GradientRing,
@@ -411,7 +410,7 @@ export default function AssessmentResultPage() {
 
   if (loading) {
     return (
-      <MainLayout>
+      <MainLayout fullWidthContent>
         <Box sx={{ py: 8, display: "flex", justifyContent: "center" }}>
           <CircularProgress />
         </Box>
@@ -550,14 +549,12 @@ export default function AssessmentResultPage() {
   };
 
   return (
-    <MainLayout>
-      <Box sx={{ bgcolor: "var(--canvas)", minHeight: "100%" }}>
+    <MainLayout fullWidthContent>
+      <Box sx={{ bgcolor: "var(--canvas)", minHeight: "100%", p: { xs: 2, sm: 3, md: 4 } }}>
       <Box
         sx={{
           maxWidth: "1200px",
           mx: "auto",
-          px: { xs: 2, md: 3 },
-          py: 3,
         }}
       >
         {/* Top Actions */}
@@ -588,11 +585,71 @@ export default function AssessmentResultPage() {
           </Button>
         </Box>
 
-        {/* Header */}
-        <AssessmentResultHeader
-          assessmentTitle={assessmentResult?.assessment_name || ""}
-          status={assessmentResult?.status || ""}
-        />
+        {/* Header — prominent dark gradient banner (mirrors assessment management).
+            Non-excluded from the DOM PDF path; the assessment title is data-driven in
+            the vector PDF regardless. Interactive chrome stays in the action bar above. */}
+        <Box
+          sx={{
+            mb: 3,
+            position: "relative",
+            overflow: "hidden",
+            borderRadius: "22px",
+            p: { xs: 3, md: 4 },
+            color: "#fff",
+            background:
+              "linear-gradient(115deg, #2b1244 0%, #3d1663 45%, #6b1a52 82%, #7d2058 100%)",
+            boxShadow: "0 28px 56px -28px rgba(61, 22, 99, 0.55)",
+          }}
+        >
+          <Box
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 999,
+              background: "var(--gradient-ai)",
+              fontSize: "0.7rem",
+              fontWeight: 800,
+              letterSpacing: "0.1em",
+              mb: 1.5,
+            }}
+          >
+            <IconWrapper icon="mdi:file-document-check" size={14} /> YOUR RESULT
+          </Box>
+          <Typography
+            sx={{
+              fontFamily: "var(--font-jakarta)",
+              fontWeight: 800,
+              fontSize: { xs: "1.5rem", md: "2rem" },
+              lineHeight: 1.15,
+              mb: 1.5,
+            }}
+          >
+            {assessmentResult?.assessment_name || ""}
+          </Typography>
+          <Box
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 999,
+              bgcolor: "rgba(255,255,255,0.14)",
+              border: "1px solid rgba(255,255,255,0.24)",
+              fontSize: "0.78rem",
+              fontWeight: 700,
+              letterSpacing: "0.01em",
+            }}
+          >
+            <IconWrapper icon="mdi:check-circle" size={15} />
+            {assessmentResult?.status && assessmentResult.status !== "submitted"
+              ? assessmentResult.status
+              : "Completed"}
+          </Box>
+        </Box>
 
         {/* Multi-attempt selector. Renders only when this learner has more
             than one submitted attempt — i.e. admin has granted at least one
@@ -611,7 +668,11 @@ export default function AssessmentResultPage() {
               <IconWrapper icon="mdi:history" size={18} color="var(--ai-violet)" />
               <Typography
                 variant="subtitle2"
-                sx={{ fontWeight: 700, color: "var(--font-primary)" }}
+                sx={{
+                  fontFamily: "var(--font-jakarta)",
+                  fontWeight: 800,
+                  color: "var(--font-primary)",
+                }}
               >
                 Attempt history
               </Typography>
@@ -751,6 +812,8 @@ export default function AssessmentResultPage() {
             borderRadius: "var(--radius-card)",
             bgcolor: "var(--card-bg)",
             border: "1px solid var(--border-default)",
+            boxShadow:
+              "0 2px 8px color-mix(in srgb, var(--font-primary) 8%, transparent)",
             display: "flex",
             flexDirection: { xs: "column", sm: "row" },
             alignItems: "center",
@@ -857,12 +920,22 @@ export default function AssessmentResultPage() {
               mt: 3,
               mb: 2,
               p: 2.5,
-              borderRadius: 2,
-              border: "1px solid",
-              borderColor: "divider",
+              borderRadius: "var(--radius-card)",
+              bgcolor: "var(--card-bg)",
+              border: "1px solid var(--border-default)",
+              boxShadow:
+                "0 2px 8px color-mix(in srgb, var(--font-primary) 8%, transparent)",
             }}
           >
-            <Typography variant="subtitle1" fontWeight={700} gutterBottom>
+            <Typography
+              variant="subtitle1"
+              gutterBottom
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                color: "var(--font-primary)",
+              }}
+            >
               {appreciationCertificateContent ? "Your certificate" : "Your certificate"}
             </Typography>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>

--- a/components/assessment/AssessmentReadinessPanel.tsx
+++ b/components/assessment/AssessmentReadinessPanel.tsx
@@ -132,81 +132,14 @@ export function AssessmentReadinessPanel({
     };
   }, [slug]);
 
-  // ── Loading: a subtle skeleton that hints at the card shape ──────────────
-  if (loading) {
-    return (
-      <Box
-        sx={{
-          p: 3,
-          borderRadius: "var(--radius-card)",
-          border: "1px solid var(--border-default)",
-          bgcolor: "var(--card-bg)",
-        }}
-      >
-        <Skeleton
-          variant="rounded"
-          width="60%"
-          height={16}
-          sx={{ mb: 2, bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--surface))" }}
-        />
-        <Skeleton
-          variant="rounded"
-          width="85%"
-          height={24}
-          sx={{ mb: 3, bgcolor: "color-mix(in srgb, var(--ai-violet) 12%, var(--surface))" }}
-        />
-        {[0, 1, 2].map((i) => (
-          <Skeleton
-            key={i}
-            variant="rounded"
-            height={14}
-            sx={{ mb: 1.5, bgcolor: "color-mix(in srgb, var(--ai-violet) 10%, var(--surface))" }}
-          />
-        ))}
-      </Box>
-    );
-  }
+  // The panel is a bonus, not a placeholder: while loading OR when the backend
+  // has no real readiness for this assessment (topics unmapped / no practice
+  // history), render NOTHING at all — no skeleton, no "not mapped yet" message.
+  // It simply appears once (and only if) there is a genuine estimate to show.
+  if (loading) return null;
 
   const available = readiness?.available === true;
-
-  // ── Not available: gentle muted card, reason only, no fabricated numbers ──
-  if (!available) {
-    return (
-      <Box
-        sx={{
-          p: 3,
-          borderRadius: "var(--radius-card)",
-          border: "1px solid var(--border-default)",
-          bgcolor: "var(--surface)",
-        }}
-      >
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
-          <IconWrapper
-            icon="mdi:star-four-points-outline"
-            size={18}
-            color="var(--ai-violet)"
-          />
-          <Typography
-            sx={{
-              fontSize: "0.72rem",
-              fontWeight: 700,
-              letterSpacing: "0.4px",
-              textTransform: "uppercase",
-              color: "var(--font-tertiary)",
-            }}
-          >
-            AI Readiness Check
-          </Typography>
-        </Box>
-        <Typography
-          sx={{ fontSize: "0.875rem", color: "var(--font-secondary)", lineHeight: 1.6 }}
-        >
-          {readiness?.reason ||
-            "We don't have enough practice history to estimate your readiness for this assessment yet."}
-        </Typography>
-      </Box>
-    );
-  }
+  if (!available) return null;
 
   const softest = readiness?.softest_topic ?? null;
 


### PR DESCRIPTION
Design polish on the student assessment pages, per feedback ("too dull", "banner header like the assessment-management page", "font should match", "readiness hidden when unmapped", "full-width CTA"). **Presentation only** — no data/behaviour/gating changed; `tsc` clean + `next build` ✓.

- **Banner headers** matching the management page's dark eggplant→magenta gradient band (22px radius, deep shadow, AI pill, `var(--font-jakarta)` 800 title) on the **hub** (the "Next up" band is now always shown, with a welcome variant), **instructions** (plain header → banner; chips move below), and **result** ("YOUR RESULT" banner + defined score/certificate cards for contrast).
- **`fullWidthContent` + `p:{md:4}`** and `var(--font-jakarta)` display titles across all three, so layout and type match the management page.
- **Instructions:** the consent + "Continue to device check" CTA is now a **full-width action bar** below the two columns (was cramped in the sidebar).
- **AI Readiness panel:** renders **nothing** when the backend has no real readiness (topics unmapped / no practice history) — no skeleton, no "not mapped yet" message.

Preserved: instructions `handleStart` nav branches, result `show_result===false` hidden gate + `.exclude-from-pdf` + psychometric branch, hub `nextUp`/filters, device-check untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
