### PR TITLE
feat(dashboard): move 'What's next' widgets into the right rail

### DIFF
--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -21,7 +21,7 @@ import { UpNextPanel } from "./UpNextPanel";
 import { LeaderboardPanel } from "./LeaderboardPanel";
 import { ContinueCoursesRow } from "./ContinueCoursesRow";
 import { DashboardSkeleton } from "./DashboardSkeleton";
-import { DashboardModulesRow } from "./modules/DashboardModulesRow";
+import { DashboardModulesRow, DashboardModulesRail } from "./modules/DashboardModulesRow";
 
 /** Legacy fallback - ONLY for tenants WITHOUT the adaptive feature (the dashboard endpoint 403s) or
  *  an unrecoverable load failure. Every adaptive-enabled tenant gets DashboardV2 (the full layout or
@@ -101,30 +101,28 @@ export function DashboardV2() {
     // skill profile + certificate + up-next + leaderboard on the right. Course Readiness and Skill
     // Profile are core to the adaptive dashboard, so they render whenever there's an active course
     // (no separate feature flag - that mismatch was what made them intermittently disappear).
-    // Below the grid, tenant-gated module widgets (assessments / live / jobs / community).
-    <>
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5, alignItems: "start" }}>
-        <Box sx={{ minWidth: 0 }}>
-          {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
-          <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
-          <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
-          {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
-        </Box>
-
-        <Stack spacing={2}>
-          <SkillProfilePanel
-            courses={data.courses}
-            activeCourseId={activeCourse?.id ?? null}
-            onSelect={setActiveCourseId}
-            crossCourseMastery={data.aggregate.overallMasteryAvg}
-          />
-          {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
-          {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
-          {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
-        </Stack>
+    // The tenant-gated module widgets live in the right rail (they fill it out
+    // and each sizes to its content) rather than a sparse full-width grid.
+    <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" }, gap: 2.5, alignItems: "start" }}>
+      <Box sx={{ minWidth: 0 }}>
+        {data.briefing && <AiBriefingHero briefing={data.briefing} profile={data.profile} />}
+        <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
+        <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
+        {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
       </Box>
 
-      <DashboardModulesRow />
-    </>
+      <Stack spacing={2}>
+        <SkillProfilePanel
+          courses={data.courses}
+          activeCourseId={activeCourse?.id ?? null}
+          onSelect={setActiveCourseId}
+          crossCourseMastery={data.aggregate.overallMasteryAvg}
+        />
+        {activeCourse?.certificate.enabled && <CertificatePanel course={activeCourse} />}
+        {courseEnabled && <UpNextPanel items={data.crossCourseUpNext} />}
+        <DashboardModulesRail />
+        {!hideLeaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
+      </Stack>
+    </Box>
   );
 }

--- a/components/dashboard/v2/modules/DashboardModulesRow.tsx
+++ b/components/dashboard/v2/modules/DashboardModulesRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
@@ -14,26 +15,56 @@ import { JobOpeningsPanel } from "./JobOpeningsPanel";
 import { CommunityHighlightsPanel } from "./CommunityHighlightsPanel";
 
 /**
- * A full-width "What's next for you" row of tenant-gated module widgets shown
- * below the main dashboard grid. Each widget renders ONLY when its module is
- * enabled for the tenant (strict feature check), fetches its own data, and
- * hides itself on error - so a slow/missing endpoint never blanks the page.
+ * The tenant-gated "What's next for you" module widgets. Each renders ONLY when
+ * its module is enabled for the tenant (strict feature check), fetches its own
+ * data, and hides itself on error - so a slow/missing endpoint never blanks the
+ * page. Rendered two ways:
+ *   - DashboardModulesRail: stacked in the right sidebar (main dashboard) so the
+ *     rail fills out and each panel sizes to its content (no empty grid gaps).
+ *   - DashboardModulesRow: a full-width 2-up grid (the empty-adaptive dashboard,
+ *     which has no sidebar).
  */
-export function DashboardModulesRow() {
+function useGatedPanels(): ReactNode[] {
   const assessment = useIsAssessmentEnabled();
   const live = useIsLiveSessionsEnabled();
   const jobs = useIsJobsEnabled();
   const community = useIsCommunityEnabled();
 
-  const panels = [
+  return [
     assessment && <UpcomingAssessmentsPanel key="assessment" />,
     live && <LiveSessionsPanel key="live" />,
     jobs && <JobOpeningsPanel key="jobs" />,
     community && <CommunityHighlightsPanel key="community" />,
-  ].filter(Boolean);
+  ].filter(Boolean) as ReactNode[];
+}
 
+function SectionLabel() {
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 0.5, mt: 0.5 }}>
+      <Icon icon="mdi:compass-outline" width={17} color="#7c3aed" />
+      <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "#0f172a" }}>
+        What&apos;s next for you
+      </Typography>
+    </Stack>
+  );
+}
+
+/** Right-sidebar variant: a labelled, single-column stack of the enabled panels. */
+export function DashboardModulesRail() {
+  const panels = useGatedPanels();
   if (panels.length === 0) return null;
+  return (
+    <>
+      <SectionLabel />
+      {panels}
+    </>
+  );
+}
 
+/** Full-width variant (empty-adaptive dashboard, no sidebar): 2-up responsive grid. */
+export function DashboardModulesRow() {
+  const panels = useGatedPanels();
+  if (panels.length === 0) return null;
   return (
     <Box sx={{ mt: 2.5 }}>
       <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
@@ -47,7 +78,7 @@ export function DashboardModulesRow() {
           display: "grid",
           gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0,1fr))" },
           gap: 2,
-          alignItems: "stretch",
+          alignItems: "start",
         }}
       >
         {panels}


### PR DESCRIPTION
## What
Two dashboard complaints, one fix. The tenant-gated widgets (assessments/live/jobs/community) sat in a **sparse full-width 2×2 grid** below the dashboard, while the **right sidebar ended early** and left a big empty gap.

- New **`DashboardModulesRail`** renders the same gated panels **in the right sidebar** (single column, under "What's next for you", after Up Next), so the rail fills out to match the tall left column and **each panel sizes to its content** — no more stretched, half-empty cards.
- The full-width `DashboardModulesRow` is kept only for the **empty-adaptive dashboard** (which has no sidebar); its grid now aligns to `start` (not `stretch`) so short cards don't stretch into empty space either.
- Gating, per-widget fetch, shimmer/empty/hide-on-error all unchanged.

## Result
- Right sidebar is filled (addresses "page looks empty").
- "What's next" cards are content-height and match the existing rail panels (Up Next / Skill Profile) — no sparse gaps.

## Verification
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)