### PR TITLE
feat(celebrations): Duolingo-style XP lightning + fire polish + fly-to-nav fix

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,7 @@ import { TelemetryProvider } from "@/components/providers/TelemetryProvider";
 import { ProfileActivationBlocker } from "@/components/auth/ProfileActivationBlocker";
 import { TenantSetupBlocker } from "@/components/auth/TenantSetupBlocker";
 import { XPGainProvider } from "@/components/community/XPGainProvider";
+import { XpCelebrationOverlay } from "@/components/common/XpCelebrationOverlay";
 import { TourProvider } from "@/components/community/TourProvider";
 import { config } from "@/lib/config";
 import { themeToCssBlock } from "@/lib/theme/themeToCssBlock";
@@ -126,6 +127,7 @@ export default async function RootLayout({
                                     <ProfileActivationBlocker />
                                     <TenantSetupBlocker />
                                     {children}
+                                    <XpCelebrationOverlay />
                                   </TourProvider>
                                 </XPGainProvider>
                               </ToastProvider>

--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -9,6 +9,7 @@ import { AdaptiveCodingProblemPanel } from "@/components/coding/AdaptiveCodingPr
 import { AdaptiveCodingSubmissions } from "@/components/coding/AdaptiveCodingSubmissions";
 import { useToast } from "@/components/common/Toast";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
+import { celebrateXp } from "@/lib/xp/xpCelebration";
 import {
   getAvailableLanguages,
   getLanguageId,
@@ -237,6 +238,7 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
       } else if (res.grade.all_passed) {
         setSolvedAlready(true);
         setPointsEarned(res.points_earned ?? 0);  // freezes the timer HUD on the earned points
+        if (res.points_earned) celebrateXp(res.points_earned);
         const pts = res.points_earned ? ` · +${res.points_earned} pts` : "";
         showToast(`Passed - clean & correct${pts}`, "success");
       } else {

--- a/components/common/StreakCelebrationOverlay.tsx
+++ b/components/common/StreakCelebrationOverlay.tsx
@@ -18,6 +18,7 @@ export function StreakCelebrationOverlay() {
   const { celebrating, celebrateCount } = useStreakCelebration();
   const [phase, setPhase] = useState<Phase>("idle");
   const [flyTo, setFlyTo] = useState<{ x: number; y: number } | null>(null);
+  const [flyFrom, setFlyFrom] = useState<{ x: number; y: number } | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const flyingRef = useRef(false);
 
@@ -42,11 +43,36 @@ export function StreakCelebrationOverlay() {
     [celebrating, celebrateCount],
   );
 
+  // Rising embers around the flame - the "fire" feel.
+  const embers = useMemo(
+    () =>
+      Array.from({ length: 14 }, (_, i) => ({
+        id: i,
+        x: (Math.random() - 0.5) * 120,
+        rise: 90 + Math.random() * 90,
+        size: 4 + Math.random() * 5,
+        delay: Math.random() * 1.1,
+        duration: 1.1 + Math.random() * 0.8,
+        drift: (Math.random() - 0.5) * 40,
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [celebrating, celebrateCount],
+  );
+
   // Start the flame's flight to the nav (idempotent - also used by tap-to-skip).
   const startFly = useCallback(() => {
     if (flyingRef.current) return;
     flyingRef.current = true;
     if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null; }
+    // Start the flight from the flame disc's ACTUAL on-screen position (it sits
+    // above screen-centre, being the top of the disc + number + text column) so
+    // the flame doesn't visibly jump down to centre before flying. Read it while
+    // the burst is still mounted (before we switch phase).
+    const disc = typeof document !== "undefined" ? document.getElementById("streak-burst-flame") : null;
+    if (disc) {
+      const dr = disc.getBoundingClientRect();
+      setFlyFrom({ x: dr.left + dr.width / 2, y: dr.top + dr.height / 2 });
+    }
     const el = typeof document !== "undefined" ? document.getElementById("nav-streak-flame") : null;
     if (el) {
       const r = el.getBoundingClientRect();
@@ -60,7 +86,7 @@ export function StreakCelebrationOverlay() {
   }, []);
 
   useEffect(() => {
-    if (!celebrating) { setPhase("idle"); setFlyTo(null); flyingRef.current = false; return; }
+    if (!celebrating) { setPhase("idle"); setFlyTo(null); setFlyFrom(null); flyingRef.current = false; return; }
     flyingRef.current = false;
     setPhase("burst");
     timerRef.current = setTimeout(startFly, BURST_MS);
@@ -97,7 +123,13 @@ export function StreakCelebrationOverlay() {
       {/* Center burst: confetti + flame + count */}
       <AnimatePresence>
         {phase === "burst" && (
-          <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}>
+          <motion.div
+            key="burst"
+            initial={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.35, ease: "easeOut" }}
+            style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}
+          >
             {/* Confetti */}
             {confetti.map((c) => (
               <motion.div
@@ -114,6 +146,22 @@ export function StreakCelebrationOverlay() {
               />
             ))}
 
+            {/* Rising embers behind the flame */}
+            {embers.map((e) => (
+              <motion.div
+                key={`ember-${e.id}`}
+                initial={{ x: e.x, y: 20, opacity: 0, scale: 1 }}
+                animate={{ x: e.x + e.drift, y: -e.rise, opacity: [0, 1, 0], scale: 0.4 }}
+                transition={{ duration: e.duration, delay: e.delay, repeat: Infinity, ease: "easeOut" }}
+                style={{
+                  position: "absolute", left: "50%", top: "55%", zIndex: 1,
+                  width: e.size, height: e.size, borderRadius: "50%",
+                  background: "radial-gradient(circle, #fde68a, #f97316)",
+                  boxShadow: "0 0 8px 2px rgba(249,115,22,0.45)",
+                }}
+              />
+            ))}
+
             <motion.div
               initial={{ scale: 0, opacity: 0, y: 10 }}
               animate={{ scale: 1, opacity: 1, y: 0 }}
@@ -123,6 +171,7 @@ export function StreakCelebrationOverlay() {
             >
               {/* Glowing flame disc */}
               <motion.div
+                id="streak-burst-flame"
                 animate={{ boxShadow: [
                   "0 0 40px 8px rgba(245,158,11,0.5)",
                   "0 0 70px 18px rgba(249,115,22,0.7)",
@@ -161,7 +210,7 @@ export function StreakCelebrationOverlay() {
                 You&apos;re on fire - keep it going 🚀
               </Typography>
             </motion.div>
-          </Box>
+          </motion.div>
         )}
       </AnimatePresence>
 
@@ -179,12 +228,17 @@ export function StreakCelebrationOverlay() {
         </motion.div>
       )}
 
-      {/* Flame flies to the nav streak chip, then the nav ticks +1 */}
+      {/* Flame flies to the nav streak chip (from the disc's real spot, so no
+          jump), shrinking + fading out as it lands; then the nav ticks +1. */}
       {phase === "fly" && flyTo && (
         <motion.div
-          initial={{ x: cx, y: cy, scale: 2.2, opacity: 1 }}
-          animate={{ x: flyTo.x, y: flyTo.y, scale: 0.45, opacity: 0.95 }}
-          transition={{ duration: 0.8, ease: [0.4, 0, 0.2, 1] }}
+          initial={{ x: (flyFrom ?? { x: cx, y: cy }).x, y: (flyFrom ?? { x: cx, y: cy }).y, scale: 1.8, opacity: 1 }}
+          animate={{ x: flyTo.x, y: flyTo.y, scale: 0.4, opacity: [1, 1, 0.7, 0] }}
+          transition={{
+            duration: 0.95,
+            ease: [0.22, 1, 0.36, 1],
+            opacity: { times: [0, 0.5, 0.82, 1], ease: "easeIn" },
+          }}
           onAnimationComplete={onFlyComplete}
           style={{ position: "fixed", top: 0, left: 0, marginLeft: -28, marginTop: -28, fontSize: 56, zIndex: 3, filter: "drop-shadow(0 6px 16px rgba(249,115,22,0.6))" }}
         >

--- a/components/common/XpCelebrationOverlay.tsx
+++ b/components/common/XpCelebrationOverlay.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Box, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useXpCelebration } from "@/lib/xp/xpCelebration";
+
+const HOLD_MS = 1500;
+// Radial spark spokes (fixed angles => deterministic, SSR-safe).
+const SPARKS = Array.from({ length: 12 }, (_, i) => (i * 360) / 12);
+
+/**
+ * Global Duolingo-style "+N XP" lightning burst. Store-driven (celebrateXp),
+ * mounted once in app/layout so any earn can fire it from anywhere. Non-blocking
+ * (pointer-events: none) and self-dismissing.
+ */
+export function XpCelebrationOverlay() {
+  const { amount, token } = useXpCelebration();
+  const [shown, setShown] = useState<{ amount: number; token: number } | null>(null);
+
+  useEffect(() => {
+    if (token === 0 || amount <= 0) return;
+    setShown({ amount, token });
+    const t = setTimeout(() => setShown(null), HOLD_MS);
+    return () => clearTimeout(t);
+  }, [token, amount]);
+
+  return (
+    <AnimatePresence>
+      {shown && (
+        <motion.div
+          key={shown.token}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          style={{ position: "fixed", inset: 0, zIndex: 2300, pointerEvents: "none" }}
+          aria-hidden
+        >
+          {/* ambient glow */}
+          <motion.div
+            initial={{ scale: 0.2, opacity: 0.85 }}
+            animate={{ scale: [0.2, 1.7, 1.4], opacity: [0.85, 0.45, 0] }}
+            transition={{ duration: 0.95, ease: "easeOut" }}
+            style={{
+              position: "absolute", left: "50%", top: "50%", marginLeft: -150, marginTop: -150,
+              width: 300, height: 300, borderRadius: "50%",
+              background: "radial-gradient(circle, rgba(250,204,21,0.55) 0%, rgba(168,85,247,0.28) 45%, transparent 70%)",
+            }}
+          />
+          {/* white flash */}
+          <motion.div
+            initial={{ scale: 0.4, opacity: 0.75 }}
+            animate={{ scale: 1.3, opacity: 0 }}
+            transition={{ duration: 0.35, ease: "easeOut" }}
+            style={{
+              position: "absolute", left: "50%", top: "50%", marginLeft: -95, marginTop: -95,
+              width: 190, height: 190, borderRadius: "50%",
+              background: "radial-gradient(circle, rgba(255,255,255,0.9), transparent 60%)",
+            }}
+          />
+          {/* radial sparks (opacity-only anim so the static radial transform holds) */}
+          {SPARKS.map((deg, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: [0, 1, 0] }}
+              transition={{ duration: 0.55, delay: 0.05 + (i % 4) * 0.03, ease: "easeOut" }}
+              style={{
+                position: "absolute", left: "50%", top: "50%",
+                width: 3, height: 44, borderRadius: 2,
+                background: "linear-gradient(#fef08a, #f59e0b)",
+                transform: `translate(-50%, -50%) rotate(${deg}deg) translateY(-66px)`,
+                transformOrigin: "center",
+              }}
+            />
+          ))}
+          {/* bolt + XP (centered via framer x/y -50% so scale/rotate compose cleanly) */}
+          <motion.div
+            initial={{ scale: 0, rotate: -22, opacity: 0 }}
+            animate={{ scale: [0, 1.25, 1], rotate: [-22, 8, 0], opacity: 1 }}
+            transition={{ type: "spring", stiffness: 420, damping: 15 }}
+            style={{
+              position: "absolute", left: "50%", top: "50%", x: "-50%", y: "-50%",
+              display: "flex", flexDirection: "column", alignItems: "center", gap: 8,
+            }}
+          >
+            <Box
+              sx={{
+                width: 96, height: 96, borderRadius: "30%", display: "grid", placeItems: "center",
+                background: "linear-gradient(135deg, #fde047 0%, #f59e0b 100%)",
+                boxShadow: "0 14px 34px -8px rgba(245,158,11,0.75), 0 0 0 7px rgba(250,204,21,0.16)",
+              }}
+            >
+              <Icon icon="mdi:lightning-bolt" width={56} color="#fff" />
+            </Box>
+            <motion.div initial={{ y: 12, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: 0.12 }}>
+              <Typography
+                sx={{
+                  fontWeight: 900, fontSize: "1.85rem", color: "#fff", letterSpacing: "-0.02em",
+                  textShadow: "0 2px 12px rgba(245,158,11,0.85)",
+                }}
+              >
+                +{shown.amount} XP
+              </Typography>
+            </motion.div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/hooks/useAdaptiveSession.ts
+++ b/hooks/useAdaptiveSession.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { adaptiveQuizService } from "@/lib/services/adaptive-quiz.service";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
+import { celebrateXp } from "@/lib/xp/xpCelebration";
 import type {
   AdaptiveQuestion,
   AdaptiveSessionDetail,
@@ -177,8 +178,12 @@ export function useAdaptiveSession({
         };
       });
       resetForNextQuestion();
-      // Finishing the quiz counts as a completion — trigger the streak celebration.
-      if (result.session_complete) notifyContentCompleted();
+      // Finishing the quiz counts as a completion — celebrate the session XP + streak.
+      if (result.session_complete) {
+        const totalXp = sessionPoints + (result.points_earned ?? 0);
+        celebrateXp(totalXp);
+        notifyContentCompleted();
+      }
       return result;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to submit answer");

--- a/lib/hooks/useAssessmentSubmission.ts
+++ b/lib/hooks/useAssessmentSubmission.ts
@@ -7,6 +7,7 @@ import {
   SESSION_START_SCREENSHOT_TYPE,
   type ViolationScreenshotSample,
 } from "@/lib/services/assessment.service";
+import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import { stopAllMediaTracks } from "@/lib/utils/cameraUtils";
 import { getProctoringService } from "@/lib/services/proctoring.service";
 import { formatAssessmentResponses } from "@/utils/assessment.utils";
@@ -289,7 +290,12 @@ export function useAssessmentSubmission({
       try {
         await assessmentService.finalSubmit(slug, requestBody);
         // If we get here, submission was successful (API throws on error)
-        
+
+        // Submitting an assessment is a completion too - fire the streak celebration
+        // (this path previously never did, so assessments didn't keep the streak alive
+        // in the UI even though the backend counted them).
+        notifyContentCompleted();
+
         // Mark as navigated to prevent duplicate navigation
         hasNavigatedRef.current = true;
       } catch (submitError: any) {

--- a/lib/xp/xpCelebration.ts
+++ b/lib/xp/xpCelebration.ts
@@ -1,0 +1,41 @@
+"use client";
+
+/**
+ * XP celebration store - a tiny module-level store (no provider) so any flow that
+ * earns points can fire a Duolingo-style lightning "+N XP" burst from anywhere,
+ * including immersive pages with no layout. Mirrors lib/streak/streakCelebration.
+ *
+ * Usage: `celebrateXp(pointsEarned)` after a server-confirmed earn; the global
+ * <XpCelebrationOverlay/> (mounted in app/layout) plays the lightning burst.
+ */
+import { useSyncExternalStore } from "react";
+
+export interface XpCelebrationState {
+  amount: number;
+  /** Increments on every trigger so the overlay re-plays even for the same amount. */
+  token: number;
+}
+
+let state: XpCelebrationState = { amount: 0, token: 0 };
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+function getSnapshot() {
+  return state;
+}
+
+/** Fire a lightning "+N XP" burst. No-op for non-positive / invalid amounts. */
+export function celebrateXp(amount: number) {
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) return;
+  state = { amount: Math.round(amount), token: state.token + 1 };
+  listeners.forEach((l) => l());
+}
+
+export function useXpCelebration(): XpCelebrationState {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## What
Duolingo-style micro-celebrations for XP + streaks, plus a fix for the fly-to-nav glitch.

### ⚡ XP lightning burst (new)
A global "+N XP" **lightning zap** (bolt + electric sparks + glow flash) that plays after an earn. New module store `lib/xp/xpCelebration.ts` + `XpCelebrationOverlay` mounted once in `app/layout` (works everywhere, non-blocking). Fired from:
- adaptive **quiz** session-complete → session total XP (`useAdaptiveSession`)
- adaptive **coding** solve → points earned (`AdaptiveCodingSolve`)

### 🔥 Fire celebration polish
Rising **embers** behind the flame for a richer fire feel (the streak celebration already existed).

### 🐛 Fly-to-nav glitch — RCA + fix
**Root cause:** the flame flew from *exact screen-centre*, but the burst disc actually sits well **above** centre (it's the top of the disc → number → "day streak" → subtitle column), so at the burst→fly handoff the flame **jumped down ~80px** before flying.
**Fix:** start the flight from the disc's **real on-screen position** (`#streak-burst-flame` rect). Plus smoother easing, the burst **fades out** during the handoff, and the flame **fades to 0** as it lands on the nav chip.

### Bonus
Assessment submit now fires `notifyContentCompleted()` — submitting an assessment keeps the streak alive in the UI (it never did before).

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)