### PR TITLE
feat(live-sessions): manual/configurable email trigger panel

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -39,6 +39,7 @@ import {
   PlatformChip,
 } from "@/components/live-sessions/ui/LiveSessionUI";
 import { LiveSessionRosterSection } from "@/components/admin/live-sessions/LiveSessionRosterSection";
+import { LiveSessionEmailPanel } from "@/components/admin/live-sessions/LiveSessionEmailPanel";
 import { LiveSessionOccurrenceTimeline } from "@/components/admin/live-sessions/LiveSessionOccurrenceTimeline";
 import { ZoomAttendanceSection } from "@/components/admin/live-sessions/ZoomAttendanceSection";
 import { GoogleMeetParticipantsSection } from "@/components/admin/live-sessions/GoogleMeetParticipantsSection";
@@ -546,6 +547,7 @@ export default function LiveSessionDetailPage() {
                 {/* Attendance (Zoom) */}
                 {tabKey === "attendance" && (
                   <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                    <SectionCard><LiveSessionEmailPanel liveClassId={activity.id} /></SectionCard>
                     <SectionCard><LiveSessionRosterSection liveClassId={activity.id} meetingStatus={activity.meeting_status ?? null} cohortName={activity.cohort_detail?.name ?? null} /></SectionCard>
                     <SectionCard><ZoomAttendanceSection liveClassId={activity.id} /></SectionCard>
                   </Box>

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -547,7 +547,7 @@ export default function LiveSessionDetailPage() {
                 {/* Attendance (Zoom) */}
                 {tabKey === "attendance" && (
                   <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                    <SectionCard><LiveSessionEmailPanel liveClassId={activity.id} /></SectionCard>
+                    <SectionCard><LiveSessionEmailPanel liveClassId={activity.id} meetingStatus={activity.meeting_status ?? null} /></SectionCard>
                     <SectionCard><LiveSessionRosterSection liveClassId={activity.id} meetingStatus={activity.meeting_status ?? null} cohortName={activity.cohort_detail?.name ?? null} /></SectionCard>
                     <SectionCard><ZoomAttendanceSection liveClassId={activity.id} /></SectionCard>
                   </Box>
@@ -565,7 +565,10 @@ export default function LiveSessionDetailPage() {
 
                 {/* Participants (Google Meet) — synced post-meeting from the Meet REST API */}
                 {tabKey === "participants" && (
-                  <SectionCard><GoogleMeetParticipantsSection liveClassId={activity.id} /></SectionCard>
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                    <SectionCard><LiveSessionEmailPanel liveClassId={activity.id} meetingStatus={activity.meeting_status ?? null} /></SectionCard>
+                    <SectionCard><GoogleMeetParticipantsSection liveClassId={activity.id} /></SectionCard>
+                  </Box>
                 )}
 
                 {/* Recording */}

--- a/components/admin/live-sessions/LiveSessionEmailPanel.tsx
+++ b/components/admin/live-sessions/LiveSessionEmailPanel.tsx
@@ -33,14 +33,30 @@ function fmt(iso: string | null): string {
   });
 }
 
+/** Local `datetime-local` value (YYYY-MM-DDTHH:mm) for ~1 min from now, in the admin's own tz —
+ *  used as the picker's `min` so a past time (which the sweeper would fire immediately) can't be set. */
+function localMin(): string {
+  const d = new Date(Date.now() + 60_000);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 /** Manual/configurable live-session emails: an auto-reminders opt-in toggle, a "Send now" +
  *  schedule-a-time trigger, and the full send status (invite/reminders + each scheduled/sent send). */
-export function LiveSessionEmailPanel({ liveClassId }: { liveClassId: number }) {
+export function LiveSessionEmailPanel({
+  liveClassId,
+  meetingStatus,
+}: {
+  liveClassId: number;
+  meetingStatus?: string | null;
+}) {
   const { showToast } = useToast();
   const [status, setStatus] = useState<LiveSessionEmailStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [scheduleAt, setScheduleAt] = useState("");
   const [busy, setBusy] = useState(false);
+  // A session that already happened can't be invited to (the BE rejects it too).
+  const sessionOver = meetingStatus === "ended" || meetingStatus === "expired";
 
   const load = useCallback(async () => {
     try {
@@ -57,20 +73,37 @@ export function LiveSessionEmailPanel({ liveClassId }: { liveClassId: number }) 
   }, [load]);
 
   const run = useCallback(
-    async (fn: () => Promise<unknown>, okMsg: string) => {
+    async (fn: () => Promise<unknown>, okMsg: string): Promise<boolean> => {
       setBusy(true);
       try {
         await fn();
         showToast(okMsg, "success");
         await load();
+        return true;
       } catch {
         showToast("Something went wrong — please try again.", "error");
+        return false;
       } finally {
         setBusy(false);
       }
     },
     [showToast, load],
   );
+
+  const schedule = useCallback(async () => {
+    if (!scheduleAt) return;
+    if (new Date(scheduleAt).getTime() <= Date.now()) {
+      showToast('Pick a future time, or use "Send email now".', "error");
+      return;
+    }
+    const ok = await run(
+      () => adminLiveActivitiesService.triggerEmail(liveClassId, {
+        scheduled_times: [new Date(scheduleAt).toISOString()],
+      }),
+      "Scheduled",
+    );
+    if (ok) setScheduleAt(""); // clear only on success so a failed attempt keeps the value
+  }, [scheduleAt, run, showToast, liveClassId]);
 
   if (loading) {
     return (
@@ -106,7 +139,9 @@ export function LiveSessionEmailPanel({ liveClassId }: { liveClassId: number }) 
       </Box>
 
       <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>
-        Emails are manual by default — nothing is sent unless you trigger it here (or turn on auto reminders).
+        {sessionOver
+          ? "This session is over — invites can no longer be sent."
+          : "Emails are manual by default — nothing is sent unless you trigger it here (or turn on auto reminders)."}
       </Typography>
 
       {/* Trigger controls */}
@@ -114,7 +149,7 @@ export function LiveSessionEmailPanel({ liveClassId }: { liveClassId: number }) 
         <Button
           size="small"
           variant="contained"
-          disabled={busy}
+          disabled={busy || sessionOver}
           startIcon={<IconWrapper icon="mdi:email-fast-outline" size={15} />}
           onClick={() =>
             void run(() => adminLiveActivitiesService.triggerEmail(liveClassId, { send_now: true }), "Email sending…")
@@ -127,24 +162,18 @@ export function LiveSessionEmailPanel({ liveClassId }: { liveClassId: number }) 
           type="datetime-local"
           size="small"
           value={scheduleAt}
+          disabled={sessionOver}
           onChange={(e) => setScheduleAt(e.target.value)}
           InputLabelProps={{ shrink: true }}
+          inputProps={{ min: localMin() }}
           sx={{ minWidth: 210 }}
         />
         <Button
           size="small"
           variant="outlined"
-          disabled={busy || !scheduleAt}
+          disabled={busy || !scheduleAt || sessionOver}
           startIcon={<IconWrapper icon="mdi:calendar-plus" size={15} />}
-          onClick={() =>
-            void run(
-              () =>
-                adminLiveActivitiesService.triggerEmail(liveClassId, {
-                  scheduled_times: [new Date(scheduleAt).toISOString()],
-                }),
-              "Scheduled",
-            ).then(() => setScheduleAt(""))
-          }
+          onClick={() => void schedule()}
           sx={{ textTransform: "none", fontWeight: 700, borderRadius: 999 }}
         >
           Schedule

--- a/components/admin/live-sessions/LiveSessionEmailPanel.tsx
+++ b/components/admin/live-sessions/LiveSessionEmailPanel.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControlLabel,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminLiveActivitiesService,
+  type EmailTrigger,
+  type LiveSessionEmailStatus,
+} from "@/lib/services/admin/admin-live-activities.service";
+
+const STATUS_TONE: Record<EmailTrigger["status"], string> = {
+  scheduled: "var(--accent-indigo, #6366f1)",
+  sent: "var(--success-500, #5fa564)",
+  failed: "var(--error-500, #ea4335)",
+  cancelled: "var(--font-tertiary, #6b7280)",
+};
+
+function fmt(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+  });
+}
+
+/** Manual/configurable live-session emails: an auto-reminders opt-in toggle, a "Send now" +
+ *  schedule-a-time trigger, and the full send status (invite/reminders + each scheduled/sent send). */
+export function LiveSessionEmailPanel({ liveClassId }: { liveClassId: number }) {
+  const { showToast } = useToast();
+  const [status, setStatus] = useState<LiveSessionEmailStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [scheduleAt, setScheduleAt] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setStatus(await adminLiveActivitiesService.getEmailStatus(liveClassId));
+    } catch {
+      setStatus(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [liveClassId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const run = useCallback(
+    async (fn: () => Promise<unknown>, okMsg: string) => {
+      setBusy(true);
+      try {
+        await fn();
+        showToast(okMsg, "success");
+        await load();
+      } catch {
+        showToast("Something went wrong — please try again.", "error");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [showToast, load],
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ py: 2, display: "flex", justifyContent: "center" }}>
+        <CircularProgress size={22} />
+      </Box>
+    );
+  }
+  if (!status) return null;
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1.5, gap: 1, flexWrap: "wrap" }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
+          Emails
+        </Typography>
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={status.auto_reminders_enabled}
+              disabled={busy}
+              onChange={(e) =>
+                void run(
+                  () => adminLiveActivitiesService.triggerEmail(liveClassId, { auto_reminders_enabled: e.target.checked }),
+                  e.target.checked ? "Auto reminders on" : "Auto reminders off",
+                )
+              }
+            />
+          }
+          label={<Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>Auto reminders (24h + 1h)</Typography>}
+        />
+      </Box>
+
+      <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>
+        Emails are manual by default — nothing is sent unless you trigger it here (or turn on auto reminders).
+      </Typography>
+
+      {/* Trigger controls */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2, flexWrap: "wrap" }}>
+        <Button
+          size="small"
+          variant="contained"
+          disabled={busy}
+          startIcon={<IconWrapper icon="mdi:email-fast-outline" size={15} />}
+          onClick={() =>
+            void run(() => adminLiveActivitiesService.triggerEmail(liveClassId, { send_now: true }), "Email sending…")
+          }
+          sx={{ textTransform: "none", fontWeight: 700, borderRadius: 999 }}
+        >
+          Send email now
+        </Button>
+        <TextField
+          type="datetime-local"
+          size="small"
+          value={scheduleAt}
+          onChange={(e) => setScheduleAt(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+          sx={{ minWidth: 210 }}
+        />
+        <Button
+          size="small"
+          variant="outlined"
+          disabled={busy || !scheduleAt}
+          startIcon={<IconWrapper icon="mdi:calendar-plus" size={15} />}
+          onClick={() =>
+            void run(
+              () =>
+                adminLiveActivitiesService.triggerEmail(liveClassId, {
+                  scheduled_times: [new Date(scheduleAt).toISOString()],
+                }),
+              "Scheduled",
+            ).then(() => setScheduleAt(""))
+          }
+          sx={{ textTransform: "none", fontWeight: 700, borderRadius: 999 }}
+        >
+          Schedule
+        </Button>
+      </Box>
+
+      {/* Log: invite + reminders */}
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5, mb: 1.5 }}>
+        {([
+          ["Invite", status.invite],
+          ["24h reminder", status.reminder_24h],
+          ["1h reminder", status.reminder_1h],
+        ] as const).map(([label, log]) => (
+          <Box key={label} sx={{ display: "flex", alignItems: "center", gap: 1, fontSize: "0.8rem" }}>
+            <IconWrapper
+              icon={log?.sent_at ? "mdi:email-check-outline" : "mdi:email-outline"}
+              size={14}
+              color={log?.sent_at ? "var(--success-500)" : "var(--font-tertiary)"}
+            />
+            <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+              {label}:{" "}
+              {log?.sent_at
+                ? `${log.recipients_count} recipients · ${fmt(log.sent_at)}${log.failures_count ? ` · ${log.failures_count} failed` : ""}`
+                : "not sent"}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+
+      {/* Scheduled + sent triggers */}
+      {status.triggers.length > 0 && (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+          <Typography variant="caption" sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
+            Triggers
+          </Typography>
+          {status.triggers.map((tr) => (
+            <Box
+              key={tr.id}
+              sx={{
+                display: "flex", alignItems: "center", gap: 1, px: 1.5, py: 0.75,
+                borderRadius: 2, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
+              }}
+            >
+              <Chip
+                label={tr.status}
+                size="small"
+                sx={{
+                  height: 20, fontSize: "0.68rem", fontWeight: 700, textTransform: "capitalize",
+                  bgcolor: `color-mix(in srgb, ${STATUS_TONE[tr.status]} 15%, transparent)`,
+                  color: STATUS_TONE[tr.status],
+                }}
+              />
+              <Typography variant="caption" sx={{ color: "var(--font-secondary)", flexGrow: 1 }}>
+                {tr.status === "sent"
+                  ? `${tr.recipients_count} recipients · ${fmt(tr.sent_at)}`
+                  : `for ${fmt(tr.scheduled_for)}`}
+              </Typography>
+              {tr.status === "scheduled" && (
+                <Button
+                  size="small"
+                  color="inherit"
+                  disabled={busy}
+                  onClick={() =>
+                    void run(() => adminLiveActivitiesService.cancelEmailTrigger(liveClassId, tr.id), "Cancelled")
+                  }
+                  sx={{ minWidth: 0, px: 1, fontSize: "0.68rem", textTransform: "none", color: "var(--font-secondary)" }}
+                >
+                  Cancel
+                </Button>
+              )}
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -411,6 +411,29 @@ export interface AssignMeetingInput {
   topic_name?: string;
 }
 
+export interface EmailLogEntry {
+  sent_at: string | null;
+  recipients_count: number;
+  failures_count: number;
+}
+
+export interface EmailTrigger {
+  id: number;
+  scheduled_for: string | null;
+  status: "scheduled" | "sent" | "failed" | "cancelled";
+  sent_at: string | null;
+  recipients_count: number;
+  failures_count: number;
+}
+
+export interface LiveSessionEmailStatus {
+  auto_reminders_enabled: boolean;
+  invite: EmailLogEntry | null;
+  reminder_24h: EmailLogEntry | null;
+  reminder_1h: EmailLogEntry | null;
+  triggers: EmailTrigger[];
+}
+
 export const adminLiveActivitiesService = {
   getLiveActivities: async (): Promise<LiveActivity[]> => {
     const response = await apiClient.get<LiveActivity[]>(
@@ -566,6 +589,34 @@ export const adminLiveActivitiesService = {
     const response = await apiClient.post<ZoomApiResponse<unknown>>(
       `${BASE}/live-activities/${liveClassId}/attendance/mark/`,
       input
+    );
+    return response.data;
+  },
+
+  /** Full email status for a session: auto flag + invite/reminder log + scheduled/sent triggers. */
+  getEmailStatus: async (liveClassId: number): Promise<LiveSessionEmailStatus> => {
+    const response = await apiClient.get<ZoomApiResponse<LiveSessionEmailStatus>>(
+      `${BASE}/live-activities/${liveClassId}/email/triggers/`
+    );
+    return response.data.data as LiveSessionEmailStatus;
+  },
+
+  /** Trigger a live-session email: send now and/or schedule N one-time sends, and/or toggle auto. */
+  triggerEmail: async (
+    liveClassId: number,
+    input: { send_now?: boolean; scheduled_times?: string[]; auto_reminders_enabled?: boolean }
+  ): Promise<ZoomApiResponse<{ created: EmailTrigger[]; auto_reminders_enabled: boolean }>> => {
+    const response = await apiClient.post<ZoomApiResponse<{ created: EmailTrigger[]; auto_reminders_enabled: boolean }>>(
+      `${BASE}/live-activities/${liveClassId}/email/triggers/`,
+      input
+    );
+    return response.data;
+  },
+
+  /** Cancel a still-scheduled email trigger. */
+  cancelEmailTrigger: async (liveClassId: number, triggerId: number): Promise<ZoomApiResponse<unknown>> => {
+    const response = await apiClient.delete<ZoomApiResponse<unknown>>(
+      `${BASE}/live-activities/${liveClassId}/email/triggers/?trigger_id=${triggerId}`
     );
     return response.data;
   },


### PR DESCRIPTION
## What

Adds the **Emails** panel to the live-session detail page — the FE for the manual/configurable email feature (BE ai-linc-backend#403).

Live-session emails are now **manual by default**. Nothing is sent unless an admin triggers it, or turns on auto reminders for that specific session.

## Panel controls
- **Auto reminders (24h + 1h)** — a per-session opt-in switch (default off).
- **Send email now** — enqueues a forced invite send immediately.
- **Schedule** — pick a datetime, creates a one-time scheduled send (repeatable → N scheduled sends).
- **Status** — invite / 24h / 1h reminder logs (recipients + timestamp + failures), plus every trigger with its `scheduled/sent/failed/cancelled` chip; still-scheduled triggers can be cancelled.

## Backing endpoint
`GET/POST/DELETE .../live-activities/<id>/email/triggers/` (ai-linc-backend#403, merged). A beat sweeper fires due scheduled triggers every 5 min.

## Verification
- `npx tsc --noEmit` clean (0 errors).
- Panel rendered in the Attendance tab above the roster on the session detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)