### PR TITLE
feat(ui): card/list view toggle across the card modules

### DIFF
--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -2,13 +2,14 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { Box, ButtonBase, Typography } from "@mui/material";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useToast } from "@/components/common/Toast";
 import { KpiRail, Reveal } from "@/components/scorecard/shared";
+import { ViewToggle, type ListView } from "@/components/common/list";
 import {
   adminAdaptiveCourseService,
   type AdaptiveCourseJob,
@@ -27,6 +28,7 @@ export default function AdminAdaptiveCoursesPage() {
   const [error, setError] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<AdminAdaptiveCourseListItem | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [viewMode, setViewMode] = useState<ListView>("cards");
 
   const load = useCallback(async () => {
     try {
@@ -189,6 +191,12 @@ export default function AdminAdaptiveCoursesPage() {
           )}
 
           {!loading && courses.length > 0 && (
+            <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
+              <ViewToggle value={viewMode} onChange={setViewMode} />
+            </Box>
+          )}
+
+          {!loading && courses.length > 0 && viewMode === "cards" && (
             <Box
               sx={{
                 display: "grid",
@@ -206,6 +214,19 @@ export default function AdminAdaptiveCoursesPage() {
                     onDelete={() => setPendingDelete(course)}
                   />
                 </Reveal>
+              ))}
+            </Box>
+          )}
+
+          {!loading && courses.length > 0 && viewMode === "list" && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+              {courses.map((course) => (
+                <CourseRow
+                  key={course.id}
+                  course={course}
+                  onOpen={() => push(`/admin/adaptive-courses/${course.id}`)}
+                  onPrefetch={() => prefetch(`/admin/adaptive-courses/${course.id}`)}
+                />
               ))}
             </Box>
           )}
@@ -344,6 +365,84 @@ function CourseCard({
         </ButtonBase>
       </Box>
     </Box>
+  );
+}
+
+function CourseRow({
+  course,
+  onOpen,
+  onPrefetch,
+}: {
+  course: AdminAdaptiveCourseListItem;
+  onOpen: () => void;
+  onPrefetch: () => void;
+}) {
+  return (
+    <Box
+      onMouseEnter={onPrefetch}
+      onClick={onOpen}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        p: 2,
+        borderRadius: 2,
+        cursor: "pointer",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "all .15s",
+        "&:hover": {
+          borderColor: "#a855f7",
+          boxShadow: "0 6px 16px -8px rgba(124,58,237,0.35)",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          flexShrink: 0,
+          borderRadius: 2,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "white",
+          background: "linear-gradient(135deg, #a855f7 0%, #6366f1 100%)",
+        }}
+      >
+        <Icon icon="mdi:robot-excited-outline" width={24} />
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.98rem", lineHeight: 1.3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {course.title}
+        </Typography>
+        <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.82rem", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {course.is_published ? "Published" : "Draft"} · {course.submodule_count} submodules · {course.article_count} articles
+        </Typography>
+      </Box>
+
+      <Stack direction="row" spacing={2.5} sx={{ display: { xs: "none", md: "flex" }, flexShrink: 0 }}>
+        <RowStat value={course.module_count} label="modules" />
+        <RowStat value={course.quiz_count} label="quizzes" />
+        <RowStat value={course.coding_count ?? 0} label="coding" />
+      </Stack>
+
+      <Icon icon="mdi:chevron-right" width={22} style={{ color: "var(--font-tertiary)", flexShrink: 0 }} />
+    </Box>
+  );
+}
+
+function RowStat({ value, label }: { value: number; label: string }) {
+  return (
+    <Stack alignItems="center" spacing={0}>
+      <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "var(--font-primary)", lineHeight: 1.2 }}>
+        {value}
+      </Typography>
+      <Typography sx={{ color: "var(--font-tertiary)", fontSize: "0.68rem" }}>
+        {label}
+      </Typography>
+    </Stack>
   );
 }
 

--- a/app/admin/cohorts/page.tsx
+++ b/app/admin/cohorts/page.tsx
@@ -10,8 +10,11 @@ import {
   DialogContent,
   DialogTitle,
   MenuItem,
+  Stack,
   TextField,
+  Typography,
 } from "@mui/material";
+import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
@@ -25,11 +28,22 @@ import {
   type SegmentedTab,
 } from "@/components/admin/assessment/shared";
 import { CohortCard } from "@/components/admin/cohorts/CohortCard";
+import { ViewToggle, type ListView } from "@/components/common/list";
 import {
   adminCohortsService,
   type CohortListItem,
   type CohortStatus,
 } from "@/lib/services/admin/admin-cohorts.service";
+
+const COHORT_ACCENT = "#a855f7";
+
+const STATUS_LABEL: Record<CohortStatus, string> = {
+  draft: "Draft",
+  scheduled: "Scheduled",
+  active: "Active",
+  completed: "Completed",
+  archived: "Archived",
+};
 
 type StatusTab = "all" | CohortStatus;
 
@@ -43,6 +57,7 @@ export default function AdminCohortsPage() {
   const [error, setError] = useState<string | null>(null);
   const [statusTab, setStatusTab] = useState<StatusTab>("all");
   const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useState<ListView>("cards");
   const [pendingDelete, setPendingDelete] = useState<CohortListItem | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
@@ -183,12 +198,18 @@ export default function AdminCohortsPage() {
         )}
 
         {!loading && filtered.length > 0 && (
+          <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 2.5, mb: 0.5 }}>
+            <ViewToggle value={viewMode} onChange={setViewMode} />
+          </Box>
+        )}
+
+        {!loading && filtered.length > 0 && viewMode === "cards" && (
           <Box
             sx={{
               display: "grid",
               gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
               gap: 2,
-              mt: 2.5,
+              mt: 1,
             }}
           >
             {filtered.map((cohort) => (
@@ -197,6 +218,18 @@ export default function AdminCohortsPage() {
                 cohort={cohort}
                 onOpen={() => push(`/admin/cohorts/${cohort.id}`)}
                 onArchive={() => setPendingDelete(cohort)}
+              />
+            ))}
+          </Box>
+        )}
+
+        {!loading && filtered.length > 0 && viewMode === "list" && (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mt: 1 }}>
+            {filtered.map((cohort) => (
+              <CohortRow
+                key={cohort.id}
+                cohort={cohort}
+                onOpen={() => push(`/admin/cohorts/${cohort.id}`)}
               />
             ))}
           </Box>
@@ -230,6 +263,83 @@ export default function AdminCohortsPage() {
         onCancel={() => setPendingDelete(null)}
       />
     </PageShell>
+  );
+}
+
+function RowStat({ value, label }: { value: number | string; label: string }) {
+  return (
+    <Stack alignItems="center" spacing={0} sx={{ minWidth: 56 }}>
+      <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "var(--font-primary)", lineHeight: 1.2 }}>
+        {value}
+      </Typography>
+      <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary)", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+        {label}
+      </Typography>
+    </Stack>
+  );
+}
+
+function CohortRow({ cohort, onOpen }: { cohort: CohortListItem; onOpen: () => void }) {
+  const secondary = [
+    cohort.code,
+    STATUS_LABEL[cohort.status],
+    cohort.start_date ? `Starts ${cohort.start_date}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Box
+      onClick={onOpen}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        p: 2,
+        borderRadius: 2,
+        cursor: "pointer",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "all .15s",
+        "&:hover": {
+          borderColor: COHORT_ACCENT,
+          boxShadow: "0 6px 16px -8px rgba(124,58,237,0.35)",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          flexShrink: 0,
+          borderRadius: 2,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "var(--gradient-ai)",
+          color: "#fff",
+        }}
+      >
+        <Icon icon="mdi:account-group" width={22} />
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography noWrap sx={{ fontWeight: 800, fontSize: "0.98rem", color: "var(--font-primary)" }}>
+          {cohort.name}
+        </Typography>
+        <Typography noWrap sx={{ fontSize: "0.82rem", color: "var(--font-secondary)" }}>
+          {secondary || "No details yet"}
+        </Typography>
+      </Box>
+
+      <Stack direction="row" spacing={2.5} sx={{ display: { xs: "none", md: "flex" } }}>
+        <RowStat value={cohort.member_count} label="Members" />
+        <RowStat value={cohort.artifact_count} label="Assignments" />
+        <RowStat value={cohort.end_date ? cohort.end_date.slice(5) : "—"} label="Ends" />
+      </Stack>
+
+      <Icon icon="mdi:chevron-right" width={22} style={{ color: "var(--font-tertiary)", flexShrink: 0 }} />
+    </Box>
   );
 }
 

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -32,6 +32,7 @@ import { VirtualBackgroundsDialog } from "@/components/admin/live-sessions/Virtu
 import { LiveSessionCard } from "@/components/live-sessions/ui/LiveSessionCard";
 import { LiveSessionsCalendar } from "@/components/live-sessions/ui/LiveSessionsCalendar";
 import { SessionFilterChips } from "@/components/live-sessions/ui/LiveSessionUI";
+import { ViewToggle, type ListView } from "@/components/common/list";
 import { useToast } from "@/components/common/Toast";
 import type { LiveActivity } from "@/lib/services/admin/admin-live-activities.service";
 import { zoomService } from "@/lib/services/zoom.service";
@@ -99,6 +100,8 @@ export default function AdminLiveSessionsPage() {
   } = useAdminLiveSessions();
 
   const [viewMode, setViewMode] = useState<"list" | "calendar">("list");
+  // Card ↔ compact-row layout for the (non-calendar) sessions list.
+  const [listView, setListView] = useState<ListView>("cards");
 
   const refreshZoomStatus = useCallback(() => {
     zoomService
@@ -374,25 +377,28 @@ export default function AdminLiveSessionsPage() {
 
                 <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 1.5, flexWrap: "wrap" }}>
                   <SessionFilterChips options={filterOptions} value={filter} onChange={setFilter} />
-                  <Box sx={{ display: "inline-flex", p: 0.375, borderRadius: 999, border: "1px solid var(--border-default)", bgcolor: "var(--card-bg)" }}>
-                    {([
-                      { key: "list", icon: "mdi:view-grid-outline", label: t("adminLiveSessions.viewList", "List") },
-                      { key: "calendar", icon: "mdi:calendar-month-outline", label: t("adminLiveSessions.viewCalendar", "Calendar") },
-                    ] as const).map((v) => {
-                      const active = viewMode === v.key;
-                      return (
-                        <Box key={v.key} component="button" onClick={() => setViewMode(v.key)}
-                          sx={{
-                            display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.75, py: 0.75, borderRadius: 999,
-                            border: "none", cursor: "pointer", fontSize: "0.8rem", fontWeight: 700, fontFamily: "inherit",
-                            bgcolor: active ? "var(--accent-indigo)" : "transparent",
-                            color: active ? "#fff" : "var(--font-secondary)",
-                          }}>
-                          <IconWrapper icon={v.icon} size={16} />
-                          {v.label}
-                        </Box>
-                      );
-                    })}
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                    {viewMode === "list" && <ViewToggle value={listView} onChange={setListView} />}
+                    <Box sx={{ display: "inline-flex", p: 0.375, borderRadius: 999, border: "1px solid var(--border-default)", bgcolor: "var(--card-bg)" }}>
+                      {([
+                        { key: "list", icon: "mdi:view-grid-outline", label: t("adminLiveSessions.viewList", "List") },
+                        { key: "calendar", icon: "mdi:calendar-month-outline", label: t("adminLiveSessions.viewCalendar", "Calendar") },
+                      ] as const).map((v) => {
+                        const active = viewMode === v.key;
+                        return (
+                          <Box key={v.key} component="button" onClick={() => setViewMode(v.key)}
+                            sx={{
+                              display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.75, py: 0.75, borderRadius: 999,
+                              border: "none", cursor: "pointer", fontSize: "0.8rem", fontWeight: 700, fontFamily: "inherit",
+                              bgcolor: active ? "var(--accent-indigo)" : "transparent",
+                              color: active ? "#fff" : "var(--font-secondary)",
+                            }}>
+                            <IconWrapper icon={v.icon} size={16} />
+                            {v.label}
+                          </Box>
+                        );
+                      })}
+                    </Box>
                   </Box>
                 </Box>
 
@@ -406,37 +412,45 @@ export default function AdminLiveSessionsPage() {
                   </Box>
                 ) : (
                   <>
-                    <Box
-                      sx={{
-                        display: "grid",
-                        gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
-                        gap: 2,
-                        alignItems: "stretch",
-                      }}
-                    >
-                      {pagedSessions.map((s, idx) => (
-                        <Reveal key={s.id} delay={Math.min(idx, 8) * 0.05}>
-                          <LiveSessionCard
-                            session={s}
-                            variant="admin"
-                            creatingZoom={creatingZoomId === s.id}
-                            creatingGoogleMeet={creatingGoogleMeetId === s.id}
-                            watchingRecording={watchingRecordingId === s.id}
-                            onOpen={openDetail}
-                            onCreateZoom={(sess) => handleCreateZoom(sess.id)}
-                            onCreateGoogleMeet={(sess) => handleCreateGoogleMeet(sess.id)}
-                            onStart={(sess) => sess.zoom_start_url && window.open(sess.zoom_start_url, "_blank")}
-                            onJoin={(sess) => {
-                              const url = sess.is_google_meet ? sess.join_link?.trim() : sess.zoom_join_url?.trim();
-                              if (url) window.open(url, "_blank");
-                            }}
-                            onCopyPasscode={handleCopyPassword}
-                            onWatchRecording={handleWatchRecording}
-                            formatDateTime={formatDateTime}
-                          />
-                        </Reveal>
-                      ))}
-                    </Box>
+                    {listView === "cards" ? (
+                      <Box
+                        sx={{
+                          display: "grid",
+                          gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+                          gap: 2,
+                          alignItems: "stretch",
+                        }}
+                      >
+                        {pagedSessions.map((s, idx) => (
+                          <Reveal key={s.id} delay={Math.min(idx, 8) * 0.05}>
+                            <LiveSessionCard
+                              session={s}
+                              variant="admin"
+                              creatingZoom={creatingZoomId === s.id}
+                              creatingGoogleMeet={creatingGoogleMeetId === s.id}
+                              watchingRecording={watchingRecordingId === s.id}
+                              onOpen={openDetail}
+                              onCreateZoom={(sess) => handleCreateZoom(sess.id)}
+                              onCreateGoogleMeet={(sess) => handleCreateGoogleMeet(sess.id)}
+                              onStart={(sess) => sess.zoom_start_url && window.open(sess.zoom_start_url, "_blank")}
+                              onJoin={(sess) => {
+                                const url = sess.is_google_meet ? sess.join_link?.trim() : sess.zoom_join_url?.trim();
+                                if (url) window.open(url, "_blank");
+                              }}
+                              onCopyPasscode={handleCopyPassword}
+                              onWatchRecording={handleWatchRecording}
+                              formatDateTime={formatDateTime}
+                            />
+                          </Reveal>
+                        ))}
+                      </Box>
+                    ) : (
+                      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+                        {pagedSessions.map((s) => (
+                          <SessionListRow key={s.id} session={s} onOpen={openDetail} />
+                        ))}
+                      </Box>
+                    )}
 
                     {pageCount > 1 && (
                       <Box sx={{ display: "flex", justifyContent: "center", mt: 1 }}>
@@ -482,6 +496,117 @@ export default function AdminLiveSessionsPage() {
           onClose={() => setPlayerSession(null)}
         />
     </PageShell>
+  );
+}
+
+// Meeting status → short label for the compact row (mirrors the card's status pill).
+const ROW_STATUS_LABEL: Record<string, string> = {
+  live: "Live now",
+  scheduled: "Scheduled",
+  ended: "Ended",
+  expired: "Expired",
+  cancelled: "Cancelled",
+};
+
+/**
+ * Compact list-row rendering of a live session — the "list" counterpart to LiveSessionCard.
+ * Reuses the same LiveActivity fields (topic, datetime, course/recurrence meta, status, attendance,
+ * duration) and the SAME openDetail navigation the card uses.
+ */
+function SessionListRow({ session, onOpen }: { session: LiveActivity; onOpen: (s: LiveActivity) => void }) {
+  const { t } = useTranslation("common");
+
+  const isCancelled = session.zoom_status === "cancelled" || session.google_status === "cancelled";
+  const status = isCancelled ? "cancelled" : session.meeting_status ?? "scheduled";
+  const statusLabel = ROW_STATUS_LABEL[status] ?? ROW_STATUS_LABEL.scheduled;
+
+  const dt = session.class_datetime ? new Date(session.class_datetime) : null;
+  const validDt = dt && !isNaN(dt.getTime()) ? dt : null;
+  const dateStr = validDt ? validDt.toLocaleDateString(undefined, { month: "short", day: "numeric" }) : "—";
+  const timeStr = validDt ? validDt.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }) : "—";
+  const durStr = session.duration_minutes ? `${session.duration_minutes}m` : "—";
+  const attendees = session.attendance_count ?? 0;
+
+  const rowIcon = session.is_google_meet
+    ? "mdi:google"
+    : session.zoom_meeting_type === "webinar"
+      ? "mdi:presentation"
+      : "mdi:video-outline";
+
+  const metaText = session.recurrence_summary
+    ? session.recurrence_summary
+    : session.course_detail?.title
+      ? session.course_detail.title
+      : t("liveSessions.oneTimeSession", "One-time session");
+
+  const stats: { value: string | number; label: string }[] = [
+    { value: statusLabel, label: t("adminLiveSessions.status", "Status") },
+    { value: attendees, label: t("adminLiveSessions.attendees", "Attendees") },
+    { value: durStr, label: t("liveSessions.duration", "Duration") },
+  ];
+
+  return (
+    <Box
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(session)}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onOpen(session); }}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        p: 2,
+        borderRadius: 2,
+        cursor: "pointer",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "all .15s",
+        opacity: isCancelled ? 0.7 : 1,
+        "&:hover": {
+          borderColor: "var(--accent-indigo)",
+          boxShadow: "0 6px 16px -8px rgba(124,58,237,0.35)",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          flexShrink: 0,
+          borderRadius: 2,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)",
+        }}
+      >
+        <IconWrapper icon={rowIcon} size={22} color="#fff" />
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.98rem", color: "var(--font-primary)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {session.topic_name || t("adminLiveSessions.untitledSession", "Untitled session")}
+        </Typography>
+        <Typography sx={{ fontSize: "0.82rem", color: "var(--font-secondary)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {`${dateStr} · ${timeStr} · ${metaText}`}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: { xs: "none", md: "flex" }, alignItems: "center", gap: 2.5, flexShrink: 0 }}>
+        {stats.map((stat) => (
+          <Box key={stat.label} sx={{ display: "flex", flexDirection: "column", alignItems: "center", minWidth: 0 }}>
+            <Typography sx={{ fontWeight: 700, fontSize: "0.9rem", color: "var(--font-primary)", whiteSpace: "nowrap" }}>
+              {stat.value}
+            </Typography>
+            <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary)", whiteSpace: "nowrap" }}>
+              {stat.label}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+
+      <IconWrapper icon="mdi:chevron-right" size={22} color="var(--font-tertiary)" />
+    </Box>
   );
 }
 

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -19,6 +19,7 @@ import {
   LinearProgress,
   Checkbox,
   ListItemText,
+  Stack,
 } from "@mui/material";
 import {
   coursesService,
@@ -28,6 +29,7 @@ import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { CourseCard } from "@/components/course/CourseCard";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { ViewToggle, type ListView } from "@/components/common/list";
 import { useToast } from "@/components/common/Toast";
 import { usePayment } from "@/hooks/usePayment";
 import type { Course as CourseCardCourse } from "@/components/course/interfaces";
@@ -53,6 +55,7 @@ export default function CoursesPage() {
   const [pageSize, setPageSize] = useState(ITEMS_PER_PAGE);
   const [filter, setFilter] = useState<FilterType>("all");
   const [sortBy, setSortBy] = useState<SortType>("recent");
+  const [viewMode, setViewMode] = useState<ListView>("cards");
   const [enrollingCourseId, setEnrollingCourseId] = useState<number | null>(
     null
   );
@@ -547,6 +550,9 @@ export default function CoursesPage() {
                 <MenuItem value="title">{t("courses.titleAZ")}</MenuItem>
               </Select>
             </FormControl>
+            <Box sx={{ ml: { sm: "auto" }, alignSelf: { xs: "flex-end", sm: "center" } }}>
+              <ViewToggle value={viewMode} onChange={setViewMode} />
+            </Box>
           </Box>
         </Paper>
 
@@ -700,7 +706,7 @@ export default function CoursesPage() {
               {t("courses.noCoursesFound")}
             </Typography>
           </Box>
-        ) : (
+        ) : viewMode === "cards" ? (
           <Box
             sx={{
               display: "grid",
@@ -718,6 +724,16 @@ export default function CoursesPage() {
                 course={course}
                 onEnroll={handleEnroll}
                 enrolling={enrollingCourseId === course.id}
+              />
+            ))}
+          </Box>
+        ) : (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+            {paginatedCourses.map((course) => (
+              <CourseRow
+                key={course.id}
+                course={course}
+                onOpen={() => router.push(`/courses/${course.id}`)}
               />
             ))}
           </Box>
@@ -841,5 +857,121 @@ export default function CoursesPage() {
           </Box>
         )}
     </PageShell>
+  );
+}
+
+function CourseRow({
+  course,
+  onOpen,
+}: {
+  course: CourseCardCourse;
+  onOpen: () => void;
+}) {
+  const isEnrolled = course.is_enrolled;
+  const s = course.stats;
+  const totalLessons =
+    (s?.video?.total || 0) +
+    (s?.article?.total || 0) +
+    (s?.quiz?.total || 0) +
+    (s?.assignment?.total || 0) +
+    (s?.coding_problem?.total || 0) +
+    (s?.subjective_question?.total || 0);
+
+  const stats: { value: string; label: string }[] = [];
+  if (isEnrolled) {
+    stats.push({ value: `${course.progress || 0}%`, label: "Progress" });
+  }
+  stats.push({ value: String(totalLessons), label: "Lessons" });
+  stats.push({
+    value: course.difficulty_level || "Beginner",
+    label: "Level",
+  });
+
+  return (
+    <Box
+      onClick={onOpen}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        p: 2,
+        borderRadius: 2,
+        cursor: "pointer",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "all .15s",
+        "&:hover": {
+          borderColor: "var(--accent-indigo)",
+          boxShadow: "0 6px 16px -8px rgba(124,58,237,0.35)",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          flexShrink: 0,
+          borderRadius: 2,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background:
+            "linear-gradient(135deg, var(--accent-indigo) 0%, var(--accent-indigo-dark, #4f46e5) 100%)",
+        }}
+      >
+        <IconWrapper
+          icon={isEnrolled ? "mdi:book-open-variant" : "mdi:book-outline"}
+          size={22}
+          color="#fff"
+        />
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          noWrap
+          sx={{ fontWeight: 800, fontSize: "0.98rem", color: "var(--font-primary)" }}
+        >
+          {course.title}
+        </Typography>
+        <Typography
+          noWrap
+          sx={{ color: "var(--font-secondary)", fontSize: "0.82rem" }}
+        >
+          {course.subtitle ||
+            course.description ||
+            course.instructors?.[0]?.name ||
+            " "}
+        </Typography>
+      </Box>
+
+      <Stack
+        direction="row"
+        spacing={2.5}
+        sx={{ display: { xs: "none", md: "flex" } }}
+      >
+        {stats.map((st) => (
+          <Stack key={st.label} alignItems="center" spacing={0}>
+            <Typography
+              sx={{ fontWeight: 700, fontSize: "0.9rem", color: "var(--font-primary)" }}
+            >
+              {st.value}
+            </Typography>
+            <Typography sx={{ color: "var(--font-tertiary)", fontSize: "0.68rem" }}>
+              {st.label}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+
+      <IconWrapper icon="mdi:chevron-right" size={22} color="var(--font-tertiary)" />
+    </Box>
   );
 }

--- a/app/jobs-v2/page.tsx
+++ b/app/jobs-v2/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { Box, LinearProgress, Typography, Tabs, Tab } from "@mui/material";
+import Link from "next/link";
+import { Box, LinearProgress, Typography, Tabs, Tab, Avatar, Stack } from "@mui/material";
+import { Briefcase, Clock, ChevronRight } from "lucide-react";
+import { ViewToggle, type ListView } from "@/components/common/list";
+import { formatDistanceToNow } from "@/lib/utils/date-utils";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { JobCardV2 } from "@/components/jobs-v2/JobCardV2";
@@ -91,6 +95,101 @@ type JobsV2FiltersState = {
   skills?: string[];
 };
 
+/** Compact list-row view of a job — reuses the card's `/jobs-v2/[id]` navigation. */
+function JobRowV2({ job }: { job: JobV2 }) {
+  const postedLabel = (() => {
+    if (!job.created_at) return "—";
+    try {
+      const d = new Date(job.created_at);
+      return Number.isNaN(d.getTime()) ? "—" : formatDistanceToNow(d);
+    } catch {
+      return "—";
+    }
+  })();
+
+  const subtitle = [job.company_name, job.location].filter(Boolean).join(" · ");
+
+  const stats: Array<{ value: string; label: string }> = [];
+  if (job.job_type) stats.push({ value: job.job_type, label: "Type" });
+  if (job.years_of_experience) stats.push({ value: job.years_of_experience, label: "Experience" });
+  stats.push({ value: postedLabel, label: "Posted" });
+
+  return (
+    <Box
+      component={Link}
+      href={`/jobs-v2/${job.id}`}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        p: 2,
+        borderRadius: 2,
+        cursor: "pointer",
+        textDecoration: "none",
+        color: "inherit",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "all .15s",
+        "&:hover": {
+          borderColor: "#06b6d4",
+          boxShadow: "0 6px 16px -8px rgba(6,182,212,0.35)",
+        },
+      }}
+    >
+      <Avatar
+        src={job.company_logo}
+        alt={job.company_name}
+        variant="rounded"
+        sx={{
+          width: 44,
+          height: 44,
+          flexShrink: 0,
+          borderRadius: 2,
+          bgcolor: "#06b6d4",
+          color: "#fff",
+          fontWeight: 700,
+        }}
+      >
+        {job.company_name?.[0]?.toUpperCase() || <Briefcase size={20} color="#fff" />}
+      </Avatar>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          noWrap
+          sx={{ fontWeight: 800, fontSize: "0.98rem", color: "var(--font-primary)" }}
+        >
+          {job.job_title || "Job Title"}
+        </Typography>
+        <Typography noWrap sx={{ fontSize: "0.82rem", color: "var(--font-secondary)" }}>
+          {subtitle || "—"}
+        </Typography>
+      </Box>
+
+      <Stack
+        direction="row"
+        spacing={2.5}
+        sx={{ display: { xs: "none", md: "flex" }, alignItems: "center" }}
+      >
+        {stats.map((s, i) => (
+          <Stack key={i} alignItems="center" spacing={0}>
+            <Typography
+              noWrap
+              sx={{ fontWeight: 700, fontSize: "0.85rem", color: "var(--font-primary)", maxWidth: 140 }}
+            >
+              {s.value}
+            </Typography>
+            <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary)" }}>
+              {s.label}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+
+      <ChevronRight size={18} style={{ color: "var(--font-tertiary)", flexShrink: 0 }} />
+    </Box>
+  );
+}
+
 export default function JobsV2Page() {
   const { showToast } = useToast();
   const [loading, setLoading] = useState(true);
@@ -102,6 +201,7 @@ export default function JobsV2Page() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(ITEMS_PER_PAGE);
   const [activeTab, setActiveTab] = useState<"browse" | "applied">("browse");
+  const [viewMode, setViewMode] = useState<ListView>("cards");
 
   const fetchJobs = useCallback(async () => {
     try {
@@ -400,17 +500,30 @@ export default function JobsV2Page() {
             ) : activeTab === "browse" ? (
               <>
                 <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mb: 2 }}>
-                  <JobListHeader
-                    totalCount={filteredJobs.length}
-                    pageSize={pageSize}
-                    onPageSizeChange={handlePageSizeChange}
-                  />
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <JobListHeader
+                        totalCount={filteredJobs.length}
+                        pageSize={pageSize}
+                        onPageSizeChange={handlePageSizeChange}
+                      />
+                    </Box>
+                    <ViewToggle value={viewMode} onChange={setViewMode} />
+                  </Box>
                 </Box>
-                <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                  {paginatedJobs.map((job) => (
-                    <JobCardV2 key={job.id} job={job} />
-                  ))}
-                </Box>
+                {viewMode === "cards" ? (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                    {paginatedJobs.map((job) => (
+                      <JobCardV2 key={job.id} job={job} />
+                    ))}
+                  </Box>
+                ) : (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                    {paginatedJobs.map((job) => (
+                      <JobRowV2 key={job.id} job={job} />
+                    ))}
+                  </Box>
+                )}
                 <Box sx={{ mt: 3 }}>
                   <JobPagination
                     totalCount={filteredJobs.length}
@@ -546,16 +659,29 @@ export default function JobsV2Page() {
             </Box>
           ) : activeTab === "browse" ? (
             <>
-              <JobListHeader
-                totalCount={filteredJobs.length}
-                pageSize={pageSize}
-                onPageSizeChange={handlePageSizeChange}
-              />
-              <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 2 }}>
-                {paginatedJobs.map((job) => (
-                  <JobCardV2 key={job.id} job={job} onFavoriteChange={handleFavoriteChange} />
-                ))}
+              <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <JobListHeader
+                    totalCount={filteredJobs.length}
+                    pageSize={pageSize}
+                    onPageSizeChange={handlePageSizeChange}
+                  />
+                </Box>
+                <ViewToggle value={viewMode} onChange={setViewMode} />
               </Box>
+              {viewMode === "cards" ? (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 2 }}>
+                  {paginatedJobs.map((job) => (
+                    <JobCardV2 key={job.id} job={job} onFavoriteChange={handleFavoriteChange} />
+                  ))}
+                </Box>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mt: 2 }}>
+                  {paginatedJobs.map((job) => (
+                    <JobRowV2 key={job.id} job={job} />
+                  ))}
+                </Box>
+              )}
               <Box sx={{ mt: 3, mb: 4 }}>
                 <JobPagination
                   totalCount={filteredJobs.length}

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -2,10 +2,13 @@
 
 import { useState, useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Box, CircularProgress, Pagination, Typography } from "@mui/material";
+import { Box, CircularProgress, Pagination, Stack, Typography } from "@mui/material";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { KpiRail, Reveal } from "@/components/scorecard/shared";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { StatusChip, type ChipTone } from "@/components/admin/assessment/shared";
+import { ViewToggle, type ListView } from "@/components/common/list";
 import { LiveSessionsEmptyState } from "@/components/live-sessions/LiveSessionsEmptyState";
 import { LiveSessionsFeatureBlocked } from "@/components/live-sessions/LiveSessionsFeatureBlocked";
 import { useLiveSessions } from "@/components/live-sessions/useLiveSessions";
@@ -17,9 +20,116 @@ import type { StudentLiveSession } from "@/lib/services/live-sessions";
 
 const PAST = new Set(["ended", "expired"]);
 
+// Compact list-row status pill mapping (mirrors the card's STATUS_CHIP grammar).
+const ROW_STATUS: Record<string, { tone: ChipTone; label: string }> = {
+  live: { tone: "success", label: "Live now" },
+  scheduled: { tone: "info", label: "Upcoming" },
+  ended: { tone: "neutral", label: "Ended" },
+  expired: { tone: "warning", label: "Expired" },
+};
+
+/** Compact list-row rendering of a session — same open/join handler as the card. */
+function SessionRow({
+  session,
+  onOpen,
+  formatDateTime,
+}: {
+  session: StudentLiveSession;
+  onOpen: (s: StudentLiveSession) => void;
+  formatDateTime: (dateString: string) => string;
+}) {
+  const status = session.meeting_status ?? "scheduled";
+  const chip = ROW_STATUS[status] ?? ROW_STATUS.scheduled;
+  const subtitle = session.class_datetime
+    ? formatDateTime(session.class_datetime)
+    : session.course_detail?.title || "One-time session";
+  const durStr = session.duration_minutes ? `${session.duration_minutes}m` : "—";
+
+  return (
+    <Box
+      onClick={() => onOpen(session)}
+      role="button"
+      tabIndex={0}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        p: 2,
+        borderRadius: 2,
+        cursor: "pointer",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "all .15s",
+        "&:hover": {
+          borderColor: "var(--accent-indigo)",
+          boxShadow: "0 6px 16px -8px rgba(124,58,237,0.35)",
+        },
+      }}
+    >
+      <Box
+        sx={{
+          width: 44,
+          height: 44,
+          flexShrink: 0,
+          borderRadius: 2,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #6366f1 0%, #4f46e5 100%)",
+        }}
+      >
+        <IconWrapper icon="mdi:video" size={22} color="#fff" />
+      </Box>
+
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          sx={{
+            fontWeight: 800,
+            fontSize: "0.98rem",
+            color: "var(--font-primary)",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {session.topic_name || "Untitled session"}
+        </Typography>
+        <Typography
+          sx={{
+            color: "var(--font-secondary)",
+            fontSize: "0.82rem",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {subtitle}
+        </Typography>
+      </Box>
+
+      <Stack
+        direction="row"
+        spacing={2.5}
+        sx={{ display: { xs: "none", md: "flex" }, alignItems: "center" }}
+      >
+        <StatusChip label={chip.label} tone={chip.tone} />
+        <Stack alignItems="center" spacing={0}>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.9rem", color: "var(--font-primary)" }}>
+            {durStr}
+          </Typography>
+          <Typography sx={{ fontSize: "0.68rem", color: "var(--font-tertiary)" }}>Duration</Typography>
+        </Stack>
+      </Stack>
+
+      <IconWrapper icon="mdi:chevron-right" size={20} color="var(--font-tertiary)" />
+    </Box>
+  );
+}
+
 export default function LiveSessionsPage() {
   const { t } = useTranslation("common");
   const [filter, setFilter] = useState("all");
+  const [viewMode, setViewMode] = useState<ListView>("cards");
   const {
     loadingClientInfo,
     hasLiveSessionsFeature,
@@ -63,6 +173,21 @@ export default function LiveSessionsPage() {
   useEffect(() => {
     setPage(0);
   }, [filter, setPage]);
+
+  // Same open/join behaviour the card's CTA uses: join if live/upcoming, else
+  // fall back to the recording player, else the AI summary dialog.
+  const openSession = (sess: StudentLiveSession) => {
+    const url = sess.is_google_meet ? sess.join_link?.trim() : sess.zoom_join_url?.trim();
+    if (url) {
+      window.open(url, "_blank");
+      return;
+    }
+    if (sess.has_recording || sess.zoom_recording_url?.trim() || sess.recording_link?.trim()) {
+      handleWatchRecording(sess);
+      return;
+    }
+    if (sess.zoom_ai_summary || sess.google_ai_summary) setSummarySession(sess);
+  };
 
   if (loadingClientInfo || (hasLiveSessionsFeature && loading && sessions.length === 0)) {
     return (
@@ -111,7 +236,12 @@ export default function LiveSessionsPage() {
                 ]}
               />
 
-              <SessionFilterChips options={filterOptions} value={filter} onChange={setFilter} />
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <SessionFilterChips options={filterOptions} value={filter} onChange={setFilter} />
+                </Box>
+                <ViewToggle value={viewMode} onChange={setViewMode} />
+              </Box>
 
               {filteredSessions.length === 0 ? (
                 <Box sx={{ textAlign: "center", py: 6 }}>
@@ -121,32 +251,45 @@ export default function LiveSessionsPage() {
                 </Box>
               ) : (
                 <>
-                  <Box
-                    sx={{
-                      display: "grid",
-                      gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
-                      gap: 2,
-                      alignItems: "stretch",
-                    }}
-                  >
-                    {pagedSessions.map((s, idx) => (
-                      <Reveal key={s.id} delay={Math.min(idx, 8) * 0.05}>
-                        <LiveSessionCard<StudentLiveSession>
+                  {viewMode === "cards" ? (
+                    <Box
+                      sx={{
+                        display: "grid",
+                        gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+                        gap: 2,
+                        alignItems: "stretch",
+                      }}
+                    >
+                      {pagedSessions.map((s, idx) => (
+                        <Reveal key={s.id} delay={Math.min(idx, 8) * 0.05}>
+                          <LiveSessionCard<StudentLiveSession>
+                            session={s}
+                            variant="student"
+                            watchingRecording={watchingRecordingId === s.id}
+                            onJoin={(sess) => {
+                              const url = sess.is_google_meet ? sess.join_link?.trim() : sess.zoom_join_url?.trim();
+                              if (url) window.open(url, "_blank");
+                            }}
+                            onCopyPasscode={handleCopyPassword}
+                            onWatchRecording={handleWatchRecording}
+                            onViewSummary={(sess) => setSummarySession(sess)}
+                            formatDateTime={formatDateTime}
+                          />
+                        </Reveal>
+                      ))}
+                    </Box>
+                  ) : (
+                    <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+                      {pagedSessions.map((s) => (
+                        <SessionRow
+                          key={s.id}
                           session={s}
-                          variant="student"
-                          watchingRecording={watchingRecordingId === s.id}
-                          onJoin={(sess) => {
-                            const url = sess.is_google_meet ? sess.join_link?.trim() : sess.zoom_join_url?.trim();
-                            if (url) window.open(url, "_blank");
-                          }}
-                          onCopyPasscode={handleCopyPassword}
-                          onWatchRecording={handleWatchRecording}
-                          onViewSummary={(sess) => setSummarySession(sess)}
+                          onOpen={openSession}
                           formatDateTime={formatDateTime}
                         />
-                      </Reveal>
-                    ))}
-                  </Box>
+                      ))}
+                    </Box>
+                  )}
 
                   {pageCount > 1 && (
                     <Box sx={{ display: "flex", justifyContent: "center", mt: 1 }}>


### PR DESCRIPTION
Adds the shared `ViewToggle` + a compact list-row view (matching adaptive-courses) to **courses, jobs-v2, live-sessions, admin/cohorts, admin/live-sessions, admin/adaptive-courses**. Card grid unchanged in cards mode; list mode reuses each item's data + the card's own open/nav handler. Filters/tabs/sort/pagination untouched. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)