### PR TITLE
fix(dashboard): friendly not-started states + progress-first ordering

### DIFF
--- a/components/dashboard/v2/CourseReadinessCard.tsx
+++ b/components/dashboard/v2/CourseReadinessCard.tsx
@@ -47,7 +47,9 @@ export function CourseReadinessCard({
       {/* Tabs */}
       {courses.length > 1 && (
         <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
-          {courses.map((c) => {
+          {[...courses]
+            .sort((a, b) => (b.readiness.overall.percent ?? -1) - (a.readiness.overall.percent ?? -1))
+            .map((c) => {
             const on = c.id === active.id;
             return (
               <ButtonBase
@@ -57,7 +59,9 @@ export function CourseReadinessCard({
               >
                 <Box sx={{ width: 7, height: 7, borderRadius: "50%", bgcolor: BAND_STYLE[c.readiness.overall.band].bar }} />
                 {c.title}
-                <Box component="span" sx={{ color: "rgba(255,255,255,0.5)", fontWeight: 800 }}>{c.readiness.overall.percent ?? "-"}%</Box>
+                {c.readiness.overall.percent != null && (
+                  <Box component="span" sx={{ color: "rgba(255,255,255,0.5)", fontWeight: 800 }}>{c.readiness.overall.percent}%</Box>
+                )}
               </ButtonBase>
             );
           })}
@@ -71,17 +75,28 @@ export function CourseReadinessCard({
           <Box sx={{ position: "relative", width: 150, height: 150, mx: "auto" }}>
             <AnimatedRing value={overall.percent ?? 0} size={150} strokeWidth={12} color="#a855f7" colorEnd="#6366f1" trackColor="rgba(255,255,255,0.12)" showValue={false} />
             <Box sx={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
-              <Typography sx={{ fontWeight: 900, fontSize: "2rem", color: "#fff", lineHeight: 1 }}>
-                {overall.percent ?? "-"}<Box component="span" sx={{ fontSize: "1rem" }}>%</Box>
-              </Typography>
-              <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 1, color: "rgba(255,255,255,0.6)", mt: 0.4 }}>READY</Typography>
+              {overall.percent == null ? (
+                <>
+                  <Typography sx={{ fontWeight: 900, fontSize: "1.5rem", color: "rgba(255,255,255,0.9)", lineHeight: 1 }}>New</Typography>
+                  <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 1, color: "rgba(255,255,255,0.6)", mt: 0.4 }}>TO START</Typography>
+                </>
+              ) : (
+                <>
+                  <Typography sx={{ fontWeight: 900, fontSize: "2rem", color: "#fff", lineHeight: 1 }}>
+                    {overall.percent}<Box component="span" sx={{ fontSize: "1rem" }}>%</Box>
+                  </Typography>
+                  <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 1, color: "rgba(255,255,255,0.6)", mt: 0.4 }}>READY</Typography>
+                </>
+              )}
             </Box>
           </Box>
           <Typography sx={{ mt: 1, fontSize: "0.78rem", fontWeight: 700, color: "rgba(255,255,255,0.7)" }}>{active.title}</Typography>
         </Box>
 
         <Box sx={{ flex: 1, width: "100%" }}>
-          {SIGNALS.map((s) => {
+          {[...SIGNALS]
+            .sort((a, b) => (active.readiness[b.key].percent ?? -1) - (active.readiness[a.key].percent ?? -1))
+            .map((s) => {
             const cell = active.readiness[s.key];
             return <SignalBar key={s.key} icon={s.icon} label={s.label} sub={s.sub} percent={cell.percent} band={cell.band} dark />;
           })}

--- a/components/dashboard/v2/SkillProfilePanel.tsx
+++ b/components/dashboard/v2/SkillProfilePanel.tsx
@@ -95,7 +95,11 @@ export function SkillProfilePanel({
       <Box sx={{ p: 1.5, borderRadius: 3, bgcolor: "#f5f3ff", border: "1px solid #ede9fe", mb: 1.5 }}>
         <Typography sx={{ fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5, color: "#94a3b8" }}>MASTERY · THIS COURSE</Typography>
         <Stack direction="row" alignItems="baseline" justifyContent="space-between">
-          <Typography sx={{ fontWeight: 900, fontSize: "2.2rem", lineHeight: 1, color: "#6366f1" }}>{sp.mastery ?? "-"}%</Typography>
+          {sp.mastery == null ? (
+            <Typography sx={{ fontWeight: 800, fontSize: "1.15rem", lineHeight: 1.1, color: "#94a3b8" }}>Not started yet</Typography>
+          ) : (
+            <Typography sx={{ fontWeight: 900, fontSize: "2.2rem", lineHeight: 1, color: "#6366f1" }}>{sp.mastery}%</Typography>
+          )}
           <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8" }}>{sp.skillsTracked} skills tracked</Typography>
         </Stack>
         {crossCourseMastery != null && (
@@ -105,7 +109,7 @@ export function SkillProfilePanel({
 
       {sp.skills.length > 0 ? (
         <Stack spacing={1.1}>
-          {sp.skills.slice(0, 6).map((sk) => {
+          {[...sp.skills].sort((a, b) => b.percent - a.percent).slice(0, 6).map((sk) => {
             const s = SKILL_STYLE[sk.band];
             return (
               <Box key={sk.skill}>

--- a/components/dashboard/v2/parts.tsx
+++ b/components/dashboard/v2/parts.tsx
@@ -126,8 +126,8 @@ export function SignalBar({
           {sub && <Typography sx={{ fontSize: "0.66rem", color: subColor }}>{sub}</Typography>}
         </Box>
         <BandPill band={band} dark={dark} />
-        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: textColor, minWidth: 42, textAlign: "right" }}>
-          {percent == null ? "-" : `${percent}%`}
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: percent == null ? subColor : textColor, minWidth: 42, textAlign: "right" }}>
+          {percent == null ? "New" : `${percent}%`}
         </Typography>
       </Stack>
       <LinearProgress


### PR DESCRIPTION
## What

First-time learners saw bare `-` placeholders in the student dashboard (Skill Profile mastery, Course Readiness ring/signals, course tabs), which read as broken. This replaces them with intentional not-started copy and orders courses/skills/signals progress-first.

### Changes
- **SkillProfilePanel**: mastery `null` → **"Not started yet"** (muted) instead of `-%`; skills sorted by progress desc so ones with data show first.
- **CourseReadinessCard**: readiness ring `null` → **"New / TO START"**; the course tab `%` chip is hidden when null; course tabs and the four readiness signals sorted by progress desc.
- **parts `SignalBar`**: null signal → **"New"** (muted) instead of `-`.

All ordering uses `[...arr].sort(...)` copies — the underlying arrays (and backend strongest/weakest contract) are untouched.

## Why
Directly addresses the reported UX issue: "in your skills profile it shows '-' in some of course skills that are not started ... it looks ugly for first time learner" and "give priority to show the courses/skills which have any progress ... same goes for course readiness."

## Verification
- `npx tsc --noEmit` clean.
- No behavior change beyond display; ring fill already used `?? 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)