### PR TITLE
tweak(sidebar): widen nav drawer to 264px

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -45,7 +45,7 @@ import { normalizeThemeSettings } from "@/lib/theme/normalizeThemeSettings";
 import { buildSidebarLogoBrandingUi } from "@/lib/theme/authHeroBranding";
 import { resolveClientLogoUrl } from "@/lib/utils/resolveClientLogoUrl";
 
-const DRAWER_WIDTH = 240;
+const DRAWER_WIDTH = 264;
 const DRAWER_WIDTH_COLLAPSED = 64;
 
 /**


### PR DESCRIPTION
Bumps the sidebar DRAWER_WIDTH 240 → 264 for a little more room (section labels + info icons). MainLayout already offsets content by DRAWER_WIDTH, so the content area follows automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)