### PR TITLE
fix(adaptive-courses): consistent card alignment

### DIFF
--- a/components/courses/AdaptiveCourseCard.tsx
+++ b/components/courses/AdaptiveCourseCard.tsx
@@ -24,7 +24,12 @@ export function AdaptiveCourseCard({
         width: "100%",
         height: "100%",
         textAlign: "left",
-        display: "block",
+        // Flex column so every card lines up: image on top, meta pinned to the
+        // bottom - regardless of whether a course has a description or more
+        // metric rows. Fixes the ragged, inconsistent card layout.
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
         borderRadius: 3,
         p: 2.5,
         bgcolor: "var(--card-bg, #fff)",
@@ -38,15 +43,16 @@ export function AdaptiveCourseCard({
         },
       }}
     >
-      {course.card_image_url && (
-        <Box sx={{ width: "100%", aspectRatio: "16 / 9", borderRadius: 2.5, overflow: "hidden", mb: 1.5, bgcolor: "color-mix(in srgb, #6366f1 8%, transparent)" }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
+      {/* Always render the image band (fallback gradient) so the header lines up. */}
+      <Box sx={{ width: "100%", aspectRatio: "16 / 9", borderRadius: 2.5, overflow: "hidden", mb: 1.5, flexShrink: 0, background: "linear-gradient(135deg, color-mix(in srgb, #6366f1 14%, transparent), color-mix(in srgb, #a855f7 12%, transparent))" }}>
+        {course.card_image_url && (
+          // eslint-disable-next-line @next/next/no-img-element
           <img src={course.card_image_url} alt={course.title} loading="lazy" style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} />
-        </Box>
-      )}
+        )}
+      </Box>
 
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.5 }}>
-        <Box sx={{ width: 44, height: 44, borderRadius: 3, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)", boxShadow: "0 14px 26px -14px rgba(168, 85, 247, 0.6)" }}>
+        <Box sx={{ width: 44, height: 44, borderRadius: 3, flexShrink: 0, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)", boxShadow: "0 14px 26px -14px rgba(168, 85, 247, 0.6)" }}>
           <Icon icon="mdi:book-education-outline" width={22} />
         </Box>
         <Box component="span" sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.65rem", fontWeight: 800, letterSpacing: 0.4, textTransform: "uppercase", color: "#a855f7", bgcolor: "color-mix(in srgb, #a855f7 14%, transparent)" }}>
@@ -54,14 +60,13 @@ export function AdaptiveCourseCard({
         </Box>
       </Box>
 
-      <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3 }}>{course.title}</Typography>
-      {course.description && (
-        <Typography sx={{ color: "text.secondary", mt: 0.75, fontSize: "0.86rem", lineHeight: 1.5, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
-          {course.description}
-        </Typography>
-      )}
+      <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{course.title}</Typography>
+      <Typography sx={{ color: "text.secondary", mt: 0.75, fontSize: "0.86rem", lineHeight: 1.5, minHeight: "2.6em", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+        {course.description || ""}
+      </Typography>
 
-      <Box sx={{ display: "flex", gap: 2, mt: 2, flexWrap: "wrap" }}>
+      {/* Meta pinned to the card bottom so it aligns across every card. */}
+      <Box sx={{ display: "flex", gap: 1.5, columnGap: 2, mt: "auto", pt: 2, flexWrap: "wrap" }}>
         <Metric icon="mdi:view-module-outline" label="modules" value={course.module_count} />
         <Metric icon="mdi:file-tree-outline" label="submodules" value={course.submodule_count} />
         <Metric icon="mdi:book-open-variant" label="articles" value={course.article_count} />


### PR DESCRIPTION
## Problem
The adaptive course cards were ragged (see report): the image only rendered when present, the description was optional, and content used `display:block`, so the **metric row floated up** right after a missing description — cards without a description (e.g. DSA Course) or with more metric rows had their meta at a different height than their neighbours.

## Fix
- The card is now a **flex column**; the metric row is **pinned to the bottom** (`mt:auto`) so it aligns across every card in a row (the grid already stretches cards to equal height).
- The **image band always renders** (fallback gradient) and the **description reserves a consistent 2-line slot**, so the image + badge + title line up card-to-card.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)