### PR TITLE
feat(admin): move Settings into profile menu + full-width preview

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   CircularProgress,
   Paper,
+  Stack,
   TextField,
   Typography,
 } from "@mui/material";
@@ -71,9 +72,162 @@ function SettingCard({
   );
 }
 
+/**
+ * Live preview of how the branding inputs land in the product: the browser tab
+ * (favicon + app name) and the login screen (logo + tagline) on the fixed
+ * midnight-hyper palette. Updates as the admin types.
+ */
+function LivePreview({
+  logoUrl,
+  faviconUrl,
+  loginSlogan,
+  appName,
+}: {
+  logoUrl: string;
+  faviconUrl: string;
+  loginSlogan: string;
+  appName: string;
+}) {
+  const logo = logoUrl.trim();
+  const favicon = faviconUrl.trim();
+  const slogan = loginSlogan.trim() || "Learn faster. Grow further.";
+
+  return (
+    <Box
+      sx={{
+        position: { lg: "sticky" },
+        top: { lg: 16 },
+        borderRadius: 3,
+        border: "1px solid var(--border-default)",
+        bgcolor: "var(--card-bg)",
+        overflow: "hidden",
+      }}
+    >
+      <Box sx={{ px: 2.25, pt: 2, pb: 1.25 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", color: "var(--font-primary)" }}>
+          Live preview
+        </Typography>
+        <Typography sx={{ fontSize: "0.78rem", color: "var(--font-secondary)" }}>
+          How your logo, favicon, and tagline appear.
+        </Typography>
+      </Box>
+
+      {/* Browser-tab mock */}
+      <Box sx={{ px: 2.25, pb: 1.5 }}>
+        <Box sx={{ display: "flex", alignItems: "flex-end", gap: 0.5 }}>
+          <Box
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.75,
+              maxWidth: 220,
+              px: 1.25,
+              py: 0.75,
+              borderTopLeftRadius: 10,
+              borderTopRightRadius: 10,
+              bgcolor: "#ffffff",
+              border: "1px solid #e5e7eb",
+              borderBottom: "none",
+              boxShadow: "0 -1px 2px rgba(16,24,40,0.04)",
+            }}
+          >
+            {favicon ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={favicon} alt="" width={16} height={16} style={{ objectFit: "contain", flexShrink: 0 }} />
+            ) : (
+              <Box sx={{ width: 16, height: 16, borderRadius: "50%", bgcolor: "#c4b5fd", flexShrink: 0 }} />
+            )}
+            <Typography noWrap sx={{ fontSize: "0.72rem", fontWeight: 600, color: "#334155" }}>
+              {appName}
+            </Typography>
+            <Box component="span" sx={{ ml: 0.25, color: "#94a3b8", fontSize: "0.8rem", lineHeight: 1 }}>
+              ×
+            </Box>
+          </Box>
+        </Box>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            px: 1.25,
+            py: 0.75,
+            borderRadius: "0 8px 8px 8px",
+            bgcolor: "#f1f5f9",
+            border: "1px solid #e5e7eb",
+          }}
+        >
+          <Box sx={{ width: 10, height: 10, borderRadius: "50%", border: "2px solid #cbd5e1", flexShrink: 0 }} />
+          <Typography noWrap sx={{ fontSize: "0.72rem", color: "#94a3b8", fontFamily: "ui-monospace, monospace" }}>
+            app.yourdomain.com
+          </Typography>
+        </Box>
+      </Box>
+
+      {/* Login-screen mock (fixed midnight-hyper palette) */}
+      <Box sx={{ px: 2.25, pb: 2.25 }}>
+        <Box
+          sx={{
+            borderRadius: 2.5,
+            p: 3,
+            textAlign: "center",
+            color: "#fff",
+            background: "radial-gradient(120% 90% at 50% 0%, #2a1150 0%, #14061f 55%, #0f0518 100%)",
+            border: "1px solid rgba(168,85,247,0.25)",
+          }}
+        >
+          <Box sx={{ minHeight: 44, display: "flex", alignItems: "center", justifyContent: "center", mb: 1.5 }}>
+            {logo ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={logo} alt="Logo" style={{ maxHeight: 44, maxWidth: 200, objectFit: "contain" }} />
+            ) : (
+              <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "rgba(255,255,255,0.5)" }}>Your logo</Typography>
+            )}
+          </Box>
+          <Typography sx={{ fontSize: "0.82rem", color: "rgba(255,255,255,0.72)", mb: 2, lineHeight: 1.5 }}>
+            {slogan}
+          </Typography>
+          <Stack spacing={1} sx={{ mb: 1.75 }}>
+            {["Email", "Password"].map((ph) => (
+              <Box
+                key={ph}
+                sx={{
+                  height: 34,
+                  borderRadius: 1.5,
+                  bgcolor: "rgba(255,255,255,0.06)",
+                  border: "1px solid rgba(255,255,255,0.14)",
+                  display: "flex",
+                  alignItems: "center",
+                  px: 1.25,
+                }}
+              >
+                <Typography sx={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.4)" }}>{ph}</Typography>
+              </Box>
+            ))}
+          </Stack>
+          <Box
+            sx={{
+              height: 36,
+              borderRadius: 999,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontWeight: 800,
+              fontSize: "0.82rem",
+              background: "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)",
+            }}
+          >
+            Sign in
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
 export default function AdminSettingsPage() {
   const { showToast } = useToast();
-  const { refreshClientInfo } = useClientInfo();
+  const { refreshClientInfo, clientInfo } = useClientInfo();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [uploadingFavicon, setUploadingFavicon] = useState(false);
@@ -141,7 +295,7 @@ export default function AdminSettingsPage() {
   };
 
   return (
-    <PageShell maxWidth={920}>
+    <PageShell>
       <ModulePageHeader
         eyebrow="Admin"
         title="Settings"
@@ -164,7 +318,15 @@ export default function AdminSettingsPage() {
           <CircularProgress />
         </Box>
       ) : (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 400px" },
+            gap: 2.5,
+            alignItems: "start",
+          }}
+        >
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
           {/* App logo */}
           <SettingCard
             icon="mdi:image-outline"
@@ -263,6 +425,14 @@ export default function AdminSettingsPage() {
               sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
             />
           </SettingCard>
+          </Box>
+
+          <LivePreview
+            logoUrl={logoUrl}
+            faviconUrl={faviconUrl}
+            loginSlogan={loginSlogan}
+            appName={clientInfo?.name || "Your app"}
+          />
         </Box>
       )}
     </PageShell>

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -35,7 +35,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useLeaderboardAndStreak } from "@/lib/hooks/useLeaderboardAndStreak";
 import { useStreakCelebration, primeNavStreak } from "@/lib/streak/streakCelebration";
 import { IconWrapper } from "@/components/common/IconWrapper";
-import { Settings } from "lucide-react";
+import { Settings, ShieldCheck } from "lucide-react";
 import { LanguageSelect } from "@/components/common/LanguageSelect";
 import { useTranslation } from "react-i18next";
 import { isRtl } from "@/lib/i18n";
@@ -66,6 +66,11 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
   const role = user?.role;
   const canToggleAdminMode = isFullAdminRole(role);
   const effectiveAdminMode = isAdminOnlyRole(role) || isAdminMode;
+  // Admin "Settings" (logo / favicon / login text) moved from the sidebar into
+  // this menu; keep the same gate the sidebar item used (admin_branding feature).
+  const canSeeAdminSettings =
+    canToggleAdminMode &&
+    Boolean(clientInfo?.features?.some((f) => f.name === "admin_branding"));
   const { i18n, t } = useTranslation("common");
   const rtl = isRtl(i18n.language || "en");
   const {
@@ -1075,7 +1080,7 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
                     : "transparent",
                 }}
               >
-                <Box component="span" sx={{ marginInlineEnd: 1.5, display: "inline-flex" }}><Settings size={18} /></Box>
+                <Box component="span" sx={{ marginInlineEnd: 1.5, display: "inline-flex" }}><ShieldCheck size={18} /></Box>
                 {isAdminMode ? t("common.exitAdminMode") : t("common.switchToAdmin")}
               </MenuItem>
             )}
@@ -1089,8 +1094,20 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
               }}
             >
               <Box component="span" sx={{ marginInlineEnd: 1.5, display: "inline-flex" }}><User size={18} /></Box>
-              {t("common.profileSettings")}
+              {t("common.profile")}
             </MenuItem>
+
+            {canSeeAdminSettings && (
+              <MenuItem
+                onClick={() => {
+                  router.push("/admin/settings");
+                  handleMenuClose();
+                }}
+              >
+                <Box component="span" sx={{ marginInlineEnd: 1.5, display: "inline-flex" }}><Settings size={18} /></Box>
+                {t("common.settings")}
+              </MenuItem>
+            )}
 
             <MenuItem
               onClick={() => {

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -131,13 +131,7 @@ const ADMIN_SECTIONS: NavSection[] = [
     icon: "mdi:email-outline",
     itemFeatures: ["admin_emails", "admin_notifications"],
   },
-  {
-    id: "admin_settings",
-    labelKey: "navSection.settings",
-    label: "Settings",
-    icon: "mdi:cog-outline",
-    itemFeatures: ["admin_branding"],
-  },
+  // Admin Settings moved out of the sidebar into the profile menu (top-right).
 ];
 const ADMIN_STANDALONE_TOP = ["admin_dashboard"];
 const ADMIN_STANDALONE_BOTTOM = ["admin_tickets"];
@@ -486,15 +480,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
       descKey: "navDesc.admin_manage_instructors",
       orgAdminOnly: true,
     },
-    {
-      label: "Settings",
-      labelKey: "nav.settings",
-      path: "/admin/settings",
-      icon: "mdi:cog-outline",
-      featureName: "admin_branding",
-      descKey: "navDesc.admin_branding",
-      orgAdminOnly: true,
-    },
+    // "Settings" (admin logo / favicon / login-page text) now lives in the
+    // profile menu (AppBar), not the sidebar.
     {
       label: "Course Builder",
       labelKey: "nav.courseBuilder",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -271,6 +271,7 @@
     "quickLinks": "Quick Links",
     "todaysLeaders": "Today's Leaders",
     "profileSettings": "Profile Settings",
+    "profile": "Profile",
     "dashboard":"Back to dashboard",
     "saving": "Saving...",
     "uploading": "Uploading…",


### PR DESCRIPTION
## What
Reorganizes admin **Settings** (logo / favicon / login-page text) per request.

- **Sidebar**: removed the "Settings" section + item — it's no longer a sidebar destination.
- **Profile menu** (top-right): renamed "Profile Settings" → **"Profile"**, and added a new **"Settings"** item that opens `/admin/settings`. Gated to admins **with the `admin_branding` feature** (the exact gate the old sidebar item used). The admin-mode toggle now uses a shield icon so it no longer shares the cog with Settings.
- **Admin Settings page**: now **full-width** with a two-column layout — the logo/favicon/login-text cards on the left and a sticky **Live preview** on the right:
  - a **browser-tab mock** (favicon + app name + URL bar), and
  - a **login-screen mock** (logo + tagline on the fixed midnight-hyper palette, with mock email/password fields + a gradient Sign-in button)

  — both updating live as you type.

## Verification
- `npx tsc --noEmit` clean. Added the `common.profile` i18n key. No dangling `admin_settings` references; `/admin/settings` route unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)