### PR TITLE
feat(cohorts): Assessment-Management UI + edit basics + bulk CSV enroll

### DIFF
--- a/app/admin/cohorts/[cohortId]/page.tsx
+++ b/app/admin/cohorts/[cohortId]/page.tsx
@@ -3,39 +3,50 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { Box, ButtonBase, Typography } from "@mui/material";
+import { Box, Button, Paper, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
 import {
+  AssessmentSectionHero,
+  AssessmentBreadcrumb,
+  SegmentedTabs,
+  type SegmentedTab,
+  StatusChip,
+  type ChipTone,
+} from "@/components/admin/assessment/shared";
+import {
   adminCohortsService,
   type CohortDetail,
+  type CohortStatus,
 } from "@/lib/services/admin/admin-cohorts.service";
 import { CohortRosterTab } from "@/components/admin/cohorts/CohortRosterTab";
 import { CohortAssignmentsTab } from "@/components/admin/cohorts/CohortAssignmentsTab";
 import { CohortScheduleTab } from "@/components/admin/cohorts/CohortScheduleTab";
+import { CohortDetailsTab } from "@/components/admin/cohorts/CohortDetailsTab";
 
-type TabKey = "roster" | "assignments" | "schedule";
+type TabKey = "roster" | "assignments" | "schedule" | "details";
 
-const TABS: Array<[TabKey, string, string]> = [
-  ["roster", "Roster", "mdi:account-multiple"],
-  ["assignments", "Assignments", "mdi:cube-outline"],
-  ["schedule", "Schedule", "mdi:calendar-clock"],
+const TABS: SegmentedTab<TabKey>[] = [
+  { value: "roster", label: "Roster", icon: "mdi:account-multiple" },
+  { value: "assignments", label: "Assignments", icon: "mdi:cube-outline" },
+  { value: "schedule", label: "Schedule", icon: "mdi:calendar-clock" },
+  { value: "details", label: "Details", icon: "mdi:card-text-outline" },
 ];
 
-const STATUS_COLOR: Record<string, string> = {
-  draft: "#94a3b8",
-  scheduled: "#6366f1",
-  active: "#10b981",
-  completed: "#0ea5e9",
-  archived: "#a1a1aa",
+const STATUS_TONE: Record<CohortStatus, ChipTone> = {
+  draft: "warning",
+  scheduled: "info",
+  active: "success",
+  completed: "info",
+  archived: "neutral",
 };
 
 export default function AdminCohortDetailPage() {
   const params = useParams();
   const cohortId = Number(params.cohortId);
   const { push } = useInstantNavigation();
-  const { showToast } = useToast();
+  const { showToast: _showToast } = useToast();
   const [cohort, setCohort] = useState<CohortDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -58,130 +69,84 @@ export default function AdminCohortDetailPage() {
   if (loading) {
     return (
       <MainLayout fullWidthContent>
-        <Typography sx={{ textAlign: "center", py: 8, color: "text.secondary" }}>Loading…</Typography>
+        <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%" }}>
+          <Typography sx={{ textAlign: "center", py: 8, color: "var(--font-tertiary)" }}>Loading…</Typography>
+        </Box>
       </MainLayout>
     );
   }
   if (error || !cohort) {
     return (
       <MainLayout fullWidthContent>
-        <Box sx={{ textAlign: "center", py: 8 }}>
-          <Typography sx={{ color: "#ef4444", fontWeight: 700 }}>{error || "Not found."}</Typography>
-          <ButtonBase onClick={() => push("/admin/cohorts")} sx={{ mt: 2, fontWeight: 700, color: "#6366f1" }}>
+        <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%", textAlign: "center" }}>
+          <Typography sx={{ color: "var(--error-500, #ea4335)", fontWeight: 700, py: 6 }}>{error || "Not found."}</Typography>
+          <Button onClick={() => push("/admin/cohorts")} sx={{ textTransform: "none" }}>
             ← Back to cohorts
-          </ButtonBase>
+          </Button>
         </Box>
       </MainLayout>
     );
   }
 
-  const color = STATUS_COLOR[cohort.status] ?? "#94a3b8";
-
   return (
     <MainLayout fullWidthContent>
-      <Box sx={{ maxWidth: 1400, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
-        {/* Header */}
-        <ButtonBase
+      <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%" }}>
+        <AssessmentBreadcrumb
+          segments={[
+            { label: "Admin", href: "/admin/dashboard" },
+            { label: "Cohorts", href: "/admin/cohorts" },
+            { label: cohort.name },
+          ]}
+        />
+        <Button
           onClick={() => push("/admin/cohorts")}
-          sx={{ color: "text.secondary", fontWeight: 700, mb: 1.5, fontSize: "0.85rem" }}
+          startIcon={<Icon icon="mdi:arrow-left" width={16} />}
+          sx={{ textTransform: "none", color: "var(--font-secondary)", mb: 1, mt: 0.5 }}
         >
-          <Icon icon="mdi:arrow-left" width={16} />&nbsp;Cohorts
-        </ButtonBase>
-        <Box
+          Back to Cohorts
+        </Button>
+
+        <AssessmentSectionHero
+          chapter={`COHORT · #${cohort.id}`}
+          title={cohort.name}
+          subtitle={
+            [cohort.code, cohort.start_date && `${cohort.start_date} → ${cohort.end_date || "—"}`]
+              .filter(Boolean)
+              .join("  ·  ") || undefined
+          }
+          accent="violet"
+          icon="mdi:account-group-outline"
+          rightSlot={
+            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+              <StatusChip label={cohort.status} tone={STATUS_TONE[cohort.status]} />
+              <StatusChip label={`${cohort.member_count} members`} tone="neutral" icon="mdi:account-multiple" />
+              <StatusChip label={`${cohort.artifact_count} assignments`} tone="ai" icon="mdi:cube-outline" />
+            </Box>
+          }
+        />
+
+        <Box sx={{ mt: 3, mb: 2.5 }}>
+          <SegmentedTabs<TabKey> tabs={TABS} value={tab} onChange={setTab} />
+        </Box>
+
+        <Paper
+          elevation={0}
           sx={{
-            borderRadius: 4,
-            p: { xs: 2.5, md: 3 },
-            mb: 3,
-            background: "linear-gradient(135deg, color-mix(in srgb, #6366f1 12%, var(--card-bg)) 0%, var(--card-bg) 70%)",
-            border: "1px solid var(--border-default)",
+            borderRadius: "16px",
+            bgcolor: "transparent",
+            ...(tab === "details" || tab === "schedule" ? {} : { p: 0 }),
           }}
         >
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
-            <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.4rem", md: "1.7rem" } }}>{cohort.name}</Typography>
-            <Box
-              sx={{
-                px: 1.25,
-                py: 0.35,
-                borderRadius: 999,
-                fontSize: "0.72rem",
-                fontWeight: 800,
-                textTransform: "uppercase",
-                color,
-                bgcolor: `color-mix(in srgb, ${color} 15%, transparent)`,
-              }}
-            >
-              {cohort.status}
-            </Box>
-            {cohort.code && (
-              <Typography sx={{ fontFamily: "monospace", color: "text.secondary", fontSize: "0.85rem" }}>
-                {cohort.code}
-              </Typography>
-            )}
-          </Box>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 3, mt: 1.5 }}>
-            <HeaderStat icon="mdi:account-multiple" value={cohort.member_count} label="members" />
-            <HeaderStat icon="mdi:cube-outline" value={cohort.artifact_count} label="assignments" />
-            <HeaderStat
-              icon="mdi:calendar-range"
-              value={`${cohort.start_date || "—"} → ${cohort.end_date || "—"}`}
-              label=""
-            />
-          </Box>
-        </Box>
-
-        {/* Tab pills */}
-        <Box sx={{ display: "flex", gap: 1, mb: 3, flexWrap: "wrap" }}>
-          {TABS.map(([key, label, icon]) => {
-            const active = tab === key;
-            return (
-              <ButtonBase
-                key={key}
-                onClick={() => setTab(key)}
-                sx={{
-                  px: 2.25,
-                  py: 1,
-                  borderRadius: 999,
-                  fontWeight: 700,
-                  fontSize: "0.88rem",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 0.6,
-                  color: active ? "white" : "text.secondary",
-                  background: active
-                    ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)"
-                    : "var(--card-bg)",
-                  border: active ? "none" : "1px solid var(--border-default)",
-                }}
-              >
-                <Icon icon={icon} width={16} />
-                {label}
-              </ButtonBase>
-            );
-          })}
-        </Box>
-
-        {tab === "roster" && <CohortRosterTab cohortId={cohort.id} onChanged={() => void load()} />}
-        {tab === "assignments" && (
-          <CohortAssignmentsTab cohortId={cohort.id} artifacts={cohort.artifacts} onChanged={() => void load()} />
-        )}
-        {tab === "schedule" && <CohortScheduleTab cohort={cohort} onSaved={() => void load()} />}
+          {tab === "roster" && (
+            <CohortRosterTab cohortId={cohort.id} cohortName={cohort.name} onChanged={() => void load()} />
+          )}
+          {tab === "assignments" && (
+            <CohortAssignmentsTab cohortId={cohort.id} artifacts={cohort.artifacts} onChanged={() => void load()} />
+          )}
+          {tab === "schedule" && <CohortScheduleTab cohort={cohort} onSaved={() => void load()} />}
+          {tab === "details" && <CohortDetailsTab cohort={cohort} onSaved={() => void load()} />}
+        </Paper>
       </Box>
     </MainLayout>
-  );
-}
-
-function HeaderStat({ icon, value, label }: { icon: string; value: number | string; label: string }) {
-  return (
-    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-      <Icon icon={icon} width={18} style={{ color: "#a855f7" }} />
-      <Typography component="span" sx={{ fontWeight: 800 }}>
-        {value}
-      </Typography>
-      {label && (
-        <Typography component="span" sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
-          {label}
-        </Typography>
-      )}
-    </Box>
   );
 }

--- a/app/admin/cohorts/page.tsx
+++ b/app/admin/cohorts/page.tsx
@@ -5,35 +5,34 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import {
   Box,
   Button,
-  ButtonBase,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   MenuItem,
   TextField,
-  Typography,
 } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useToast } from "@/components/common/Toast";
-import { KpiRail, Reveal } from "@/components/scorecard/shared";
-import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
-import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
+import {
+  AssessmentSectionHero,
+  AssessmentFilterBar,
+  AssessmentEmptyState,
+  StatStrip,
+  type StatItem,
+  SegmentedTabs,
+  type SegmentedTab,
+} from "@/components/admin/assessment/shared";
+import { CohortCard } from "@/components/admin/cohorts/CohortCard";
 import {
   adminCohortsService,
   type CohortListItem,
   type CohortStatus,
 } from "@/lib/services/admin/admin-cohorts.service";
 
-const STATUS_COLOR: Record<CohortStatus, string> = {
-  draft: "#94a3b8",
-  scheduled: "#6366f1",
-  active: "#10b981",
-  completed: "#0ea5e9",
-  archived: "#a1a1aa",
-};
+type StatusTab = "all" | CohortStatus;
 
 const STATUS_OPTIONS: CohortStatus[] = ["draft", "scheduled", "active", "completed", "archived"];
 
@@ -43,6 +42,8 @@ export default function AdminCohortsPage() {
   const [cohorts, setCohorts] = useState<CohortListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [statusTab, setStatusTab] = useState<StatusTab>("all");
+  const [search, setSearch] = useState("");
   const [pendingDelete, setPendingDelete] = useState<CohortListItem | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
@@ -61,12 +62,40 @@ export default function AdminCohortsPage() {
     void load();
   }, [load]);
 
-  const stats = useMemo(() => {
-    const active = cohorts.filter((c) => c.status === "active").length;
-    const members = cohorts.reduce((n, c) => n + c.member_count, 0);
-    const artifacts = cohorts.reduce((n, c) => n + c.artifact_count, 0);
-    return { total: cohorts.length, active, members, artifacts };
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { all: cohorts.length };
+    for (const s of STATUS_OPTIONS) c[s] = 0;
+    for (const co of cohorts) c[co.status] = (c[co.status] ?? 0) + 1;
+    return c;
   }, [cohorts]);
+
+  const stats: StatItem[] = useMemo(
+    () => [
+      { label: "Cohorts", value: cohorts.length, icon: "mdi:account-group", tone: "var(--ai-violet, #7c3aed)" },
+      { label: "Active", value: counts.active ?? 0, icon: "mdi:play-circle-outline", tone: "var(--success-500, #5fa564)" },
+      { label: "Members", value: cohorts.reduce((n, c) => n + c.member_count, 0), icon: "mdi:account-multiple", tone: "var(--ai-pink, #ec4899)" },
+      { label: "Assignments", value: cohorts.reduce((n, c) => n + c.artifact_count, 0), icon: "mdi:cube-outline", tone: "var(--accent-indigo, #6366f1)" },
+    ],
+    [cohorts, counts],
+  );
+
+  const statusTabs: SegmentedTab<StatusTab>[] = [
+    { value: "all", label: "All", count: counts.all },
+    { value: "active", label: "Active", icon: "mdi:play-circle-outline", count: counts.active },
+    { value: "scheduled", label: "Scheduled", icon: "mdi:calendar-clock", count: counts.scheduled },
+    { value: "draft", label: "Drafts", icon: "mdi:file-document-edit-outline", count: counts.draft },
+    { value: "completed", label: "Completed", icon: "mdi:check-circle-outline", count: counts.completed },
+    { value: "archived", label: "Archived", icon: "mdi:archive-outline", count: counts.archived },
+  ];
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return cohorts.filter((c) => {
+      if (statusTab !== "all" && c.status !== statusTab) return false;
+      if (q && !(c.name.toLowerCase().includes(q) || (c.code ?? "").toLowerCase().includes(q))) return false;
+      return true;
+    });
+  }, [cohorts, statusTab, search]);
 
   async function handleConfirmDelete() {
     if (!pendingDelete) return;
@@ -85,97 +114,113 @@ export default function AdminCohortsPage() {
 
   return (
     <MainLayout fullWidthContent>
-      <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
-        <AdaptiveSectionShell>
-          <AdaptiveSectionHero
-            chapter="Manage · Cohorts"
-            title="Cohort Builder"
-            subtitle="Group students into time-boxed cohorts and map learning artifacts — adaptive courses, live-session series, assessments, mock interviews and job tracks — to the cohort. Enroll a batch once; everything you assign reaches exactly those learners."
+      <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, bgcolor: "var(--canvas)", minHeight: "100%" }}>
+        <AssessmentSectionHero
+          chapter="MANAGE · COHORTS"
+          title="Cohort Builder"
+          subtitle="Group students into time-boxed cohorts and map learning artifacts — adaptive courses, live sessions, assessments, mock interviews and job tracks — to the cohort."
+          accent="violet"
+          icon="mdi:account-group-outline"
+          rightSlot={
+            <Button
+              onClick={() => setCreateOpen(true)}
+              startIcon={<Icon icon="mdi:plus" width={18} />}
+              sx={{
+                px: 2.5,
+                py: 1.1,
+                borderRadius: "999px",
+                fontWeight: 800,
+                textTransform: "none",
+                color: "#fff",
+                background: "var(--gradient-ai)",
+                boxShadow: "0 16px 32px -16px rgba(124,58,237,0.5)",
+                "&:hover": { filter: "brightness(1.05)" },
+              }}
+            >
+              New cohort
+            </Button>
+          }
+        />
+
+        {!loading && cohorts.length > 0 && (
+          <Box sx={{ mt: 3 }}>
+            <StatStrip items={stats} />
+          </Box>
+        )}
+
+        {!loading && cohorts.length > 0 && (
+          <Box sx={{ mt: 3, mb: 2 }}>
+            <SegmentedTabs<StatusTab> tabs={statusTabs} value={statusTab} onChange={setStatusTab} />
+          </Box>
+        )}
+
+        {!loading && cohorts.length > 0 && (
+          <AssessmentFilterBar
+            search={search}
+            onSearchChange={setSearch}
+            searchPlaceholder="Search cohorts by name or code…"
+          />
+        )}
+
+        {loading && (
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+              gap: 2,
+              mt: 3,
+            }}
+          >
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Box key={i} sx={{ height: 210, borderRadius: "16px", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", opacity: 0.6 }} />
+            ))}
+          </Box>
+        )}
+
+        {error && (
+          <AssessmentEmptyState icon="mdi:alert-circle-outline" title="Couldn't load cohorts" description={error} />
+        )}
+
+        {!loading && !error && cohorts.length === 0 && (
+          <AssessmentEmptyState
             icon="mdi:account-group-outline"
-            accent="indigo"
-            rightSlot={
-              <ButtonBase
+            title="No cohorts yet"
+            description="Create a batch, then enroll students and map assessments, interviews, courses and live sessions to it."
+            action={
+              <Button
                 onClick={() => setCreateOpen(true)}
-                sx={{
-                  px: 3,
-                  py: 1.4,
-                  borderRadius: 999,
-                  fontWeight: 800,
-                  color: "white",
-                  background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
-                  boxShadow: "0 18px 36px -16px rgba(168, 85, 247, 0.55)",
-                  fontSize: "0.92rem",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 0.75,
-                  "&:hover": { transform: "translateY(-1px)" },
-                  transition: "transform 120ms ease",
-                }}
+                variant="contained"
+                sx={{ textTransform: "none", borderRadius: "999px", fontWeight: 700, background: "var(--gradient-ai)" }}
               >
-                <Icon icon="mdi:plus" width={18} />
                 New cohort
-              </ButtonBase>
+              </Button>
             }
           />
+        )}
 
-          {cohorts.length > 0 && (
-            <KpiRail
-              items={[
-                { value: stats.total, label: "Cohorts", accent: "#6366f1" },
-                { value: stats.active, label: "Active", accent: "#10b981" },
-                { value: stats.members, label: "Members", accent: "#ec4899" },
-                { value: stats.artifacts, label: "Assignments", accent: "#a855f7" },
-              ]}
-            />
-          )}
+        {!loading && filtered.length > 0 && (
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+              gap: 2,
+              mt: 2.5,
+            }}
+          >
+            {filtered.map((cohort) => (
+              <CohortCard
+                key={cohort.id}
+                cohort={cohort}
+                onOpen={() => push(`/admin/cohorts/${cohort.id}`)}
+                onArchive={() => setPendingDelete(cohort)}
+              />
+            ))}
+          </Box>
+        )}
 
-          {loading && (
-            <Typography sx={{ color: "text.secondary", textAlign: "center", py: 6 }}>Loading…</Typography>
-          )}
-          {error && (
-            <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>
-          )}
-
-          {!loading && !error && cohorts.length === 0 && (
-            <Box
-              sx={{
-                p: { xs: 3, md: 5 },
-                borderRadius: 4,
-                textAlign: "center",
-                bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
-                border: "1px dashed color-mix(in srgb, var(--border-default) 90%, transparent)",
-              }}
-            >
-              <Icon icon="mdi:account-group-outline" width={48} style={{ color: "#a855f7" }} />
-              <Typography sx={{ fontWeight: 800, mt: 1.5, fontSize: "1.1rem" }}>No cohorts yet.</Typography>
-              <Typography sx={{ color: "text.secondary", mt: 0.75, maxWidth: 560, mx: "auto", lineHeight: 1.5 }}>
-                Click <strong>New cohort</strong> to create a batch, then enroll students and map assessments,
-                interviews, courses and live sessions to it.
-              </Typography>
-            </Box>
-          )}
-
-          {!loading && cohorts.length > 0 && (
-            <Box
-              sx={{
-                display: "grid",
-                gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
-                gap: 2,
-                alignItems: "stretch",
-              }}
-            >
-              {cohorts.map((cohort, idx) => (
-                <Reveal key={cohort.id} delay={Math.min(idx, 8) * 0.05}>
-                  <CohortCard
-                    cohort={cohort}
-                    onOpen={() => push(`/admin/cohorts/${cohort.id}`)}
-                    onDelete={() => setPendingDelete(cohort)}
-                  />
-                </Reveal>
-              ))}
-            </Box>
-          )}
-        </AdaptiveSectionShell>
+        {!loading && cohorts.length > 0 && filtered.length === 0 && (
+          <AssessmentEmptyState icon="mdi:filter-off-outline" title="No cohorts match" description="Try a different status filter or search." />
+        )}
       </Box>
 
       <CreateCohortDialog
@@ -192,7 +237,7 @@ export default function AdminCohortsPage() {
         title="Archive cohort"
         message={
           pendingDelete
-            ? `"${pendingDelete.name}" will be removed from the working set. Member and assignment history is kept — nothing is destroyed.`
+            ? `"${pendingDelete.name}" will be removed from the working set. Member and assignment history is kept.`
             : ""
         }
         confirmText={deleting ? "Archiving…" : "Archive"}
@@ -202,99 +247,6 @@ export default function AdminCohortsPage() {
         onCancel={() => setPendingDelete(null)}
       />
     </MainLayout>
-  );
-}
-
-function Metric({ icon, value, label }: { icon: string; value: number | string; label: string }) {
-  return (
-    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
-      <Icon icon={icon} width={16} style={{ color: "#a855f7" }} />
-      <Typography component="span" sx={{ fontWeight: 800, fontSize: "0.9rem" }}>
-        {value}
-      </Typography>
-      <Typography component="span" sx={{ color: "text.secondary", fontSize: "0.8rem" }}>
-        {label}
-      </Typography>
-    </Box>
-  );
-}
-
-function CohortCard({
-  cohort,
-  onOpen,
-  onDelete,
-}: {
-  cohort: CohortListItem;
-  onOpen: () => void;
-  onDelete: () => void;
-}) {
-  const color = STATUS_COLOR[cohort.status];
-  return (
-    <Box
-      sx={{
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        borderRadius: 4,
-        p: 2.5,
-        bgcolor: "var(--card-bg)",
-        border: "1px solid var(--border-default)",
-        transition: "box-shadow 160ms ease, transform 160ms ease",
-        "&:hover": { boxShadow: "0 20px 40px -24px rgba(99,102,241,0.45)", transform: "translateY(-2px)" },
-      }}
-    >
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1, mb: 1 }}>
-        <Box
-          sx={{
-            px: 1.25,
-            py: 0.35,
-            borderRadius: 999,
-            fontSize: "0.7rem",
-            fontWeight: 800,
-            textTransform: "uppercase",
-            letterSpacing: "0.04em",
-            color,
-            bgcolor: `color-mix(in srgb, ${color} 14%, transparent)`,
-          }}
-        >
-          {cohort.status}
-        </Box>
-        <ButtonBase
-          onClick={onDelete}
-          sx={{ p: 0.5, borderRadius: 2, color: "text.secondary", "&:hover": { color: "#ef4444" } }}
-          aria-label="Archive cohort"
-        >
-          <Icon icon="mdi:archive-outline" width={18} />
-        </ButtonBase>
-      </Box>
-
-      <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3 }}>{cohort.name}</Typography>
-      {cohort.code && (
-        <Typography sx={{ color: "text.secondary", fontSize: "0.78rem", mt: 0.25, fontFamily: "monospace" }}>
-          {cohort.code}
-        </Typography>
-      )}
-
-      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mt: 1.5 }}>
-        <Metric icon="mdi:account-multiple" value={cohort.member_count} label="members" />
-        <Metric icon="mdi:cube-outline" value={cohort.artifact_count} label="assignments" />
-      </Box>
-      {(cohort.start_date || cohort.end_date) && (
-        <Typography sx={{ color: "text.secondary", fontSize: "0.78rem", mt: 1 }}>
-          {cohort.start_date || "—"} → {cohort.end_date || "—"}
-        </Typography>
-      )}
-
-      <Box sx={{ flexGrow: 1 }} />
-      <Button
-        onClick={onOpen}
-        variant="outlined"
-        fullWidth
-        sx={{ mt: 2, borderRadius: 999, fontWeight: 700, textTransform: "none" }}
-      >
-        Open
-      </Button>
-    </Box>
   );
 }
 
@@ -350,7 +302,7 @@ function CreateCohortDialog({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={{ fontWeight: 800 }}>New cohort</DialogTitle>
+      <DialogTitle sx={{ fontWeight: 800, fontFamily: "var(--font-jakarta)" }}>New cohort</DialogTitle>
       <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
         <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} autoFocus fullWidth />
         <TextField
@@ -360,13 +312,7 @@ function CreateCohortDialog({
           helperText="A stable identifier, e.g. DS-2025-JAN"
           fullWidth
         />
-        <TextField
-          select
-          label="Status"
-          value={status}
-          onChange={(e) => setStatus(e.target.value as CohortStatus)}
-          fullWidth
-        >
+        <TextField select label="Status" value={status} onChange={(e) => setStatus(e.target.value as CohortStatus)} fullWidth>
           {STATUS_OPTIONS.map((s) => (
             <MenuItem key={s} value={s}>
               {s}
@@ -374,22 +320,8 @@ function CreateCohortDialog({
           ))}
         </TextField>
         <Box sx={{ display: "flex", gap: 2 }}>
-          <TextField
-            label="Start date"
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-            fullWidth
-          />
-          <TextField
-            label="End date"
-            type="date"
-            value={endDate}
-            onChange={(e) => setEndDate(e.target.value)}
-            InputLabelProps={{ shrink: true }}
-            fullWidth
-          />
+          <TextField label="Start date" type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} InputLabelProps={{ shrink: true }} fullWidth />
+          <TextField label="End date" type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} InputLabelProps={{ shrink: true }} fullWidth />
         </Box>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
@@ -400,7 +332,7 @@ function CreateCohortDialog({
           onClick={() => void submit()}
           disabled={saving}
           variant="contained"
-          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+          sx={{ textTransform: "none", borderRadius: "999px", fontWeight: 700, background: "var(--gradient-ai)" }}
         >
           {saving ? "Creating…" : "Create cohort"}
         </Button>

--- a/components/admin/cohorts/CohortCard.tsx
+++ b/components/admin/cohorts/CohortCard.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Box, ButtonBase, IconButton, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { CohortListItem, CohortStatus } from "@/lib/services/admin/admin-cohorts.service";
+
+const STATUS: Record<CohortStatus, { label: string; color: string; bar: string }> = {
+  draft: { label: "Draft", color: "var(--warning-500, #f59e0b)", bar: "linear-gradient(90deg, #f59e0b, #fbbf24)" },
+  scheduled: { label: "Scheduled", color: "var(--accent-indigo, #6366f1)", bar: "linear-gradient(90deg, var(--accent-indigo, #6366f1), var(--ai-violet, #7c3aed))" },
+  active: { label: "Active", color: "var(--success-500, #5fa564)", bar: "var(--gradient-ai)" },
+  completed: { label: "Completed", color: "var(--tone-proctored, #06b6d4)", bar: "linear-gradient(90deg, #06b6d4, #0ea5e9)" },
+  archived: { label: "Archived", color: "var(--font-tertiary, #6b7280)", bar: "linear-gradient(90deg, #9ca3af, #6b7280)" },
+};
+
+function MiniStat({ icon, value, label }: { icon: string; value: number | string; label: string }) {
+  return (
+    <Box sx={{ flex: 1, px: 1.5, py: 1.25, textAlign: "center" }}>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5 }}>
+        <Icon icon={icon} width={14} style={{ color: "var(--ai-violet, #7c3aed)" }} />
+        <Typography sx={{ fontFamily: "var(--font-mono)", fontWeight: 700, fontSize: "1rem", color: "var(--font-primary)" }}>
+          {value}
+        </Typography>
+      </Box>
+      <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary)", textTransform: "uppercase", letterSpacing: "0.04em", mt: 0.25 }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+export function CohortCard({
+  cohort,
+  onOpen,
+  onArchive,
+}: {
+  cohort: CohortListItem;
+  onOpen: () => void;
+  onArchive: () => void;
+}) {
+  const s = STATUS[cohort.status];
+  return (
+    <Box
+      onClick={onOpen}
+      sx={{
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        cursor: "pointer",
+        borderRadius: "16px",
+        overflow: "hidden",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+        transition: "box-shadow 180ms ease, transform 180ms ease",
+        "&:hover": {
+          boxShadow: "0 14px 32px -18px color-mix(in srgb, var(--font-primary) 40%, transparent)",
+          transform: "translateY(-2px)",
+        },
+      }}
+    >
+      <Box sx={{ height: 5, background: s.bar }} />
+      <Box sx={{ p: 2.25, display: "flex", flexDirection: "column", flexGrow: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.25 }}>
+          <Box sx={{ width: 9, height: 9, borderRadius: "50%", bgcolor: s.color }} />
+          <Typography sx={{ fontSize: "0.72rem", fontWeight: 800, letterSpacing: "0.05em", textTransform: "uppercase", color: s.color }}>
+            {s.label}
+          </Typography>
+          <Box sx={{ flexGrow: 1 }} />
+          {cohort.code && (
+            <Typography sx={{ fontFamily: "var(--font-mono)", fontSize: "0.72rem", color: "var(--font-tertiary)" }}>
+              {cohort.code}
+            </Typography>
+          )}
+          <Box onClick={(e) => e.stopPropagation()}>
+            <IconButton size="small" onClick={onArchive} aria-label="Archive cohort" sx={{ color: "var(--font-tertiary)", "&:hover": { color: "var(--error-500, #ea4335)" } }}>
+              <Icon icon="mdi:archive-outline" width={17} />
+            </IconButton>
+          </Box>
+        </Box>
+
+        <Typography sx={{ fontFamily: "var(--font-jakarta)", fontWeight: 800, fontSize: "1.15rem", lineHeight: 1.25, color: "var(--font-primary)" }}>
+          {cohort.name}
+        </Typography>
+
+        <Box sx={{ flexGrow: 1 }} />
+
+        <Box
+          sx={{
+            display: "flex",
+            mt: 2,
+            borderRadius: "12px",
+            overflow: "hidden",
+            border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+            "& > *:not(:last-child)": { borderRight: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)" },
+          }}
+        >
+          <MiniStat icon="mdi:account-multiple" value={cohort.member_count} label="Members" />
+          <MiniStat icon="mdi:cube-outline" value={cohort.artifact_count} label="Assignments" />
+          <MiniStat
+            icon="mdi:calendar-range"
+            value={cohort.start_date ? cohort.start_date.slice(5) : "—"}
+            label="Starts"
+          />
+        </Box>
+
+        <ButtonBase
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpen();
+          }}
+          sx={{
+            mt: 1.75,
+            py: 1,
+            borderRadius: "10px",
+            fontWeight: 700,
+            fontSize: "0.88rem",
+            color: "var(--ai-violet, #7c3aed)",
+            border: "1px solid color-mix(in srgb, var(--ai-violet, #7c3aed) 30%, transparent)",
+            "&:hover": { bgcolor: "color-mix(in srgb, var(--ai-violet, #7c3aed) 8%, transparent)" },
+          }}
+        >
+          Open
+        </ButtonBase>
+      </Box>
+    </Box>
+  );
+}

--- a/components/admin/cohorts/CohortDetailsTab.tsx
+++ b/components/admin/cohorts/CohortDetailsTab.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import { adminCohortsService, type CohortDetail } from "@/lib/services/admin/admin-cohorts.service";
+
+/** Edit a cohort's basic info — title, code, description. Mirrors the assessment
+ *  BasicInfoSection card look. */
+export function CohortDetailsTab({ cohort, onSaved }: { cohort: CohortDetail; onSaved: () => void }) {
+  const { showToast } = useToast();
+  const [name, setName] = useState(cohort.name);
+  const [code, setCode] = useState(cohort.code ?? "");
+  const [description, setDescription] = useState(cohort.description ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const dirty =
+    name !== cohort.name || code !== (cohort.code ?? "") || description !== (cohort.description ?? "");
+
+  async function save() {
+    if (!name.trim()) {
+      showToast("Give the cohort a name.", "error");
+      return;
+    }
+    setSaving(true);
+    try {
+      await adminCohortsService.updateCohort(cohort.id, {
+        name: name.trim(),
+        code: code.trim() || null,
+        description,
+      });
+      showToast("Saved.", "success");
+      onSaved();
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't save.", "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        maxWidth: 760,
+        borderRadius: "16px",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.05), 0 1px 3px rgba(16,24,40,0.08)",
+        p: { xs: 2.5, md: 3 },
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 2.5 }}>
+        <Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: "12px",
+            display: "grid",
+            placeItems: "center",
+            color: "var(--ai-violet, #7c3aed)",
+            bgcolor: "color-mix(in srgb, var(--ai-violet, #7c3aed) 12%, transparent)",
+          }}
+        >
+          <Icon icon="mdi:card-text-outline" width={20} />
+        </Box>
+        <Box>
+          <Typography sx={{ fontFamily: "var(--font-jakarta)", fontWeight: 800, fontSize: "1.05rem", color: "var(--font-primary)" }}>
+            Basics
+          </Typography>
+          <Typography sx={{ fontSize: "0.82rem", color: "var(--font-tertiary)" }}>
+            The cohort's name, code and description.
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2.25 }}>
+        <TextField
+          label="Cohort name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          inputProps={{ maxLength: 255 }}
+          helperText={`${name.length}/255`}
+          fullWidth
+        />
+        <TextField
+          label="Code (optional)"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          helperText="A stable identifier, e.g. DS-2025-JAN"
+          fullWidth
+        />
+        <TextField
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          multiline
+          minRows={4}
+          fullWidth
+        />
+      </Box>
+
+      <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
+        <Button
+          onClick={() => void save()}
+          disabled={saving || !dirty}
+          variant="contained"
+          sx={{ textTransform: "none", borderRadius: "999px", fontWeight: 700, px: 3, background: "var(--gradient-ai)" }}
+        >
+          {saving ? "Saving…" : "Save changes"}
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/components/admin/cohorts/CohortRosterTab.tsx
+++ b/components/admin/cohorts/CohortRosterTab.tsx
@@ -9,10 +9,19 @@ import {
   type CohortMember,
 } from "@/lib/services/admin/admin-cohorts.service";
 import { EnrollCohortStudentsDialog } from "./EnrollCohortStudentsDialog";
+import { BulkEnrollmentDialog } from "@/components/admin/manage-students/BulkEnrollmentDialog";
 
 const PAGE_SIZE = 25;
 
-export function CohortRosterTab({ cohortId, onChanged }: { cohortId: number; onChanged: () => void }) {
+export function CohortRosterTab({
+  cohortId,
+  cohortName,
+  onChanged,
+}: {
+  cohortId: number;
+  cohortName: string;
+  onChanged: () => void;
+}) {
   const { showToast } = useToast();
   const [members, setMembers] = useState<CohortMember[]>([]);
   const [count, setCount] = useState(0);
@@ -20,6 +29,7 @@ export function CohortRosterTab({ cohortId, onChanged }: { cohortId: number; onC
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [enrollOpen, setEnrollOpen] = useState(false);
+  const [bulkOpen, setBulkOpen] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -76,10 +86,18 @@ export function CohortRosterTab({ cohortId, onChanged }: { cohortId: number; onC
           sx={{ minWidth: 220 }}
         />
         <Button
+          onClick={() => setBulkOpen(true)}
+          variant="outlined"
+          startIcon={<Icon icon="mdi:upload-outline" width={16} />}
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+        >
+          Upload CSV
+        </Button>
+        <Button
           onClick={() => setEnrollOpen(true)}
           variant="contained"
           startIcon={<Icon icon="mdi:account-plus" width={16} />}
-          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700 }}
+          sx={{ textTransform: "none", borderRadius: 999, fontWeight: 700, background: "var(--gradient-ai)" }}
         >
           Enroll students
         </Button>
@@ -170,6 +188,17 @@ export function CohortRosterTab({ cohortId, onChanged }: { cohortId: number; onC
         enrolledIds={enrolledIds}
         onClose={() => setEnrollOpen(false)}
         onEnrolled={() => {
+          setPage(1);
+          void load();
+          onChanged();
+        }}
+      />
+
+      <BulkEnrollmentDialog
+        open={bulkOpen}
+        onClose={() => setBulkOpen(false)}
+        lockedCohort={{ id: cohortId, name: cohortName }}
+        onSuccess={() => {
           setPage(1);
           void load();
           onChanged();

--- a/components/admin/manage-students/BulkEnrollmentDialog.tsx
+++ b/components/admin/manage-students/BulkEnrollmentDialog.tsx
@@ -52,6 +52,9 @@ interface BulkEnrollmentDialogProps {
   /** When set, the dialog enrolls into this one adaptive course (course-builder
    *  Students tab). The course-selection step is replaced by a fixed target. */
   lockedAdaptiveCourse?: { id: number; title: string };
+  /** When set, the dialog enrolls into this one cohort (Cohort Builder Roster
+   *  tab). The course-selection step is replaced by a fixed target. */
+  lockedCohort?: { id: number; name: string };
 }
 
 export function BulkEnrollmentDialog({
@@ -59,6 +62,7 @@ export function BulkEnrollmentDialog({
   onClose,
   onSuccess,
   lockedAdaptiveCourse,
+  lockedCohort,
 }: BulkEnrollmentDialogProps) {
   const { showToast } = useToast();
   const { t } = useTranslation("common");
@@ -98,8 +102,8 @@ export function BulkEnrollmentDialog({
   }, [open]);
 
   const loadCourses = async () => {
-    // Locked mode: target course is fixed, no course lists needed.
-    if (lockedAdaptiveCourse) return;
+    // Locked mode: target course/cohort is fixed, no course lists needed.
+    if (lockedAdaptiveCourse || lockedCohort) return;
     try {
       setLoadingCourses(true);
       const raw = await adminCoursesService.getCourses();
@@ -283,6 +287,7 @@ export function BulkEnrollmentDialog({
       // has a target, so it passes.
       if (
         !lockedAdaptiveCourse &&
+        !lockedCohort &&
         selectedCourseIds.length === 0 &&
         selectedAdaptiveCourseIds.length === 0
       ) {
@@ -308,6 +313,7 @@ export function BulkEnrollmentDialog({
         students: parsedStudents,
         course_ids: courseIdsString,
         adaptive_course_ids: adaptiveIdsString,
+        cohort_ids: lockedCohort ? String(lockedCohort.id) : "",
       });
 
       setCurrentJob(job);
@@ -603,14 +609,19 @@ export function BulkEnrollmentDialog({
               {t("adminManageStudents.selectCoursesDesc")}
             </Typography>
 
-            {lockedAdaptiveCourse ? (
+            {lockedAdaptiveCourse || lockedCohort ? (
               <Box>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                   Students will be enrolled into:
                 </Typography>
                 <Chip
-                  icon={<IconWrapper icon="mdi:book-education-outline" size={16} />}
-                  label={lockedAdaptiveCourse.title}
+                  icon={
+                    <IconWrapper
+                      icon={lockedCohort ? "mdi:account-group" : "mdi:book-education-outline"}
+                      size={16}
+                    />
+                  }
+                  label={lockedCohort ? lockedCohort.name : lockedAdaptiveCourse!.title}
                   color="primary"
                 />
               </Box>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -691,7 +691,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   >
                     <SidebarNavButton
                       icon={item.icon}
-                      label={t(item.labelKey)}
+                      label={t(item.labelKey, item.label)}
                       isActive={!!isActive}
                       collapsed={collapsed}
                       rtl={rtl}

--- a/lib/services/admin/admin-student-enrollment.service.ts
+++ b/lib/services/admin/admin-student-enrollment.service.ts
@@ -70,6 +70,8 @@ export interface CreateEnrollmentJobRequest {
   course_ids?: string;
   /** Comma-separated adaptive course ids like "12,13". Optional if course_ids given. */
   adaptive_course_ids?: string;
+  /** Comma-separated cohort ids like "4,5" — enroll the CSV straight into cohorts. */
+  cohort_ids?: string;
 }
 
 /** Quick-enroll ONE student (modal). name + email required; everything else optional (courses

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -15,6 +15,7 @@
     "instructors": "المعلمون",
     "courseBuilder": "منشئ الدورات",
     "aiCourseBuilder": "منشئ الدورات بالذكاء الاصطناعي",
+    "adminCohorts": "المجموعات",
     "emails": "البريد الإلكتروني",
     "notifications": "الإشعارات",
     "adminLiveSessions": "الجلسات المباشرة",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -15,6 +15,7 @@
     "instructors": "Instructors",
     "courseBuilder": "Course Builder",
     "aiCourseBuilder": "AI Course Builder",
+    "adminCohorts": "Cohorts",
     "emails": "Emails",
     "notifications": "Notifications",
     "adminLiveSessions": "Live Sessions",


### PR DESCRIPTION
## Cohort Builder enhancements (from the first staging review)

- **Nav label fix** — the sidebar showed the raw `nav.adminCohorts`. Added the i18n key (en + ar) → "Cohorts", and made the render fall back to `item.label` so a missing key can never render raw again.
- **Grid redesign to the Assessment-Management look** — warm `--canvas`, `AssessmentSectionHero`, `StatStrip`, a `SegmentedTabs` status filter (all/active/scheduled/draft/completed/archived), `AssessmentFilterBar` search, and a new `CohortCard` (status accent bar, mono mini-stats, hover lift) matching `AssessmentCard`. Empty/filter states via `AssessmentEmptyState`.
- **Detail page redesign** — `AssessmentBreadcrumb` + `AssessmentSectionHero` (status + count chips) + `SegmentedTabs`, plus a new **Details** tab to **edit the cohort title / code / description**.
- **Bulk CSV upload into a cohort** — reuses `BulkEnrollmentDialog` with a new `lockedCohort` mode (mirrors `lockedAdaptiveCourse`); an **Upload CSV** button on the roster; `cohort_ids` threaded through the enrollment-job service. (Backend honors `cohort_ids` — ai-linc-backend #400.)

`tsc --noEmit` clean. Cohort Builder is enabled on the 23 course-builder clients, so this shows on staging for their admins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)