### PR TITLE
feat(dashboard): tenant-gated 'What's next' module widgets

### DIFF
--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -21,6 +21,7 @@ import { UpNextPanel } from "./UpNextPanel";
 import { LeaderboardPanel } from "./LeaderboardPanel";
 import { ContinueCoursesRow } from "./ContinueCoursesRow";
 import { DashboardSkeleton } from "./DashboardSkeleton";
+import { DashboardModulesRow } from "./modules/DashboardModulesRow";
 
 /** Legacy fallback - ONLY for tenants WITHOUT the adaptive feature (the dashboard endpoint 403s) or
  *  an unrecoverable load failure. Every adaptive-enabled tenant gets DashboardV2 (the full layout or
@@ -53,6 +54,7 @@ function EmptyAdaptiveDashboard({ data, hideLeaderboard }: { data: LearnerDashbo
         </Button>
       </Box>
       {!hideLeaderboard && data?.leaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
+      <DashboardModulesRow />
     </Stack>
   );
 }
@@ -99,25 +101,30 @@ export function DashboardV2() {
     // skill profile + certificate + up-next + leaderboard on the right. Course Readiness and Skill
     // Profile are core to the adaptive dashboard, so they render whenever there's an active course
     // (no separate feature flag - that mismatch was what made them intermittently disappear).
-    <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5, alignItems: "start" }}>
-      <Box sx={{ minWidth: 0 }}>
-        {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
-        <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
-        <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
-        {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
+    // Below the grid, tenant-gated module widgets (assessments / live / jobs / community).
+    <>
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5, alignItems: "start" }}>
+        <Box sx={{ minWidth: 0 }}>
+          {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
+          <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
+          <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
+          {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
+        </Box>
+
+        <Stack spacing={2}>
+          <SkillProfilePanel
+            courses={data.courses}
+            activeCourseId={activeCourse?.id ?? null}
+            onSelect={setActiveCourseId}
+            crossCourseMastery={data.aggregate.overallMasteryAvg}
+          />
+          {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
+          {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
+          {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
+        </Stack>
       </Box>
 
-      <Stack spacing={2}>
-        <SkillProfilePanel
-          courses={data.courses}
-          activeCourseId={activeCourse?.id ?? null}
-          onSelect={setActiveCourseId}
-          crossCourseMastery={data.aggregate.overallMasteryAvg}
-        />
-        {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
-        {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
-        {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
-      </Stack>
-    </Box>
+      <DashboardModulesRow />
+    </>
   );
 }

--- a/components/dashboard/v2/modules/CommunityHighlightsPanel.tsx
+++ b/components/dashboard/v2/modules/CommunityHighlightsPanel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { communityService, type Thread } from "@/lib/services/community.service";
+import { avatarColor } from "../parts";
+import { ModuleEmpty, ModuleHeader, ModulePanel, ModuleRowsSkeleton } from "./shared";
+
+const GRADIENT = "linear-gradient(135deg, #a855f7, #ec4899)";
+
+function netScore(t: Thread): number {
+  return (t.upvotes ?? 0) - (t.downvotes ?? 0);
+}
+
+export function CommunityHighlightsPanel() {
+  const router = useRouter();
+  const [items, setItems] = useState<Thread[] | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    communityService
+      .getThreads({ sort: "popular" })
+      .then((list) => {
+        if (cancelled) return;
+        // Server sorts by popularity; guard with a client sort in case it doesn't.
+        const top = [...(list ?? [])].sort((a, b) => netScore(b) - netScore(a)).slice(0, 3);
+        setItems(top);
+      })
+      .catch(() => { if (!cancelled) setHidden(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (hidden) return null;
+
+  return (
+    <ModulePanel>
+      <ModuleHeader icon="mdi:forum-outline" title="Community highlights" gradient={GRADIENT} onViewAll={() => router.push("/community")} />
+      {items == null ? (
+        <ModuleRowsSkeleton rows={3} />
+      ) : items.length === 0 ? (
+        <ModuleEmpty icon="mdi:message-outline" message="No community posts yet - start the conversation." />
+      ) : (
+        <Stack spacing={1}>
+          {items.map((t) => {
+            const name = t.author?.name || t.author?.user_name || "Member";
+            return (
+              <ButtonBase
+                key={t.id}
+                onClick={() => router.push(`/community/${t.id}`)}
+                sx={{ width: "100%", justifyContent: "flex-start", textAlign: "left", p: 1, borderRadius: 2.5, border: "1px solid #eef2f7", "&:hover": { bgcolor: "#fdf4ff", borderColor: "#f0abfc" } }}
+              >
+                <Stack direction="row" spacing={1.25} alignItems="center" sx={{ width: "100%", minWidth: 0 }}>
+                  <Box sx={{ width: 34, height: 34, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center", color: "#fff", fontWeight: 800, fontSize: "0.85rem", bgcolor: avatarColor(name) }}>
+                    {name.charAt(0).toUpperCase()}
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    {t.is_pinned && (
+                      <Typography component="span" sx={{ fontSize: "0.62rem", fontWeight: 800, color: "#c026d3", mr: 0.5 }}>
+                        <Icon icon="mdi:pin" width={11} style={{ verticalAlign: "-2px" }} /> PINNED
+                      </Typography>
+                    )}
+                    <Typography noWrap sx={{ fontWeight: 700, fontSize: "0.86rem", color: "#0f172a" }}>{t.title}</Typography>
+                    <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 0.4 }}>
+                      <Typography noWrap sx={{ fontSize: "0.68rem", color: "#94a3b8", fontWeight: 600, maxWidth: 96 }}>{name}</Typography>
+                      <Stack direction="row" spacing={0.3} alignItems="center">
+                        <Icon icon="mdi:arrow-up-bold" width={13} color="#a855f7" />
+                        <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, color: "#7c3aed" }}>{netScore(t)}</Typography>
+                      </Stack>
+                      <Stack direction="row" spacing={0.3} alignItems="center">
+                        <Icon icon="mdi:comment-outline" width={12} color="#94a3b8" />
+                        <Typography sx={{ fontSize: "0.7rem", fontWeight: 700, color: "#64748b" }}>{t.comments_count ?? 0}</Typography>
+                      </Stack>
+                    </Stack>
+                  </Box>
+                  <Icon icon="mdi:chevron-right" width={18} color="#cbd5e1" />
+                </Stack>
+              </ButtonBase>
+            );
+          })}
+        </Stack>
+      )}
+    </ModulePanel>
+  );
+}

--- a/components/dashboard/v2/modules/DashboardModulesRow.tsx
+++ b/components/dashboard/v2/modules/DashboardModulesRow.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Box, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import {
+  useIsAssessmentEnabled,
+  useIsCommunityEnabled,
+  useIsJobsEnabled,
+  useIsLiveSessionsEnabled,
+} from "@/lib/contexts/ClientInfoContext";
+import { UpcomingAssessmentsPanel } from "./UpcomingAssessmentsPanel";
+import { LiveSessionsPanel } from "./LiveSessionsPanel";
+import { JobOpeningsPanel } from "./JobOpeningsPanel";
+import { CommunityHighlightsPanel } from "./CommunityHighlightsPanel";
+
+/**
+ * A full-width "What's next for you" row of tenant-gated module widgets shown
+ * below the main dashboard grid. Each widget renders ONLY when its module is
+ * enabled for the tenant (strict feature check), fetches its own data, and
+ * hides itself on error - so a slow/missing endpoint never blanks the page.
+ */
+export function DashboardModulesRow() {
+  const assessment = useIsAssessmentEnabled();
+  const live = useIsLiveSessionsEnabled();
+  const jobs = useIsJobsEnabled();
+  const community = useIsCommunityEnabled();
+
+  const panels = [
+    assessment && <UpcomingAssessmentsPanel key="assessment" />,
+    live && <LiveSessionsPanel key="live" />,
+    jobs && <JobOpeningsPanel key="jobs" />,
+    community && <CommunityHighlightsPanel key="community" />,
+  ].filter(Boolean);
+
+  if (panels.length === 0) return null;
+
+  return (
+    <Box sx={{ mt: 2.5 }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+        <Icon icon="mdi:compass-outline" width={18} color="#7c3aed" />
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a" }}>
+          What&apos;s next for you
+        </Typography>
+      </Stack>
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0,1fr))" },
+          gap: 2,
+          alignItems: "stretch",
+        }}
+      >
+        {panels}
+      </Box>
+    </Box>
+  );
+}

--- a/components/dashboard/v2/modules/JobOpeningsPanel.tsx
+++ b/components/dashboard/v2/modules/JobOpeningsPanel.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { jobsV2Service, type JobV2 } from "@/lib/services/jobs-v2.service";
+import { ModuleEmpty, ModuleHeader, ModulePanel, ModuleRowsSkeleton, Pill, timeUntil } from "./shared";
+
+const GRADIENT = "linear-gradient(135deg, #10b981, #0d9488)";
+const SOON_MS = 14 * 86_400_000;
+
+function isOpen(j: JobV2): boolean {
+  return j.status !== "closed" && j.status !== "completed" && j.status !== "inactive";
+}
+function deadlineMs(j: JobV2): number {
+  if (!j.application_deadline) return Infinity;
+  const ms = new Date(j.application_deadline).getTime();
+  return Number.isNaN(ms) || ms < Date.now() ? Infinity : ms;
+}
+
+/** Approaching-deadline jobs first (soonest), then latest posted. */
+function selectJobs(list: JobV2[]): JobV2[] {
+  const now = Date.now();
+  return list
+    .filter(isOpen)
+    .sort((a, b) => {
+      const ad = deadlineMs(a), bd = deadlineMs(b);
+      const aSoon = ad - now < SOON_MS, bSoon = bd - now < SOON_MS;
+      if (aSoon && bSoon) return ad - bd;
+      if (aSoon) return -1;
+      if (bSoon) return 1;
+      const ac = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const bc = b.created_at ? new Date(b.created_at).getTime() : 0;
+      return bc - ac;
+    })
+    .slice(0, 3);
+}
+
+export function JobOpeningsPanel() {
+  const router = useRouter();
+  const [items, setItems] = useState<JobV2[] | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    jobsV2Service
+      .getJobs()
+      .then((res) => { if (!cancelled) setItems(selectJobs(res?.results ?? [])); })
+      .catch(() => { if (!cancelled) setHidden(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (hidden) return null;
+
+  return (
+    <ModulePanel>
+      <ModuleHeader icon="mdi:briefcase-outline" title="Job openings" gradient={GRADIENT} onViewAll={() => router.push("/jobs-v2")} />
+      {items == null ? (
+        <ModuleRowsSkeleton rows={2} />
+      ) : items.length === 0 ? (
+        <ModuleEmpty icon="mdi:briefcase-search-outline" message="No open roles right now - check back soon." />
+      ) : (
+        <Stack spacing={1}>
+          {items.map((j) => {
+            const dl = timeUntil(j.application_deadline);
+            const applied = j.has_applied;
+            return (
+              <ButtonBase
+                key={j.id}
+                onClick={() => router.push(`/jobs-v2/${j.id}`)}
+                sx={{ width: "100%", justifyContent: "flex-start", textAlign: "left", p: 1, borderRadius: 2.5, border: "1px solid #eef2f7", "&:hover": { bgcolor: "#f0fdf9", borderColor: "#a7f3d0" } }}
+              >
+                <Stack direction="row" spacing={1.25} alignItems="center" sx={{ width: "100%", minWidth: 0 }}>
+                  <Box sx={{ width: 38, height: 38, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: "#047857", bgcolor: "#d1fae5", fontWeight: 800, fontSize: "1rem" }}>
+                    {(j.company_name || "?").charAt(0).toUpperCase()}
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography noWrap sx={{ fontWeight: 700, fontSize: "0.86rem", color: "#0f172a" }}>{j.job_title}</Typography>
+                    <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mt: 0.4 }}>
+                      <Typography noWrap sx={{ fontSize: "0.72rem", color: "#64748b", fontWeight: 600, maxWidth: 120 }}>
+                        {j.company_name}{j.location ? ` · ${j.location}` : ""}
+                      </Typography>
+                      {applied ? (
+                        <Pill icon="mdi:check" color="#15803d" bg="#f0fdf4">Applied</Pill>
+                      ) : dl ? (
+                        <Pill icon="mdi:timer-sand" color={dl.soon ? "#b91c1c" : "#475569"} bg={dl.soon ? "#fef2f2" : "#f1f5f9"}>Closes {dl.text}</Pill>
+                      ) : null}
+                    </Stack>
+                  </Box>
+                  <Icon icon="mdi:chevron-right" width={18} color="#cbd5e1" />
+                </Stack>
+              </ButtonBase>
+            );
+          })}
+        </Stack>
+      )}
+    </ModulePanel>
+  );
+}

--- a/components/dashboard/v2/modules/LiveSessionsPanel.tsx
+++ b/components/dashboard/v2/modules/LiveSessionsPanel.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { studentLiveSessionsService, type StudentLiveSession } from "@/lib/services/live-sessions";
+import { ModuleEmpty, ModuleHeader, ModulePanel, ModuleRowsSkeleton, Pill, fmtDateTime, timeUntil } from "./shared";
+
+const GRADIENT = "linear-gradient(135deg, #06b6d4, #3b82f6)";
+
+function joinUrl(s: StudentLiveSession): string | null {
+  return (s.is_google_meet ? s.join_link : s.zoom_join_url) ?? null;
+}
+
+/** Live sessions first, then soonest scheduled. */
+function selectSessions(list: StudentLiveSession[]): StudentLiveSession[] {
+  const relevant = list.filter((s) => s.meeting_status === "live" || s.meeting_status === "scheduled");
+  return relevant
+    .sort((a, b) => {
+      const rank = (s: StudentLiveSession) => (s.meeting_status === "live" ? 0 : 1);
+      if (rank(a) !== rank(b)) return rank(a) - rank(b);
+      const at = a.class_datetime ? new Date(a.class_datetime).getTime() : Infinity;
+      const bt = b.class_datetime ? new Date(b.class_datetime).getTime() : Infinity;
+      return at - bt;
+    })
+    .slice(0, 3);
+}
+
+export function LiveSessionsPanel() {
+  const router = useRouter();
+  const [items, setItems] = useState<StudentLiveSession[] | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    studentLiveSessionsService
+      .getSessions()
+      .then((list) => { if (!cancelled) setItems(selectSessions(list ?? [])); })
+      .catch(() => { if (!cancelled) setHidden(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (hidden) return null;
+
+  return (
+    <ModulePanel>
+      <ModuleHeader icon="mdi:video-outline" title="Live sessions" gradient={GRADIENT} onViewAll={() => router.push("/live-sessions")} />
+      {items == null ? (
+        <ModuleRowsSkeleton rows={2} />
+      ) : items.length === 0 ? (
+        <ModuleEmpty icon="mdi:calendar-blank-outline" message="No live sessions scheduled right now." />
+      ) : (
+        <Stack spacing={1}>
+          {items.map((s) => {
+            const live = s.meeting_status === "live";
+            const url = joinUrl(s);
+            const t = timeUntil(s.class_datetime);
+            return (
+              <ButtonBase
+                key={s.id}
+                onClick={() => router.push("/live-sessions")}
+                sx={{ width: "100%", justifyContent: "flex-start", textAlign: "left", p: 1, borderRadius: 2.5, border: "1px solid", borderColor: live ? "#a5f3fc" : "#eef2f7", bgcolor: live ? "#ecfeff" : "transparent", "&:hover": { bgcolor: live ? "#cffafe" : "#f0f9ff" } }}
+              >
+                <Stack direction="row" spacing={1.25} alignItems="center" sx={{ width: "100%", minWidth: 0 }}>
+                  <Box sx={{ width: 38, height: 38, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: "#0891b2", bgcolor: "#cffafe" }}>
+                    <Icon icon={s.is_google_meet ? "mdi:google" : "mdi:video"} width={19} />
+                  </Box>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography noWrap sx={{ fontWeight: 700, fontSize: "0.86rem", color: "#0f172a" }}>{s.topic_name || s.name || "Live session"}</Typography>
+                    <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mt: 0.4 }}>
+                      {live ? (
+                        <Pill icon="mdi:circle" color="#dc2626" bg="#fef2f2">LIVE NOW</Pill>
+                      ) : (
+                        <Pill icon="mdi:calendar-clock" color="#0e7490" bg="#ecfeff">{t?.text ?? fmtDateTime(s.class_datetime)}</Pill>
+                      )}
+                      {s.course_detail?.title && (
+                        <Typography noWrap sx={{ fontSize: "0.68rem", color: "#94a3b8", fontWeight: 600, maxWidth: 120 }}>{s.course_detail.title}</Typography>
+                      )}
+                    </Stack>
+                  </Box>
+                  {live && url ? (
+                    <Box
+                      component="span"
+                      role="button"
+                      tabIndex={0}
+                      onClick={(e) => { e.stopPropagation(); window.open(url, "_blank", "noopener,noreferrer"); }}
+                      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.stopPropagation(); window.open(url, "_blank", "noopener,noreferrer"); } }}
+                      sx={{ flexShrink: 0, px: 1.5, py: 0.6, borderRadius: 999, fontSize: "0.72rem", fontWeight: 800, color: "#fff", background: "linear-gradient(135deg, #06b6d4, #2563eb)", cursor: "pointer", "&:hover": { filter: "brightness(1.05)" } }}
+                    >
+                      Join
+                    </Box>
+                  ) : (
+                    <Icon icon="mdi:chevron-right" width={18} color="#cbd5e1" />
+                  )}
+                </Stack>
+              </ButtonBase>
+            );
+          })}
+        </Stack>
+      )}
+    </ModulePanel>
+  );
+}

--- a/components/dashboard/v2/modules/UpcomingAssessmentsPanel.tsx
+++ b/components/dashboard/v2/modules/UpcomingAssessmentsPanel.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { assessmentService, type Assessment } from "@/lib/services/assessment.service";
+import { ModuleEmpty, ModuleHeader, ModulePanel, ModuleRowsSkeleton, Pill, fmtDateTime, timeUntil } from "./shared";
+
+const GRADIENT = "linear-gradient(135deg, #6366f1, #8b5cf6)";
+
+function isSubmitted(a: Assessment): boolean {
+  return a.status === "submitted" || a.status === "completed" || a.status === "finalized";
+}
+function isExpired(a: Assessment): boolean {
+  if (a.status === "expired") return true;
+  if (a.end_time && new Date(a.end_time).getTime() < Date.now() && !isSubmitted(a)) return true;
+  return false;
+}
+function startsInFuture(a: Assessment): boolean {
+  return Boolean(a.start_time && new Date(a.start_time).getTime() > Date.now());
+}
+
+/** Available (current) first, sorted by soonest due; then scheduled, by start. */
+function selectUpcoming(list: Assessment[]): Assessment[] {
+  const actionable = list.filter((a) => !isSubmitted(a) && !isExpired(a));
+  const available = actionable
+    .filter((a) => !startsInFuture(a))
+    .sort((a, b) => (a.end_time ? new Date(a.end_time).getTime() : Infinity) - (b.end_time ? new Date(b.end_time).getTime() : Infinity));
+  const scheduled = actionable
+    .filter(startsInFuture)
+    .sort((a, b) => new Date(a.start_time!).getTime() - new Date(b.start_time!).getTime());
+  return [...available, ...scheduled].slice(0, 3);
+}
+
+function TimingChip({ a }: { a: Assessment }) {
+  if (a.status === "in_progress") {
+    return <Pill icon="mdi:progress-clock" color="#b45309" bg="#fffbeb">In progress</Pill>;
+  }
+  if (startsInFuture(a)) {
+    const t = timeUntil(a.start_time);
+    return <Pill icon="mdi:calendar-clock" color="#4338ca" bg="#eef2ff">Starts {t?.text ?? fmtDateTime(a.start_time)}</Pill>;
+  }
+  const due = timeUntil(a.end_time);
+  if (due) {
+    return <Pill icon="mdi:timer-sand" color={due.soon ? "#b91c1c" : "#475569"} bg={due.soon ? "#fef2f2" : "#f1f5f9"}>Due {due.text}</Pill>;
+  }
+  return <Pill icon="mdi:play-circle-outline" color="#15803d" bg="#f0fdf4">Available now</Pill>;
+}
+
+export function UpcomingAssessmentsPanel() {
+  const router = useRouter();
+  const [items, setItems] = useState<Assessment[] | null>(null);
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    assessmentService
+      .getActiveAssessments()
+      .then((list) => { if (!cancelled) setItems(selectUpcoming(list ?? [])); })
+      .catch(() => { if (!cancelled) setHidden(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (hidden) return null;
+
+  return (
+    <ModulePanel>
+      <ModuleHeader icon="mdi:clipboard-text-clock-outline" title="Assessments" gradient={GRADIENT} onViewAll={() => router.push("/assessments")} />
+      {items == null ? (
+        <ModuleRowsSkeleton rows={2} />
+      ) : items.length === 0 ? (
+        <ModuleEmpty icon="mdi:check-circle-outline" message="You're all caught up - no assessments waiting." />
+      ) : (
+        <Stack spacing={1}>
+          {items.map((a) => (
+            <ButtonBase
+              key={a.id}
+              onClick={() => router.push(`/assessments/${a.slug}`)}
+              sx={{ width: "100%", justifyContent: "flex-start", textAlign: "left", p: 1, borderRadius: 2.5, border: "1px solid #eef2f7", "&:hover": { bgcolor: "#faf9ff", borderColor: "#e9d5ff" } }}
+            >
+              <Stack direction="row" spacing={1.25} alignItems="center" sx={{ width: "100%", minWidth: 0 }}>
+                <Box sx={{ width: 38, height: 38, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: "#6366f1", bgcolor: "#eef2ff" }}>
+                  <Icon icon="mdi:file-document-check-outline" width={19} />
+                </Box>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography noWrap sx={{ fontWeight: 700, fontSize: "0.86rem", color: "#0f172a" }}>{a.title}</Typography>
+                  <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mt: 0.4 }}>
+                    <TimingChip a={a} />
+                    <Typography sx={{ fontSize: "0.68rem", color: "#94a3b8", fontWeight: 600 }}>
+                      {a.duration_minutes}m · {a.number_of_questions} Q
+                    </Typography>
+                  </Stack>
+                </Box>
+                <Icon icon="mdi:chevron-right" width={18} color="#cbd5e1" />
+              </Stack>
+            </ButtonBase>
+          ))}
+        </Stack>
+      )}
+    </ModulePanel>
+  );
+}

--- a/components/dashboard/v2/modules/shared.tsx
+++ b/components/dashboard/v2/modules/shared.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Box, ButtonBase, Skeleton, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PanelCard } from "../parts";
+
+/**
+ * Shared chrome + helpers for the tenant-gated dashboard module widgets
+ * (upcoming assessments, live sessions, job openings, community highlights).
+ * Each widget is self-contained: it fetches its own data, and on an
+ * unrecoverable error it hides itself rather than blanking the dashboard.
+ */
+
+/** Card header: gradient icon badge + title + optional "View all" affordance. */
+export function ModuleHeader({
+  icon,
+  title,
+  gradient,
+  onViewAll,
+  viewAllLabel = "View all",
+}: {
+  icon: string;
+  title: string;
+  gradient: string;
+  onViewAll?: () => void;
+  viewAllLabel?: string;
+}) {
+  return (
+    <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 1.5 }}>
+      <Box sx={{ width: 32, height: 32, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", color: "#fff", background: gradient }}>
+        <Icon icon={icon} width={18} />
+      </Box>
+      <Typography sx={{ fontWeight: 800, fontSize: "1rem", color: "#0f172a", flex: 1, minWidth: 0 }}>
+        {title}
+      </Typography>
+      {onViewAll && (
+        <ButtonBase onClick={onViewAll} sx={{ fontSize: "0.74rem", fontWeight: 700, color: "#7c3aed", gap: 0.25, flexShrink: 0 }}>
+          {viewAllLabel}
+          <Icon icon="mdi:arrow-right" width={14} />
+        </ButtonBase>
+      )}
+    </Stack>
+  );
+}
+
+/** Consistent white card wrapper for a module widget (no bottom margin - the
+ *  grid handles spacing; full height so cells in a row line up). */
+export function ModulePanel({ children }: { children: ReactNode }) {
+  return <PanelCard sx={{ mb: 0, height: "100%", display: "flex", flexDirection: "column" }}>{children}</PanelCard>;
+}
+
+/** Slim shimmer that matches a list of rows (single target-matched loader). */
+export function ModuleRowsSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <Stack spacing={1.25} sx={{ mt: 0.5 }}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <Stack key={i} direction="row" spacing={1.25} alignItems="center">
+          <Skeleton variant="rounded" width={38} height={38} sx={{ borderRadius: 2, flexShrink: 0 }} />
+          <Box sx={{ flex: 1 }}>
+            <Skeleton variant="text" width="70%" height={18} />
+            <Skeleton variant="text" width="45%" height={14} />
+          </Box>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
+
+/** Friendly empty state (module enabled but nothing to show right now). */
+export function ModuleEmpty({ icon, message }: { icon: string; message: string }) {
+  return (
+    <Stack alignItems="center" justifyContent="center" spacing={1} sx={{ flex: 1, py: 3, textAlign: "center" }}>
+      <Box sx={{ width: 40, height: 40, borderRadius: "50%", display: "grid", placeItems: "center", bgcolor: "#f1f5f9", color: "#94a3b8" }}>
+        <Icon icon={icon} width={22} />
+      </Box>
+      <Typography sx={{ fontSize: "0.82rem", color: "#94a3b8", fontWeight: 600, maxWidth: 220 }}>{message}</Typography>
+    </Stack>
+  );
+}
+
+/** A small pill used for timing / status / counts inside rows. */
+export function Pill({ icon, children, color, bg }: { icon?: string; children: ReactNode; color: string; bg: string }) {
+  return (
+    <Box component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.35, px: 0.85, py: 0.25, borderRadius: 999, fontSize: "0.66rem", fontWeight: 800, color, bgcolor: bg, whiteSpace: "nowrap" }}>
+      {icon && <Icon icon={icon} width={12} />}
+      {children}
+    </Box>
+  );
+}
+
+/** "in 2d" / "in 3h" / "in 12m" / "now" until an ISO datetime, with a `soon`
+ *  flag when it's close (drives amber/red urgency). Null if no/invalid date. */
+export function timeUntil(iso?: string | null): { text: string; soon: boolean; overdue: boolean } | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime() - Date.now();
+  if (Number.isNaN(ms)) return null;
+  if (ms <= 0) return { text: "now", soon: true, overdue: true };
+  const mins = Math.floor(ms / 60000);
+  if (mins < 60) return { text: `in ${mins}m`, soon: true, overdue: false };
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return { text: `in ${hrs}h`, soon: hrs < 6, overdue: false };
+  const days = Math.floor(hrs / 24);
+  return { text: `in ${days}d`, soon: days <= 2, overdue: false };
+}
+
+/** Short human date-time, e.g. "Jul 25, 3:00 PM". Empty string on bad input. */
+export function fmtDateTime(iso?: string | null): string {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}

--- a/lib/contexts/ClientInfoContext.tsx
+++ b/lib/contexts/ClientInfoContext.tsx
@@ -182,3 +182,26 @@ export function useIsAdaptiveQuizEnabled(): boolean {
     clientInfo?.features?.some((f) => f.name === "adaptive_quiz"),
   );
 }
+
+/** Learner-side module gates for the dashboard "what's next" widgets. Each uses
+ *  the same strict feature check as the sidebar so a widget only appears when the
+ *  tenant actually has that module enabled (otherwise it stays hidden). */
+export function useIsAssessmentEnabled(): boolean {
+  const { clientInfo } = useClientInfo();
+  return Boolean(clientInfo?.features?.some((f) => f.name === "assessment"));
+}
+
+export function useIsLiveSessionsEnabled(): boolean {
+  const { clientInfo } = useClientInfo();
+  return Boolean(clientInfo?.features?.some((f) => f.name === "live_sessions"));
+}
+
+export function useIsJobsEnabled(): boolean {
+  const { clientInfo } = useClientInfo();
+  return Boolean(clientInfo?.features?.some((f) => f.name === "jobs_v2"));
+}
+
+export function useIsCommunityEnabled(): boolean {
+  const { clientInfo } = useClientInfo();
+  return Boolean(clientInfo?.features?.some((f) => f.name === "community_forum"));
+}


### PR DESCRIPTION
## What
Adds a full-width **"What's next for you"** row of self-contained module widgets below the main student dashboard grid, so the dashboard reads as "filled" for every learner (addresses the request to surface next assessments, live sessions, jobs, and community posts).

| Widget | Content | Sort | Feature gate |
|---|---|---|---|
| **Upcoming assessments** | current + scheduled; timing chips (In progress / Due in Xh / Starts in Xd / Available now) | available (soonest due) then scheduled | `assessment` |
| **Live sessions** | live-now (with **Join** button) + scheduled; countdown; Zoom/Meet aware | live first, then soonest | `live_sessions` |
| **Job openings** | "Closes in Xd" urgency, "Applied" state | approaching-deadline first, then latest posted | `jobs_v2` |
| **Community highlights** | most-popular threads (net score), author + vote/comment counts | popularity | `community_forum` |

## Design
- Each widget renders **only when its module is enabled for the tenant** — new strict feature hooks `useIsAssessmentEnabled` / `useIsLiveSessionsEnabled` / `useIsJobsEnabled` / `useIsCommunityEnabled` (same `.some(f => f.name === …)` pattern as the existing dashboard gates).
- Each **fetches its own data client-side** after the main dashboard paints (never blocks first paint), shows a **target-matched shimmer** while loading, a **friendly empty state** when there's nothing, and **hides itself on error** — a slow/missing endpoint never blanks the page.
- Consistent white-card chrome with distinct per-module accent (indigo / cyan / emerald / pink) and content; 2-up responsive grid.
- Rendered on **both** the populated dashboard and the empty-adaptive state.

## Files
- New: `components/dashboard/v2/modules/` — `shared.tsx`, `UpcomingAssessmentsPanel`, `LiveSessionsPanel`, `JobOpeningsPanel`, `CommunityHighlightsPanel`, `DashboardModulesRow`.
- Edited: `DashboardV2.tsx` (wire the row into both states), `lib/contexts/ClientInfoContext.tsx` (4 gate hooks).

Reuses existing student services only (`assessmentService.getActiveAssessments`, `studentLiveSessionsService.getSessions`, `jobsV2Service.getJobs`, `communityService.getThreads({sort:"popular"})`) — no backend changes.

## Verification
- `npx tsc --noEmit` clean.
- Gating verified against sidebar feature names; each panel independently error-isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)