### PR TITLE
feat(community): refresh dashboard total after a community earn

### DIFF
--- a/components/community/XPGainProvider.tsx
+++ b/components/community/XPGainProvider.tsx
@@ -4,6 +4,7 @@ import { createContext, useCallback, useContext, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Box, Typography } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { invalidateLearnerDashboard } from "@/lib/services/adaptive-journey.service";
 
 interface XPGain {
   id: string;
@@ -34,6 +35,10 @@ export function XPGainProvider({ children }: { children: React.ReactNode }) {
 
   const showXPGain = useCallback((delta: number, icon: string, label?: string) => {
     if (delta <= 0) return;
+    // Community points now fold into the unified "total points", so a community
+    // earn should refresh the dashboard's cached payload - then its Total Points
+    // card animates old -> new (with the lightning bolt) on the next visit.
+    invalidateLearnerDashboard();
     const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     setGains((prev) => [...prev, { id, delta, icon, label }]);
     // Auto-dismiss faster - feels less like a notification, more like haptic feedback.


### PR DESCRIPTION
Companion to BE #411 (community XP folds into the unified total points). Now that community points count toward the dashboard's **Total points**, this busts the cached learner-dashboard payload on every community earn — via the single `showXPGain` chokepoint — so the Total Points card **animates old → new with the lightning bolt** on the learner's next visit instead of waiting for the 60s cache to expire.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)