### PR TITLE
perf(dashboard): short-TTL client cache for the learner dashboard payload

### DIFF
--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -22,11 +22,41 @@ import type { LeaderboardPeriod, LeaderboardStreaks } from "@/lib/types/leaderbo
 const BASE = "/adaptive-journey/api";
 const ADMIN = "/adaptive-journey/api/admin";
 
+// Short-lived in-memory cache for the (expensive) learner dashboard payload so
+// navigating away and back is instant instead of refetching everything each
+// time. A shared in-flight promise means concurrent mounts make one request.
+const DASHBOARD_TTL_MS = 60_000;
+let dashboardCache: { at: number; data: LearnerDashboard } | null = null;
+let dashboardInflight: Promise<LearnerDashboard> | null = null;
+
+/** Drop the cached dashboard so the next read refetches (e.g. after an action
+ *  that changes progress/points). */
+export function invalidateLearnerDashboard() {
+  dashboardCache = null;
+}
+
 export const adaptiveJourneyService = {
   // ---- Learner surfaces ----
-  async getLearnerDashboard(): Promise<LearnerDashboard> {
-    const { data } = await apiClient.get<LearnerDashboard>(`${BASE}/learner/dashboard/`);
-    return data;
+  async getLearnerDashboard(force = false): Promise<LearnerDashboard> {
+    if (!force) {
+      if (dashboardCache && Date.now() - dashboardCache.at < DASHBOARD_TTL_MS) {
+        return dashboardCache.data;
+      }
+      if (dashboardInflight) return dashboardInflight;
+    }
+    const req = apiClient
+      .get<LearnerDashboard>(`${BASE}/learner/dashboard/`)
+      .then(({ data }) => {
+        dashboardCache = { at: Date.now(), data };
+        dashboardInflight = null;
+        return data;
+      })
+      .catch((e) => {
+        dashboardInflight = null;
+        throw e;
+      });
+    if (!force) dashboardInflight = req;
+    return req;
   },
 
   async getPointsSystem(): Promise<PointsSystem> {


### PR DESCRIPTION
## Why
RCA of "the whole dashboard takes too long to load" found **zero client caching** — every visit/remount refetched the full (expensive) dashboard payload, so navigating away and back always paid the whole cost.

## Fix
A **60s in-memory cache** + a **shared in-flight promise** on `getLearnerDashboard()` (mirrors the existing leaderboard/streak module cache). Repeat visits within the window are **instant**, and concurrent mounts make a single request. `force` param + `invalidateLearnerDashboard()` for explicit refresh after progress-changing actions.

This addresses the repeat-visit cost. The first-load backend cost (per-course journey-board N+1, a `select_for_update` in `ensure_default_journey` on every read) is a separate backend follow-up.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)