### PR TITLE
feat(cohorts): Cohort Builder admin UI

### DIFF
--- a/app/admin/cohorts/[cohortId]/loading.tsx
+++ b/app/admin/cohorts/[cohortId]/loading.tsx
@@ -1,0 +1,11 @@
+import { Box, Skeleton } from "@mui/material";
+
+export default function Loading() {
+  return (
+    <Box sx={{ maxWidth: 1400, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+      <Skeleton variant="rounded" height={120} sx={{ borderRadius: 4, mb: 2 }} />
+      <Skeleton variant="rounded" height={44} sx={{ borderRadius: 999, mb: 3, maxWidth: 420 }} />
+      <Skeleton variant="rounded" height={400} sx={{ borderRadius: 4 }} />
+    </Box>
+  );
+}

--- a/app/admin/cohorts/[cohortId]/page.tsx
+++ b/app/admin/cohorts/[cohortId]/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { Box, ButtonBase, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminCohortsService,
+  type CohortDetail,
+} from "@/lib/services/admin/admin-cohorts.service";
+import { CohortRosterTab } from "@/components/admin/cohorts/CohortRosterTab";
+import { CohortAssignmentsTab } from "@/components/admin/cohorts/CohortAssignmentsTab";
+import { CohortScheduleTab } from "@/components/admin/cohorts/CohortScheduleTab";
+
+type TabKey = "roster" | "assignments" | "schedule";
+
+const TABS: Array<[TabKey, string, string]> = [
+  ["roster", "Roster", "mdi:account-multiple"],
+  ["assignments", "Assignments", "mdi:cube-outline"],
+  ["schedule", "Schedule", "mdi:calendar-clock"],
+];
+
+const STATUS_COLOR: Record<string, string> = {
+  draft: "#94a3b8",
+  scheduled: "#6366f1",
+  active: "#10b981",
+  completed: "#0ea5e9",
+  archived: "#a1a1aa",
+};
+
+export default function AdminCohortDetailPage() {
+  const params = useParams();
+  const cohortId = Number(params.cohortId);
+  const { push } = useInstantNavigation();
+  const { showToast } = useToast();
+  const [cohort, setCohort] = useState<CohortDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<TabKey>("roster");
+
+  const load = useCallback(async () => {
+    try {
+      setCohort(await adminCohortsService.getCohort(cohortId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't load this cohort.");
+    } finally {
+      setLoading(false);
+    }
+  }, [cohortId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <MainLayout fullWidthContent>
+        <Typography sx={{ textAlign: "center", py: 8, color: "text.secondary" }}>Loading…</Typography>
+      </MainLayout>
+    );
+  }
+  if (error || !cohort) {
+    return (
+      <MainLayout fullWidthContent>
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Typography sx={{ color: "#ef4444", fontWeight: 700 }}>{error || "Not found."}</Typography>
+          <ButtonBase onClick={() => push("/admin/cohorts")} sx={{ mt: 2, fontWeight: 700, color: "#6366f1" }}>
+            ← Back to cohorts
+          </ButtonBase>
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  const color = STATUS_COLOR[cohort.status] ?? "#94a3b8";
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1400, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        {/* Header */}
+        <ButtonBase
+          onClick={() => push("/admin/cohorts")}
+          sx={{ color: "text.secondary", fontWeight: 700, mb: 1.5, fontSize: "0.85rem" }}
+        >
+          <Icon icon="mdi:arrow-left" width={16} />&nbsp;Cohorts
+        </ButtonBase>
+        <Box
+          sx={{
+            borderRadius: 4,
+            p: { xs: 2.5, md: 3 },
+            mb: 3,
+            background: "linear-gradient(135deg, color-mix(in srgb, #6366f1 12%, var(--card-bg)) 0%, var(--card-bg) 70%)",
+            border: "1px solid var(--border-default)",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+            <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.4rem", md: "1.7rem" } }}>{cohort.name}</Typography>
+            <Box
+              sx={{
+                px: 1.25,
+                py: 0.35,
+                borderRadius: 999,
+                fontSize: "0.72rem",
+                fontWeight: 800,
+                textTransform: "uppercase",
+                color,
+                bgcolor: `color-mix(in srgb, ${color} 15%, transparent)`,
+              }}
+            >
+              {cohort.status}
+            </Box>
+            {cohort.code && (
+              <Typography sx={{ fontFamily: "monospace", color: "text.secondary", fontSize: "0.85rem" }}>
+                {cohort.code}
+              </Typography>
+            )}
+          </Box>
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 3, mt: 1.5 }}>
+            <HeaderStat icon="mdi:account-multiple" value={cohort.member_count} label="members" />
+            <HeaderStat icon="mdi:cube-outline" value={cohort.artifact_count} label="assignments" />
+            <HeaderStat
+              icon="mdi:calendar-range"
+              value={`${cohort.start_date || "—"} → ${cohort.end_date || "—"}`}
+              label=""
+            />
+          </Box>
+        </Box>
+
+        {/* Tab pills */}
+        <Box sx={{ display: "flex", gap: 1, mb: 3, flexWrap: "wrap" }}>
+          {TABS.map(([key, label, icon]) => {
+            const active = tab === key;
+            return (
+              <ButtonBase
+                key={key}
+                onClick={() => setTab(key)}
+                sx={{
+                  px: 2.25,
+                  py: 1,
+                  borderRadius: 999,
+                  fontWeight: 700,
+                  fontSize: "0.88rem",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.6,
+                  color: active ? "white" : "text.secondary",
+                  background: active
+                    ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
+                    : "var(--card-bg)",
+                  border: active ? "none" : "1px solid var(--border-default)",
+                }}
+              >
+                <Icon icon={icon} width={16} />
+                {label}
+              </ButtonBase>
+            );
+          })}
+        </Box>
+
+        {tab === "roster" && <CohortRosterTab cohortId={cohort.id} onChanged={() => void load()} />}
+        {tab === "assignments" && (
+          <CohortAssignmentsTab cohortId={cohort.id} artifacts={cohort.artifacts} onChanged={() => void load()} />
+        )}
+        {tab === "schedule" && <CohortScheduleTab cohort={cohort} onSaved={() => void load()} />}
+      </Box>
+    </MainLayout>
+  );
+}
+
+function HeaderStat({ icon, value, label }: { icon: string; value: number | string; label: string }) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+      <Icon icon={icon} width={18} style={{ color: "#a855f7" }} />
+      <Typography component="span" sx={{ fontWeight: 800 }}>
+        {value}
+      </Typography>
+      {label && (
+        <Typography component="span" sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
+          {label}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/app/admin/cohorts/loading.tsx
+++ b/app/admin/cohorts/loading.tsx
@@ -1,0 +1,14 @@
+import { Box, Skeleton } from "@mui/material";
+
+export default function Loading() {
+  return (
+    <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+      <Skeleton variant="rounded" height={140} sx={{ borderRadius: 4, mb: 3 }} />
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" }, gap: 2 }}>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} variant="rounded" height={180} sx={{ borderRadius: 4 }} />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/app/admin/cohorts/page.tsx
+++ b/app/admin/cohorts/page.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import {
+  Box,
+  Button,
+  ButtonBase,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
+import { useToast } from "@/components/common/Toast";
+import { KpiRail, Reveal } from "@/components/scorecard/shared";
+import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
+import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import {
+  adminCohortsService,
+  type CohortListItem,
+  type CohortStatus,
+} from "@/lib/services/admin/admin-cohorts.service";
+
+const STATUS_COLOR: Record<CohortStatus, string> = {
+  draft: "#94a3b8",
+  scheduled: "#6366f1",
+  active: "#10b981",
+  completed: "#0ea5e9",
+  archived: "#a1a1aa",
+};
+
+const STATUS_OPTIONS: CohortStatus[] = ["draft", "scheduled", "active", "completed", "archived"];
+
+export default function AdminCohortsPage() {
+  const { push } = useInstantNavigation();
+  const { showToast } = useToast();
+  const [cohorts, setCohorts] = useState<CohortListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<CohortListItem | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setCohorts(await adminCohortsService.listCohorts());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't load cohorts.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const stats = useMemo(() => {
+    const active = cohorts.filter((c) => c.status === "active").length;
+    const members = cohorts.reduce((n, c) => n + c.member_count, 0);
+    const artifacts = cohorts.reduce((n, c) => n + c.artifact_count, 0);
+    return { total: cohorts.length, active, members, artifacts };
+  }, [cohorts]);
+
+  async function handleConfirmDelete() {
+    if (!pendingDelete) return;
+    setDeleting(true);
+    try {
+      await adminCohortsService.deleteCohort(pendingDelete.id);
+      setCohorts((prev) => prev.filter((c) => c.id !== pendingDelete.id));
+      showToast(`"${pendingDelete.name}" archived.`, "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't delete.", "error");
+    } finally {
+      setDeleting(false);
+      setPendingDelete(null);
+    }
+  }
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        <AdaptiveSectionShell>
+          <AdaptiveSectionHero
+            chapter="Manage · Cohorts"
+            title="Cohort Builder"
+            subtitle="Group students into time-boxed cohorts and map learning artifacts — adaptive courses, live-session series, assessments, mock interviews and job tracks — to the cohort. Enroll a batch once; everything you assign reaches exactly those learners."
+            icon="mdi:account-group-outline"
+            accent="indigo"
+            rightSlot={
+              <ButtonBase
+                onClick={() => setCreateOpen(true)}
+                sx={{
+                  px: 3,
+                  py: 1.4,
+                  borderRadius: 999,
+                  fontWeight: 800,
+                  color: "white",
+                  background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
+                  boxShadow: "0 18px 36px -16px rgba(168, 85, 247, 0.55)",
+                  fontSize: "0.92rem",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.75,
+                  "&:hover": { transform: "translateY(-1px)" },
+                  transition: "transform 120ms ease",
+                }}
+              >
+                <Icon icon="mdi:plus" width={18} />
+                New cohort
+              </ButtonBase>
+            }
+          />
+
+          {cohorts.length > 0 && (
+            <KpiRail
+              items={[
+                { value: stats.total, label: "Cohorts", accent: "#6366f1" },
+                { value: stats.active, label: "Active", accent: "#10b981" },
+                { value: stats.members, label: "Members", accent: "#ec4899" },
+                { value: stats.artifacts, label: "Assignments", accent: "#a855f7" },
+              ]}
+            />
+          )}
+
+          {loading && (
+            <Typography sx={{ color: "text.secondary", textAlign: "center", py: 6 }}>Loading…</Typography>
+          )}
+          {error && (
+            <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>
+          )}
+
+          {!loading && !error && cohorts.length === 0 && (
+            <Box
+              sx={{
+                p: { xs: 3, md: 5 },
+                borderRadius: 4,
+                textAlign: "center",
+                bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+                border: "1px dashed color-mix(in srgb, var(--border-default) 90%, transparent)",
+              }}
+            >
+              <Icon icon="mdi:account-group-outline" width={48} style={{ color: "#a855f7" }} />
+              <Typography sx={{ fontWeight: 800, mt: 1.5, fontSize: "1.1rem" }}>No cohorts yet.</Typography>
+              <Typography sx={{ color: "text.secondary", mt: 0.75, maxWidth: 560, mx: "auto", lineHeight: 1.5 }}>
+                Click <strong>New cohort</strong> to create a batch, then enroll students and map assessments,
+                interviews, courses and live sessions to it.
+              </Typography>
+            </Box>
+          )}
+
+          {!loading && cohorts.length > 0 && (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+                gap: 2,
+                alignItems: "stretch",
+              }}
+            >
+              {cohorts.map((cohort, idx) => (
+                <Reveal key={cohort.id} delay={Math.min(idx, 8) * 0.05}>
+                  <CohortCard
+                    cohort={cohort}
+                    onOpen={() => push(`/admin/cohorts/${cohort.id}`)}
+                    onDelete={() => setPendingDelete(cohort)}
+                  />
+                </Reveal>
+              ))}
+            </Box>
+          )}
+        </AdaptiveSectionShell>
+      </Box>
+
+      <CreateCohortDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={(c) => {
+          setCreateOpen(false);
+          push(`/admin/cohorts/${c.id}`);
+        }}
+      />
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Archive cohort"
+        message={
+          pendingDelete
+            ? `"${pendingDelete.name}" will be removed from the working set. Member and assignment history is kept — nothing is destroyed.`
+            : ""
+        }
+        confirmText={deleting ? "Archiving…" : "Archive"}
+        cancelText="Cancel"
+        confirmColor="error"
+        onConfirm={() => void handleConfirmDelete()}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </MainLayout>
+  );
+}
+
+function Metric({ icon, value, label }: { icon: string; value: number | string; label: string }) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+      <Icon icon={icon} width={16} style={{ color: "#a855f7" }} />
+      <Typography component="span" sx={{ fontWeight: 800, fontSize: "0.9rem" }}>
+        {value}
+      </Typography>
+      <Typography component="span" sx={{ color: "text.secondary", fontSize: "0.8rem" }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+function CohortCard({
+  cohort,
+  onOpen,
+  onDelete,
+}: {
+  cohort: CohortListItem;
+  onOpen: () => void;
+  onDelete: () => void;
+}) {
+  const color = STATUS_COLOR[cohort.status];
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        borderRadius: 4,
+        p: 2.5,
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "box-shadow 160ms ease, transform 160ms ease",
+        "&:hover": { boxShadow: "0 20px 40px -24px rgba(99,102,241,0.45)", transform: "translateY(-2px)" },
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1, mb: 1 }}>
+        <Box
+          sx={{
+            px: 1.25,
+            py: 0.35,
+            borderRadius: 999,
+            fontSize: "0.7rem",
+            fontWeight: 800,
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+            color,
+            bgcolor: `color-mix(in srgb, ${color} 14%, transparent)`,
+          }}
+        >
+          {cohort.status}
+        </Box>
+        <ButtonBase
+          onClick={onDelete}
+          sx={{ p: 0.5, borderRadius: 2, color: "text.secondary", "&:hover": { color: "#ef4444" } }}
+          aria-label="Archive cohort"
+        >
+          <Icon icon="mdi:archive-outline" width={18} />
+        </ButtonBase>
+      </Box>
+
+      <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3 }}>{cohort.name}</Typography>
+      {cohort.code && (
+        <Typography sx={{ color: "text.secondary", fontSize: "0.78rem", mt: 0.25, fontFamily: "monospace" }}>
+          {cohort.code}
+        </Typography>
+      )}
+
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
+        <Metric icon="mdi:account-multiple" value={cohort.member_count} label="members" />
+        <Metric icon="mdi:cube-outline" value={cohort.artifact_count} label="assignments" />
+      </Box>
+      {(cohort.start_date || cohort.end_date) && (
+        <Typography sx={{ color: "text.secondary", fontSize: "0.78rem", mt: 1 }}>
+          {cohort.start_date || "—"} → {cohort.end_date || "—"}
+        </Typography>
+      )}
+
+      <Box sx={{ flexGrow: 1 }} />
+      <Button
+        onClick={onOpen}
+        variant="outlined"
+        fullWidth
+        sx={{ mt: 2, borderRadius: 999, fontWeight: 700, textTransform: "none" }}
+      >
+        Open
+      </Button>
+    </Box>
+  );
+}
+
+function CreateCohortDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (c: CohortListItem) => void;
+}) {
+  const { showToast } = useToast();
+  const [name, setName] = useState("");
+  const [code, setCode] = useState("");
+  const [status, setStatus] = useState<CohortStatus>("draft");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setCode("");
+      setStatus("draft");
+      setStartDate("");
+      setEndDate("");
+    }
+  }, [open]);
+
+  async function submit() {
+    if (!name.trim()) {
+      showToast("Give the cohort a name.", "error");
+      return;
+    }
+    setSaving(true);
+    try {
+      const created = await adminCohortsService.createCohort({
+        name: name.trim(),
+        code: code.trim() || null,
+        status,
+        start_date: startDate || null,
+        end_date: endDate || null,
+      });
+      showToast("Cohort created.", "success");
+      onCreated(created);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't create cohort.", "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ fontWeight: 800 }}>New cohort</DialogTitle>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+        <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} autoFocus fullWidth />
+        <TextField
+          label="Code (optional)"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          helperText="A stable identifier, e.g. DS-2025-JAN"
+          fullWidth
+        />
+        <TextField
+          select
+          label="Status"
+          value={status}
+          onChange={(e) => setStatus(e.target.value as CohortStatus)}
+          fullWidth
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <TextField
+            label="Start date"
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            fullWidth
+          />
+          <TextField
+            label="End date"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            fullWidth
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} sx={{ textTransform: "none" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => void submit()}
+          disabled={saving}
+          variant="contained"
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+        >
+          {saving ? "Creating…" : "Create cohort"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/cohorts/CohortAssignmentsTab.tsx
+++ b/components/admin/cohorts/CohortAssignmentsTab.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  ButtonBase,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { config } from "@/lib/config";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminCohortsService,
+  type CohortArtifact,
+  type CohortArtifactType,
+} from "@/lib/services/admin/admin-cohorts.service";
+import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
+import { getAssessments } from "@/lib/services/admin/admin-assessment.service";
+
+const TYPE_META: Record<CohortArtifactType, { label: string; icon: string; color: string }> = {
+  adaptive_course: { label: "Adaptive course", icon: "mdi:robot-outline", color: "#6366f1" },
+  live_series: { label: "Live series", icon: "mdi:video-outline", color: "#ec4899" },
+  classic_course: { label: "Course", icon: "mdi:book-open-variant", color: "#0ea5e9" },
+  assessment: { label: "Assessment", icon: "mdi:clipboard-text-outline", color: "#a855f7" },
+  mock_interview: { label: "Mock interview", icon: "mdi:account-voice", color: "#f59e0b" },
+  job_posting: { label: "Job", icon: "mdi:briefcase-outline", color: "#10b981" },
+};
+
+const ASSIGNABLE: CohortArtifactType[] = [
+  "adaptive_course",
+  "assessment",
+  "mock_interview",
+  "live_series",
+  "classic_course",
+  "job_posting",
+];
+
+// Types with a built-in target picker; others use a numeric id field.
+const PICKER_TYPES = new Set<CohortArtifactType>(["adaptive_course", "assessment"]);
+
+export function CohortAssignmentsTab({
+  cohortId,
+  artifacts,
+  onChanged,
+}: {
+  cohortId: number;
+  artifacts: CohortArtifact[];
+  onChanged: () => void;
+}) {
+  const { showToast } = useToast();
+  const [addOpen, setAddOpen] = useState(false);
+
+  async function remove(a: CohortArtifact) {
+    if (!window.confirm("Remove this assignment from the cohort?")) return;
+    try {
+      await adminCohortsService.removeArtifact(cohortId, a.id);
+      showToast("Assignment removed.", "success");
+      onChanged();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't remove.", "error");
+    }
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>
+          Assignments <span style={{ color: "#a855f7" }}>{artifacts.length}</span>
+        </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <Button
+          onClick={() => setAddOpen(true)}
+          variant="contained"
+          startIcon={<Icon icon="mdi:plus" width={16} />}
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+        >
+          Add assignment
+        </Button>
+      </Box>
+
+      {artifacts.length === 0 && (
+        <Box sx={{ p: 4, borderRadius: 4, textAlign: "center", border: "1px dashed var(--border-default)" }}>
+          <Typography sx={{ color: "text.secondary" }}>
+            Nothing assigned yet — map an adaptive course, assessment, interview, live series or job to this cohort.
+          </Typography>
+        </Box>
+      )}
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+        {artifacts.map((a) => {
+          const meta = TYPE_META[a.artifact_type];
+          return (
+            <Box
+              key={a.id}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                px: 2,
+                py: 1.25,
+                borderRadius: 3,
+                bgcolor: "var(--card-bg)",
+                border: "1px solid var(--border-default)",
+              }}
+            >
+              <Box
+                sx={{
+                  width: 34,
+                  height: 34,
+                  borderRadius: 2,
+                  display: "grid",
+                  placeItems: "center",
+                  color: meta.color,
+                  bgcolor: `color-mix(in srgb, ${meta.color} 14%, transparent)`,
+                }}
+              >
+                <Icon icon={meta.icon} width={18} />
+              </Box>
+              <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }} noWrap>
+                  {a.target?.label || `#${a.target?.id ?? "?"}`}
+                </Typography>
+                <Typography sx={{ color: "text.secondary", fontSize: "0.78rem" }}>
+                  {meta.label} · {a.role}
+                  {a.is_required ? " · required" : ""}
+                </Typography>
+              </Box>
+              <ButtonBase
+                onClick={() => void remove(a)}
+                sx={{ p: 0.75, borderRadius: 2, color: "text.secondary", "&:hover": { color: "#ef4444" } }}
+                aria-label="Remove assignment"
+              >
+                <Icon icon="mdi:close" width={18} />
+              </ButtonBase>
+            </Box>
+          );
+        })}
+      </Box>
+
+      <AssignArtifactDialog
+        open={addOpen}
+        cohortId={cohortId}
+        onClose={() => setAddOpen(false)}
+        onAssigned={() => {
+          setAddOpen(false);
+          onChanged();
+        }}
+      />
+    </Box>
+  );
+}
+
+interface TargetOption {
+  id: number;
+  label: string;
+}
+
+function AssignArtifactDialog({
+  open,
+  cohortId,
+  onClose,
+  onAssigned,
+}: {
+  open: boolean;
+  cohortId: number;
+  onClose: () => void;
+  onAssigned: () => void;
+}) {
+  const { showToast } = useToast();
+  const [type, setType] = useState<CohortArtifactType>("assessment");
+  const [role, setRole] = useState<"primary" | "supplemental">("supplemental");
+  const [targetId, setTargetId] = useState<string>("");
+  const [options, setOptions] = useState<TargetOption[]>([]);
+  const [loadingOpts, setLoadingOpts] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setType("assessment");
+      setRole("supplemental");
+      setTargetId("");
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !PICKER_TYPES.has(type)) {
+      setOptions([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingOpts(true);
+    setTargetId("");
+    (async () => {
+      try {
+        let opts: TargetOption[] = [];
+        if (type === "adaptive_course") {
+          const courses = await adminAdaptiveCourseService.listCourses();
+          opts = courses.map((c) => ({ id: c.id, label: c.title }));
+        } else if (type === "assessment") {
+          const assessments = await getAssessments(config.clientId);
+          opts = (assessments as Array<{ id: number; title: string }>).map((a) => ({
+            id: a.id,
+            label: a.title,
+          }));
+        }
+        if (!cancelled) setOptions(opts);
+      } catch {
+        if (!cancelled) setOptions([]);
+      } finally {
+        if (!cancelled) setLoadingOpts(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [type, open]);
+
+  async function submit() {
+    const id = Number(targetId);
+    if (!id) {
+      showToast("Pick a target.", "error");
+      return;
+    }
+    setSaving(true);
+    try {
+      await adminCohortsService.assignArtifact(cohortId, {
+        artifact_type: type,
+        target_id: id,
+        role,
+      });
+      showToast("Assigned.", "success");
+      onAssigned();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't assign — already mapped, or wrong tenant.", "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const usePicker = PICKER_TYPES.has(type);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ fontWeight: 800 }}>Add assignment</DialogTitle>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
+        <TextField
+          select
+          label="Type"
+          value={type}
+          onChange={(e) => setType(e.target.value as CohortArtifactType)}
+        >
+          {ASSIGNABLE.map((t) => (
+            <MenuItem key={t} value={t}>
+              {TYPE_META[t].label}
+            </MenuItem>
+          ))}
+        </TextField>
+
+        {usePicker ? (
+          <TextField
+            select
+            label={loadingOpts ? "Loading…" : "Target"}
+            value={targetId}
+            onChange={(e) => setTargetId(e.target.value)}
+            disabled={loadingOpts}
+          >
+            {options.length === 0 && (
+              <MenuItem value="" disabled>
+                {loadingOpts ? "Loading…" : "None available"}
+              </MenuItem>
+            )}
+            {options.map((o) => (
+              <MenuItem key={o.id} value={String(o.id)}>
+                {o.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        ) : (
+          <TextField
+            label="Target id"
+            type="number"
+            value={targetId}
+            onChange={(e) => setTargetId(e.target.value)}
+            helperText={`Enter the ${TYPE_META[type].label} id (from its own admin page).`}
+          />
+        )}
+
+        <TextField
+          select
+          label="Role"
+          value={role}
+          onChange={(e) => setRole(e.target.value as "primary" | "supplemental")}
+          helperText="Primary = the batch this cohort runs. Supplemental = an additional mapped artifact."
+        >
+          <MenuItem value="supplemental">Supplemental</MenuItem>
+          <MenuItem value="primary">Primary</MenuItem>
+        </TextField>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} sx={{ textTransform: "none" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => void submit()}
+          disabled={saving}
+          variant="contained"
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+        >
+          {saving ? "Assigning…" : "Assign"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/cohorts/CohortRosterTab.tsx
+++ b/components/admin/cohorts/CohortRosterTab.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Box, Button, ButtonBase, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminCohortsService,
+  type CohortMember,
+} from "@/lib/services/admin/admin-cohorts.service";
+import { EnrollCohortStudentsDialog } from "./EnrollCohortStudentsDialog";
+
+const PAGE_SIZE = 25;
+
+export function CohortRosterTab({ cohortId, onChanged }: { cohortId: number; onChanged: () => void }) {
+  const { showToast } = useToast();
+  const [members, setMembers] = useState<CohortMember[]>([]);
+  const [count, setCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [enrollOpen, setEnrollOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await adminCohortsService.listMembers(cohortId, {
+        search: search || undefined,
+        page,
+        page_size: PAGE_SIZE,
+      });
+      setMembers(res.results);
+      setCount(res.count);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't load the roster.", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [cohortId, page, search, showToast]);
+
+  useEffect(() => {
+    const t = setTimeout(() => void load(), 300);
+    return () => clearTimeout(t);
+  }, [load]);
+
+  async function remove(m: CohortMember) {
+    if (!window.confirm(`Remove ${m.name || m.email} from this cohort?`)) return;
+    try {
+      await adminCohortsService.removeMembers(cohortId, [m.student_id]);
+      showToast("Removed.", "success");
+      void load();
+      onChanged();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't remove.", "error");
+    }
+  }
+
+  const enrolledIds = new Set(members.map((m) => m.student_id));
+  const totalPages = Math.max(1, Math.ceil(count / PAGE_SIZE));
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2, flexWrap: "wrap" }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>
+          Members <span style={{ color: "#a855f7" }}>{count}</span>
+        </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <TextField
+          placeholder="Search…"
+          value={search}
+          onChange={(e) => {
+            setPage(1);
+            setSearch(e.target.value);
+          }}
+          size="small"
+          sx={{ minWidth: 220 }}
+        />
+        <Button
+          onClick={() => setEnrollOpen(true)}
+          variant="contained"
+          startIcon={<Icon icon="mdi:account-plus" width={16} />}
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+        >
+          Enroll students
+        </Button>
+      </Box>
+
+      {loading && <Typography sx={{ color: "text.secondary", py: 4, textAlign: "center" }}>Loading…</Typography>}
+      {!loading && members.length === 0 && (
+        <Box
+          sx={{
+            p: 4,
+            borderRadius: 4,
+            textAlign: "center",
+            border: "1px dashed var(--border-default)",
+          }}
+        >
+          <Typography sx={{ color: "text.secondary" }}>
+            No members yet — click <strong>Enroll students</strong> to add a batch.
+          </Typography>
+        </Box>
+      )}
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+        {members.map((m) => (
+          <Box
+            key={m.id}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              px: 2,
+              py: 1.25,
+              borderRadius: 3,
+              bgcolor: "var(--card-bg)",
+              border: "1px solid var(--border-default)",
+            }}
+          >
+            <Box
+              sx={{
+                width: 36,
+                height: 36,
+                borderRadius: "50%",
+                display: "grid",
+                placeItems: "center",
+                fontWeight: 800,
+                fontSize: "0.85rem",
+                color: "white",
+                background: "linear-gradient(135deg, #6366f1, #a855f7)",
+              }}
+            >
+              {(m.name || m.email || "?").slice(0, 1).toUpperCase()}
+            </Box>
+            <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+              <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }} noWrap>
+                {m.name || m.email}
+              </Typography>
+              <Typography sx={{ color: "text.secondary", fontSize: "0.78rem" }} noWrap>
+                {m.email} · joined {m.enrolled_at?.slice(0, 10)} · {m.source}
+              </Typography>
+            </Box>
+            <ButtonBase
+              onClick={() => void remove(m)}
+              sx={{ p: 0.75, borderRadius: 2, color: "text.secondary", "&:hover": { color: "#ef4444" } }}
+              aria-label="Remove member"
+            >
+              <Icon icon="mdi:account-remove-outline" width={18} />
+            </ButtonBase>
+          </Box>
+        ))}
+      </Box>
+
+      {totalPages > 1 && (
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 2, mt: 2 }}>
+          <Button disabled={page <= 1} onClick={() => setPage((p) => p - 1)} sx={{ textTransform: "none" }}>
+            Prev
+          </Button>
+          <Typography sx={{ fontSize: "0.85rem", color: "text.secondary" }}>
+            {page} / {totalPages}
+          </Typography>
+          <Button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)} sx={{ textTransform: "none" }}>
+            Next
+          </Button>
+        </Box>
+      )}
+
+      <EnrollCohortStudentsDialog
+        open={enrollOpen}
+        cohortId={cohortId}
+        enrolledIds={enrolledIds}
+        onClose={() => setEnrollOpen(false)}
+        onEnrolled={() => {
+          setPage(1);
+          void load();
+          onChanged();
+        }}
+      />
+    </Box>
+  );
+}

--- a/components/admin/cohorts/CohortScheduleTab.tsx
+++ b/components/admin/cohorts/CohortScheduleTab.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, MenuItem, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminCohortsService,
+  type CohortDetail,
+  type CohortStatus,
+} from "@/lib/services/admin/admin-cohorts.service";
+
+const STATUS_OPTIONS: CohortStatus[] = ["draft", "scheduled", "active", "completed", "archived"];
+
+export function CohortScheduleTab({ cohort, onSaved }: { cohort: CohortDetail; onSaved: () => void }) {
+  const { showToast } = useToast();
+  const [status, setStatus] = useState<CohortStatus>(cohort.status);
+  const [startDate, setStartDate] = useState(cohort.start_date ?? "");
+  const [endDate, setEndDate] = useState(cohort.end_date ?? "");
+  const [timezone, setTimezone] = useState(cohort.timezone ?? "Asia/Kolkata");
+  const [stagger, setStagger] = useState(cohort.week_stagger_days ?? 7);
+  const [window, setWindow] = useState(cohort.week_window_days ?? 10);
+  const [capacity, setCapacity] = useState<string>(cohort.capacity != null ? String(cohort.capacity) : "");
+  const [saving, setSaving] = useState(false);
+
+  async function save() {
+    setSaving(true);
+    try {
+      await adminCohortsService.updateCohort(cohort.id, {
+        status,
+        start_date: startDate || null,
+        end_date: endDate || null,
+        timezone,
+        week_stagger_days: Number(stagger),
+        week_window_days: Number(window),
+        capacity: capacity.trim() === "" ? null : Number(capacity),
+      });
+      showToast("Schedule saved.", "success");
+      onSaved();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't save.", "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        borderRadius: 4,
+        p: { xs: 2.5, md: 3 },
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        maxWidth: 720,
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
+        <Icon icon="mdi:calendar-clock" width={20} style={{ color: "#a855f7" }} />
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Schedule &amp; lifecycle</Typography>
+      </Box>
+
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 2 }}>
+        <TextField
+          select
+          label="Status"
+          value={status}
+          onChange={(e) => setStatus(e.target.value as CohortStatus)}
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          label="Capacity"
+          type="number"
+          value={capacity}
+          onChange={(e) => setCapacity(e.target.value)}
+          helperText="Blank = unlimited"
+        />
+        <TextField
+          label="Start date"
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="End date"
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField label="Timezone" value={timezone} onChange={(e) => setTimezone(e.target.value)} />
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <TextField
+            label="Week stagger (days)"
+            type="number"
+            value={stagger}
+            onChange={(e) => setStagger(Number(e.target.value))}
+            fullWidth
+          />
+          <TextField
+            label="Week window (days)"
+            type="number"
+            value={window}
+            onChange={(e) => setWindow(Number(e.target.value))}
+            fullWidth
+          />
+        </Box>
+      </Box>
+
+      <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
+        <Button
+          onClick={() => void save()}
+          disabled={saving}
+          variant="contained"
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700, px: 3 }}
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/components/admin/cohorts/EnrollCohortStudentsDialog.tsx
+++ b/components/admin/cohorts/EnrollCohortStudentsDialog.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import { adminStudentService, type Student } from "@/lib/services/admin/admin-student.service";
+import { adminCohortsService } from "@/lib/services/admin/admin-cohorts.service";
+
+export function EnrollCohortStudentsDialog({
+  open,
+  cohortId,
+  enrolledIds,
+  onClose,
+  onEnrolled,
+}: {
+  open: boolean;
+  cohortId: number;
+  enrolledIds: Set<number>;
+  onClose: () => void;
+  onEnrolled: () => void;
+}) {
+  const { showToast } = useToast();
+  const [search, setSearch] = useState("");
+  const [students, setStudents] = useState<Student[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async (q: string) => {
+    setLoading(true);
+    try {
+      const res = await adminStudentService.getManageStudents({
+        search: q || undefined,
+        role: "student",
+        page: 1,
+        limit: 20,
+      });
+      setStudents(res.students);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't load students.", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelected(new Set());
+    setSearch("");
+    void load("");
+  }, [open, load]);
+
+  useEffect(() => {
+    if (!open) return;
+    const t = setTimeout(() => void load(search), 350);
+    return () => clearTimeout(t);
+  }, [search, open, load]);
+
+  function toggle(id: number) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function submit() {
+    if (selected.size === 0) return;
+    setSaving(true);
+    try {
+      const res = await adminCohortsService.enrollMembers(cohortId, Array.from(selected));
+      const parts = [`${res.succeeded} enrolled`];
+      if (res.skipped) parts.push(`${res.skipped} already in`);
+      if (res.missing?.length) parts.push(`${res.missing.length} skipped`);
+      showToast(parts.join(" · "), "success");
+      onEnrolled();
+      onClose();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't enroll.", "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ fontWeight: 800 }}>Enroll students</DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <TextField
+          placeholder="Search by name or email…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          fullWidth
+          size="small"
+          sx={{ mb: 1.5 }}
+        />
+        <Box sx={{ maxHeight: 360, overflowY: "auto", display: "flex", flexDirection: "column", gap: 0.5 }}>
+          {loading && <Typography sx={{ color: "text.secondary", py: 2, textAlign: "center" }}>Loading…</Typography>}
+          {!loading && students.length === 0 && (
+            <Typography sx={{ color: "text.secondary", py: 2, textAlign: "center" }}>No students found.</Typography>
+          )}
+          {students.map((s) => {
+            const already = enrolledIds.has(s.id);
+            return (
+              <Box
+                key={s.id}
+                onClick={() => !already && toggle(s.id)}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  px: 1,
+                  py: 0.75,
+                  borderRadius: 2,
+                  cursor: already ? "default" : "pointer",
+                  opacity: already ? 0.5 : 1,
+                  "&:hover": { bgcolor: already ? "transparent" : "color-mix(in srgb, #6366f1 8%, transparent)" },
+                }}
+              >
+                <Checkbox checked={already || selected.has(s.id)} disabled={already} size="small" />
+                <Box sx={{ minWidth: 0 }}>
+                  <Typography sx={{ fontWeight: 700, fontSize: "0.88rem" }} noWrap>
+                    {s.name || s.username || s.email}
+                  </Typography>
+                  <Typography sx={{ color: "text.secondary", fontSize: "0.78rem" }} noWrap>
+                    {s.email}
+                    {already ? " · already enrolled" : ""}
+                  </Typography>
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} sx={{ textTransform: "none" }}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => void submit()}
+          disabled={saving || selected.size === 0}
+          variant="contained"
+          startIcon={<Icon icon="mdi:account-plus" width={16} />}
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+        >
+          {saving ? "Enrolling…" : `Enroll ${selected.size || ""}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -305,6 +305,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
       icon: "mdi:robot",
       featureName: "admin_ai_course_builder",
     },
+    {
+      label: "Cohorts",
+      labelKey: "nav.adminCohorts",
+      path: "/admin/cohorts",
+      icon: "mdi:account-group",
+      featureName: "admin_cohorts",
+    },
     // {
     //   label: "Workshop Registration",
     //   path: "/admin/workshop-registration",

--- a/lib/services/admin/admin-cohorts.service.ts
+++ b/lib/services/admin/admin-cohorts.service.ts
@@ -1,0 +1,213 @@
+import apiClient from "@/lib/services/api";
+
+const BASE = "/cohort/api/admin";
+
+export type CohortStatus =
+  | "draft"
+  | "scheduled"
+  | "active"
+  | "completed"
+  | "archived";
+
+export type EnrollMode = "invite_only" | "self_serve" | "paid";
+
+export type CohortArtifactType =
+  | "adaptive_course"
+  | "live_series"
+  | "classic_course"
+  | "assessment"
+  | "mock_interview"
+  | "job_posting";
+
+export interface CohortListItem {
+  id: number;
+  name: string;
+  code: string | null;
+  status: CohortStatus;
+  start_date: string | null;
+  end_date: string | null;
+  timezone: string;
+  capacity: number | null;
+  waitlist_enabled: boolean;
+  enroll_mode: EnrollMode;
+  is_template: boolean;
+  member_count: number;
+  artifact_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CohortArtifact {
+  id: number;
+  artifact_type: CohortArtifactType;
+  target: { id: number; label: string } | null;
+  role: "primary" | "supplemental";
+  visibility: "enrolled_only" | "open_to_client";
+  is_required: boolean;
+  order: number;
+  weight: number;
+  status: "active" | "paused" | "removed";
+  visible_from: string | null;
+  available_from: string | null;
+  due_at: string | null;
+  closes_at: string | null;
+  drip_mode: string;
+  drip_offset_days: number;
+  result_release_mode: string;
+  result_release_at: string | null;
+  created_at: string;
+}
+
+export interface CohortStaffMember {
+  id: number;
+  profile: number;
+  name: string;
+  role: string;
+  can_grade: boolean;
+  can_message: boolean;
+  can_manage_roster: boolean;
+}
+
+export interface CohortDetail extends CohortListItem {
+  description: string;
+  week_stagger_days: number;
+  week_window_days: number;
+  content_locked: boolean;
+  cloned_from: number | null;
+  artifacts: CohortArtifact[];
+  staff: CohortStaffMember[];
+}
+
+export interface CohortMember {
+  id: number;
+  student_id: number;
+  name: string;
+  email: string;
+  status: string;
+  source: string;
+  wave: number | null;
+  enrolled_at: string;
+  completed_at: string | null;
+}
+
+export interface CohortMembersResponse {
+  count: number;
+  page: number;
+  page_size: number;
+  results: CohortMember[];
+}
+
+export interface EnrollActionResult {
+  succeeded: number;
+  skipped?: number;
+  failed?: Array<{ student_id: number | null; detail: string }>;
+  missing?: number[];
+  removed?: number;
+}
+
+export interface CohortWritePayload {
+  name?: string;
+  code?: string | null;
+  description?: string;
+  status?: CohortStatus;
+  start_date?: string | null;
+  end_date?: string | null;
+  timezone?: string;
+  capacity?: number | null;
+  waitlist_enabled?: boolean;
+  enroll_mode?: EnrollMode;
+  week_stagger_days?: number;
+  week_window_days?: number;
+  content_locked?: boolean;
+  is_template?: boolean;
+}
+
+export interface AssignArtifactPayload {
+  artifact_type: CohortArtifactType;
+  target_id: number;
+  role?: "primary" | "supplemental";
+  visibility?: "enrolled_only" | "open_to_client";
+  is_required?: boolean;
+  order?: number;
+  available_from?: string;
+  due_at?: string;
+  closes_at?: string;
+}
+
+export const adminCohortsService = {
+  async listCohorts(params?: { status?: CohortStatus }): Promise<CohortListItem[]> {
+    const { data } = await apiClient.get<CohortListItem[]>(`${BASE}/cohorts/`, {
+      params: params?.status ? { status: params.status } : {},
+    });
+    return data;
+  },
+
+  async getCohort(cohortId: number): Promise<CohortDetail> {
+    const { data } = await apiClient.get<CohortDetail>(`${BASE}/cohorts/${cohortId}/`);
+    return data;
+  },
+
+  async createCohort(payload: CohortWritePayload): Promise<CohortDetail> {
+    const { data } = await apiClient.post<CohortDetail>(`${BASE}/cohorts/`, payload);
+    return data;
+  },
+
+  async updateCohort(cohortId: number, payload: CohortWritePayload): Promise<CohortDetail> {
+    const { data } = await apiClient.patch<CohortDetail>(`${BASE}/cohorts/${cohortId}/`, payload);
+    return data;
+  },
+
+  async deleteCohort(cohortId: number): Promise<{ id: number; is_deleted: boolean }> {
+    const { data } = await apiClient.delete<{ id: number; is_deleted: boolean }>(
+      `${BASE}/cohorts/${cohortId}/`,
+    );
+    return data;
+  },
+
+  async listMembers(
+    cohortId: number,
+    params?: { search?: string; page?: number; page_size?: number },
+  ): Promise<CohortMembersResponse> {
+    const { data } = await apiClient.get<CohortMembersResponse>(
+      `${BASE}/cohorts/${cohortId}/members/`,
+      { params },
+    );
+    return data;
+  },
+
+  async enrollMembers(cohortId: number, studentIds: number[]): Promise<EnrollActionResult> {
+    const { data } = await apiClient.post<EnrollActionResult>(
+      `${BASE}/cohorts/${cohortId}/members/enroll/`,
+      { student_ids: studentIds },
+    );
+    return data;
+  },
+
+  async removeMembers(cohortId: number, studentIds: number[]): Promise<EnrollActionResult> {
+    const { data } = await apiClient.post<EnrollActionResult>(
+      `${BASE}/cohorts/${cohortId}/members/remove/`,
+      { student_ids: studentIds },
+    );
+    return data;
+  },
+
+  async listArtifacts(cohortId: number): Promise<CohortArtifact[]> {
+    const { data } = await apiClient.get<CohortArtifact[]>(`${BASE}/cohorts/${cohortId}/artifacts/`);
+    return data;
+  },
+
+  async assignArtifact(cohortId: number, payload: AssignArtifactPayload): Promise<CohortArtifact> {
+    const { data } = await apiClient.post<CohortArtifact>(
+      `${BASE}/cohorts/${cohortId}/artifacts/`,
+      payload,
+    );
+    return data;
+  },
+
+  async removeArtifact(cohortId: number, artifactId: number): Promise<{ id: number; status: string }> {
+    const { data } = await apiClient.delete<{ id: number; status: string }>(
+      `${BASE}/cohorts/${cohortId}/artifacts/${artifactId}/`,
+    );
+    return data;
+  },
+};


### PR DESCRIPTION
## Cohort Builder admin UI (Phase 3b → staging)

The admin surface for the new Cohort Builder, cloned from the adaptive-courses look (`AdaptiveSectionShell`/`Hero`, `KpiRail`, `Reveal`, `MainLayout`). Talks to the new `/cohort/api/admin` endpoints (shipped to BE master).

### What's here
- **Service** `admin-cohorts.service.ts` — typed: cohorts CRUD, roster (list/enroll/remove), artifacts (list/assign/remove).
- **Grid** `/admin/cohorts` — cards + KPI rail + "New cohort" dialog + archive (soft-delete).
- **Detail** `/admin/cohorts/[cohortId]` — **Roster · Assignments · Schedule** tabs.
  - **Roster** — paginated + search, "Enroll students" from the tenant directory (reuses `getManageStudents`), remove.
  - **Assignments** — list/remove + assign dialog with target pickers for **adaptive courses** & **assessments** (numeric id for the other types), primary/supplemental role.
  - **Schedule** — status / start-end dates / timezone / week calendar / capacity editor.
- **Sidebar** — new admin "Cohorts" item (`featureName: admin_cohorts`).

### Gating / rollout
Appears only for tenants with the `admin_cohorts` nav feature; the API needs `cohort_builder`. Both are off by default — nothing shows until a tenant is opted in. `tsc --noEmit` clean.

### To try on staging
Enable `admin_cohorts` + `cohort_builder` on the staging tenant, then: create a cohort → enroll a batch → assign an assessment → set a schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)