### PR TITLE
feat(live-sessions): cohort mapping + manual attendance roll-call

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -387,7 +387,7 @@ export default function LiveSessionDetailPage() {
               <AdaptiveSectionHero
                 chapter={t("adminLiveSessions.chapter", "Manage · Live Sessions")}
                 title={activity.topic_name || t("adminLiveSessions.untitledSession", "Untitled session")}
-                subtitle={`${formatDateTime(activity.class_datetime)} · ${activity.duration_minutes} ${t("liveSessions.minShort", "min")}${activity.course_detail?.title ? ` · ${activity.course_detail.title}` : ""}`}
+                subtitle={`${formatDateTime(activity.class_datetime)} · ${activity.duration_minutes} ${t("liveSessions.minShort", "min")}${activity.course_detail?.title ? ` · ${activity.course_detail.title}` : ""}${activity.cohort_detail?.name ? ` · 👥 ${activity.cohort_detail.name}` : ""}`}
                 accent="indigo"
                 icon={platformIcon(activity)}
                 rightSlot={headerActions}
@@ -546,7 +546,7 @@ export default function LiveSessionDetailPage() {
                 {/* Attendance (Zoom) */}
                 {tabKey === "attendance" && (
                   <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                    <SectionCard><LiveSessionRosterSection liveClassId={activity.id} /></SectionCard>
+                    <SectionCard><LiveSessionRosterSection liveClassId={activity.id} meetingStatus={activity.meeting_status ?? null} cohortName={activity.cohort_detail?.name ?? null} /></SectionCard>
                     <SectionCard><ZoomAttendanceSection liveClassId={activity.id} /></SectionCard>
                   </Box>
                 )}

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -32,6 +32,7 @@ import {
 import { RecurrenceControls } from "@/components/admin/live-sessions/RecurrenceControls";
 import { summarizeRecurrence } from "@/lib/utils/live-session-recurrence";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
+import { adminCohortsService } from "@/lib/services/admin/admin-cohorts.service";
 import { googleService } from "@/lib/services/google.service";
 import {
   getLiveSessionErrorMessage,
@@ -74,6 +75,9 @@ export default function CreateLiveSessionPage() {
   const [courseId, setCourseId] = useState<number | null>(null);
   const [courses, setCourses] = useState<{ id: number; title: string }[]>([]);
   const [loadingCourses, setLoadingCourses] = useState(false);
+  const [cohortId, setCohortId] = useState<number | null>(null);
+  const [cohorts, setCohorts] = useState<{ id: number; name: string }[]>([]);
+  const [loadingCohorts, setLoadingCohorts] = useState(false);
 
   const [presets, setPresets] = useState<MeetingPreset[]>([]);
   const [templates, setTemplates] = useState<MeetingTemplate[]>([]);
@@ -170,6 +174,21 @@ export default function CreateLiveSessionPage() {
     return () => { cancelled = true; };
   }, []);
 
+  // Load cohorts once (Cohort Builder) — a session may target a cohort instead of / with a course.
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingCohorts(true);
+    adminCohortsService
+      .listCohorts()
+      .then((list) => {
+        if (cancelled) return;
+        setCohorts(list.map((c) => ({ id: c.id, name: c.name })));
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoadingCohorts(false); });
+    return () => { cancelled = true; };
+  }, []);
+
   // Load presets + native templates for Zoom/Webinar sessions.
   useEffect(() => {
     if (isMeet) return;
@@ -259,6 +278,7 @@ export default function CreateLiveSessionPage() {
             duration_minutes: duration,
             instructor_id: getValidInstructorId(),
             course: courseId ?? undefined,
+            cohort: cohortId ?? undefined,
             join_link: meetLink.trim(),
             is_google_meet: true,
             closes_at: closesIso,
@@ -284,6 +304,7 @@ export default function CreateLiveSessionPage() {
             duration_minutes: duration,
             instructor_id: getValidInstructorId(),
             course: courseId ?? undefined,
+            cohort: cohortId ?? undefined,
             is_google_meet: true,
             google_source: "platform",
             closes_at: closesIso,
@@ -334,6 +355,7 @@ export default function CreateLiveSessionPage() {
           duration_minutes: duration,
           instructor_id: getValidInstructorId(),
           course: courseId ?? undefined,
+            cohort: cohortId ?? undefined,
           zoom_meeting_type: isWebinar ? "webinar" : "meeting",
         });
         setCreatedSession(session);
@@ -604,6 +626,20 @@ export default function CreateLiveSessionPage() {
                         <MenuItem key={c.id} value={c.id}>{c.title}</MenuItem>
                       ))}
                     </TextField>
+                    <TextField
+                      select
+                      label="Cohort (optional)"
+                      value={cohortId ?? ""}
+                      onChange={(e) => setCohortId(e.target.value === "" ? null : Number(e.target.value))}
+                      size="small" disabled={loadingCohorts}
+                      sx={{ flex: "1 1 240px" }}
+                      helperText="Map this session to a cohort — its members see it and appear on the roster."
+                    >
+                      <MenuItem value="">{t("adminLiveSessions.none")}</MenuItem>
+                      {cohorts.map((c) => (
+                        <MenuItem key={c.id} value={c.id}>{c.name}</MenuItem>
+                      ))}
+                    </TextField>
                   </Box>
                 </Box>
               )}
@@ -691,6 +727,7 @@ export default function CreateLiveSessionPage() {
                       <ReviewRow label={t("adminLiveSessions.classDateAndTime")} value={classDatetime ? new Date(classDatetime).toLocaleString() : "—"} />
                       <ReviewRow label={t("adminLiveSessions.durationMinutes")} value={`${durationMinutes} min`} />
                       {courseId != null && <ReviewRow label={t("adminLiveSessions.course")} value={courses.find((c) => c.id === courseId)?.title ?? String(courseId)} />}
+                      {cohortId != null && <ReviewRow label="Cohort" value={cohorts.find((c) => c.id === cohortId)?.name ?? String(cohortId)} />}
                       {isMeet && <ReviewRow label={t("adminLiveSessions.meetMode", "Google Meet mode")} value={isAutoMeet ? t("adminLiveSessions.meetModeAuto", "Auto-create (recommended)") : t("adminLiveSessions.meetModeManual", "Paste my own link")} />}
                       {isMeet && meetMode === "manual" && <ReviewRow label={t("adminLiveSessions.meetLink")} value={meetLink.trim() || "—"} />}
                       {!isMeet && selectedTemplateId && <ReviewRow label={t("adminLiveSessions.meetingTemplate", "Template")} value={templates.find((tp) => tp.id === selectedTemplateId)?.name ?? selectedTemplateId} />}

--- a/components/admin/live-sessions/LiveSessionRosterSection.tsx
+++ b/components/admin/live-sessions/LiveSessionRosterSection.tsx
@@ -26,18 +26,28 @@ import { useToast } from "@/components/common/Toast";
 
 interface LiveSessionRosterSectionProps {
   liveClassId: number;
+  /** From the session's meeting_status — the mark-present control only shows once ended. */
+  meetingStatus?: string | null;
+  /** When the session is mapped to a cohort, its name (shown as a label). */
+  cohortName?: string | null;
 }
 
 /**
- * Admin "who joined vs who didn't" view: enrolled roster joined against synced Zoom participants
- * (matched by email), plus unmatched guests. Complements ZoomAttendanceSection (raw participant list).
+ * Admin "who joined vs who didn't" view: the roster (course-enrolled OR cohort members) joined
+ * against synced Zoom participants (matched by email), plus unmatched guests. After the session
+ * ends, staff can manually mark a student present (e.g. joined by phone) — those show as "Manual".
  */
-export function LiveSessionRosterSection({ liveClassId }: LiveSessionRosterSectionProps) {
+export function LiveSessionRosterSection({
+  liveClassId,
+  meetingStatus = null,
+  cohortName = null,
+}: LiveSessionRosterSectionProps) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [data, setData] = useState<LiveSessionRosterResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
+  const [markingId, setMarkingId] = useState<number | null>(null);
 
   const fetchRoster = useCallback(async () => {
     try {
@@ -68,6 +78,18 @@ export function LiveSessionRosterSection({ liveClassId }: LiveSessionRosterSecti
     }
   }, [liveClassId, showToast, t, fetchRoster]);
 
+  const handleMark = useCallback(async (studentId: number, present: boolean) => {
+    try {
+      setMarkingId(studentId);
+      await adminLiveActivitiesService.markAttendance(liveClassId, { student_id: studentId, present });
+      await fetchRoster();
+    } catch {
+      showToast("Could not update attendance", "error");
+    } finally {
+      setMarkingId(null);
+    }
+  }, [liveClassId, fetchRoster, showToast]);
+
   useEffect(() => {
     fetchRoster();
   }, [fetchRoster]);
@@ -87,7 +109,7 @@ export function LiveSessionRosterSection({ liveClassId }: LiveSessionRosterSecti
           {t("adminLiveSessions.rosterTitle", "Attendance roster")}
         </Typography>
         <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-          {t("adminLiveSessions.rosterNoCourse", "Tag this session to a course to see who joined and who missed it.")}
+          {t("adminLiveSessions.rosterNoCourse", "Tag this session to a course or cohort to see who joined and who missed it.")}
         </Typography>
       </Box>
     );
@@ -97,13 +119,30 @@ export function LiveSessionRosterSection({ liveClassId }: LiveSessionRosterSecti
   const students = [...data.students].sort(
     (a, b) => Number(b.attended) - Number(a.attended)
   );
+  // Manual "mark present" is only offered once the session has ended (a roll call after the fact).
+  const sessionEnded =
+    meetingStatus === "ended" || meetingStatus === "expired" || Boolean(data.session_ended);
 
   return (
     <Box sx={{ mb: 3 }}>
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
-          {t("adminLiveSessions.rosterTitle", "Attendance roster")}
-        </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1, gap: 1, flexWrap: "wrap" }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
+            {t("adminLiveSessions.rosterTitle", "Attendance roster")}
+          </Typography>
+          {cohortName && (
+            <Chip
+              icon={<IconWrapper icon="mdi:account-group" size={13} />}
+              label={cohortName}
+              size="small"
+              sx={{
+                fontWeight: 700, fontSize: "0.72rem",
+                bgcolor: "color-mix(in srgb, var(--ai-violet, #7c3aed) 14%, transparent)",
+                color: "var(--ai-violet, #7c3aed)",
+              }}
+            />
+          )}
+        </Box>
         <Chip
           label={t("adminLiveSessions.rosterJoinedOfEnrolled", "{{joined}} of {{enrolled}} joined", {
             joined: data.joined_count,
@@ -161,10 +200,10 @@ export function LiveSessionRosterSection({ liveClassId }: LiveSessionRosterSecti
           <Table size="small" sx={{ tableLayout: "fixed", width: "100%" }}>
             <TableHead>
               <TableRow sx={{ bgcolor: "var(--surface)" }}>
-                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "34%" }}>{t("adminLiveSessions.name", "Name")}</TableCell>
-                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "32%" }}>{t("adminLiveSessions.email", "Email")}</TableCell>
-                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "18%" }}>{t("adminLiveSessions.status", "Status")}</TableCell>
-                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "16%" }}>{t("adminLiveSessions.duration", "Duration")}</TableCell>
+                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "26%" }}>{t("adminLiveSessions.name", "Name")}</TableCell>
+                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "26%" }}>{t("adminLiveSessions.email", "Email")}</TableCell>
+                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "34%" }}>{t("adminLiveSessions.status", "Status")}</TableCell>
+                <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "14%" }}>{t("adminLiveSessions.duration", "Duration")}</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -183,30 +222,59 @@ export function LiveSessionRosterSection({ liveClassId }: LiveSessionRosterSecti
                     {s.email}
                   </TableCell>
                   <TableCell sx={{ ...tableCellSx }}>
-                    {(() => {
-                      // "Missed" only once the session has actually ended. Before that a non-attendee
-                      // is Upcoming (not started) or Not joined yet (live) — never "missed".
-                      const st = s.attended
-                        ? { label: t("adminLiveSessions.attended", "Joined"), color: "var(--success-500)" }
-                        : data.session_ended
-                          ? { label: t("adminLiveSessions.missed", "Missed"), color: "var(--warning-500)" }
-                          : data.session_started
-                            ? { label: t("adminLiveSessions.notJoinedYet", "Not joined yet"), color: "var(--font-secondary)" }
-                            : { label: t("adminLiveSessions.upcoming", "Not started"), color: "var(--font-secondary)" };
-                      return (
-                        <Chip
-                          label={st.label}
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
+                      {(() => {
+                        // "Missed" only once the session has actually ended. Before that a non-attendee
+                        // is Upcoming (not started) or Not joined yet (live) — never "missed".
+                        const st = s.attended
+                          ? {
+                              label: s.manual
+                                ? t("adminLiveSessions.presentManual", "Present (manual)")
+                                : t("adminLiveSessions.attended", "Joined"),
+                              color: "var(--success-500)",
+                            }
+                          : data.session_ended
+                            ? { label: t("adminLiveSessions.missed", "Missed"), color: "var(--warning-500)" }
+                            : data.session_started
+                              ? { label: t("adminLiveSessions.notJoinedYet", "Not joined yet"), color: "var(--font-secondary)" }
+                              : { label: t("adminLiveSessions.upcoming", "Not started"), color: "var(--font-secondary)" };
+                        return (
+                          <Chip
+                            label={st.label}
+                            size="small"
+                            sx={{
+                              height: 20,
+                              fontSize: "0.7rem",
+                              fontWeight: 600,
+                              bgcolor: `color-mix(in srgb, ${st.color} 16%, transparent)`,
+                              color: st.color,
+                            }}
+                          />
+                        );
+                      })()}
+                      {/* After the session ends, staff can mark a non-attendee present, or undo a manual mark. */}
+                      {sessionEnded && !s.attended && (
+                        <Button
                           size="small"
-                          sx={{
-                            height: 20,
-                            fontSize: "0.7rem",
-                            fontWeight: 600,
-                            bgcolor: `color-mix(in srgb, ${st.color} 16%, transparent)`,
-                            color: st.color,
-                          }}
-                        />
-                      );
-                    })()}
+                          disabled={markingId === s.user_profile_id}
+                          onClick={() => void handleMark(s.user_profile_id, true)}
+                          sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.65rem", textTransform: "none", fontWeight: 700 }}
+                        >
+                          {t("adminLiveSessions.markPresent", "Mark present")}
+                        </Button>
+                      )}
+                      {sessionEnded && s.attended && s.manual && (
+                        <Button
+                          size="small"
+                          color="inherit"
+                          disabled={markingId === s.user_profile_id}
+                          onClick={() => void handleMark(s.user_profile_id, false)}
+                          sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.65rem", textTransform: "none", color: "var(--font-secondary)" }}
+                        >
+                          {t("adminLiveSessions.undo", "Undo")}
+                        </Button>
+                      )}
+                    </Box>
                   </TableCell>
                   <TableCell sx={{ ...tableCellSx }}>
                     {s.attended ? formatDurationSeconds(s.duration_seconds) : "—"}

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -96,6 +96,8 @@ export interface LiveActivity {
   zoom_participants?: ZoomParticipant[];
   course?: number | null;
   course_detail?: CourseDetail | null;
+  cohort?: number | null;
+  cohort_detail?: { id: number; name: string; status: string } | null;
   attendance_count?: number;
   zoom_attendance_synced_at?: string | null;
   zoom_transcript_synced_at?: string | null;
@@ -109,6 +111,8 @@ export interface RosterStudent {
   name: string;
   email: string;
   attended: boolean;
+  /** True when attendance came ONLY from an admin's manual "present" mark (no Zoom join). */
+  manual?: boolean;
   duration_seconds: number;
   join_time: string | null;
   leave_time: string | null;
@@ -402,6 +406,7 @@ export interface WebinarEditInput {
 /** Payload to assign an imported (unassigned) meeting to a course/instructor. */
 export interface AssignMeetingInput {
   course_id?: number | null;
+  cohort_id?: number | null;
   instructor?: string;
   topic_name?: string;
 }
@@ -548,6 +553,19 @@ export const adminLiveActivitiesService = {
   ): Promise<LiveSessionRosterResponse> => {
     const response = await apiClient.get<LiveSessionRosterResponse>(
       `${BASE}/live-activities/${liveClassId}/zoom/roster/`
+    );
+    return response.data;
+  },
+
+  /** Staff manually mark a roster student present (or clear it) for the session,
+   *  or one occurrence of a recurring series. */
+  markAttendance: async (
+    liveClassId: number,
+    input: { student_id: number; occurrence_id?: number; present: boolean }
+  ): Promise<ZoomApiResponse<unknown>> => {
+    const response = await apiClient.post<ZoomApiResponse<unknown>>(
+      `${BASE}/live-activities/${liveClassId}/attendance/mark/`,
+      input
     );
     return response.data;
   },

--- a/lib/services/live-class.service.ts
+++ b/lib/services/live-class.service.ts
@@ -19,6 +19,8 @@ export interface LiveClassSession {
   closes_at?: string | null;
   course?: number | null;
   course_detail?: { id: number; title: string; slug: string } | null;
+  cohort?: number | null;
+  cohort_detail?: { id: number; name: string; status: string } | null;
 }
 
 export interface CreateLiveClassSessionPayload {
@@ -29,6 +31,7 @@ export interface CreateLiveClassSessionPayload {
   instructor_id?: number;
   instructor?: number;
   course?: number | null;
+  cohort?: number | null;
   join_link?: string;
   is_google_meet?: boolean;
   google_source?: "platform" | "manual";
@@ -44,6 +47,7 @@ export interface UpdateLiveClassSessionPayload {
   meeting_link?: string;
   status?: string;
   course?: number | null;
+  cohort?: number | null;
 }
 
 export const liveClassService = {


### PR DESCRIPTION
## Cohort ↔ live-session integration (FE) — backend: ai-linc-backend #402

- **Wizard**: a "Cohort (optional)" selector alongside the course one (fetches `adminCohortsService.listCohorts()`); the cohort is sent on all three `createSession` payloads + shown in Review.
- **Detail page**: the cohort name shows in the header; the roster gets `meeting_status` + cohort name.
- **Roster / attendance**: a cohort chip; each row shows **"Present (manual)"** when marked by hand, and — once the session has **ended** — staff get a **"Mark present"** action (or "Undo" for a manual mark). Cohort members appear on the roster even with no course tag (union roster).
- Services carry `cohort`/`cohort_detail`/`manual` + a new `markAttendance(...)`.

`tsc --noEmit` clean. Enabled on the 23 course-builder clients already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)