### PR TITLE
feat(live-sessions): recurring Zoom in the create wizard + month calendar view

### DIFF
--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -29,7 +29,10 @@ import {
   adminLiveActivitiesService,
   MeetingPreset,
   MeetingTemplate,
+  LiveSessionRecurrence,
 } from "@/lib/services/admin/admin-live-activities.service";
+import { RecurrenceControls } from "@/components/admin/live-sessions/RecurrenceControls";
+import { summarizeRecurrence } from "@/lib/utils/live-session-recurrence";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
 import { googleService } from "@/lib/services/google.service";
 import {
@@ -66,6 +69,7 @@ export default function CreateLiveSessionPage() {
   const [description, setDescription] = useState("");
   const [classDatetime, setClassDatetime] = useState("");
   const [durationMinutes, setDurationMinutes] = useState(60);
+  const [recurrence, setRecurrence] = useState<LiveSessionRecurrence | null>(null);
   const [closesAt, setClosesAt] = useState("");
   const [meetLink, setMeetLink] = useState("");
   const [instructorId, setInstructorId] = useState("");
@@ -342,6 +346,7 @@ export default function CreateLiveSessionPage() {
         template_id: selectedTemplateId || undefined,
         passcode: isWebinar && webinarPasscode.trim() ? webinarPasscode.trim() : undefined,
         registration_required: isWebinar ? registrationRequired : undefined,
+        recurrence: recurrence ?? undefined,
       });
 
       if (result.status === "error") {
@@ -649,6 +654,12 @@ export default function CreateLiveSessionPage() {
                       />
                     </>
                   )}
+                  <Box>
+                    <Typography sx={{ fontSize: "0.9rem", fontWeight: 700, color: "var(--font-primary)", mb: 1 }}>
+                      {t("adminLiveSessions.recurrence", "Recurrence")}
+                    </Typography>
+                    <RecurrenceControls startDatetime={classDatetime} onChange={setRecurrence} />
+                  </Box>
                 </Box>
               )}
 
@@ -666,6 +677,7 @@ export default function CreateLiveSessionPage() {
                       {!isMeet && selectedTemplateId && <ReviewRow label={t("adminLiveSessions.meetingTemplate", "Template")} value={templates.find((tp) => tp.id === selectedTemplateId)?.name ?? selectedTemplateId} />}
                       {!isMeet && selectedPresetId !== "" && <ReviewRow label={t("adminLiveSessions.meetingPreset", "Preset")} value={presets.find((p) => p.id === selectedPresetId)?.name ?? String(selectedPresetId)} />}
                       {isWebinar && <ReviewRow label={t("adminLiveSessions.requireRegistration", "Registration")} value={registrationRequired ? t("liveSessions.yes", "Yes") : t("liveSessions.no", "No")} />}
+                      {!isMeet && recurrence && <ReviewRow label={t("adminLiveSessions.recurrence", "Recurrence")} value={summarizeRecurrence(recurrence)} />}
                     </Box>
                   </SectionCard>
                   <InfoCallout icon="mdi:information-outline">

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -32,6 +32,7 @@ import {
 import { MeetingPresetsDialog } from "@/components/admin/live-sessions/MeetingPresetsDialog";
 import { VirtualBackgroundsDialog } from "@/components/admin/live-sessions/VirtualBackgroundsDialog";
 import { LiveSessionCard } from "@/components/live-sessions/ui/LiveSessionCard";
+import { LiveSessionsCalendar } from "@/components/live-sessions/ui/LiveSessionsCalendar";
 import { SessionFilterChips } from "@/components/live-sessions/ui/LiveSessionUI";
 import { useToast } from "@/components/common/Toast";
 import type { LiveActivity } from "@/lib/services/admin/admin-live-activities.service";
@@ -92,6 +93,8 @@ export default function AdminLiveSessionsPage() {
     handleWatchRecording,
     formatDateTime,
   } = useAdminLiveSessions();
+
+  const [viewMode, setViewMode] = useState<"list" | "calendar">("list");
 
   const refreshZoomStatus = useCallback(() => {
     zoomService
@@ -331,9 +334,33 @@ export default function AdminLiveSessionsPage() {
                   ]}
                 />
 
-                <SessionFilterChips options={filterOptions} value={filter} onChange={setFilter} />
+                <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1.5, flexWrap: "wrap" }}>
+                  <SessionFilterChips options={filterOptions} value={filter} onChange={setFilter} />
+                  <Box sx={{ display: "inline-flex", p: 0.375, borderRadius: 999, border: "1px solid var(--border-default)", bgcolor: "var(--card-bg)" }}>
+                    {([
+                      { key: "list", icon: "mdi:view-grid-outline", label: t("adminLiveSessions.viewList", "List") },
+                      { key: "calendar", icon: "mdi:calendar-month-outline", label: t("adminLiveSessions.viewCalendar", "Calendar") },
+                    ] as const).map((v) => {
+                      const active = viewMode === v.key;
+                      return (
+                        <Box key={v.key} component="button" onClick={() => setViewMode(v.key)}
+                          sx={{
+                            display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.75, py: 0.75, borderRadius: 999,
+                            border: "none", cursor: "pointer", fontSize: "0.8rem", fontWeight: 700, fontFamily: "inherit",
+                            bgcolor: active ? "var(--accent-indigo)" : "transparent",
+                            color: active ? "#fff" : "var(--font-secondary)",
+                          }}>
+                          <IconWrapper icon={v.icon} size={16} />
+                          {v.label}
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                </Box>
 
-                {filteredSessions.length === 0 ? (
+                {viewMode === "calendar" ? (
+                  <LiveSessionsCalendar sessions={filteredSessions} onOpen={openDetail} />
+                ) : filteredSessions.length === 0 ? (
                   <Box sx={{ textAlign: "center", py: 6 }}>
                     <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
                       {t("adminLiveSessions.noSessionsForFilter", "No sessions match this filter.")}

--- a/components/admin/live-sessions/RecurrenceControls.tsx
+++ b/components/admin/live-sessions/RecurrenceControls.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Box, Chip, MenuItem, Radio, TextField, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import type { LiveSessionRecurrence } from "@/lib/services/admin/admin-live-activities.service";
+import { expandRecurrence, summarizeRecurrence } from "@/lib/utils/live-session-recurrence";
+
+type Freq = "none" | "daily" | "weekly" | "monthly";
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+interface RecurrenceControlsProps {
+  /** The session's start (the wizard's classDatetime, `YYYY-MM-DDTHH:mm`). */
+  startDatetime: string;
+  onChange: (rule: LiveSessionRecurrence | null) => void;
+}
+
+/**
+ * "Repeat" controls for the create wizard: frequency + interval + (weekly days | monthly day) +
+ * end (after N / on date), with a live preview of the next dates. Emits the friendly
+ * LiveSessionRecurrence the backend expects, or null for a one-off session.
+ */
+export function RecurrenceControls({ startDatetime, onChange }: RecurrenceControlsProps) {
+  const { t } = useTranslation("common");
+  const start = useMemo(() => new Date(startDatetime), [startDatetime]);
+  const startDow = isNaN(start.getTime()) ? 1 : start.getDay();
+
+  const [freq, setFreq] = useState<Freq>("none");
+  const [interval, setInterval] = useState(1);
+  const [weeklyDays, setWeeklyDays] = useState<number[]>([startDow]);
+  const [endType, setEndType] = useState<"count" | "date">("count");
+  const [endCount, setEndCount] = useState(10);
+  const [endDate, setEndDate] = useState("");
+
+  // Keep the weekly default aligned to the chosen start day until the user edits it.
+  const touchedWeekly = useRef(false);
+  useEffect(() => {
+    if (!touchedWeekly.current) setWeeklyDays([startDow]);
+  }, [startDow]);
+
+  const rule: LiveSessionRecurrence | null = useMemo(() => {
+    if (freq === "none") return null;
+    const end =
+      endType === "count"
+        ? { type: "count" as const, count: Math.max(1, Math.min(50, endCount || 1)) }
+        : { type: "date" as const, date: endDate };
+    if (endType === "date" && !endDate) return null; // incomplete → treat as not-yet-valid
+    const base = { interval: Math.max(1, interval), end };
+    if (freq === "weekly")
+      return { frequency: "weekly", weekly_days: weeklyDays.length ? weeklyDays : [startDow], ...base };
+    if (freq === "monthly")
+      return { frequency: "monthly", monthly_day: isNaN(start.getDate()) ? 1 : start.getDate(), ...base };
+    return { frequency: "daily", ...base };
+  }, [freq, interval, weeklyDays, endType, endCount, endDate, startDow, start]);
+
+  // Emit upward without depending on onChange identity.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  useEffect(() => {
+    onChangeRef.current(rule);
+  }, [rule]);
+
+  const preview = useMemo(() => (rule ? expandRecurrence(rule, start).slice(0, 4) : []), [rule, start]);
+  const totalCount = useMemo(() => (rule ? expandRecurrence(rule, start).length : 0), [rule, start]);
+
+  const unitLabel = freq === "daily" ? "day" : freq === "weekly" ? "week" : "month";
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.75 }}>
+      <TextField
+        select size="small" label={t("adminLiveSessions.repeat", "Repeat")}
+        value={freq} onChange={(e) => setFreq(e.target.value as Freq)}
+        sx={{ maxWidth: 260 }}
+      >
+        <MenuItem value="none">{t("adminLiveSessions.repeatNone", "Does not repeat")}</MenuItem>
+        <MenuItem value="daily">{t("adminLiveSessions.repeatDaily", "Daily")}</MenuItem>
+        <MenuItem value="weekly">{t("adminLiveSessions.repeatWeekly", "Weekly")}</MenuItem>
+        <MenuItem value="monthly">{t("adminLiveSessions.repeatMonthly", "Monthly")}</MenuItem>
+      </TextField>
+
+      {freq !== "none" && (
+        <Box
+          sx={{
+            display: "flex", flexDirection: "column", gap: 1.75, p: 2, borderRadius: 3,
+            border: "1px solid color-mix(in srgb, var(--accent-indigo) 22%, transparent)",
+            bgcolor: "color-mix(in srgb, var(--accent-indigo) 5%, transparent)",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", fontWeight: 600 }}>
+              {t("adminLiveSessions.repeatEvery", "Repeat every")}
+            </Typography>
+            <TextField
+              type="number" size="small" value={interval}
+              onChange={(e) => setInterval(Math.max(1, parseInt(e.target.value || "1", 10)))}
+              inputProps={{ min: 1, max: freq === "daily" ? 90 : freq === "weekly" ? 12 : 3 }}
+              sx={{ width: 84 }}
+            />
+            <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", fontWeight: 600 }}>
+              {interval > 1 ? `${unitLabel}s` : unitLabel}
+            </Typography>
+          </Box>
+
+          {freq === "weekly" && (
+            <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap" }}>
+              {WEEKDAYS.map((label, dow) => {
+                const on = weeklyDays.includes(dow);
+                return (
+                  <Chip
+                    key={dow} label={label} size="small"
+                    onClick={() => {
+                      touchedWeekly.current = true;
+                      setWeeklyDays((prev) =>
+                        prev.includes(dow) ? prev.filter((d) => d !== dow) : [...prev, dow]
+                      );
+                    }}
+                    sx={{
+                      fontWeight: 700, cursor: "pointer",
+                      bgcolor: on ? "var(--accent-indigo)" : "var(--surface)",
+                      color: on ? "#fff" : "var(--font-secondary)",
+                      border: "1px solid var(--border-default)",
+                      "&:hover": { bgcolor: on ? "var(--accent-indigo-dark)" : "var(--surface-indigo-light)" },
+                    }}
+                  />
+                );
+              })}
+            </Box>
+          )}
+
+          {freq === "monthly" && !isNaN(start.getDate()) && (
+            <Typography sx={{ fontSize: "0.82rem", color: "var(--font-tertiary)" }}>
+              {t("adminLiveSessions.repeatMonthlyOnDay", "On day")} {start.getDate()} {t("adminLiveSessions.ofEachMonth", "of each month")}
+            </Typography>
+          )}
+
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+            <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", fontWeight: 600 }}>
+              {t("adminLiveSessions.repeatEnds", "Ends")}
+            </Typography>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+              <Radio size="small" checked={endType === "count"} onChange={() => setEndType("count")} />
+              <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)" }}>
+                {t("adminLiveSessions.repeatAfter", "After")}
+              </Typography>
+              <TextField
+                type="number" size="small" value={endCount} disabled={endType !== "count"}
+                onChange={(e) => setEndCount(Math.max(1, Math.min(50, parseInt(e.target.value || "1", 10))))}
+                inputProps={{ min: 1, max: 50 }} sx={{ width: 84 }}
+              />
+              <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)" }}>
+                {t("adminLiveSessions.occurrences", "occurrences")}
+              </Typography>
+            </Box>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+              <Radio size="small" checked={endType === "date"} onChange={() => setEndType("date")} />
+              <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)" }}>
+                {t("adminLiveSessions.repeatOnDate", "On date")}
+              </Typography>
+              <TextField
+                type="date" size="small" value={endDate} disabled={endType !== "date"}
+                onChange={(e) => setEndDate(e.target.value)}
+                InputLabelProps={{ shrink: true }} sx={{ width: 180 }}
+              />
+            </Box>
+          </Box>
+
+          {rule && preview.length > 0 && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, pt: 0.5 }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                <IconWrapper icon="mdi:calendar-refresh" size={16} color="var(--accent-indigo)" />
+                <Typography sx={{ fontSize: "0.82rem", fontWeight: 700, color: "var(--font-primary)" }}>
+                  {summarizeRecurrence(rule)}{totalCount ? ` · ${totalCount} ${t("adminLiveSessions.sessions", "sessions")}` : ""}
+                </Typography>
+              </Box>
+              <Typography sx={{ fontSize: "0.78rem", color: "var(--font-tertiary)" }}>
+                {t("adminLiveSessions.repeatNextDates", "Next")}: {preview.map((d) =>
+                  d.toLocaleDateString(undefined, { month: "short", day: "numeric" })).join(" · ")}
+                {totalCount > preview.length ? " …" : ""}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/live-sessions/ui/LiveSessionsCalendar.tsx
+++ b/components/live-sessions/ui/LiveSessionsCalendar.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Box, ButtonBase, Chip, Typography } from "@mui/material";
+import { useTranslation } from "react-i18next";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import type { LiveActivity } from "@/lib/services/admin/admin-live-activities.service";
+
+type Status = "scheduled" | "live" | "ended" | "expired" | "cancelled";
+
+const STATUS_COLOR: Record<Status, string> = {
+  scheduled: "var(--accent-indigo)",
+  live: "var(--success-500)",
+  ended: "var(--font-tertiary)",
+  expired: "var(--warning-500)",
+  cancelled: "var(--error-500)",
+};
+
+interface DayEntry {
+  session: LiveActivity;
+  when: Date;
+  status: Status;
+  recurring: boolean;
+}
+
+const dayKey = (d: Date) => `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+
+/** Explode a session into one calendar entry per date — per occurrence for a recurring series,
+ * otherwise a single entry on its class_datetime. */
+function entriesFor(session: LiveActivity): DayEntry[] {
+  if (session.occurrences && session.occurrences.length) {
+    return session.occurrences
+      .filter((o) => o.status !== "cancelled")
+      .map((o) => ({
+        session,
+        when: new Date(o.occurrence_datetime),
+        status: (o.meeting_status as Status) || "scheduled",
+        recurring: true,
+      }));
+  }
+  return [{
+    session,
+    when: new Date(session.class_datetime),
+    status: (session.meeting_status as Status) || "scheduled",
+    recurring: false,
+  }];
+}
+
+interface LiveSessionsCalendarProps {
+  sessions: LiveActivity[];
+  onOpen: (session: LiveActivity) => void;
+}
+
+export function LiveSessionsCalendar({ sessions, onOpen }: LiveSessionsCalendarProps) {
+  const { t } = useTranslation("common");
+  const today = new Date();
+  const [cursor, setCursor] = useState(new Date(today.getFullYear(), today.getMonth(), 1));
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  // Bucket all entries by day.
+  const byDay = useMemo(() => {
+    const map = new Map<string, DayEntry[]>();
+    for (const s of sessions) {
+      for (const e of entriesFor(s)) {
+        if (isNaN(e.when.getTime())) continue;
+        const k = dayKey(e.when);
+        let list = map.get(k);
+        if (!list) { list = []; map.set(k, list); }
+        list.push(e);
+      }
+    }
+    for (const list of map.values()) list.sort((a, b) => a.when.getTime() - b.when.getTime());
+    return map;
+  }, [sessions]);
+
+  // 6x7 grid of dates starting on the Sunday on/before the 1st.
+  const cells = useMemo(() => {
+    const first = new Date(cursor.getFullYear(), cursor.getMonth(), 1);
+    const gridStart = new Date(first);
+    gridStart.setDate(1 - first.getDay());
+    return Array.from({ length: 42 }, (_, i) => {
+      const d = new Date(gridStart);
+      d.setDate(gridStart.getDate() + i);
+      return d;
+    });
+  }, [cursor]);
+
+  const monthLabel = cursor.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+  const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const selectedEntries = selectedKey ? byDay.get(selectedKey) ?? [] : [];
+
+  const navBtn = (icon: string, onClick: () => void) => (
+    <ButtonBase onClick={onClick} sx={{
+      width: 34, height: 34, borderRadius: "10px", border: "1px solid var(--border-default)",
+      color: "var(--font-secondary)", "&:hover": { bgcolor: "var(--surface)" },
+    }}>
+      <IconWrapper icon={icon} size={18} />
+    </ButtonBase>
+  );
+
+  return (
+    <Box sx={{
+      p: { xs: 1.5, md: 2.5 }, borderRadius: "18px", border: "1px solid var(--border-default)",
+      bgcolor: "var(--card-bg)",
+    }}>
+      {/* Month header */}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 2, flexWrap: "wrap", gap: 1 }}>
+        <Typography sx={{ fontSize: "1.05rem", fontWeight: 800, color: "var(--font-primary)" }}>{monthLabel}</Typography>
+        <Box sx={{ display: "flex", gap: 0.75, alignItems: "center" }}>
+          <ButtonBase onClick={() => { setCursor(new Date(today.getFullYear(), today.getMonth(), 1)); }}
+            sx={{ px: 1.75, py: 0.75, borderRadius: 999, fontSize: "0.8rem", fontWeight: 700,
+              border: "1px solid var(--border-default)", color: "var(--font-secondary)",
+              "&:hover": { bgcolor: "var(--surface)" } }}>
+            {t("adminLiveSessions.today", "Today")}
+          </ButtonBase>
+          {navBtn("mdi:chevron-left", () => setCursor(new Date(cursor.getFullYear(), cursor.getMonth() - 1, 1)))}
+          {navBtn("mdi:chevron-right", () => setCursor(new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1)))}
+        </Box>
+      </Box>
+
+      {/* Weekday header */}
+      <Box sx={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 0.5, mb: 0.5 }}>
+        {weekdays.map((w) => (
+          <Typography key={w} sx={{ textAlign: "center", fontSize: "0.72rem", fontWeight: 700,
+            letterSpacing: "0.04em", color: "var(--font-tertiary)", textTransform: "uppercase" }}>{w}</Typography>
+        ))}
+      </Box>
+
+      {/* Day grid */}
+      <Box sx={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 0.5 }}>
+        {cells.map((d, i) => {
+          const inMonth = d.getMonth() === cursor.getMonth();
+          const isToday = dayKey(d) === dayKey(today);
+          const k = dayKey(d);
+          const entries = byDay.get(k) ?? [];
+          const selected = selectedKey === k;
+          return (
+            <ButtonBase
+              key={i}
+              onClick={() => setSelectedKey(entries.length ? k : null)}
+              sx={{
+                display: "flex", flexDirection: "column", alignItems: "stretch", justifyContent: "flex-start",
+                minHeight: { xs: 62, md: 92 }, p: 0.75, borderRadius: "10px", textAlign: "left",
+                border: selected ? "1.5px solid var(--accent-indigo)" : "1px solid transparent",
+                bgcolor: isToday ? "color-mix(in srgb, var(--accent-indigo) 8%, transparent)" : "transparent",
+                opacity: inMonth ? 1 : 0.38,
+                cursor: entries.length ? "pointer" : "default",
+                "&:hover": { bgcolor: entries.length ? "var(--surface)" : undefined },
+              }}
+            >
+              <Typography sx={{
+                fontSize: "0.78rem", fontWeight: isToday ? 800 : 600, mb: 0.4,
+                color: isToday ? "var(--accent-indigo)" : "var(--font-secondary)",
+                fontVariantNumeric: "tabular-nums",
+              }}>{d.getDate()}</Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.3, overflow: "hidden" }}>
+                {entries.slice(0, 3).map((e, j) => (
+                  <Box key={j} onClick={(ev) => { ev.stopPropagation(); onOpen(e.session); }}
+                    sx={{
+                      display: "flex", alignItems: "center", gap: 0.4, px: 0.5, py: 0.15, borderRadius: "5px",
+                      bgcolor: `color-mix(in srgb, ${STATUS_COLOR[e.status]} 14%, transparent)`,
+                      "&:hover": { bgcolor: `color-mix(in srgb, ${STATUS_COLOR[e.status]} 24%, transparent)` },
+                    }}>
+                    <Box sx={{ width: 5, height: 5, borderRadius: "50%", bgcolor: STATUS_COLOR[e.status], flexShrink: 0 }} />
+                    <Typography sx={{ fontSize: "0.66rem", fontWeight: 600, color: "var(--font-primary)",
+                      whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                      {e.session.topic_name}
+                    </Typography>
+                  </Box>
+                ))}
+                {entries.length > 3 && (
+                  <Typography sx={{ fontSize: "0.64rem", fontWeight: 700, color: "var(--font-tertiary)", pl: 0.5 }}>
+                    +{entries.length - 3} {t("adminLiveSessions.more", "more")}
+                  </Typography>
+                )}
+              </Box>
+            </ButtonBase>
+          );
+        })}
+      </Box>
+
+      {/* Selected-day panel */}
+      {selectedKey && selectedEntries.length > 0 && (
+        <Box sx={{ mt: 2, pt: 2, borderTop: "1px solid var(--border-default)", display: "flex", flexDirection: "column", gap: 1 }}>
+          <Typography sx={{ fontSize: "0.85rem", fontWeight: 800, color: "var(--font-primary)" }}>
+            {new Date(selectedEntries[0].when).toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" })}
+          </Typography>
+          {selectedEntries.map((e, j) => (
+            <ButtonBase key={j} onClick={() => onOpen(e.session)}
+              sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1, width: "100%",
+                p: 1.25, borderRadius: "12px", border: "1px solid var(--border-default)", textAlign: "left",
+                "&:hover": { bgcolor: "var(--surface)" } }}>
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1, minWidth: 0 }}>
+                <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: STATUS_COLOR[e.status], flexShrink: 0 }} />
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography sx={{ fontSize: "0.86rem", fontWeight: 700, color: "var(--font-primary)",
+                    whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{e.session.topic_name}</Typography>
+                  <Typography sx={{ fontSize: "0.76rem", color: "var(--font-tertiary)" }}>
+                    {e.when.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })} · {e.session.duration_minutes} {t("liveSessions.minShort", "min")}
+                  </Typography>
+                </Box>
+              </Box>
+              {e.recurring && (
+                <Chip size="small" icon={<IconWrapper icon="mdi:calendar-refresh" size={13} />} label={t("adminLiveSessions.recurring", "Recurring")}
+                  sx={{ fontSize: "0.68rem", fontWeight: 700, bgcolor: "var(--surface-indigo-light)", color: "var(--accent-indigo)" }} />
+              )}
+            </ButtonBase>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -20,6 +20,31 @@ export interface CourseDetail {
   slug: string;
 }
 
+/** Friendly recurrence rule sent to the backend (0=Sunday..6=Saturday for weekdays). */
+export interface LiveSessionRecurrence {
+  frequency: "daily" | "weekly" | "monthly";
+  interval: number;
+  weekly_days?: number[];
+  monthly_day?: number;
+  monthly_week?: number;
+  monthly_week_day?: number;
+  end: { type: "count"; count: number } | { type: "date"; date: string };
+}
+
+/** One dated instance of a recurring series (from the backend). */
+export interface LiveClassOccurrence {
+  id: number;
+  zoom_occurrence_id: string;
+  occurrence_datetime: string;
+  duration_minutes: number;
+  status: "scheduled" | "started" | "ended" | "cancelled";
+  meeting_status: "scheduled" | "live" | "ended" | "expired" | "cancelled";
+  zoom_recording_url?: string | null;
+  zoom_recording_duration_seconds?: number | null;
+  has_recording: boolean;
+  zoom_ai_summary?: string | null;
+}
+
 export interface LiveActivity {
   id: number;
   client?: number;
@@ -54,6 +79,9 @@ export interface LiveActivity {
   zoom_registration_url?: string | null;
   zoom_registration_required?: boolean;
   zoom_is_recurring?: boolean;
+  zoom_recurrence?: LiveSessionRecurrence | null;
+  recurrence_summary?: string | null;
+  occurrences?: LiveClassOccurrence[];
   zoom_meeting_id?: string | null;
   zoom_meeting_uuid?: string | null;
   zoom_start_url?: string | null;
@@ -253,6 +281,7 @@ export interface CreateZoomOptions {
   template_id?: string;
   passcode?: string;
   registration_required?: boolean;
+  recurrence?: LiveSessionRecurrence;
 }
 
 /** Native Zoom webinar template (GET zoom/webinar-templates/). */

--- a/lib/utils/live-session-recurrence.ts
+++ b/lib/utils/live-session-recurrence.ts
@@ -1,0 +1,111 @@
+/**
+ * Client-side expansion of the friendly recurrence rule (mirrors the backend's
+ * live_class/recurrence.py) — used for the wizard's "next dates" preview and to plot a recurring
+ * series' occurrences on the calendar before the backend has minted them. Weekday numbering is
+ * JS `Date.getDay()` (0=Sunday..6=Saturday), matching the backend contract.
+ */
+import type { LiveSessionRecurrence } from "@/lib/services/admin/admin-live-activities.service";
+
+const DAY_ABBR = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const DAY_FULL = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+const ORDINAL: Record<number, string> = { 1: "first", 2: "second", 3: "third", 4: "fourth", [-1]: "last" };
+
+// Hard cap so a malformed rule can never loop unbounded (backend caps a series at 50).
+const HARD_CAP = 60;
+
+function endBound(rule: LiveSessionRecurrence): { count: number; until: Date | null } {
+  if (rule.end.type === "count") return { count: Math.min(rule.end.count, HARD_CAP), until: null };
+  const until = new Date(`${rule.end.date}T23:59:59`);
+  return { count: HARD_CAP, until: isNaN(until.getTime()) ? null : until };
+}
+
+function nthWeekdayOfMonth(year: number, month: number, weekday: number, nth: number): Date | null {
+  if (nth === -1) {
+    const last = new Date(year, month + 1, 0);
+    const offset = (last.getDay() - weekday + 7) % 7;
+    return new Date(year, month, last.getDate() - offset);
+  }
+  const first = new Date(year, month, 1);
+  const offset = (weekday - first.getDay() + 7) % 7;
+  const day = 1 + offset + (nth - 1) * 7;
+  const d = new Date(year, month, day);
+  return d.getMonth() === month ? d : null;
+}
+
+/** Generate the occurrence start Dates for a recurrence rule, given the first session's Date. */
+export function expandRecurrence(rule: LiveSessionRecurrence | null, start: Date): Date[] {
+  if (!rule || isNaN(start.getTime())) return [];
+  const { count, until } = endBound(rule);
+  const out: Date[] = [];
+  const push = (d: Date) => {
+    if (out.length >= count) return false;
+    if (until && d > until) return false;
+    out.push(d);
+    return true;
+  };
+  const hms = [start.getHours(), start.getMinutes(), start.getSeconds()] as const;
+  const at = (y: number, m: number, day: number) => new Date(y, m, day, hms[0], hms[1], hms[2]);
+
+  if (rule.frequency === "daily") {
+    const step = Math.max(1, rule.interval);
+    for (let i = 0; out.length < count; i += step) {
+      const d = at(start.getFullYear(), start.getMonth(), start.getDate() + i);
+      if (!push(d)) break;
+      if (i > HARD_CAP * step) break;
+    }
+  } else if (rule.frequency === "weekly") {
+    const days = (rule.weekly_days && rule.weekly_days.length ? rule.weekly_days : [start.getDay()])
+      .slice().sort((a, b) => a - b);
+    const stepWeeks = Math.max(1, rule.interval);
+    // Anchor to the Sunday of the start week, then walk blocks of `interval` weeks.
+    const weekStart = at(start.getFullYear(), start.getMonth(), start.getDate() - start.getDay());
+    for (let w = 0; out.length < count; w += stepWeeks) {
+      let overflow = false;
+      for (const dow of days) {
+        const d = at(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate() + w * 7 + dow);
+        if (d < start) continue;
+        if (!push(d)) { overflow = true; break; }
+      }
+      if (overflow) break;
+      if (w > HARD_CAP * 7 * stepWeeks) break;
+    }
+  } else {
+    // monthly
+    const stepMonths = Math.max(1, rule.interval);
+    for (let i = 0; out.length < count; i += stepMonths) {
+      const y = start.getFullYear();
+      const m = start.getMonth() + i;
+      let d: Date | null;
+      if (rule.monthly_week != null && rule.monthly_week_day != null) {
+        d = nthWeekdayOfMonth(y, m, rule.monthly_week_day, rule.monthly_week);
+        if (d) d = at(d.getFullYear(), d.getMonth(), d.getDate());
+      } else {
+        const dom = rule.monthly_day ?? start.getDate();
+        const lastDay = new Date(y, m + 1, 0).getDate();
+        d = at(y, m, Math.min(dom, lastDay));
+      }
+      if (d && d >= start && !push(d)) break;
+      if (i > HARD_CAP * stepMonths) break;
+    }
+  }
+  return out;
+}
+
+/** A short human sentence for the rule (parity with the backend's humanize_recurrence). */
+export function summarizeRecurrence(rule: LiveSessionRecurrence | null): string {
+  if (!rule) return "Does not repeat";
+  const n = rule.interval || 1;
+  let base: string;
+  if (rule.frequency === "daily") base = n === 1 ? "Every day" : `Every ${n} days`;
+  else if (rule.frequency === "weekly") {
+    const days = (rule.weekly_days ?? []).slice().sort((a, b) => a - b).map((d) => DAY_ABBR[d]).join(", ");
+    base = `${n === 1 ? "Weekly" : `Every ${n} weeks`}${days ? ` on ${days}` : ""}`;
+  } else {
+    const every = n === 1 ? "Monthly" : `Every ${n} months`;
+    base = rule.monthly_week != null && rule.monthly_week_day != null
+      ? `${every} on the ${ORDINAL[rule.monthly_week] ?? ""} ${DAY_FULL[rule.monthly_week_day]}`
+      : `${every} on day ${rule.monthly_day ?? ""}`;
+  }
+  if (rule.end.type === "count") return `${base}, ${rule.end.count} time${rule.end.count === 1 ? "" : "s"}`;
+  return `${base}, until ${rule.end.date}`;
+}


### PR DESCRIPTION
Frontend for **recurring Zoom meetings/webinars** + a **month calendar** (backend: ai-linc-backend #377).

**Create wizard** — a **Recurrence** block in the Zoom step (Zoom/webinar only): frequency (daily/weekly/monthly) + interval + weekday chips (weekly) / day-of-month (monthly) + end (after N occurrences or on a date), with a live **"next dates" preview** and a summary. The rule is threaded into `createZoom()` as `recurrence`; a review row shows it. Reuses the retry-safe session guard.

**Month calendar** — a **List / Calendar** toggle on the admin live-sessions list. The calendar plots each session on its date and expands a recurring series into **one entry per occurrence** (from the backend `occurrences[]`), colored by status; click a day to list its sessions, click one to open its detail. Hand-rolled month grid (no calendar lib added), token-consistent with the design system.

**Also:** service types (`LiveSessionRecurrence`, `LiveClassOccurrence`, `occurrences`/`zoom_recurrence`/`recurrence_summary`, `CreateZoomOptions.recurrence`) + `lib/utils/live-session-recurrence.ts` (`expandRecurrence`/`summarizeRecurrence`, mirroring the backend rule).

**Verified:** `tsc --noEmit` clean, `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
