### PR TITLE
feat(profile): college dropdown (master-data autocomplete) + degree dropdown

### DIFF
--- a/components/profile/CollegeAutocomplete.tsx
+++ b/components/profile/CollegeAutocomplete.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Autocomplete, Box, CircularProgress, TextField, Typography } from "@mui/material";
+import { collegesService, type CollegeOption } from "@/lib/services/colleges.service";
+
+/**
+ * Searchable college / university picker backed by the global college
+ * master-data endpoint, with **free-text fallback** (`freeSolo`): if a learner's
+ * institution isn't in the list they can still type it, and it's stored as a
+ * plain string exactly like before. Debounced server search (250ms).
+ *
+ * The field's value is a plain string (the college name), so this is a
+ * drop-in replacement for the free-text TextField it supersedes - it keeps the
+ * same `value: string` / `onChange(name: string)` contract.
+ */
+export function CollegeAutocomplete({
+  value,
+  onChange,
+  label,
+  placeholder = "Search or type your college",
+  required = false,
+  error = false,
+  helperText,
+  size = "small",
+  fullWidth = true,
+}: {
+  value: string;
+  onChange: (name: string) => void;
+  label?: string;
+  placeholder?: string;
+  required?: boolean;
+  error?: boolean;
+  helperText?: string;
+  size?: "small" | "medium";
+  fullWidth?: boolean;
+}) {
+  const [input, setInput] = useState(value || "");
+  const [options, setOptions] = useState<CollegeOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reflect an externally-set value (e.g. editing an existing entry).
+  useEffect(() => {
+    setInput((prev) => (prev === (value || "") ? prev : value || ""));
+  }, [value]);
+
+  // Debounced server-side search on the typed text.
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setLoading(true);
+      try {
+        const res = await collegesService.search(input, 20);
+        setOptions(res);
+      } catch {
+        setOptions([]); // fail soft - free typing still works
+      } finally {
+        setLoading(false);
+      }
+    }, 250);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [input]);
+
+  return (
+    <Autocomplete<CollegeOption, false, false, true>
+      freeSolo
+      fullWidth={fullWidth}
+      options={options}
+      loading={loading}
+      // Server already filtered; never re-filter client-side.
+      filterOptions={(x) => x}
+      getOptionLabel={(o) => (typeof o === "string" ? o : o.name)}
+      inputValue={input}
+      onInputChange={(_, v) => {
+        setInput(v);
+        onChange(v);
+      }}
+      onChange={(_, v) => {
+        const name = typeof v === "string" ? v : v?.name ?? "";
+        setInput(name);
+        onChange(name);
+      }}
+      isOptionEqualToValue={(o, v) => o.name === (typeof v === "string" ? v : v?.name)}
+      renderOption={(props, option) => {
+        const meta = [option.city, option.state].filter(Boolean).join(", ");
+        return (
+          <Box component="li" {...props} key={option.id}>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography sx={{ fontSize: "0.88rem", fontWeight: 600, color: "var(--font-primary)" }} noWrap>
+                {option.name}
+              </Typography>
+              {meta && (
+                <Typography sx={{ fontSize: "0.72rem", color: "var(--font-secondary)" }} noWrap>
+                  {meta}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+        );
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          label={label}
+          placeholder={placeholder}
+          required={required}
+          error={error}
+          helperText={helperText}
+          size={size}
+          InputProps={{
+            ...params.InputProps,
+            endAdornment: (
+              <>
+                {loading ? <CircularProgress size={16} sx={{ mr: 1 }} /> : null}
+                {params.InputProps.endAdornment}
+              </>
+            ),
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/components/profile/EducationSection.tsx
+++ b/components/profile/EducationSection.tsx
@@ -2,10 +2,12 @@
 
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Box, Paper, Typography, Button, TextField, IconButton, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
+import { Autocomplete, Box, Paper, Typography, Button, TextField, IconButton, Dialog, DialogTitle, DialogContent, DialogActions } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { UserProfile, Education } from "@/lib/services/profile.service";
 import { LoadingButton } from "@/components/common/LoadingButton";
+import { CollegeAutocomplete } from "@/components/profile/CollegeAutocomplete";
+import { DEGREE_OPTIONS } from "@/lib/profile/academic-options";
 
 interface EducationSectionProps {
   profile: UserProfile;
@@ -479,31 +481,33 @@ export function EducationSection({
         </DialogTitle>
         <DialogContent sx={{ px: { xs: 2.5, sm: 3 }, pb: 2 }}>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5, pt: { xs: 3, sm: 3.5 } }}>
-            <TextField
+            <CollegeAutocomplete
               label="Institution"
               value={formData.institution}
-              onChange={(e) => setFormData({ ...formData, institution: e.target.value })}
-              fullWidth
-              size="small"
-              sx={{
-                "& .MuiOutlinedInput-root": {
-                  borderRadius: 1.5,
-                  fontSize: "0.9375rem",
-                },
-              }}
+              onChange={(name) => setFormData({ ...formData, institution: name })}
             />
-            <TextField
-              label="Degree"
+            <Autocomplete
+              freeSolo
+              options={DEGREE_OPTIONS}
               value={formData.degree}
-              onChange={(e) => setFormData({ ...formData, degree: e.target.value })}
-              fullWidth
-              size="small"
-              sx={{
-                "& .MuiOutlinedInput-root": {
-                  borderRadius: 1.5,
-                  fontSize: "0.9375rem",
-                },
-              }}
+              inputValue={formData.degree}
+              onInputChange={(_, v) => setFormData({ ...formData, degree: v })}
+              onChange={(_, v) => setFormData({ ...formData, degree: v ?? "" })}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Degree"
+                  placeholder="Select or type your degree"
+                  fullWidth
+                  size="small"
+                  sx={{
+                    "& .MuiOutlinedInput-root": {
+                      borderRadius: 1.5,
+                      fontSize: "0.9375rem",
+                    },
+                  }}
+                />
+              )}
             />
             <TextField
               label="Field of Study"

--- a/components/profile/PersonalInformationCard.tsx
+++ b/components/profile/PersonalInformationCard.tsx
@@ -6,6 +6,7 @@ import { Box, Paper, Typography, TextField, Button, MenuItem, Select, FormContro
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { UserProfile } from "@/lib/services/profile.service";
+import { CollegeAutocomplete } from "@/components/profile/CollegeAutocomplete";
 
 interface PersonalInformationCardProps {
   profile: UserProfile;
@@ -866,18 +867,10 @@ export function PersonalInformationCard({
               </Typography>
             </Box>
             {editing ? (
-              <TextField
-                value={formData.college_name}
-                onChange={handleChange("college_name")}
-                fullWidth
-                size="small"
-                placeholder="Enter college/university name"
-                sx={{
-                  "& .MuiOutlinedInput-root": {
-                    borderRadius: 1.5,
-                    fontSize: "0.9375rem",
-                  },
-                }}
+              <CollegeAutocomplete
+                value={formData.college_name || ""}
+                onChange={(name) => setFormData({ ...formData, college_name: name })}
+                placeholder="Search or type your college/university"
               />
             ) : (
               <Typography

--- a/lib/profile/academic-options.ts
+++ b/lib/profile/academic-options.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared academic option lists for the profile dropdowns. College names come
+ * from the backend master-data endpoint (see colleges.service); degrees are a
+ * small, stable, hardcoded set (like zskillup's course list). All degree
+ * pickers are `freeSolo`, so a value not in this list can still be typed.
+ */
+export const DEGREE_OPTIONS = [
+  "B.Tech",
+  "B.E.",
+  "B.Sc",
+  "BCA",
+  "B.Com",
+  "BBA",
+  "B.A",
+  "B.Arch",
+  "M.Tech",
+  "M.E.",
+  "M.Sc",
+  "MCA",
+  "M.Com",
+  "MBA",
+  "M.A",
+  "Ph.D",
+  "Diploma",
+  "Other",
+];

--- a/lib/services/colleges.service.ts
+++ b/lib/services/colleges.service.ts
@@ -1,0 +1,24 @@
+import apiClient from "./api";
+
+export interface CollegeOption {
+  id: number;
+  name: string;
+  city?: string;
+  state?: string;
+}
+
+/**
+ * Global college / university master-data used by the profile "college"
+ * dropdown. Backed by GET /accounts/colleges/?search=&limit= (not tenant
+ * scoped). The profile still stores the college NAME as free text, so this is
+ * only a source of search suggestions - if the endpoint is unavailable the
+ * caller falls back to free typing.
+ */
+export const collegesService = {
+  search: async (query: string, limit = 20): Promise<CollegeOption[]> => {
+    const res = await apiClient.get(`/accounts/colleges/`, {
+      params: { search: query.trim(), limit },
+    });
+    return res.data?.colleges ?? [];
+  },
+};


### PR DESCRIPTION
## What
Delivers the profile-Phase-2 ask: **college selected from a dropdown** instead of free text (the one real gap — the profile is already sectioned, computes completion, and syncs to the resume).

- **`colleges.service`** — `GET /accounts/colleges/?search=&limit=` (fail-soft).
- **`CollegeAutocomplete`** — `freeSolo` MUI Autocomplete with debounced server search (250ms) and `name + city/state` option rows. The value stays a **plain string**, so it's a drop-in for the `TextField` it replaces. If the endpoint is unavailable or a college isn't in the list, the learner just **types it** (exactly today's behavior).
- Wired into **`PersonalInformationCard`** (`college_name`) and **`EducationSection`** (`institution`).
- **`EducationSection` degree** is now a `freeSolo` dropdown from a shared `DEGREE_OPTIONS` list (`lib/profile/academic-options`).

## Why the rest of the ask is already covered
Research confirmed the profile already: is sectioned (Education/Experience/Skills/…), computes completion (`profileCompletion.ts`), and one-way-syncs to the resume (`buildResumeInitialData`). Adding an education entry **already** increases progress and flows into the resume — only the **input UX** (free text → dropdown) was missing.

## Depends on
Backend PR **AI-Linc-LMS/ai-linc-backend#405** (College master-data + `/accounts/colleges/` + `seed_colleges`). This FE **degrades gracefully** without it — the autocomplete just returns no suggestions and free typing works — so it's safe to ship independently.

## Verification
- `npx tsc --noEmit` clean.
- Value contract unchanged (string in/out), so existing save plumbing (`updateUserProfile`, arrays replaced whole) and resume seeding are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)