### PR TITLE
feat(live-sessions): widen pages + redesign wizard & dialogs to the assessment style

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -362,8 +362,8 @@ export default function LiveSessionDetailPage() {
   if (!authLoading && !canAccessAdmin) return null;
 
   return (
-    <MainLayout>
-      <Container maxWidth="lg" sx={{ py: { xs: 3, md: 5 } }}>
+    <MainLayout fullWidthContent>
+      <Container maxWidth="xl" sx={{ py: { xs: 3, md: 5 } }}>
         <AdaptiveSectionShell meshOpacity={0.3}>
           {loading && !activity ? (
             <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -18,8 +18,6 @@ import {
   Typography,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
-import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { useAuth } from "@/lib/auth/auth-context";
@@ -376,35 +374,53 @@ export default function CreateLiveSessionPage() {
   if (!authLoading && !canAccessAdmin) return null;
 
   return (
-    <MainLayout>
-      <Container maxWidth="md" sx={{ py: { xs: 3, md: 5 } }}>
-        <AdaptiveSectionShell meshOpacity={0.3}>
-          <AdaptiveSectionHero
-            chapter={t("adminLiveSessions.createChapter", "Create · Live Sessions")}
-            title={t("adminLiveSessions.createTitle", "New live session")}
-            subtitle={t("adminLiveSessions.createSubtitle", "Set the details, configure Zoom, review, and go live.")}
-            accent="indigo"
-            icon="mdi:video-plus"
-            rightSlot={
-              <ButtonBase
-                onClick={() => router.push("/admin/live-sessions")}
+    <MainLayout fullWidthContent>
+      <Container maxWidth="lg" sx={{ py: { xs: 3, md: 5 } }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          {/* Clean header (assessment style) */}
+          <Box sx={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 2, flexWrap: "wrap" }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.75, minWidth: 0 }}>
+              <Box
                 sx={{
-                  px: 2.25,
-                  py: 1,
-                  borderRadius: 999,
-                  fontWeight: 700,
-                  color: "var(--font-secondary)",
-                  border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
-                  fontSize: "0.82rem",
+                  width: 52, height: 52, borderRadius: "14px", flexShrink: 0,
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                  background: "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)", color: "#fff",
                 }}
               >
-                {t("adminLiveSessions.cancel", "Cancel")}
-              </ButtonBase>
-            }
-          />
+                <IconWrapper icon="mdi:video-plus" size={26} color="#fff" />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--font-tertiary)" }}>
+                  {t("adminLiveSessions.createChapter", "Create · Live Session")}
+                </Typography>
+                <Typography sx={{ fontSize: { xs: "1.5rem", md: "1.9rem" }, fontWeight: 800, lineHeight: 1.15, letterSpacing: "-0.02em", color: "var(--font-primary)" }}>
+                  {t("adminLiveSessions.createTitle", "New live session")}
+                </Typography>
+                <Typography sx={{ mt: 0.25, fontSize: "0.9rem", color: "var(--font-secondary)" }}>
+                  {t("adminLiveSessions.createSubtitle", "Set the details, configure Zoom, review, and go live.")}
+                </Typography>
+              </Box>
+            </Box>
+            <ButtonBase
+              onClick={() => router.push("/admin/live-sessions")}
+              sx={{ px: 2.25, py: 1, borderRadius: 999, fontWeight: 700, color: "var(--font-secondary)", border: "1px solid var(--border-default)", fontSize: "0.82rem", "&:hover": { bgcolor: "var(--surface)" } }}
+            >
+              {t("adminLiveSessions.cancel", "Cancel")}
+            </ButtonBase>
+          </Box>
 
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-            <Stepper activeStep={stepIndex} alternativeLabel>
+            <Stepper
+              activeStep={stepIndex}
+              alternativeLabel
+              sx={{
+                "& .MuiStepIcon-root": { color: "var(--border-default)" },
+                "& .MuiStepIcon-root.Mui-active": { color: "var(--accent-indigo)" },
+                "& .MuiStepIcon-root.Mui-completed": { color: "var(--accent-indigo)" },
+                "& .MuiStepLabel-label": { fontSize: "0.82rem", fontWeight: 600, color: "var(--font-tertiary)", mt: "6px !important" },
+                "& .MuiStepLabel-label.Mui-active": { color: "var(--font-primary)", fontWeight: 700 },
+                "& .MuiStepLabel-label.Mui-completed": { color: "var(--font-secondary)" },
+              }}
+            >
               {steps.map((s) => (
                 <Step key={s.key}>
                   <StepLabel>{s.label}</StepLabel>
@@ -414,11 +430,10 @@ export default function CreateLiveSessionPage() {
 
             <Box
               sx={{
-                p: { xs: 2, md: 3 },
-                borderRadius: 4,
-                bgcolor: "color-mix(in srgb, var(--card-bg) 65%, transparent)",
-                border: "1px solid color-mix(in srgb, var(--border-default) 60%, transparent)",
-                backdropFilter: "blur(18px) saturate(140%)",
+                p: { xs: 2.5, md: 3.5 },
+                borderRadius: "var(--radius-card)",
+                bgcolor: "var(--card-bg)",
+                border: "1px solid var(--border-default)",
               }}
             >
               {stepKey === "details" && (
@@ -665,7 +680,11 @@ export default function CreateLiveSessionPage() {
 
               {stepKey === "review" && (
                 <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                  <SectionCard title={t("adminLiveSessions.stepReview", "Review")} icon="mdi:clipboard-check-outline">
+                  <SectionCard
+                    title={t("adminLiveSessions.stepReview", "Review")}
+                    icon="mdi:clipboard-check-outline"
+                    sx={{ backdropFilter: "none", boxShadow: "none", bgcolor: "var(--surface)", borderRadius: "14px", border: "1px solid var(--border-default)" }}
+                  >
                     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
                       <ReviewRow label={t("adminLiveSessions.sessionType")} value={isMeet ? t("adminLiveSessions.sessionTypeMeet") : isWebinar ? t("adminLiveSessions.sessionTypeWebinar", "Zoom Webinar") : t("adminLiveSessions.sessionTypeZoom")} />
                       <ReviewRow label={t("adminLiveSessions.topicName")} value={topicName.trim() || "—"} />
@@ -756,9 +775,10 @@ export default function CreateLiveSessionPage() {
                   onClick={() => setStepIndex((i) => Math.max(0, i - 1))}
                   disabled={stepIndex === 0}
                   sx={{
-                    px: 2.5, py: 1.1, borderRadius: 999, fontWeight: 700,
-                    color: stepIndex === 0 ? "text.disabled" : "var(--font-primary)",
-                    border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+                    px: 2.75, py: 1.15, borderRadius: "12px", fontWeight: 700, fontSize: "0.9rem",
+                    color: stepIndex === 0 ? "var(--font-tertiary)" : "var(--font-primary)",
+                    border: "1px solid var(--border-default)",
+                    "&:hover": { bgcolor: stepIndex === 0 ? "transparent" : "var(--surface)" },
                     "&:disabled": { cursor: "not-allowed" },
                   }}
                 >
@@ -769,10 +789,8 @@ export default function CreateLiveSessionPage() {
                     onClick={() => stepValid && setStepIndex((i) => i + 1)}
                     disabled={!stepValid}
                     sx={{
-                      px: 3, py: 1.2, borderRadius: 999, fontWeight: 800, color: "white", fontSize: "0.92rem",
-                      background: stepValid ? NEXT_GRADIENT : "color-mix(in srgb, #6366f1 35%, transparent)",
-                      "&:hover": { transform: stepValid ? "translateY(-1px)" : "none" },
-                      transition: "transform 120ms ease",
+                      px: 3.25, py: 1.2, borderRadius: "12px", fontWeight: 700, color: "white", fontSize: "0.9rem",
+                      background: stepValid ? "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)" : "color-mix(in srgb, #6366f1 35%, transparent)",
                       "&:disabled": { cursor: "not-allowed" },
                     }}
                   >
@@ -783,9 +801,9 @@ export default function CreateLiveSessionPage() {
                     onClick={() => void handleCreate()}
                     disabled={!detailsValid || creating}
                     sx={{
-                      px: 3, py: 1.2, borderRadius: 999, fontWeight: 800, color: "white", fontSize: "0.92rem",
+                      px: 3.25, py: 1.2, borderRadius: "12px", fontWeight: 700, color: "white", fontSize: "0.9rem",
                       display: "inline-flex", alignItems: "center", gap: 0.75,
-                      background: detailsValid && !creating ? "linear-gradient(135deg, #10b981 0%, #6366f1 100%)" : "color-mix(in srgb, #10b981 40%, transparent)",
+                      background: detailsValid && !creating ? "linear-gradient(135deg, #10b981 0%, #059669 100%)" : "color-mix(in srgb, #10b981 40%, transparent)",
                       "&:disabled": { cursor: "not-allowed" },
                     }}
                   >
@@ -796,7 +814,6 @@ export default function CreateLiveSessionPage() {
               </Box>
             )}
           </Box>
-        </AdaptiveSectionShell>
       </Container>
     </MainLayout>
   );

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -185,8 +185,8 @@ export default function AdminLiveSessionsPage() {
 
   if (loadingClientInfo) {
     return (
-      <MainLayout>
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+      <MainLayout fullWidthContent>
+        <Container maxWidth="xl" sx={{ py: 4 }}>
           <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
             <CircularProgress />
           </Box>
@@ -197,8 +197,8 @@ export default function AdminLiveSessionsPage() {
 
   if (canAccessAdmin && !hasAdminLiveSessionsFeature) {
     return (
-      <MainLayout>
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+      <MainLayout fullWidthContent>
+        <Container maxWidth="xl" sx={{ py: 4 }}>
           <AdminLiveSessionsFeatureBlocked />
         </Container>
       </MainLayout>
@@ -207,8 +207,8 @@ export default function AdminLiveSessionsPage() {
 
   if (loading && sessions.length === 0) {
     return (
-      <MainLayout>
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+      <MainLayout fullWidthContent>
+        <Container maxWidth="xl" sx={{ py: 4 }}>
           <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
             <CircularProgress />
           </Box>
@@ -225,8 +225,8 @@ export default function AdminLiveSessionsPage() {
   ];
 
   return (
-    <MainLayout>
-      <Container maxWidth="lg" sx={{ py: { xs: 3, md: 5 }, position: "relative" }}>
+    <MainLayout fullWidthContent>
+      <Container maxWidth="xl" sx={{ py: { xs: 3, md: 5 }, position: "relative" }}>
         {loading && sessions.length > 0 && (
           <LinearProgress sx={{ position: "absolute", insetInlineStart: 0, insetInlineEnd: 0, top: 0, zIndex: 1 }} />
         )}

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -67,8 +67,8 @@ export default function LiveSessionsPage() {
 
   if (loadingClientInfo || (hasLiveSessionsFeature && loading && sessions.length === 0)) {
     return (
-      <MainLayout>
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+      <MainLayout fullWidthContent>
+        <Container maxWidth="xl" sx={{ py: 4 }}>
           <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
             <CircularProgress />
           </Box>
@@ -79,8 +79,8 @@ export default function LiveSessionsPage() {
 
   if (!hasLiveSessionsFeature) {
     return (
-      <MainLayout>
-        <Container maxWidth="lg" sx={{ py: 4 }}>
+      <MainLayout fullWidthContent>
+        <Container maxWidth="xl" sx={{ py: 4 }}>
           <LiveSessionsFeatureBlocked />
         </Container>
       </MainLayout>
@@ -95,8 +95,8 @@ export default function LiveSessionsPage() {
   ];
 
   return (
-    <MainLayout>
-      <Container maxWidth="lg" sx={{ py: { xs: 3, md: 5 } }}>
+    <MainLayout fullWidthContent>
+      <Container maxWidth="xl" sx={{ py: { xs: 3, md: 5 } }}>
         <AdaptiveSectionShell meshOpacity={0.3}>
           <AdaptiveSectionHero
             chapter={t("liveSessions.chapter", "Learn · Live Sessions")}

--- a/components/admin/live-sessions/AssignMeetingDialog.tsx
+++ b/components/admin/live-sessions/AssignMeetingDialog.tsx
@@ -115,7 +115,13 @@ export function AssignMeetingDialog({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { borderRadius: "18px", border: "1px solid var(--border-default)", backgroundColor: "var(--card-bg)", backgroundImage: "none" } }}
+    >
       <DialogTitle>
         <Box
           sx={{
@@ -124,10 +130,10 @@ export function AssignMeetingDialog({
             alignItems: "center",
           }}
         >
-          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
             {t("adminLiveSessions.assignMeetingTitle", "Assign imported meeting")}
           </Typography>
-          <IconButton onClick={onClose} size="small">
+          <IconButton onClick={onClose} size="small" sx={{ color: "var(--font-secondary)" }}>
             <IconWrapper icon="mdi:close" size={20} />
           </IconButton>
         </Box>
@@ -175,14 +181,17 @@ export function AssignMeetingDialog({
         </Box>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={onClose}>{t("adminLiveSessions.cancel")}</Button>
+        <Button onClick={onClose} sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}>{t("adminLiveSessions.cancel")}</Button>
         <Button
           variant="contained"
           onClick={handleAssign}
           disabled={saving}
           sx={{
+            borderRadius: "12px",
+            textTransform: "none",
+            fontWeight: 700,
             bgcolor: "var(--accent-indigo)",
-            color: "var(--font-light)",
+            color: "#fff",
             "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
           }}
         >

--- a/components/admin/live-sessions/EditWebinarDialog.tsx
+++ b/components/admin/live-sessions/EditWebinarDialog.tsx
@@ -89,13 +89,26 @@ export function EditWebinarDialog({ activity, open, onClose, onSaved }: Props) {
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
       <DialogTitle>
         <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
             {t("adminLiveSessions.editWebinar", "Edit webinar")}
           </Typography>
-          <IconButton onClick={onClose} size="small">
+          <IconButton onClick={onClose} size="small" sx={{ color: "var(--font-secondary)" }}>
             <IconWrapper icon="mdi:close" size={20} />
           </IconButton>
         </Box>
@@ -140,12 +153,24 @@ export function EditWebinarDialog({ activity, open, onClose, onSaved }: Props) {
         </Box>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={onClose}>{t("adminLiveSessions.cancel")}</Button>
+        <Button
+          onClick={onClose}
+          sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}
+        >
+          {t("adminLiveSessions.cancel")}
+        </Button>
         <Button
           variant="contained"
           onClick={handleSave}
           disabled={saving}
-          sx={{ bgcolor: "var(--accent-indigo)", color: "var(--font-light)", "&:hover": { bgcolor: "var(--accent-indigo-dark)" } }}
+          sx={{
+            borderRadius: "12px",
+            textTransform: "none",
+            fontWeight: 700,
+            background: "var(--accent-indigo)",
+            color: "#fff",
+            "&:hover": { background: "var(--accent-indigo-dark)" },
+          }}
         >
           {saving ? <CircularProgress size={20} color="inherit" /> : t("adminLiveSessions.save", "Save")}
         </Button>

--- a/components/admin/live-sessions/GoogleCredentialsDialog.tsx
+++ b/components/admin/live-sessions/GoogleCredentialsDialog.tsx
@@ -106,13 +106,33 @@ export function GoogleCredentialsDialog({ open, creds, redirectUri, onClose, onC
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
       <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <IconWrapper icon="logos:google-meet" size={22} />
-          <span>{t("adminLiveSessions.googleSettingsTitle", "Google Meet settings")}</span>
+          <IconWrapper icon="logos:google-meet" size={22} color="var(--accent-indigo)" />
+          <span style={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
+            {t("adminLiveSessions.googleSettingsTitle", "Google Meet settings")}
+          </span>
         </Box>
-        <IconButton aria-label={t("adminLiveSessions.close", "Close")} onClick={onClose} size="small">
+        <IconButton
+          aria-label={t("adminLiveSessions.close", "Close")}
+          onClick={onClose}
+          size="small"
+          sx={{ color: "var(--font-secondary)" }}
+        >
           <IconWrapper icon="mdi:close" size={20} />
         </IconButton>
       </DialogTitle>
@@ -154,7 +174,7 @@ export function GoogleCredentialsDialog({ open, creds, redirectUri, onClose, onC
                 onClick={handleDisconnect}
                 loading={disconnecting}
                 loadingText={t("adminLiveSessions.disconnecting", "Disconnecting…")}
-                sx={{ textTransform: "none", color: "var(--error-500, #ef4444)" }}
+                sx={{ borderRadius: "12px", textTransform: "none", fontWeight: 700, color: "var(--error-500, #ef4444)" }}
               >
                 {t("adminLiveSessions.disconnect", "Disconnect")}
               </LoadingButton>
@@ -286,14 +306,26 @@ export function GoogleCredentialsDialog({ open, creds, redirectUri, onClose, onC
         </Box>
 
         <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2 }}>
-          <Button onClick={onClose}>{t("adminLiveSessions.cancel", "Cancel")}</Button>
+          <Button
+            onClick={onClose}
+            sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}
+          >
+            {t("adminLiveSessions.cancel", "Cancel")}
+          </Button>
           <LoadingButton
             variant="contained"
             onClick={handleSave}
             loading={saving}
             loadingText={t("common.saving", "Saving…")}
             startIcon={<IconWrapper icon="mdi:content-save" size={18} />}
-            sx={{ bgcolor: "var(--accent-indigo)", color: "var(--font-light)", "&:hover": { bgcolor: "var(--accent-indigo-dark)" } }}
+            sx={{
+              borderRadius: "12px",
+              textTransform: "none",
+              fontWeight: 700,
+              bgcolor: "var(--accent-indigo)",
+              color: "#fff",
+              "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+            }}
           >
             {t("adminLiveSessions.save", "Save")}
           </LoadingButton>

--- a/components/admin/live-sessions/MeetingPresetsDialog.tsx
+++ b/components/admin/live-sessions/MeetingPresetsDialog.tsx
@@ -132,13 +132,19 @@ export function MeetingPresetsDialog({ open, onClose }: MeetingPresetsDialogProp
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{ sx: { borderRadius: "18px", border: "1px solid var(--border-default)", backgroundColor: "var(--card-bg)", backgroundImage: "none" } }}
+    >
       <DialogTitle>
         <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
             {t("adminLiveSessions.presetsTitle", "Meeting presets")}
           </Typography>
-          <IconButton onClick={onClose} size="small">
+          <IconButton onClick={onClose} size="small" sx={{ color: "var(--font-secondary)" }}>
             <IconWrapper icon="mdi:close" size={20} />
           </IconButton>
         </Box>
@@ -255,14 +261,17 @@ export function MeetingPresetsDialog({ open, onClose }: MeetingPresetsDialogProp
         </Box>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={onClose}>{t("adminLiveSessions.close", "Close")}</Button>
+        <Button onClick={onClose} sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}>{t("adminLiveSessions.close", "Close")}</Button>
         <Button
           variant="contained"
           onClick={handleCreate}
           disabled={saving || !name.trim()}
           sx={{
+            borderRadius: "12px",
+            textTransform: "none",
+            fontWeight: 700,
             bgcolor: "var(--accent-indigo)",
-            color: "var(--font-light)",
+            color: "#fff",
             "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
           }}
         >

--- a/components/admin/live-sessions/VirtualBackgroundsDialog.tsx
+++ b/components/admin/live-sessions/VirtualBackgroundsDialog.tsx
@@ -91,13 +91,26 @@ export function VirtualBackgroundsDialog({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
       <DialogTitle>
         <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
             {t("adminLiveSessions.virtualBackgroundsTitle", "Virtual backgrounds")}
           </Typography>
-          <IconButton onClick={onClose} size="small">
+          <IconButton onClick={onClose} size="small" sx={{ color: "var(--font-secondary)" }}>
             <IconWrapper icon="mdi:close" size={20} />
           </IconButton>
         </Box>
@@ -163,7 +176,16 @@ export function VirtualBackgroundsDialog({
         />
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={onClose}>{t("adminLiveSessions.close", "Close")}</Button>
+        <Button
+          onClick={onClose}
+          sx={{
+            borderRadius: "12px",
+            textTransform: "none",
+            color: "var(--font-secondary)",
+          }}
+        >
+          {t("adminLiveSessions.close", "Close")}
+        </Button>
         <Button
           variant="contained"
           onClick={() => fileInputRef.current?.click()}
@@ -176,9 +198,12 @@ export function VirtualBackgroundsDialog({
             )
           }
           sx={{
-            bgcolor: "var(--accent-indigo)",
-            color: "var(--font-light)",
-            "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
+            borderRadius: "12px",
+            textTransform: "none",
+            fontWeight: 700,
+            background: "var(--accent-indigo)",
+            color: "#fff",
+            "&:hover": { background: "var(--accent-indigo-dark)" },
           }}
         >
           {t("adminLiveSessions.uploadBackground", "Upload image")}

--- a/components/admin/live-sessions/ZoomCredentialsDialog.tsx
+++ b/components/admin/live-sessions/ZoomCredentialsDialog.tsx
@@ -143,13 +143,33 @@ export function ZoomCredentialsDialog({ open, onClose }: ZoomCredentialsDialogPr
   ).trim();
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 3 } }}>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
       <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           <IconWrapper icon="mdi:video-account" size={24} color="var(--accent-indigo)" />
-          <span>{t("adminLiveSessions.zoomCredentialsTitle")}</span>
+          <span style={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
+            {t("adminLiveSessions.zoomCredentialsTitle")}
+          </span>
         </Box>
-        <IconButton aria-label={t("adminLiveSessions.close")} onClick={onClose} size="small">
+        <IconButton
+          aria-label={t("adminLiveSessions.close")}
+          onClick={onClose}
+          size="small"
+          sx={{ color: "var(--font-secondary)" }}
+        >
           <IconWrapper icon="mdi:close" size={20} />
         </IconButton>
       </DialogTitle>
@@ -305,7 +325,12 @@ export function ZoomCredentialsDialog({ open, onClose }: ZoomCredentialsDialogPr
               </Collapse>
             </Box>
             <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1 }}>
-              <Button onClick={onClose}>{t("adminLiveSessions.cancel")}</Button>
+              <Button
+                onClick={onClose}
+                sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}
+              >
+                {t("adminLiveSessions.cancel")}
+              </Button>
               <LoadingButton
                 variant="contained"
                 onClick={handleSave}
@@ -313,8 +338,11 @@ export function ZoomCredentialsDialog({ open, onClose }: ZoomCredentialsDialogPr
                 loadingText={t("common.saving")}
                 startIcon={<IconWrapper icon="mdi:content-save" size={18} />}
                 sx={{
+                  borderRadius: "12px",
+                  textTransform: "none",
+                  fontWeight: 700,
                   bgcolor: "var(--accent-indigo)",
-                  color: "var(--font-light)",
+                  color: "#fff",
                   "&:hover": { bgcolor: "var(--accent-indigo-dark)" },
                   "&.Mui-disabled": {
                     color: "var(--font-secondary)",

--- a/components/live-sessions/RecordingPlayerDialog.tsx
+++ b/components/live-sessions/RecordingPlayerDialog.tsx
@@ -69,12 +69,34 @@ export function RecordingPlayerDialog({ liveClassId, title, open, onClose }: Rec
   }, [open, liveClassId, t]);
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
       <DialogTitle sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", pr: 1 }}>
-        <Typography variant="h6" sx={{ fontWeight: 600 }} noWrap>
+        <Typography
+          variant="h6"
+          sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}
+          noWrap
+        >
           {title || t("liveSessions.recording", "Recording")}
         </Typography>
-        <IconButton onClick={onClose} size="small" aria-label={t("liveSessions.close", "Close")}>
+        <IconButton
+          onClick={onClose}
+          size="small"
+          aria-label={t("liveSessions.close", "Close")}
+          sx={{ color: "var(--font-secondary)" }}
+        >
           <IconWrapper icon="mdi:close" size={20} />
         </IconButton>
       </DialogTitle>
@@ -88,7 +110,11 @@ export function RecordingPlayerDialog({ liveClassId, title, open, onClose }: Rec
             <Typography variant="body2" sx={{ color: "var(--font-secondary)", mb: 2 }}>
               {error}
             </Typography>
-            <Button variant="outlined" onClick={onClose}>
+            <Button
+              variant="outlined"
+              onClick={onClose}
+              sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}
+            >
               {t("liveSessions.close", "Close")}
             </Button>
           </Box>

--- a/components/live-sessions/StudentSessionSummaryDialog.tsx
+++ b/components/live-sessions/StudentSessionSummaryDialog.tsx
@@ -98,8 +98,21 @@ export function StudentSessionSummaryDialog({ activityId, topicName, open: contr
       </Button>
       )}
 
-      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
-        <DialogTitle sx={{ fontWeight: 600 }}>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+        maxWidth="sm"
+        fullWidth
+        PaperProps={{
+          sx: {
+            borderRadius: "18px",
+            border: "1px solid var(--border-default)",
+            backgroundColor: "var(--card-bg)",
+            backgroundImage: "none",
+          },
+        }}
+      >
+        <DialogTitle sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
           {topicName || t("liveSessions.summaryAndTranscript", "Summary & transcript")}
         </DialogTitle>
         <DialogContent dividers>
@@ -177,7 +190,12 @@ export function StudentSessionSummaryDialog({ activityId, topicName, open: contr
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => handleClose()}>{t("liveSessions.close", "Close")}</Button>
+          <Button
+            onClick={() => handleClose()}
+            sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}
+          >
+            {t("liveSessions.close", "Close")}
+          </Button>
         </DialogActions>
       </Dialog>
     </>


### PR DESCRIPTION
Continues the live-session module redesign to match the **assessment module** (follows the card redesign #1038).

**Page width** — the content was noticeably narrow. The list, detail, and student pages now use `<MainLayout fullWidthContent>` + `Container maxWidth="xl"` (was capped at `lg`), and the create wizard widened `md → lg`. Now spans like the assessment module.

**Create wizard** — dropped the adaptive glass shell + mesh + gradient hero for a clean assessment-style header (icon + eyebrow + title + subtitle + Cancel), a token-styled stepper (indigo active/complete), a flat white step card (`--card-bg` / `--border-default` / `--radius-card`, no blur), a clean review panel, and 12px-radius nav buttons. Steps/behaviour unchanged.

**All 8 dialogs** (Assign, EditWebinar, Google/Zoom credentials, MeetingPresets, VirtualBackgrounds, RecordingPlayer, StudentSessionSummary) get the clean assessment dialog shell: 18px Paper radius + `--border-default` + `--card-bg` (no glassy `backgroundImage`), fontWeight-700 title with a token-colored close button, and 12px-radius / no-text-transform buttons (indigo primary, red destructive). Every prop, handler, i18n key, input, and the video-player / summary bodies are untouched — **styling only** (6 done via a parallel workflow, 2 by hand after a transient block).

**Verified:** `tsc --noEmit` clean, `next build` passes; dialog diffs are chrome-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
