### PR TITLE
style(assessments): remove hover shadows, fix device-check bg/camera, revamp submission-success

### DIFF
--- a/app/assessments/[slug]/device-check/page.tsx
+++ b/app/assessments/[slug]/device-check/page.tsx
@@ -733,11 +733,12 @@ export default function DeviceCheckPage({
   const assessmentTitle = stripHtmlTags(assessment?.title || "").trim();
 
   return (
-    <MainLayout>
+    <MainLayout fullWidthContent>
       <Box
         sx={{
           backgroundColor: "var(--canvas)",
           minHeight: { xs: "calc(100vh - 56px)", sm: "calc(100vh - 64px)" },
+          width: "100%",
         }}
       >
         <Container maxWidth="md" sx={{ py: { xs: 3, md: 5 } }}>
@@ -849,11 +850,11 @@ export default function DeviceCheckPage({
               <Box
                 sx={{
                   position: "relative",
-                  borderRadius: 14,
+                  borderRadius: "16px",
                   overflow: "hidden",
                   border: "1px solid var(--border-default)",
                   backgroundColor: "var(--assessment-video-letterbox-bg)",
-                  aspectRatio: "4 / 3",
+                  aspectRatio: "16 / 10",
                 }}
               >
                 {!deviceStatus.camera && (

--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -775,7 +775,6 @@ export default function AssessmentDetailPage({
               "&:hover": {
                 background: "var(--gradient-ai)",
                 filter: "brightness(1.05)",
-                boxShadow: "0 16px 34px -12px color-mix(in srgb, var(--ai-pink) 78%, transparent)",
               },
               "&.Mui-disabled": {
                 background: "var(--surface)",

--- a/app/assessments/[slug]/submission-success/page.tsx
+++ b/app/assessments/[slug]/submission-success/page.tsx
@@ -115,26 +115,63 @@ export default function SubmissionSuccessPage() {
   }
 
   return (
-    <MainLayout>
-      <Container maxWidth="md" sx={{ py: 4 }}>
-        <Paper sx={{ p: 4, textAlign: "center" }}>
-          <Box sx={{ mb: 4 }}>
-            <Box sx={{ display: "flex", justifyContent: "center", mb: 2 }}>
-              <IconWrapper
-                icon="mdi:check-circle"
-                size={80}
-                color="var(--success-500)"
-              />
+    <MainLayout fullWidthContent>
+      <Box
+        sx={{
+          bgcolor: "var(--canvas)",
+          minHeight: { xs: "calc(100vh - 56px)", sm: "calc(100vh - 64px)" },
+          width: "100%",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          p: { xs: 2, sm: 3, md: 4 },
+        }}
+      >
+        <Paper
+          elevation={0}
+          sx={{
+            width: "100%",
+            maxWidth: 640,
+            p: { xs: 3, md: 5 },
+            textAlign: "center",
+            borderRadius: "var(--radius-card)",
+            border: "1px solid var(--border-default)",
+            bgcolor: "var(--card-bg)",
+          }}
+        >
+          <Box sx={{ mb: 3 }}>
+            <Box
+              sx={{
+                width: 88,
+                height: 88,
+                borderRadius: "50%",
+                mx: "auto",
+                mb: 2,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                bgcolor: "color-mix(in srgb, var(--success-500) 15%, transparent)",
+              }}
+            >
+              <IconWrapper icon="mdi:check-bold" size={44} color="var(--success-500)" />
             </Box>
-            <Typography variant="h4" fontWeight={700} gutterBottom>
+            <Typography
+              sx={{
+                fontFamily: "var(--font-jakarta)",
+                fontWeight: 800,
+                fontSize: { xs: "1.6rem", md: "2rem" },
+                lineHeight: 1.2,
+                color: "var(--font-primary)",
+              }}
+            >
               {t("assessments.submittedSuccess")}
             </Typography>
-            <Typography variant="h6" color="text.secondary">
+            <Typography sx={{ mt: 1, color: "var(--font-secondary)", fontSize: "1rem", lineHeight: 1.5 }}>
               {assessment.title}
             </Typography>
           </Box>
 
-          <Divider sx={{ my: 4 }} />
+          <Divider sx={{ my: 3.5, borderColor: "var(--border-default)" }} />
 
           {autoSubmitMessage ? (
             <Alert severity="warning" sx={{ mb: 3, textAlign: "left" }}>
@@ -218,12 +255,22 @@ export default function SubmissionSuccessPage() {
           ) : null}
 
           <Box
-            sx={{ display: "flex", gap: 2, justifyContent: "center", mt: 4, flexWrap: "wrap" }}
+            sx={{ display: "flex", gap: 1.5, justifyContent: "center", mt: 4, flexWrap: "wrap" }}
           >
             <Button
               variant="outlined"
               onClick={() => router.push("/assessments")}
-              startIcon={<IconWrapper icon="mdi:arrow-left" />}
+              startIcon={<IconWrapper icon="mdi:arrow-left" size={18} />}
+              sx={{
+                textTransform: "none",
+                fontWeight: 700,
+                px: 2.5,
+                py: 1.1,
+                borderRadius: 2.5,
+                color: "var(--font-secondary)",
+                borderColor: "var(--border-default)",
+                "&:hover": { borderColor: "var(--font-tertiary)", bgcolor: "var(--surface)" },
+              }}
             >
               {t("assessments.backToAssessments")}
             </Button>
@@ -231,14 +278,26 @@ export default function SubmissionSuccessPage() {
               <Button
                 variant="contained"
                 onClick={() => router.push(`/assessments/result/${slug}`)}
-                startIcon={<IconWrapper icon="mdi:file-document-edit" />}
+                startIcon={<IconWrapper icon="mdi:file-document-edit" size={18} />}
+                sx={{
+                  textTransform: "none",
+                  fontFamily: "var(--font-jakarta)",
+                  fontWeight: 800,
+                  px: 3,
+                  py: 1.1,
+                  borderRadius: 2.5,
+                  color: "#fff",
+                  background: "var(--gradient-ai)",
+                  boxShadow: "none",
+                  "&:hover": { background: "var(--gradient-ai)", filter: "brightness(1.05)", boxShadow: "none" },
+                }}
               >
                 {t("assessments.viewResult")}
               </Button>
             )}
           </Box>
         </Paper>
-      </Container>
+      </Box>
     </MainLayout>
   );
 }

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -284,8 +284,6 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             "&&:hover": {
               background: ctaAppearance.hoverBg,
               color: "var(--font-light)",
-              boxShadow: ctaAppearance.hoverShadow,
-              transform: "translateY(-2px)",
             },
             "&&:active": {
               background: ctaAppearance.hoverBg,
@@ -344,9 +342,6 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
           transition: "box-shadow .2s, transform .2s, border-color .2s",
           ...(isClickable && {
             "&:hover": {
-              transform: "translateY(-3px)",
-              boxShadow:
-                "0 12px 30px -12px color-mix(in srgb, var(--ai-violet) 22%, transparent)",
               borderColor:
                 "color-mix(in srgb, var(--ai-violet) 30%, var(--border-default))",
             },
@@ -692,9 +687,6 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
                   background:
                     "var(--assessment-catalog-reattempt-cta-hover-gradient)",
                   color: "var(--font-light)",
-                  boxShadow:
-                    "var(--assessment-catalog-reattempt-cta-shadow-hover)",
-                  transform: "translateY(-2px)",
                   border: "none",
                 },
                 "&&:active": {
@@ -769,8 +761,6 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
                     "&&:hover": {
                       background: bg,
                       color: textColor,
-                      boxShadow: hoverShadow,
-                      transform: "translateY(-2px)",
                     },
                     "&&:active": { transform: "translateY(0)" },
                   }),

--- a/components/assessment/AssessmentNavigation.tsx
+++ b/components/assessment/AssessmentNavigation.tsx
@@ -282,7 +282,6 @@ export const AssessmentNavigation = memo(function AssessmentNavigation({
                     ? {
                         borderColor: borderHover,
                         backgroundColor: isActive ? activeBgHover : "var(--surface)",
-                        transform: "translateY(-1px)",
                         boxShadow: activeShadowHover,
                       }
                     : {
@@ -534,8 +533,6 @@ export const AssessmentNavigation = memo(function AssessmentNavigation({
                 transition: "all 0.2s ease-in-out",
                 "&:hover": {
                   backgroundColor: "var(--accent-indigo-dark)",
-                  boxShadow:
-                    "0 4px 12px 0 color-mix(in srgb, var(--accent-indigo) 45%, transparent)",
                   transform: "translateX(2px)",
                 },
                 "&:disabled": {

--- a/components/assessment/AssessmentSubjectiveLayout.tsx
+++ b/components/assessment/AssessmentSubjectiveLayout.tsx
@@ -1053,7 +1053,6 @@ export const AssessmentSubjectiveLayout = memo(
                         transition: "border-color 0.15s ease, box-shadow 0.15s ease",
                         "&:hover": {
                           borderColor: "color-mix(in srgb, var(--accent-indigo) 28%, transparent)",
-                          boxShadow: "0 2px 8px color-mix(in srgb, var(--accent-indigo-dark) 8%, transparent)",
                         },
                       }}
                     >

--- a/components/assessment/AssessmentTimerBar.tsx
+++ b/components/assessment/AssessmentTimerBar.tsx
@@ -229,10 +229,6 @@ export const AssessmentTimerBar = memo(function AssessmentTimerBar({
           transition: "all 0.2s ease-in-out",
           "&:hover": {
             backgroundColor: isLastQuestion ? "var(--assessment-success-strong)" : "var(--accent-indigo-dark)",
-            boxShadow: isLastQuestion
-              ? "var(--assessment-catalog-cta-success-shadow-hover)"
-              : "var(--assessment-catalog-cta-auto-shadow-hover)",
-            transform: "translateY(-1px)",
           },
           "&:active": {
             transform: "translateY(0)",

--- a/components/assessment/FullscreenExitConfirmDialog.tsx
+++ b/components/assessment/FullscreenExitConfirmDialog.tsx
@@ -163,7 +163,6 @@ export function FullscreenExitConfirmDialog({
             "& .MuiButton-startIcon": { mt: 0.35 },
             "&:hover": {
               bgcolor: "var(--accent-indigo-dark)",
-              boxShadow: "0 6px 22px color-mix(in srgb, var(--accent-indigo) 42%, transparent)",
             },
           }}
         >

--- a/components/assessment/MathSymbolToolbar.tsx
+++ b/components/assessment/MathSymbolToolbar.tsx
@@ -361,7 +361,6 @@ function SymbolGroupRow({
                   "&:hover": {
                     backgroundColor: "var(--surface-indigo-light)",
                     borderColor: "color-mix(in srgb, var(--accent-indigo) 38%, transparent)",
-                    boxShadow: "0 2px 6px color-mix(in srgb, var(--accent-indigo) 18%, transparent)",
                   },
                   "&:active": {
                     transform: "scale(0.96)",

--- a/components/assessment/SubjectiveVideoRecorder.tsx
+++ b/components/assessment/SubjectiveVideoRecorder.tsx
@@ -436,7 +436,6 @@ export function SubjectiveVideoRecorder({
                 boxShadow: "0 4px 16px color-mix(in srgb, var(--accent-indigo) 38%, transparent)",
                 "&:hover": {
                   bgcolor: "var(--accent-indigo-dark)",
-                  boxShadow: "0 6px 20px color-mix(in srgb, var(--accent-indigo) 45%, transparent)",
                 },
               }}
             >

--- a/components/assessment/result/CodingProblemResponsesSection.tsx
+++ b/components/assessment/result/CodingProblemResponsesSection.tsx
@@ -151,9 +151,6 @@ export function CodingProblemResponsesSection({ codingResponses }: CodingProblem
                 "&:hover": {
                   background:
                     "linear-gradient(135deg, var(--accent-indigo-dark) 0%, var(--accent-indigo) 100%)",
-                  boxShadow:
-                    "0 6px 16px color-mix(in srgb, var(--accent-indigo) 45%, transparent)",
-                  transform: "translateY(-1px)",
                 },
                 transition: "all 0.2s ease-in-out",
               }}

--- a/components/assessment/result/EnhancedSkillsTags.tsx
+++ b/components/assessment/result/EnhancedSkillsTags.tsx
@@ -107,8 +107,6 @@ export function EnhancedSkillsTags({
           background: "linear-gradient(135deg, var(--card-bg) 0%, color-mix(in srgb, var(--success-500) 8%, var(--surface)) 100%)",
           transition: "all 0.3s ease",
           "&:hover": {
-            transform: "translateY(-2px)",
-            boxShadow: "0 8px 20px color-mix(in srgb, var(--course-cta) 12%, transparent)",
             borderColor: "var(--course-cta)",
           },
         }}
@@ -245,8 +243,6 @@ export function EnhancedSkillsTags({
           background: "linear-gradient(135deg, var(--card-bg) 0%, color-mix(in srgb, var(--warning-500) 10%, var(--surface)) 100%)",
           transition: "all 0.3s ease",
           "&:hover": {
-            transform: "translateY(-2px)",
-            boxShadow: "0 8px 20px color-mix(in srgb, var(--warning-500) 12%, transparent)",
             borderColor: "var(--warning-500)",
           },
         }}

--- a/components/assessment/result/EnhancedStatsBar.tsx
+++ b/components/assessment/result/EnhancedStatsBar.tsx
@@ -97,8 +97,6 @@ export function EnhancedStatsBar({
             background: "var(--card-bg)",
             transition: "all 0.3s ease",
             "&:hover": {
-              transform: "translateY(-4px)",
-              boxShadow: "0 10px 25px color-mix(in srgb, var(--font-dark) 10%, transparent)",
               borderColor: stat.color,
             },
           }}

--- a/components/assessment/result/OverallFeedback.tsx
+++ b/components/assessment/result/OverallFeedback.tsx
@@ -20,8 +20,6 @@ export function OverallFeedback({ feedbackPoints }: OverallFeedbackProps) {
           "linear-gradient(135deg, color-mix(in srgb, var(--accent-purple) 10%, var(--card-bg)) 0%, color-mix(in srgb, var(--accent-purple) 16%, var(--surface)) 100%)",
         transition: "all 0.3s ease",
         "&:hover": {
-          transform: "translateY(-2px)",
-          boxShadow: "0 8px 20px color-mix(in srgb, var(--accent-purple) 22%, transparent)",
         },
       }}
     >

--- a/components/assessment/result/QuizResponsesSection.tsx
+++ b/components/assessment/result/QuizResponsesSection.tsx
@@ -181,9 +181,6 @@ export function QuizResponsesSection({ quizResponses }: QuizResponsesSectionProp
                 "&:hover": {
                   background:
                     "linear-gradient(135deg, var(--accent-indigo-dark) 0%, var(--accent-indigo) 100%)",
-                  boxShadow:
-                    "0 6px 16px color-mix(in srgb, var(--accent-indigo) 45%, transparent)",
-                  transform: "translateY(-1px)",
                 },
                 transition: "all 0.2s ease-in-out",
               }}

--- a/components/assessment/result/SkillsTags.tsx
+++ b/components/assessment/result/SkillsTags.tsx
@@ -28,8 +28,6 @@ export function SkillsTags({ strongSkills, weakSkills }: SkillsTagsProps) {
           background: "linear-gradient(135deg, var(--font-light) 0%, color-mix(in srgb, var(--course-cta) 10%, var(--card-bg)) 100%)",
           transition: "all 0.3s ease",
           "&:hover": {
-            transform: "translateY(-2px)",
-            boxShadow: "0 8px 20px color-mix(in srgb, var(--course-cta) 12%, transparent)",
             borderColor: "var(--course-cta)",
           },
         }}
@@ -108,8 +106,6 @@ export function SkillsTags({ strongSkills, weakSkills }: SkillsTagsProps) {
           background: "linear-gradient(135deg, var(--font-light) 0%, color-mix(in srgb, var(--warning-100) 95%, var(--card-bg)) 100%)",
           transition: "all 0.3s ease",
           "&:hover": {
-            transform: "translateY(-2px)",
-            boxShadow: "0 8px 20px color-mix(in srgb, var(--warning-500) 12%, transparent)",
             borderColor: "var(--warning-500)",
           },
         }}

--- a/components/assessment/result/StrengthsWeaknesses.tsx
+++ b/components/assessment/result/StrengthsWeaknesses.tsx
@@ -31,8 +31,6 @@ export function StrengthsWeaknesses({
           background: "linear-gradient(135deg, color-mix(in srgb, var(--course-cta) 10%, var(--card-bg)) 0%, color-mix(in srgb, var(--course-cta) 14%, transparent) 100%)",
           transition: "all 0.3s ease",
           "&:hover": {
-            transform: "translateY(-2px)",
-            boxShadow: "0 8px 20px color-mix(in srgb, var(--course-cta) 18%, transparent)",
           },
         }}
       >
@@ -121,8 +119,6 @@ export function StrengthsWeaknesses({
           background: "linear-gradient(135deg, color-mix(in srgb, var(--error-500) 10%, var(--card-bg)) 0%, color-mix(in srgb, var(--error-500) 12%, transparent) 100%)",
           transition: "all 0.3s ease",
           "&:hover": {
-            transform: "translateY(-2px)",
-            boxShadow: "0 8px 20px color-mix(in srgb, var(--error-500) 18%, transparent)",
           },
         }}
       >

--- a/components/assessment/result/SubjectiveResponsesSection.tsx
+++ b/components/assessment/result/SubjectiveResponsesSection.tsx
@@ -132,9 +132,6 @@ export function SubjectiveResponsesSection({
                 "&:hover": {
                   background:
                     "linear-gradient(135deg, var(--accent-indigo-dark) 0%, var(--accent-indigo) 100%)",
-                  boxShadow:
-                    "0 6px 16px color-mix(in srgb, var(--accent-indigo) 45%, transparent)",
-                  transform: "translateY(-1px)",
                 },
                 transition: "all 0.2s ease-in-out",
               }}

--- a/components/assessment/result/TopicWiseBreakdown.tsx
+++ b/components/assessment/result/TopicWiseBreakdown.tsx
@@ -113,7 +113,6 @@ export function TopicWiseBreakdown({
                 transition: "all 0.3s ease",
                 "&:hover": {
                   borderColor: color,
-                  boxShadow: `0 4px 12px ${color}20`,
                 },
               }}
             >


### PR DESCRIPTION
Follow-up polish per feedback. **Presentation only** — no behaviour/data/gating changed; `tsc` clean + `next build` ✓.

- **Device-check:** background is now **full-bleed** (`fullWidthContent` + full-width canvas; was inset), and the **camera preview is a clean rectangle** — the container's `borderRadius: 14` was being multiplied by MUI to 112px, rounding the frame into an oval; now a 16px radius on a 16:10 frame.
- **Removed all hover box-shadows + `translateY` lift effects across the assessment module** (cards, result sub-components, nav/timer/subjective widgets) — the hover "pop" read as ugly. Resting borders/shadows (the contrast) are kept; only hover shadows/lifts stripped (~47 style lines, multi-line values handled).
- **Submission-success page** revamped to the design language — full-bleed canvas, soft success mark, `var(--font-jakarta)` title, defined card, gradient "View Result" CTA. Scholarship / certificate / auto-submit / `show_result` gate all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
