### PR TITLE
perf(nav): fix adaptive 3-shimmer (double-fetch + matched skeleton) + router staleTimes

### DIFF
--- a/app/adaptive-courses/[courseId]/loading.tsx
+++ b/app/adaptive-courses/[courseId]/loading.tsx
@@ -1,7 +1,21 @@
-import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+import { Box } from "@mui/material";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
+import { JourneyBoardSkeleton } from "@/components/courses/CourseSkeletons";
 
-// Route-segment shimmer — renders instantly as the navigation Suspense fallback so the page never
-// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+// Route-segment shimmer — matches the page's shell (MainLayout + AdaptiveSectionShell)
+// and its actual JourneyBoardSkeleton, so the navigation transition shows ONE
+// consistent skeleton instead of a generic shimmer that then morphs into the page's
+// own skeleton. The page renders the same JourneyBoardSkeleton (via JourneyBoard)
+// while its journey API loads, so there is no visible shape change between phases.
 export default function Loading() {
-  return <PageShimmerLayout variant="detail" />;
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        <AdaptiveSectionShell meshOpacity={0.18}>
+          <JourneyBoardSkeleton />
+        </AdaptiveSectionShell>
+      </Box>
+    </MainLayout>
+  );
 }

--- a/app/adaptive-courses/[courseId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/page.tsx
@@ -1,52 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { Box, ButtonBase, Typography } from "@mui/material";
+import { Box, ButtonBase } from "@mui/material";
 import { Icon } from "@iconify/react";
-import {
-  adaptiveCourseService,
-  type AdaptiveCourseDetail,
-} from "@/lib/services/adaptive-course.service";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { JourneyBoard } from "@/components/adaptive-journey/JourneyBoard";
-import { JourneyBoardSkeleton } from "@/components/courses/CourseSkeletons";
 
 export default function AdaptiveCourseDetailPage() {
   const { push } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
-  const [course, setCourse] = useState<AdaptiveCourseDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [notEnrolled, setNotEnrolled] = useState(false);
 
-  useEffect(() => {
-    if (!Number.isFinite(courseId)) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await adaptiveCourseService.getCourse(courseId);
-        if (!cancelled) setCourse(data);
-      } catch (e) {
-        if (cancelled) return;
-        const httpStatus = (e as { response?: { status?: number } })?.response?.status;
-        if (httpStatus === 403) {
-          setNotEnrolled(true);
-        } else {
-          setError(e instanceof Error ? e.message : "Failed to load course.");
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [courseId]);
-
+  // JourneyBoard fetches the journey (which already returns the course) and renders
+  // its own loading skeleton, 403 "not enrolled" state, and errors — so there is no
+  // page-level getCourse pre-fetch (that was a redundant round-trip + an extra
+  // skeleton phase on top of the route shimmer and JourneyBoard's own skeleton).
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
@@ -59,35 +29,7 @@ export default function AdaptiveCourseDetailPage() {
         </ButtonBase>
 
         <AdaptiveSectionShell meshOpacity={0.18}>
-          {loading && <JourneyBoardSkeleton />}
-          {error && (
-            <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>
-              {error}
-            </Typography>
-          )}
-
-          {notEnrolled && (
-            <Box sx={{ textAlign: "center", py: 6, px: 2 }}>
-              <Icon icon="mdi:lock-outline" width={48} style={{ color: "#a855f7" }} />
-              <Typography sx={{ fontWeight: 800, mt: 1.5, fontSize: "1.1rem" }}>
-                {"You're not enrolled in this course."}
-              </Typography>
-              <Typography sx={{ color: "text.secondary", mt: 0.75, maxWidth: 520, mx: "auto", lineHeight: 1.5 }}>
-                {"Ask your instructor to enroll you, then it'll appear in your Adaptive Courses."}
-              </Typography>
-              <ButtonBase
-                onClick={() => push("/adaptive-courses")}
-                sx={{ mt: 2.5, px: 2.5, py: 1, borderRadius: 999, fontWeight: 800, color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
-              >
-                Back to Adaptive Courses
-              </ButtonBase>
-            </Box>
-          )}
-
-          {/* New adaptive journey UI only — the legacy week/submodule fallback has been removed; the
-              BE guarantees a topic node per submodule, and JourneyBoard renders a new-UI empty state
-              for any transient 0-node board. */}
-          {course && <JourneyBoard courseId={courseId} />}
+          {Number.isFinite(courseId) && <JourneyBoard courseId={courseId} />}
         </AdaptiveSectionShell>
       </Box>
     </MainLayout>

--- a/next.config.ts
+++ b/next.config.ts
@@ -41,6 +41,14 @@ const nextConfig: NextConfig = {
   
   experimental: {
     optimizePackageImports: ["@mui/material", "@mui/icons-material"],
+    // Reuse the client Router Cache for visited routes so back/again navigation
+    // is instant instead of refetching the route on every visit. Default for
+    // dynamic routes is 0 (never reused); 30s makes revisits snappy without
+    // going stale. (Next.js experimental.staleTimes.)
+    staleTimes: {
+      dynamic: 30,
+      static: 180,
+    },
   },
   
   compiler: {


### PR DESCRIPTION
First perf batch from the RCA — targets the reported **3-stacked-shimmers** on the adaptive card→detail transition and **slow revisits**.

- **Collapse the double-fetch (P0-2):** the detail page pre-fetched `getCourse` only as a mount-gate/403 check + rendered a `JourneyBoardSkeleton`, then `JourneyBoard` re-fetched `getJourney` (which already returns the course + handles loading/403). Removed the redundant page fetch + skeleton → **one fewer round-trip and one fewer shimmer phase**. Renders `<JourneyBoard/>` directly.
- **Matched route skeleton (P0-3):** the `loading.tsx` rendered a generic shimmer that morphed into the page's real skeleton. It now renders the **same shell + `JourneyBoardSkeleton`**, so the transition shows **one consistent skeleton** (no shape morph).
- **Router `staleTimes` (P0-4):** `experimental.staleTimes { dynamic: 30, static: 180 }` so visited routes are reused from the client Router Cache instead of refetching on every visit → snappy back/again navigation.

Net: the adaptive detail nav goes 3 shimmers → 1, drops a redundant API round-trip, and revisits are instant. `tsc` clean.

Follow-ups (larger, deferred): hoist `MainLayout` into a shared layout (stops the header remount), TanStack Query + persistence (cold-return cache), broaden matched skeletons to other routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)