### PR TITLE
feat(ui): shared list toolkit + card/list toggle (pattern lock on adaptive-courses)

### DIFF
--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -20,6 +20,7 @@ import {
 import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { ViewToggle, type ListView } from "@/components/common/list";
 import { KpiRail, Reveal } from "@/components/scorecard/shared";
 import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
 import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
@@ -34,6 +35,7 @@ export default function AdaptiveCourseListPage() {
   const [query, setQuery] = useState("");
   const [difficulty, setDifficulty] = useState<string>("all");
   const [sort, setSort] = useState<"recent" | "title" | "content">("recent");
+  const [viewMode, setViewMode] = useState<ListView>("cards");
 
   useEffect(() => {
     if (!featureOn) {
@@ -169,6 +171,7 @@ export default function AdaptiveCourseListPage() {
                   <MenuItem value="title">Title (A–Z)</MenuItem>
                   <MenuItem value="content">Most content</MenuItem>
                 </Select>
+                <ViewToggle value={viewMode} onChange={setViewMode} />
               </Stack>
 
               {difficultyOptions.length > 0 && (
@@ -210,7 +213,7 @@ export default function AdaptiveCourseListPage() {
             </Box>
           )}
 
-          {!loading && visible.length > 0 && (
+          {!loading && visible.length > 0 && viewMode === "cards" && (
             <Box
               sx={{
                 display: "grid",
@@ -230,7 +233,87 @@ export default function AdaptiveCourseListPage() {
               ))}
             </Box>
           )}
+
+          {!loading && visible.length > 0 && viewMode === "list" && (
+            <Stack spacing={1.25}>
+              {visible.map((course) => (
+                <AdaptiveCourseRow
+                  key={course.id}
+                  course={course}
+                  onOpen={() => push(`/adaptive-courses/${course.id}`)}
+                  onHover={() => prefetch(`/adaptive-courses/${course.id}`)}
+                />
+              ))}
+            </Stack>
+          )}
     </PageShell>
+  );
+}
+
+function AdaptiveCourseRow({
+  course,
+  onOpen,
+  onHover,
+}: {
+  course: AdaptiveCourseListItem;
+  onOpen: () => void;
+  onHover: () => void;
+}) {
+  return (
+    <Box
+      onClick={onOpen}
+      onMouseEnter={onHover}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        p: 2,
+        borderRadius: 2,
+        cursor: "pointer",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "all .15s",
+        "&:hover": { borderColor: "#a855f7", boxShadow: "0 6px 16px -8px rgba(124,58,237,0.35)" },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          borderRadius: 2,
+          display: "grid",
+          placeItems: "center",
+          flexShrink: 0,
+          background: "linear-gradient(135deg,#6366f1,#a855f7)",
+          color: "#fff",
+        }}
+      >
+        <Icon icon="mdi:book-education-outline" width={22} />
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.98rem" }} noWrap>
+          {course.title}
+        </Typography>
+        <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.82rem" }} noWrap>
+          {course.description || course.target_audience || "Adaptive course"}
+        </Typography>
+      </Box>
+      <Stack direction="row" spacing={2.5} sx={{ flexShrink: 0, display: { xs: "none", md: "flex" } }}>
+        {[
+          { icon: "mdi:cube-outline", value: course.module_count, label: "modules" },
+          { icon: "mdi:help-circle-outline", value: course.quiz_count, label: "quizzes" },
+          { icon: "mdi:file-document-outline", value: course.article_count, label: "articles" },
+        ].map((m) => (
+          <Stack key={m.label} alignItems="center">
+            <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "var(--font-primary)" }}>
+              {m.value}
+            </Typography>
+            <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary)" }}>{m.label}</Typography>
+          </Stack>
+        ))}
+      </Stack>
+      <Icon icon="mdi:chevron-right" width={22} style={{ color: "var(--font-tertiary)", flexShrink: 0 }} />
+    </Box>
   );
 }
 

--- a/components/common/list/ViewToggle.tsx
+++ b/components/common/list/ViewToggle.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Box, IconButton, Tooltip } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+export type ListView = "cards" | "list";
+
+const OPTIONS: { mode: ListView; icon: string; label: string }[] = [
+  { mode: "cards", icon: "mdi:view-grid-outline", label: "Card view" },
+  { mode: "list", icon: "mdi:view-list-outline", label: "List view" },
+];
+
+/**
+ * Card ↔ list view switcher, shared across every module list so the affordance
+ * looks and behaves identically everywhere (extracted from the assessment-
+ * management hub's inline toggle).
+ */
+export function ViewToggle({
+  value,
+  onChange,
+}: {
+  value: ListView;
+  onChange: (v: ListView) => void;
+}) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: 0.5,
+        p: 0.5,
+        borderRadius: 999,
+        border: "1px solid var(--border-default)",
+        bgcolor: "var(--surface)",
+        flexShrink: 0,
+      }}
+    >
+      {OPTIONS.map((v) => {
+        const active = value === v.mode;
+        return (
+          <Tooltip key={v.mode} title={v.label}>
+            <IconButton
+              size="small"
+              aria-label={v.label}
+              onClick={() => onChange(v.mode)}
+              sx={{
+                borderRadius: 999,
+                color: active ? "#fff" : "var(--font-tertiary)",
+                bgcolor: active ? "var(--accent-indigo)" : "transparent",
+                "&:hover": {
+                  bgcolor: active ? "var(--accent-indigo-dark)" : "var(--hover-bg)",
+                },
+              }}
+            >
+              <IconWrapper icon={v.icon} size={18} />
+            </IconButton>
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+}

--- a/components/common/list/index.ts
+++ b/components/common/list/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared list-page toolkit — one search/filter/tabs/stats/view-toggle language
+ * across every module list. The search + tabs + stat primitives already exist
+ * (from the assessment-management redesign); this barrel re-exports them under
+ * generic names so any module can adopt them without an assessment-specific
+ * import path. `ViewToggle` is the one new piece.
+ */
+export { ViewToggle, type ListView } from "./ViewToggle";
+
+export {
+  AssessmentFilterBar as SearchFilterBar,
+  type FilterSelectDef,
+  type ActiveFilterChip,
+} from "@/components/admin/assessment/shared/AssessmentFilterBar";
+
+export {
+  SegmentedTabs,
+  type SegmentedTab,
+  StatStrip,
+  type StatItem,
+} from "@/components/admin/assessment/shared";


### PR DESCRIPTION
## What
First step of the **list-consistency** work you asked for (consistent search/filter + a card/list view everywhere). The search/tabs/stat primitives already exist from the assessment redesign; the missing shared piece was a **card/list view toggle**.

- **`components/common/list/`** — `ViewToggle` (extracted from the assessment hub's inline cards/table toggle) + a barrel re-exporting **`SearchFilterBar`** (= the generic `AssessmentFilterBar`), `SegmentedTabs`, `StatStrip` under generic names, so any module can adopt the same search/filter/stats without an assessment-specific import.
- **adaptive-courses (pattern lock)** — a **card ⇄ list** `ViewToggle` in the filter row + a compact list-row view. Card grid unchanged in "cards" mode.

## Preview
`/adaptive-courses` — toggle the grid/list icons in the filter row.

## Verification
- `npx tsc --noEmit` clean.

## Next (after you confirm the pattern)
Roll `ViewToggle` + a list-row view across the other card lists (courses, jobs, live-sessions, cohorts, admin adaptive/live-sessions), and standardize search/filter to the shared `SearchFilterBar` where modules currently inline their own. Scorecard/certificates get the header/stat-strip visual language (they're workspaces, not lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)