### PR TITLE
fix(time-tracking): cap deltas + heartbeat + idle guard (no more sleep-balloon)

### DIFF
--- a/hooks/useTimeTracking.ts
+++ b/hooks/useTimeTracking.ts
@@ -6,9 +6,29 @@ import {
   getTimeTrackingSessionId,
 } from "@/lib/services/activity.service";
 
+/**
+ * Tracks "time on platform" and posts small deltas to the backend.
+ *
+ * Previously this sent raw wall-clock elapsed (`Date.now() - segmentStart`) with
+ * NO cap, and only on tab-hide / unload. If the OS slept (or a tab sat open for
+ * hours) with a segment open, `Date.now()` jumped forward by the whole span and
+ * that entire duration was posted as "time spent" - the cause of absurdly large
+ * values. This version:
+ *   - sends a heartbeat every HEARTBEAT so each delta is small (~1 min),
+ *   - CAPS every delta at MAX_DELTA_SECONDS, so a sleep/suspend jump can never
+ *     post more than a minute or two,
+ *   - pauses counting when the tab is hidden OR the user has been idle
+ *     (no interaction) for IDLE_LIMIT, and
+ *   - resets the segment start synchronously before the async send, so a
+ *     hide-then-unload race can't post the same delta twice.
+ */
+const HEARTBEAT_MS = 60_000; // flush at most once a minute while active
+const MAX_DELTA_SECONDS = 120; // hard cap per send (bounds sleep/suspend jumps)
+const IDLE_LIMIT_MS = 10 * 60_000; // no interaction for 10 min => stop counting
+
 export const useTimeTracking = (active: boolean = true) => {
   const startTimeRef = useRef<number>(Date.now());
-  const accumulatedTimeRef = useRef<number>(0);
+  const lastInteractionRef = useRef<number>(Date.now());
 
   const getDeviceType = () => {
     if (typeof window === "undefined") return "desktop";
@@ -18,36 +38,43 @@ export const useTimeTracking = (active: boolean = true) => {
     return "desktop";
   };
 
-  const getFormattedDate = () => {
-    return new Date().toISOString().split("T")[0];
-  };
+  const getFormattedDate = () => new Date().toISOString().split("T")[0];
 
-  const sendTrackingData = async (isSessionEnd: boolean = false) => {
+  /**
+   * Flush the current segment. `requireActive` drops the segment if the user has
+   * been idle (used by the heartbeat); the hide/unload flushes pass it false so a
+   * genuine "leaving" still records the time up to that moment.
+   */
+  const flush = (isSessionEnd: boolean, requireActive: boolean) => {
+    if (typeof document !== "undefined" && document.hidden && !isSessionEnd) {
+      return; // don't accrue while the tab is in the background
+    }
     const now = Date.now();
-    const sessionSeconds = Math.floor((now - startTimeRef.current) / 1000);
-    const totalToSend = sessionSeconds + accumulatedTimeRef.current;
-
-    if (totalToSend <= 0) return;
-
-    try {
-      await activityService.trackTime({
-        time_spent_seconds: totalToSend,
+    const elapsed = Math.floor((now - startTimeRef.current) / 1000);
+    // Reset the segment start BEFORE the async send so a concurrent event
+    // (e.g. beforeunload right after visibilitychange) can't re-post this delta.
+    startTimeRef.current = now;
+    if (elapsed <= 0) return;
+    if (requireActive && now - lastInteractionRef.current > IDLE_LIMIT_MS) {
+      return; // idle: discard this segment entirely
+    }
+    const seconds = Math.min(elapsed, MAX_DELTA_SECONDS); // <-- the cap
+    void activityService
+      .trackTime({
+        time_spent_seconds: seconds,
         session_id: getTimeTrackingSessionId(),
         date: getFormattedDate(),
         device_type: getDeviceType(),
         session_only: isSessionEnd,
+      })
+      .catch(() => {
+        /* silently ignore */
       });
-
-      startTimeRef.current = now;
-      accumulatedTimeRef.current = 0;
-    } catch (error) {
-      // Silently fail as requested (without user knowing)
-    }
   };
 
   const resetSegmentStart = () => {
     startTimeRef.current = Date.now();
-    accumulatedTimeRef.current = 0;
+    lastInteractionRef.current = Date.now();
   };
 
   useEffect(() => {
@@ -55,35 +82,36 @@ export const useTimeTracking = (active: boolean = true) => {
 
     resetSegmentStart();
 
+    const markInteraction = () => {
+      lastInteractionRef.current = Date.now();
+    };
+    const interactionEvents = ["pointerdown", "keydown", "scroll", "mousemove", "touchstart"];
+    interactionEvents.forEach((e) =>
+      window.addEventListener(e, markInteraction, { passive: true }),
+    );
+
+    const heartbeat = window.setInterval(() => flush(false, true), HEARTBEAT_MS);
+
     const handleVisibilityChange = () => {
       if (document.hidden) {
-        // User switched tab or left — send time for this segment
-        sendTrackingData(true);
+        flush(true, false); // record time up to the moment they left
       } else {
-        // User came back — new segment, same session_id
-        resetSegmentStart();
+        resetSegmentStart(); // new segment; don't count the hidden gap
       }
     };
-
-    const handleBeforeUnload = () => {
-      sendTrackingData(true);
-    };
+    const handleBeforeUnload = () => flush(true, false);
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
     window.addEventListener("beforeunload", handleBeforeUnload);
 
     return () => {
+      window.clearInterval(heartbeat);
+      interactionEvents.forEach((e) => window.removeEventListener(e, markInteraction));
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active]);
 
   return null;
 };
-
-
-
-
-
-
-


### PR DESCRIPTION
## RCA
The time-tracking hook posted **raw wall-clock elapsed** (`Date.now() - segmentStart`) with **no cap**, flushing only on tab-hide / `beforeunload`. When the OS slept/suspended (or a tab sat open for hours) with a segment open, `Date.now()` jumped forward by the entire span and that whole duration was posted as "time spent" — the cause of the absurdly large values. (Backend then `+=`'d it and even smeared the remainder onto *yesterday*.)

## Fix (frontend)
- **Heartbeat** every 60s → each delta is small (~1 min).
- **Hard cap of 120s per send** → a sleep/suspend jump can never post more than ~2 min.
- **Pause counting** when the tab is hidden **or** the user has been idle (no `pointerdown`/`keydown`/`scroll`/`mousemove`/`touchstart`) for 10 min.
- **Synchronous segment-start reset** before the async send → kills the hide-then-unload double-post race.

## Companion
Server-side backstop caps (per-request clamp + drop the overflow-to-yesterday smear + per-day clamp) land in the backend PR so a crafted/legacy client can't over-report either.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)