### PR TITLE
feat(points): count-up + lightning zap whenever points increase

### DIFF
--- a/components/adaptive-quiz/AdaptiveQuizLayout.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizLayout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Box, Button, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
+import { AnimatedPointsCounter } from "@/components/common/AnimatedPointsCounter";
 import { useAdaptiveSession } from "@/hooks/useAdaptiveSession";
 import { AdaptiveSectionShell } from "./shared/AdaptiveSectionShell";
 import { AdaptiveSectionHero } from "./shared/AdaptiveSectionHero";
@@ -186,7 +187,8 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
             <LiveTimerRing key={`${q.mcq_id}-${notStarted ? "paused" : "run"}`} resetKey={q.mcq_id} running={!notStarted} startedAtMs={ctx.questionStartMs} />
             {/* Running total banked this quiz - always shown, ticks up on every correct answer. */}
             <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 1.5, py: 0.6, borderRadius: 999, bgcolor: "color-mix(in srgb, #7c3aed 12%, transparent)", color: "#6d28d9", fontSize: "0.82rem", fontWeight: 900 }}>
-              <Icon icon="mdi:star-four-points" width={15} /> {ctx.sessionPoints}
+              <Icon icon="mdi:star-four-points" width={15} />
+              <AnimatedPointsCounter value={ctx.sessionPoints} boltSize={16} />
               <Typography component="span" sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.06em", textTransform: "uppercase", opacity: 0.85 }}>
                 pts this quiz
               </Typography>

--- a/components/common/AnimatedPointsCounter.tsx
+++ b/components/common/AnimatedPointsCounter.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, animate, motion, useReducedMotion } from "framer-motion";
+import { Box, type SxProps, type Theme } from "@mui/material";
+import { Icon } from "@iconify/react";
+
+/**
+ * A points number that, whenever it INCREASES, tweens up from the previous value
+ * to the new one (Duolingo-style count-up) and flashes a small lightning bolt.
+ *
+ * - `value`: the current points total.
+ * - `initialFrom`: optional baseline to count up FROM on first mount (e.g. the
+ *   last-seen total from storage) so a dashboard visit animates old -> new.
+ */
+export function AnimatedPointsCounter({
+  value,
+  initialFrom,
+  duration = 0.75,
+  sx,
+  boltSize = 18,
+}: {
+  value: number;
+  initialFrom?: number;
+  duration?: number;
+  sx?: SxProps<Theme>;
+  boltSize?: number;
+}) {
+  const reduce = useReducedMotion();
+  // startRef seeds the FROM of the count-up. Seeding it with `initialFrom` makes
+  // the first mount animate initialFrom -> value (e.g. last-seen -> new total).
+  const startRef = useRef<number>(initialFrom ?? value);
+  // display inits to `value` (NOT initialFrom) so SSR/first paint matches and there's
+  // no hydration mismatch; the mount effect then tweens down-and-up from initialFrom.
+  const [display, setDisplay] = useState<number>(Math.round(value));
+  const [zap, setZap] = useState(0);
+
+  useEffect(() => {
+    const from = startRef.current;
+    startRef.current = value;
+    if (value === from) return;
+    if (value > from) setZap((z) => z + 1); // lightning only on an increase
+    if (reduce) {
+      setDisplay(Math.round(value));
+      return;
+    }
+    const controls = animate(from, value, {
+      duration,
+      ease: [0.22, 1, 0.36, 1],
+      onUpdate: (v) => setDisplay(Math.round(v)),
+    });
+    return () => controls.stop();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  return (
+    <Box component="span" sx={{ position: "relative", display: "inline-flex", alignItems: "center", ...sx }}>
+      <AnimatePresence>
+        {zap > 0 && (
+          <motion.span
+            key={zap}
+            initial={{ scale: 0.3, opacity: 0, rotate: -22 }}
+            animate={{ scale: [0.3, 1.35, 1], opacity: [0, 1, 0], rotate: [-22, 8, 0] }}
+            transition={{ duration: 0.75, ease: "easeOut" }}
+            style={{
+              position: "absolute",
+              left: -(boltSize + 2),
+              top: "50%",
+              marginTop: -boltSize / 2,
+              color: "#f59e0b",
+              display: "inline-flex",
+              filter: "drop-shadow(0 0 6px rgba(245,158,11,0.7))",
+              pointerEvents: "none",
+            }}
+          >
+            <Icon icon="mdi:lightning-bolt" width={boltSize} />
+          </motion.span>
+        )}
+      </AnimatePresence>
+      <Box component="span" sx={{ fontVariantNumeric: "tabular-nums" }}>
+        {display}
+      </Box>
+    </Box>
+  );
+}

--- a/components/dashboard/v2/StatCards.tsx
+++ b/components/dashboard/v2/StatCards.tsx
@@ -1,12 +1,31 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Box } from "@mui/material";
 import { CountUp, Reveal } from "@/components/scorecard/shared";
+import { AnimatedPointsCounter } from "@/components/common/AnimatedPointsCounter";
 import { PointsInfo } from "@/components/common/PointsInfo";
 import { StreakInfo } from "@/components/common/StreakInfo";
 import { MomentumInfo } from "@/components/common/MomentumInfo";
 import type { DashboardAggregate } from "@/lib/types/dashboard";
 import { StatBox } from "./parts";
+
+const LAST_TOTAL_KEY = "ailinc_last_total_points";
+
+/** Total points that counts up from the LAST-seen total to the current one (with
+ *  a lightning zap) whenever it has grown since the learner last saw the dashboard. */
+function TotalPointsValue({ total }: { total: number }) {
+  const [initialFrom] = useState<number | undefined>(() => {
+    if (typeof window === "undefined") return undefined;
+    const raw = window.localStorage.getItem(LAST_TOTAL_KEY);
+    const last = raw != null ? Number(raw) : NaN;
+    return Number.isFinite(last) && last < total ? last : undefined;
+  });
+  useEffect(() => {
+    if (typeof window !== "undefined") window.localStorage.setItem(LAST_TOTAL_KEY, String(total));
+  }, [total]);
+  return <AnimatedPointsCounter value={total} initialFrom={initialFrom} boltSize={16} />;
+}
 
 export function StatCards({
   aggregate, hideLeaderboard,
@@ -17,7 +36,7 @@ export function StatCards({
     <StatBox
       key="points"
       label="Total points"
-      value={<CountUp value={a.totalPoints} />}
+      value={<TotalPointsValue total={a.totalPoints} />}
       sub={a.pointsThisWeek ? `+${a.pointsThisWeek} this week` : "Start earning"}
       subColor={a.pointsThisWeek ? "#7c3aed" : "#94a3b8"}
       icon="mdi:star-four-points"


### PR DESCRIPTION
## What
Duolingo-style animated points (the "XP" = the points system). New **`AnimatedPointsCounter`** tweens the number **up from its previous value to the new one** and flashes a **lightning bolt** whenever it increases (respects reduced-motion, SSR-safe).

Wired everywhere points grow:
- **Live adaptive-quiz points HUD** ("pts this quiz") — now **ticks up + zaps on every correct answer** instead of jumping.
- **Dashboard "Total points" card** — counts up from the learner's **last-seen total** (persisted in `localStorage`) to the current one with a zap, so returning to the dashboard after earning shows **current → updated** rather than 0 → total.

The full-screen XP lightning burst on **session-complete** and **coding-solve** already landed in the earlier celebrations PR (#1078); this adds the in-place number animation requested.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)