### PR TITLE
feat(zoom): one-click Connect Zoom button + connected status

### DIFF
--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -46,6 +46,7 @@ export default function AdminLiveSessionsPage() {
   const searchParams = useSearchParams();
   const { showToast } = useToast();
   const googleRedirectHandledRef = useRef(false);
+  const zoomRedirectHandledRef = useRef(false);
   // Integrations strip: expanded when something needs the admin's attention (a failed Google
   // connect round-trip, or nothing configured yet), else collapsed so the SESSIONS are the
   // first thing on screen. DERIVED (null = auto) — a manual toggle overrides the automatics.
@@ -69,7 +70,12 @@ export default function AdminLiveSessionsPage() {
     active: false,
     webhookConfigured: false,
     webhookUrl: null,
+    oauthAvailable: false,
+    oauthConnected: false,
+    connectedEmail: null,
+    needsReconnect: false,
   });
+  const [zoomConnecting, setZoomConnecting] = useState(false);
 
   const {
     authLoading,
@@ -98,8 +104,8 @@ export default function AdminLiveSessionsPage() {
 
   const refreshZoomStatus = useCallback(() => {
     zoomService
-      .getZoomCredentials()
-      .then((data) => {
+      .getZoomStatus()
+      .then(({ credentials: data, connection, oauthAvailable }) => {
         const configured = Boolean(
           data?.account_id?.trim() && data?.zoom_client_id?.trim()
         );
@@ -109,10 +115,36 @@ export default function AdminLiveSessionsPage() {
           active: Boolean(data?.is_active),
           webhookConfigured: Boolean(data?.webhook_configured),
           webhookUrl: data?.webhook_url ?? null,
+          oauthAvailable,
+          oauthConnected: Boolean(connection?.mode === "oauth" && connection?.connected),
+          connectedEmail: connection?.connected_email ?? null,
+          needsReconnect: Boolean(connection?.needs_reconnect),
         });
       })
       .catch(() => setZoomStatus((s) => ({ ...s, loading: false })));
   }, []);
+
+  const handleZoomConnect = useCallback(async () => {
+    setZoomConnecting(true);
+    try {
+      // Bounce back to this page; the backend callback stores the refresh token.
+      const url = await zoomService.startZoomConnect("/admin/live-sessions");
+      window.location.href = url;
+    } catch {
+      setZoomConnecting(false);
+      showToast(t("adminLiveSessions.zoomConnectFailed", "Couldn't start the Zoom connection. Try again."), "error");
+    }
+  }, [showToast, t]);
+
+  const handleZoomDisconnect = useCallback(async () => {
+    try {
+      await zoomService.disconnectZoom();
+      showToast(t("adminLiveSessions.zoomDisconnected", "Zoom disconnected."), "success");
+      refreshZoomStatus();
+    } catch {
+      showToast(t("adminLiveSessions.zoomDisconnectFailed", "Couldn't disconnect Zoom."), "error");
+    }
+  }, [showToast, t, refreshZoomStatus]);
 
   // Fetch Zoom status once, to drive the integrations strip + setup card. We deliberately do NOT
   // auto-open the Zoom setup modal for unconfigured tenants — that popped up on every visit and
@@ -142,6 +174,27 @@ export default function AdminLiveSessionsPage() {
     // Strip the query params without leaving the current page.
     router.replace(window.location.pathname);
   }, [searchParams, showToast, t, router]);
+
+  // Toast the result of the Zoom "Connect" OAuth round-trip (?zoom_connected=1|0), then strip it.
+  useEffect(() => {
+    if (zoomRedirectHandledRef.current) return;
+    const flag = searchParams.get("zoom_connected");
+    if (flag == null) return;
+    zoomRedirectHandledRef.current = true;
+    if (flag === "1") {
+      showToast(t("adminLiveSessions.zoomConnectedToast", "Zoom account connected."), "success");
+      refreshZoomStatus();
+    } else {
+      const code = searchParams.get("error");
+      showToast(
+        code === "access_denied"
+          ? t("adminLiveSessions.zoomConnectDenied", "Zoom connection was cancelled.")
+          : t("adminLiveSessions.zoomConnectError", "Zoom connection failed — please try again."),
+        "error"
+      );
+    }
+    router.replace(window.location.pathname);
+  }, [searchParams, showToast, t, router, refreshZoomStatus]);
 
   const integrationsOpen =
     integrationsToggled ?? (Boolean(googleConnectError) || (zoomStatus != null && !zoomStatus.configured));
@@ -310,7 +363,13 @@ export default function AdminLiveSessionsPage() {
               </Box>
               <Collapse in={integrationsOpen} unmountOnExit={false}>
                 <Box sx={{ px: 2, pb: 2, display: "flex", flexDirection: "column", gap: 2 }}>
-                  <ZoomSetupCard status={zoomStatus} onConfigure={() => setCredentialsDialogOpen(true)} />
+                  <ZoomSetupCard
+                    status={zoomStatus}
+                    onConfigure={() => setCredentialsDialogOpen(true)}
+                    onConnect={handleZoomConnect}
+                    onDisconnect={handleZoomDisconnect}
+                    connecting={zoomConnecting}
+                  />
                   <GoogleSetupCard connectError={googleConnectError} onDismissError={() => setGoogleConnectError(null)} />
                   <ImportedMeetingsInbox
                     ref={inboxRef}

--- a/components/admin/live-sessions/ZoomSetupCard.tsx
+++ b/components/admin/live-sessions/ZoomSetupCard.tsx
@@ -7,22 +7,32 @@ import { useToast } from "@/components/common/Toast";
 
 export interface ZoomSetupStatus {
   loading: boolean;
-  configured: boolean; // account_id + client_id present
+  configured: boolean; // account_id + client_id present (S2S)
   active: boolean; // is_active toggle on
   webhookConfigured: boolean; // webhook secret saved + verified
   webhookUrl: string | null;
+  // One-click OAuth ("Connect Zoom")
+  oauthAvailable: boolean; // platform Zoom OAuth app configured on the server
+  oauthConnected: boolean; // this tenant connected via OAuth
+  connectedEmail: string | null;
+  needsReconnect: boolean;
 }
 
 interface ZoomSetupCardProps {
   status: ZoomSetupStatus;
   onConfigure: () => void;
+  /** Start the one-click OAuth connect (redirects to Zoom). */
+  onConnect?: () => void;
+  /** Disconnect the OAuth-connected Zoom account. */
+  onDisconnect?: () => void;
+  connecting?: boolean;
 }
 
 /**
  * Surfaces the Zoom connection state at the top of the admin live-sessions page so admins always
  * know what's set up and what's left — replacing the easy-to-miss header button + once-only auto-open.
  */
-export function ZoomSetupCard({ status, onConfigure }: ZoomSetupCardProps) {
+export function ZoomSetupCard({ status, onConfigure, onConnect, onDisconnect, connecting }: ZoomSetupCardProps) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
 
@@ -31,6 +41,101 @@ export function ZoomSetupCard({ status, onConfigure }: ZoomSetupCardProps) {
       <Paper elevation={0} sx={{ p: 2.25, mb: 3, borderRadius: 2, border: "1px solid var(--border-default)" }}>
         <Skeleton variant="text" width={220} height={28} />
         <Skeleton variant="text" width="60%" />
+      </Paper>
+    );
+  }
+
+  // ── One-click OAuth: connected confirmation ──────────────────────────────
+  if (status.oauthConnected && !status.needsReconnect) {
+    const accent = "var(--success-500)";
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 1.5, sm: 2 }, mb: 3, borderRadius: "18px",
+          border: `1px solid color-mix(in srgb, ${accent} 32%, var(--border-default) 68%)`,
+          bgcolor: `color-mix(in srgb, ${accent} 8%, var(--surface) 92%)`,
+          display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1.5, flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, minWidth: 0 }}>
+          <IconWrapper icon="mdi:check-decagram" size={24} color={accent} />
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+              {t("adminLiveSessions.zoomConnectedTitle", "Zoom is connected and ready")}
+            </Typography>
+            <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+              {status.connectedEmail
+                ? t("adminLiveSessions.zoomConnectedAs", "Connected as {{email}}", { email: status.connectedEmail })
+                : t("adminLiveSessions.zoomConnectedDesc", "Meetings, attendance, recordings and transcripts will sync automatically.")}
+            </Typography>
+          </Box>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          {onConnect && (
+            <Button size="small" onClick={onConnect} disabled={connecting} sx={{ textTransform: "none", borderRadius: "12px", color: "var(--font-secondary)" }}>
+              {t("adminLiveSessions.reconnectZoom", "Reconnect")}
+            </Button>
+          )}
+          {onDisconnect && (
+            <Button size="small" onClick={onDisconnect} sx={{ textTransform: "none", borderRadius: "12px", color: "var(--error-500)" }}>
+              {t("adminLiveSessions.disconnectZoom", "Disconnect")}
+            </Button>
+          )}
+        </Box>
+      </Paper>
+    );
+  }
+
+  // ── One-click OAuth: not connected (or needs reconnect) → prominent Connect button ──
+  if (status.oauthAvailable) {
+    const needs = status.needsReconnect;
+    const accent = needs ? "var(--warning-500)" : "var(--accent-indigo)";
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          p: { xs: 2, sm: 2.5 }, mb: 3, borderRadius: "18px",
+          border: `1px solid color-mix(in srgb, ${accent} 30%, var(--border-default) 70%)`,
+          bgcolor: "var(--card-bg)",
+          display: "flex", alignItems: "center", justifyContent: "space-between", gap: 2, flexWrap: "wrap",
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, minWidth: 0, flex: "1 1 320px" }}>
+          <Box sx={{ width: 44, height: 44, borderRadius: "12px", flexShrink: 0, bgcolor: `color-mix(in srgb, ${accent} 14%, var(--surface) 86%)`, display: "flex", alignItems: "center", justifyContent: "center" }}>
+            <IconWrapper icon="mdi:video-account" size={24} color={accent} />
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 700, color: "var(--font-primary)" }}>
+              {needs
+                ? t("adminLiveSessions.zoomReconnectTitle", "Reconnect your Zoom account")
+                : t("adminLiveSessions.zoomOauthTitle", "Connect Zoom in one click")}
+            </Typography>
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)", mt: 0.25 }}>
+              {needs
+                ? t("adminLiveSessions.zoomReconnectDesc", "Your Zoom authorization expired. Reconnect to keep hosting sessions.")
+                : t("adminLiveSessions.zoomOauthDesc", "Authorize once with your Zoom account — no app IDs or secrets to copy. Scheduling a session then auto-creates the Zoom meeting.")}
+            </Typography>
+          </Box>
+        </Box>
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5 }}>
+          <Button
+            variant="contained"
+            onClick={onConnect}
+            disabled={connecting}
+            startIcon={<IconWrapper icon="mdi:video-plus" size={18} color="#fff" />}
+            sx={{ textTransform: "none", fontWeight: 700, borderRadius: "12px", whiteSpace: "nowrap", bgcolor: "var(--accent-indigo)", color: "#fff", "&:hover": { bgcolor: "var(--accent-indigo-dark)" } }}
+          >
+            {connecting
+              ? t("adminLiveSessions.connecting", "Connecting…")
+              : needs
+                ? t("adminLiveSessions.reconnectZoom", "Reconnect Zoom")
+                : t("adminLiveSessions.connectZoom", "Connect Zoom")}
+          </Button>
+          <Button size="small" onClick={onConfigure} sx={{ textTransform: "none", color: "var(--font-tertiary)", fontSize: "0.75rem" }}>
+            {t("adminLiveSessions.enterCredentialsManually", "Enter credentials manually")}
+          </Button>
+        </Box>
       </Paper>
     );
   }

--- a/lib/services/zoom.service.ts
+++ b/lib/services/zoom.service.ts
@@ -17,9 +17,31 @@ export interface ZoomCredentials {
   updated_at?: string;
 }
 
+/** OAuth ("Connect Zoom") connection state, returned alongside the credentials. */
+export interface ZoomConnection {
+  mode: "s2s" | "oauth";
+  connected: boolean;
+  connected_email?: string | null;
+  connected_at?: string | null;
+  needs_reconnect?: boolean;
+}
+
 /** GET response: zoom_credentials is null when client has no config yet. */
 export interface GetZoomCredentialsResponse {
   zoom_credentials: ZoomCredentials | null;
+  zoom_connection?: ZoomConnection | null;
+  /** Whether the platform Zoom OAuth app is configured on the server (→ show the Connect button). */
+  oauth_available?: boolean;
+}
+
+export interface ZoomStatus {
+  credentials: ZoomCredentials | null;
+  connection: ZoomConnection | null;
+  oauthAvailable: boolean;
+}
+
+interface ZoomConnectResponse {
+  authorize_url: string;
 }
 
 /** PUT success response (201 create / 200 update). */
@@ -44,5 +66,35 @@ export const zoomService = {
       data
     );
     return response.data.zoom_credentials;
+  },
+
+  /** Full Zoom status: credentials + OAuth connection + whether one-click Connect is available. */
+  getZoomStatus: async (): Promise<ZoomStatus> => {
+    const response = await apiClient.get<GetZoomCredentialsResponse>(
+      `/accounts/clients/${config.clientId}/zoom-credentials/`
+    );
+    return {
+      credentials: response.data.zoom_credentials ?? null,
+      connection: response.data.zoom_connection ?? null,
+      oauthAvailable: Boolean(response.data.oauth_available),
+    };
+  },
+
+  /**
+   * Begin the one-click "Connect Zoom" consent flow. Returns the Zoom authorize URL — the caller
+   * redirects the browser to it. `returnTo` is where Zoom's callback bounces back (a relative admin
+   * path; defaults to /admin/live-sessions).
+   */
+  startZoomConnect: async (returnTo = "/admin/live-sessions"): Promise<string> => {
+    const response = await apiClient.post<ZoomConnectResponse>(
+      `/accounts/clients/${config.clientId}/zoom-credentials/connect/`,
+      { return_to: returnTo }
+    );
+    return response.data.authorize_url;
+  },
+
+  /** Disconnect Zoom (revoke + clear the stored refresh token). */
+  disconnectZoom: async (): Promise<void> => {
+    await apiClient.delete(`/accounts/clients/${config.clientId}/zoom-credentials/`);
   },
 };


### PR DESCRIPTION
Frontend for the **one-click "Connect Zoom"** flow (backend: ai-linc-backend #378). When the platform Zoom OAuth app is configured on the server, the Zoom setup card leads with a single **Connect Zoom** button instead of the manual Account ID / Client ID / Secret form.

- **Service:** `getZoomStatus()` (credentials + OAuth connection + `oauth_available`), `startZoomConnect(returnTo)` → `authorize_url`, `disconnectZoom()`.
- **ZoomSetupCard:** prominent **Connect Zoom** CTA (with a small "Enter credentials manually" fallback to the existing S2S dialog); once connected → compact **"Connected as `<email>`"** row with **Reconnect / Disconnect**; a **needs-reconnect** prompt when the authorization expired. Falls back to the existing S2S setup steps when the OAuth app isn't configured.
- **Page:** reads the connection + `oauth_available`; `handleZoomConnect` (redirects to Zoom) + `handleZoomDisconnect`; handles the `?zoom_connected=1|0` return (toast + strip param), mirroring the Google connect flow.

**Verified:** `tsc --noEmit` clean, `next build` passes. Shows only when the server has the Zoom OAuth env set, so it's safe to ship ahead of the Zoom Marketplace app being live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
