### PR TITLE
feat(sidebar): admin nav accordion + Adaptive Courses as a Learn item

### DIFF
--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -25,7 +25,6 @@ import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveS
 import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
 import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { CoursesNavTabs } from "@/components/courses/CoursesNavTabs";
 
 export default function AdaptiveCourseListPage() {
   const { push, prefetch } = useInstantNavigation();
@@ -116,7 +115,6 @@ export default function AdaptiveCourseListPage() {
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
-        <CoursesNavTabs active="adaptive" />
         <AdaptiveSectionShell meshOpacity={0.18}>
           <AdaptiveSectionHero
             chapter="Library · Adaptive Engine"

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -25,7 +25,6 @@ import {
   Course as ServiceCourse,
 } from "@/lib/services/courses.service";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { CoursesNavTabs } from "@/components/courses/CoursesNavTabs";
 import { CourseCard } from "@/components/course/CourseCard";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
@@ -324,9 +323,6 @@ export default function CoursesPage() {
             </Typography>
           </Box>
         </Box>
-
-        {/* Section switch: legacy Courses vs. the Adaptive courses page. */}
-        <CoursesNavTabs active="courses" />
 
         <Box
           sx={{

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -68,7 +68,7 @@ const STUDENT_SECTIONS: NavSection[] = [
     labelKey: "navSection.learn",
     label: "Learn",
     icon: "mdi:school-outline",
-    itemFeatures: ["course", "assessment"],
+    itemFeatures: ["course", "adaptive_quiz", "assessment"],
   },
   {
     id: "career",
@@ -87,7 +87,63 @@ const STUDENT_SECTIONS: NavSection[] = [
 ];
 const STUDENT_STANDALONE_TOP = ["dashboard"];
 const STUDENT_STANDALONE_BOTTOM = ["support"];
+
+// Admin nav gets the same collapsible-section treatment as the student side.
+const ADMIN_SECTIONS: NavSection[] = [
+  {
+    id: "admin_people",
+    labelKey: "navSection.people",
+    label: "People",
+    icon: "mdi:account-group-outline",
+    itemFeatures: ["admin_manage_students", "admin_manage_instructors", "admin_cohorts"],
+  },
+  {
+    id: "admin_content",
+    labelKey: "navSection.content",
+    label: "Content",
+    icon: "mdi:book-multiple-outline",
+    itemFeatures: [
+      "admin_course_builder",
+      "admin_ai_course_builder",
+      "admin_adaptive_quizzes",
+      "admin_verify_content",
+      "admin_certificates",
+    ],
+  },
+  {
+    id: "admin_assessments",
+    labelKey: "navSection.assessments",
+    label: "Assessments",
+    icon: "mdi:file-document-check-outline",
+    itemFeatures: ["admin_assessment", "admin_scorecard"],
+  },
+  {
+    id: "admin_engagement",
+    labelKey: "navSection.engagement",
+    label: "Engagement",
+    icon: "mdi:calendar-star",
+    itemFeatures: ["admin_live_sessions", "admin_mock_interview", "admin_attendance", "admin_jobs_v2"],
+  },
+  {
+    id: "admin_comms",
+    labelKey: "navSection.communications",
+    label: "Communications",
+    icon: "mdi:email-outline",
+    itemFeatures: ["admin_emails", "admin_notifications"],
+  },
+  {
+    id: "admin_settings",
+    labelKey: "navSection.settings",
+    label: "Settings",
+    icon: "mdi:cog-outline",
+    itemFeatures: ["admin_branding"],
+  },
+];
+const ADMIN_STANDALONE_TOP = ["admin_dashboard"];
+const ADMIN_STANDALONE_BOTTOM = ["admin_tickets"];
+
 const SIDEBAR_SECTIONS_STORAGE_KEY = "sidebar_open_sections";
+const ALL_SECTION_IDS = [...STUDENT_SECTIONS, ...ADMIN_SECTIONS].map((s) => s.id);
 
 function SidebarSectionHeader({
   icon,
@@ -330,6 +386,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
       descKey: "navDesc.courses",
     },
     {
+      label: "Adaptive Courses",
+      labelKey: "nav.adaptiveCourses",
+      path: "/adaptive-courses",
+      icon: "mdi:book-education-outline",
+      featureName: "adaptive_quiz",
+      descKey: "navDesc.adaptiveCourses",
+    },
+    {
       label: "Assessments",
       labelKey: "nav.assessments",
       path: "/assessments",
@@ -337,8 +401,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
       featureName: "assessment",
       descKey: "navDesc.assessments",
     },
-    // Adaptive courses now live under the main Courses page (AdaptiveCoursesSection),
-    // so no separate sidebar entry — see app/courses + components/courses.
     {
       label: "Mock Interview",
       labelKey: "nav.mockInterview",
@@ -679,18 +741,27 @@ export const Sidebar: React.FC<SidebarProps> = ({
     }
   };
 
-  // --- Student sidebar accordion ---------------------------------------------
+  // --- Sidebar accordion (student + admin) -----------------------------------
+  // Which section config applies to the current mode.
+  const activeSections = effectiveAdminMode ? ADMIN_SECTIONS : STUDENT_SECTIONS;
+  const activeStandaloneTop = effectiveAdminMode
+    ? ADMIN_STANDALONE_TOP
+    : STUDENT_STANDALONE_TOP;
+  const activeStandaloneBottom = effectiveAdminMode
+    ? ADMIN_STANDALONE_BOTTOM
+    : STUDENT_STANDALONE_BOTTOM;
+
   // Which sections are expanded. Persisted so the layout survives navigation and
   // reloads; defaults to all-open so nothing is hidden on a first visit.
   const [openSections, setOpenSections] = useState<Set<string>>(() => {
-    if (typeof window === "undefined") return new Set(STUDENT_SECTIONS.map((s) => s.id));
+    if (typeof window === "undefined") return new Set(ALL_SECTION_IDS);
     try {
       const raw = window.localStorage.getItem(SIDEBAR_SECTIONS_STORAGE_KEY);
       if (raw) return new Set(JSON.parse(raw) as string[]);
     } catch {
       /* ignore malformed storage */
     }
-    return new Set(STUDENT_SECTIONS.map((s) => s.id));
+    return new Set(ALL_SECTION_IDS);
   });
 
   const toggleSection = (id: string) => {
@@ -707,28 +778,28 @@ export const Sidebar: React.FC<SidebarProps> = ({
     });
   };
 
-  // Group the already-filtered flat list into sections for the student view.
+  // Group the already-filtered flat list into sections for the current mode.
   // Feature-flag/role filtering is untouched — this is a display grouping only,
   // and any item matching no section still renders (as a standalone bottom row).
   const groupedNav = useMemo(() => {
     const map = new Map<string, NavigationItem[]>();
-    STUDENT_SECTIONS.forEach((s) => map.set(s.id, []));
+    activeSections.forEach((s) => map.set(s.id, []));
     const top: NavigationItem[] = [];
     const bottom: NavigationItem[] = [];
     const used = new Set<string>();
 
     navigationItems.forEach((item) => {
-      if (STUDENT_STANDALONE_TOP.includes(item.featureName)) {
+      if (activeStandaloneTop.includes(item.featureName)) {
         top.push(item);
         used.add(item.path);
         return;
       }
-      if (STUDENT_STANDALONE_BOTTOM.includes(item.featureName)) {
+      if (activeStandaloneBottom.includes(item.featureName)) {
         bottom.push(item);
         used.add(item.path);
         return;
       }
-      const sec = STUDENT_SECTIONS.find((s) => s.itemFeatures.includes(item.featureName));
+      const sec = activeSections.find((s) => s.itemFeatures.includes(item.featureName));
       if (sec) {
         map.get(sec.id)!.push(item);
         used.add(item.path);
@@ -736,13 +807,12 @@ export const Sidebar: React.FC<SidebarProps> = ({
     });
 
     const leftovers = navigationItems.filter((i) => !used.has(i.path));
-    const sections = STUDENT_SECTIONS.map((s) => ({
-      ...s,
-      items: map.get(s.id) as NavigationItem[],
-    })).filter((s) => s.items.length > 0);
+    const sections = activeSections
+      .map((s) => ({ ...s, items: map.get(s.id) as NavigationItem[] }))
+      .filter((s) => s.items.length > 0);
 
     return { top, sections, bottom: [...bottom, ...leftovers] };
-  }, [navigationItems]);
+  }, [navigationItems, activeSections, activeStandaloneTop, activeStandaloneBottom]);
 
   // Always keep the section containing the current route open.
   useEffect(() => {
@@ -954,11 +1024,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
                 </ListItem>
               ))}
             </>
-          ) : effectiveAdminMode ? (
-            // Admin navigation stays a flat list.
-            navigationItems.map((item) => renderNavRow(item, false))
           ) : (
-            // Student navigation is grouped into collapsible sections.
+            // Navigation (student + admin) grouped into collapsible sections.
             <>
               {groupedNav.top.map((item) => renderNavRow(item, false))}
               {groupedNav.sections.map((section) => {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -30,6 +30,7 @@
     "certificateUploads": "Certificate uploads",
     "support": "My Tickets",
     "resume": "Resume",
+    "adaptiveCourses": "Adaptive Courses",
     "adminTickets": "Ticket Management",
     "adaptiveQuizzes": "Adaptive Course",
     "adminAdaptiveQuizzes": "Adaptive Course Builder"
@@ -37,11 +38,18 @@
   "navSection": {
     "learn": "Learn",
     "career": "Career",
-    "engage": "Engage"
+    "engage": "Engage",
+    "people": "People",
+    "content": "Content",
+    "assessments": "Assessments",
+    "engagement": "Engagement",
+    "communications": "Communications",
+    "settings": "Settings"
   },
   "navDesc": {
     "dashboard": "Your home base — progress, streak, and what to do next at a glance.",
     "courses": "Browse and continue your enrolled courses and learning tracks.",
+    "adaptiveCourses": "AI-personalised courses that adapt to your level in real time.",
     "assessments": "Take quizzes and tests, then review your results.",
     "mockInterview": "Practice AI-driven mock interviews with instant feedback.",
     "jobsV2": "Discover jobs matched to you and track your applications.",


### PR DESCRIPTION
## What
Two nav-structure follow-ups to #1049.

### 1. Admin sidebar accordion
The admin nav now uses the **same collapsible-section accordion** as the student side, grouped into: **People** (Manage Students, Instructors, Cohorts), **Content** (Course Builder, AI Course Builder, Adaptive Course Builder, Verify Content, Certificate uploads), **Assessments** (Assessment Management, Scorecard), **Engagement** (Live Sessions, Interview, Attendance, Jobs), **Communications** (Emails, Notifications), **Settings** (Branding & theme) — with **Dashboard** (top) and **Ticket Management** (bottom) standalone.

The grouping is a display layer over the already feature-flag/role-filtered list (course-manager/instructor allowlists, `orgAdminOnly` untouched); any admin item matching no section still renders as a standalone row, so nothing can vanish. Open sections persist to `localStorage`; the section holding the current route auto-opens.

### 2. Adaptive Courses → sidebar item
New student **Adaptive Courses** item under **Learn** (Courses · Adaptive Courses · Assessments), routing to the existing `/adaptive-courses` page, gated by the `adaptive_quiz` feature. Removed the in-page `CoursesNavTabs` switcher from both the Courses and Adaptive Courses pages — navigation is via the sidebar now.

## Verification
- `npx tsc --noEmit` clean (0 errors); `common.json` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)