### PR TITLE
fix(live-sessions): delete action + retry-safe create (Agileology duplicates)

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -80,6 +80,8 @@ export default function LiveSessionDetailPage() {
   const [endingMeeting, setEndingMeeting] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deletingWebinar, setDeletingWebinar] = useState(false);
+  const [deleteSessionConfirmOpen, setDeleteSessionConfirmOpen] = useState(false);
+  const [deletingSession, setDeletingSession] = useState(false);
   const [syncingRecording, setSyncingRecording] = useState(false);
   const [playerOpen, setPlayerOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
@@ -167,6 +169,30 @@ export default function LiveSessionDetailPage() {
       showToast(getLiveSessionErrorMessage(error), "error");
     } finally {
       setDeletingWebinar(false);
+    }
+  };
+
+  const handleDeleteSession = async () => {
+    setDeleteSessionConfirmOpen(false);
+    try {
+      setDeletingSession(true);
+      const result = await adminLiveActivitiesService.deleteLiveActivity(liveClassId);
+      if (result.status === "error") {
+        showToast(getZoomApiErrorMessage(result.message) || t("adminLiveSessions.deleteSessionFailed", "Failed to delete session"), "error");
+        return;
+      }
+      const warnings = result.data?.warnings ?? [];
+      showToast(
+        warnings.length
+          ? `${result.message || t("adminLiveSessions.sessionDeleted", "Session deleted")} ${warnings.join(" ")}`
+          : result.message || t("adminLiveSessions.sessionDeleted", "Session deleted"),
+        warnings.length ? "warning" : "success"
+      );
+      router.push("/admin/live-sessions");
+    } catch (error: unknown) {
+      showToast(getLiveSessionErrorMessage(error), "error");
+    } finally {
+      setDeletingSession(false);
     }
   };
 
@@ -308,6 +334,31 @@ export default function LiveSessionDetailPage() {
     </ButtonBase>
   );
 
+  // Delete the whole session (removes the local record + best-effort cleans up the Zoom/Google
+  // object). Always available so a session that failed to provision — no Zoom link, previously
+  // impossible to remove — can be deleted.
+  const deleteSessionButton = (
+    <ButtonBase
+      onClick={() => setDeleteSessionConfirmOpen(true)}
+      disabled={deletingSession}
+      sx={{
+        px: 2.25, py: 1, borderRadius: 999, fontWeight: 700, fontSize: "0.82rem",
+        color: "var(--error-500)", display: "inline-flex", alignItems: "center", gap: 0.5,
+        border: "1px solid color-mix(in srgb, var(--error-500) 35%, transparent)",
+        "&:hover": { background: "color-mix(in srgb, var(--error-500) 8%, transparent)" },
+      }}
+    >
+      <IconWrapper icon="mdi:trash-can-outline" size={16} />
+      {deletingSession ? t("adminLiveSessions.deleting", "Deleting…") : t("adminLiveSessions.deleteSession", "Delete")}
+    </ButtonBase>
+  );
+  const headerActions = (
+    <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+      {deleteSessionButton}
+      {backButton}
+    </Box>
+  );
+
   if (!authLoading && !canAccessAdmin) return null;
 
   return (
@@ -333,7 +384,7 @@ export default function LiveSessionDetailPage() {
                 subtitle={`${formatDateTime(activity.class_datetime)} · ${activity.duration_minutes} ${t("liveSessions.minShort", "min")}${activity.course_detail?.title ? ` · ${activity.course_detail.title}` : ""}`}
                 accent="indigo"
                 icon={platformIcon(activity)}
-                rightSlot={backButton}
+                rightSlot={headerActions}
               />
 
               <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
@@ -561,6 +612,17 @@ export default function LiveSessionDetailPage() {
         confirmColor="error"
         onConfirm={() => void handleDeleteWebinar()}
         onCancel={() => setDeleteConfirmOpen(false)}
+      />
+
+      <ConfirmDialog
+        open={deleteSessionConfirmOpen}
+        title={t("adminLiveSessions.deleteSessionConfirmTitle", "Delete this session?")}
+        message={t("adminLiveSessions.deleteSessionConfirmDesc", "This permanently removes the session from the platform and deletes its Zoom meeting/webinar or Google Meet event if one exists. Synced recordings and attendance are removed too. This can't be undone.")}
+        confirmText={deletingSession ? t("adminLiveSessions.deleting", "Deleting…") : t("adminLiveSessions.deleteSession", "Delete")}
+        cancelText={t("adminLiveSessions.cancel", "Cancel")}
+        confirmColor="error"
+        onConfirm={() => void handleDeleteSession()}
+        onCancel={() => setDeleteSessionConfirmOpen(false)}
       />
 
       <ConfirmDialog

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -319,17 +319,23 @@ export default function CreateLiveSessionPage() {
         return;
       }
 
-      // Zoom meeting / webinar: create the session, then create the Zoom object.
-      const session = await liveClassService.createSession({
-        topic_name: trimmedTopic,
-        description: description.trim() || undefined,
-        class_datetime: classDatetime,
-        duration_minutes: duration,
-        instructor_id: getValidInstructorId(),
-        course: courseId ?? undefined,
-        zoom_meeting_type: isWebinar ? "webinar" : "meeting",
-      });
-      setCreatedSession(session);
+      // Zoom meeting / webinar: create the session, then create the Zoom object. Reuse an
+      // already-created session on retry so re-clicking after the zoom/create step failed doesn't
+      // spawn duplicate rows (this, plus the server-side create dedup, is what left Agileology with
+      // 3 identical undeletable sessions).
+      let session = createdSession;
+      if (!session) {
+        session = await liveClassService.createSession({
+          topic_name: trimmedTopic,
+          description: description.trim() || undefined,
+          class_datetime: classDatetime,
+          duration_minutes: duration,
+          instructor_id: getValidInstructorId(),
+          course: courseId ?? undefined,
+          zoom_meeting_type: isWebinar ? "webinar" : "meeting",
+        });
+        setCreatedSession(session);
+      }
 
       const result = await adminLiveActivitiesService.createZoom(session.id, {
         preset_id: selectedPresetId === "" ? undefined : selectedPresetId,

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -347,6 +347,15 @@ export const adminLiveActivitiesService = {
     return response.data;
   },
 
+  deleteLiveActivity: async (
+    liveClassId: number
+  ): Promise<ZoomApiResponse<{ deleted_id: number; warnings: string[] }>> => {
+    const response = await apiClient.delete<
+      ZoomApiResponse<{ deleted_id: number; warnings: string[] }>
+    >(`${BASE}/live-activities/${liveClassId}/`);
+    return response.data;
+  },
+
   createZoom: async (
     liveClassId: number,
     options?: CreateZoomOptions


### PR DESCRIPTION
Frontend half of the Agileology fix (BE: ai-linc-backend #376). A Zoom **webinar** create that errored left **3 duplicate sessions** with no Zoom link and **no way to delete them**.

**Delete** — new `deleteLiveActivity()` → `DELETE .../live-activities/<id>/`, plus a **Delete** button in the session **detail (Manage) header** with a confirm dialog. Works for **any** session, including one that failed to provision (no Zoom link) — previously impossible to remove. Navigates back to the list on success; surfaces provider-cleanup warnings as a warning toast.

**Retry-safe create** — the Zoom/webinar branch of the create wizard now **reuses an already-created session on retry** (mirrors the Google-Meet-auto path) instead of calling `createSession` again, so re-clicking after the `zoom/create` step failed no longer spawns duplicate rows. Backed by the server-side create-idempotency guard (#376).

**Verified:** `tsc --noEmit` clean, `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
