### PR TITLE
feat(resume): dashboard-style hero header on /resume

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, CircularProgress } from "@mui/material";
+import Link from "next/link";
+import { Box, Breadcrumbs, CircularProgress, Typography } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { ResumeBuilder } from "@/components/profile/resume/ResumeBuilder";
+import { ResumeHero } from "@/components/profile/resume/ResumeHero";
 import { profileService, UserProfile } from "@/lib/services/profile.service";
 import { buildResumeInitialData } from "@/lib/utils/buildResumeInitialData";
 
 /**
  * Standalone Resume Builder route, reachable directly from the sidebar.
- * Seeds from the user's saved profile (same mapping as the /profile Resume
- * tab); the builder still works if the profile fetch fails.
+ * Leads with a dashboard-style hero, then the builder seeded from the user's
+ * saved profile (same mapping as the /profile Resume tab); the builder still
+ * works if the profile fetch fails.
  */
 export default function ResumePage() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
@@ -35,6 +38,23 @@ export default function ResumePage() {
 
   return (
     <MainLayout fullWidthContent>
+      <Breadcrumbs
+        separator="›"
+        sx={{ mb: 2, fontSize: "0.85rem", color: "var(--font-tertiary)" }}
+      >
+        <Link
+          href="/dashboard"
+          style={{ color: "var(--font-tertiary)", textDecoration: "none" }}
+        >
+          Home
+        </Link>
+        <Typography sx={{ fontSize: "0.85rem", color: "var(--font-primary)", fontWeight: 600 }}>
+          Resume Builder
+        </Typography>
+      </Breadcrumbs>
+
+      <ResumeHero />
+
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 10 }}>
           <CircularProgress />

--- a/components/profile/resume/ResumeHero.tsx
+++ b/components/profile/resume/ResumeHero.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Box, Stack, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+/** Feature highlights, mirroring the resume builder's actual capabilities. */
+const PILLS = [
+  { icon: "mdi:view-grid-outline", label: "12 templates" },
+  { icon: "mdi:speedometer", label: "Live ATS score" },
+  { icon: "mdi:auto-fix", label: "AI tailoring" },
+  { icon: "mdi:file-pdf-box", label: "One-click PDF" },
+];
+
+/**
+ * Dashboard-style hero for the Resume Builder page. Matches the AI-briefing
+ * hero's dark violet→indigo gradient so the standalone /resume route reads as
+ * part of the same product surface.
+ */
+export function ResumeHero() {
+  return (
+    <Box
+      sx={{
+        borderRadius: 5,
+        p: { xs: 2.5, md: 4 },
+        mb: 3,
+        color: "white",
+        position: "relative",
+        overflow: "hidden",
+        background:
+          "radial-gradient(120% 130% at 10% 115%, rgba(192,38,211,0.45) 0%, rgba(124,58,237,0.30) 30%, rgba(15,10,40,0) 62%), linear-gradient(150deg, #271a5c 0%, #181040 55%, #100a2c 100%)",
+        boxShadow: "0 24px 60px -30px rgba(76,29,149,0.7)",
+      }}
+    >
+      {/* faint dotted texture */}
+      <Box
+        aria-hidden
+        sx={{
+          position: "absolute",
+          inset: 0,
+          opacity: 0.4,
+          pointerEvents: "none",
+          backgroundImage:
+            "radial-gradient(rgba(255,255,255,0.08) 1px, transparent 1px)",
+          backgroundSize: "18px 18px",
+        }}
+      />
+
+      <Box sx={{ position: "relative" }}>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1.75 }}>
+          <Box
+            sx={{
+              width: 54,
+              height: 54,
+              borderRadius: 3,
+              flexShrink: 0,
+              display: "grid",
+              placeItems: "center",
+              color: "white",
+              background: "linear-gradient(135deg, #a855f7, #ec4899)",
+              boxShadow: "0 10px 24px -8px rgba(192,38,211,0.85)",
+            }}
+          >
+            <IconWrapper icon="mdi:file-account-outline" size={27} />
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              sx={{
+                fontSize: "0.7rem",
+                fontWeight: 800,
+                letterSpacing: 1.6,
+                color: "rgba(255,255,255,0.6)",
+              }}
+            >
+              CAREER
+            </Typography>
+            <Typography
+              sx={{
+                fontWeight: 900,
+                fontSize: { xs: "1.55rem", md: "2.05rem" },
+                lineHeight: 1.1,
+              }}
+            >
+              Resume Builder
+            </Typography>
+          </Box>
+        </Stack>
+
+        <Typography
+          sx={{
+            fontSize: "0.9rem",
+            color: "rgba(255,255,255,0.82)",
+            maxWidth: 660,
+            lineHeight: 1.55,
+            mb: 2.25,
+          }}
+        >
+          Craft a polished, ATS-friendly resume from your profile — pick a
+          template, edit with a live preview, check your ATS score, and export to
+          PDF in one click.
+        </Typography>
+
+        <Stack direction="row" spacing={1.25} flexWrap="wrap" useFlexGap>
+          {PILLS.map((p) => (
+            <Stack
+              key={p.label}
+              direction="row"
+              spacing={0.75}
+              alignItems="center"
+              sx={{
+                px: 1.5,
+                py: 0.75,
+                borderRadius: 999,
+                bgcolor: "rgba(255,255,255,0.1)",
+                border: "1px solid rgba(255,255,255,0.14)",
+              }}
+            >
+              <IconWrapper icon={p.icon} size={15} />
+              <Typography sx={{ fontSize: "0.8rem", fontWeight: 700 }}>
+                {p.label}
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## What
Redesigns the top of the standalone **/resume** page (added in #1049) to lead with a proper hero — modeled on the zskillup Resume Builder and styled like AI Linc's **dashboard AI-briefing hero** (dark violet→indigo gradient), so the route feels first-class.

- **Breadcrumb**: Home › Resume Builder.
- **`ResumeHero`**: icon tile + `CAREER` eyebrow + **Resume Builder** title + one-line description + four capability pills — **12 templates · Live ATS score · AI tailoring · One-click PDF** (12 = the builder's actual template count).
- The existing `ResumeBuilder` toolbar (Clear / Use-Profile / Template / ATS) + two-column editor is **unchanged**, sitting below the hero.

## Verification
- `npx tsc --noEmit` clean (0 errors).
- Self-contained hero component; no data deps; renders above the builder in the padded MainLayout content area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)