### PR TITLE
feat(points): electric '+N points' celebration everywhere points are awarded

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,7 @@ import { ProfileActivationBlocker } from "@/components/auth/ProfileActivationBlo
 import { TenantSetupBlocker } from "@/components/auth/TenantSetupBlocker";
 import { XPGainProvider } from "@/components/community/XPGainProvider";
 import { XpCelebrationOverlay } from "@/components/common/XpCelebrationOverlay";
+import { PointsPrimer } from "@/components/common/PointsPrimer";
 import { TourProvider } from "@/components/community/TourProvider";
 import { config } from "@/lib/config";
 import { themeToCssBlock } from "@/lib/theme/themeToCssBlock";
@@ -127,6 +128,7 @@ export default async function RootLayout({
                                     <ProfileActivationBlocker />
                                     <TenantSetupBlocker />
                                     {children}
+                                    <PointsPrimer />
                                     <XpCelebrationOverlay />
                                   </TourProvider>
                                 </XPGainProvider>

--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -9,7 +9,6 @@ import { AdaptiveCodingProblemPanel } from "@/components/coding/AdaptiveCodingPr
 import { AdaptiveCodingSubmissions } from "@/components/coding/AdaptiveCodingSubmissions";
 import { useToast } from "@/components/common/Toast";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
-import { celebrateXp } from "@/lib/xp/xpCelebration";
 import {
   getAvailableLanguages,
   getLanguageId,
@@ -238,7 +237,6 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
       } else if (res.grade.all_passed) {
         setSolvedAlready(true);
         setPointsEarned(res.points_earned ?? 0);  // freezes the timer HUD on the earned points
-        if (res.points_earned) celebrateXp(res.points_earned);
         const pts = res.points_earned ? ` · +${res.points_earned} pts` : "";
         showToast(`Passed - clean & correct${pts}`, "success");
       } else {

--- a/components/common/AnimatedPointsCounter.tsx
+++ b/components/common/AnimatedPointsCounter.tsx
@@ -1,85 +1,90 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { AnimatePresence, animate, motion, useReducedMotion } from "framer-motion";
+import { animate, useReducedMotion } from "framer-motion";
 import { Box, type SxProps, type Theme } from "@mui/material";
-import { Icon } from "@iconify/react";
+import ElectricBorder from "@/components/common/ElectricBorder";
 
 /**
  * A points number that, whenever it INCREASES, tweens up from the previous value
- * to the new one (Duolingo-style count-up) and flashes a small lightning bolt.
+ * to the new one (Duolingo-style count-up) and wraps itself in an animated
+ * ElectricBorder for the duration of the count - then drops the border (it runs a
+ * canvas loop, so it's only mounted during the transient increase, never idle).
  *
- * - `value`: the current points total.
+ * - `value`: current points total.
  * - `initialFrom`: optional baseline to count up FROM on first mount (e.g. the
- *   last-seen total from storage) so a dashboard visit animates old -> new.
+ *   last-seen total) so a dashboard visit animates old -> new.
  */
 export function AnimatedPointsCounter({
   value,
   initialFrom,
   duration = 0.75,
   sx,
-  boltSize = 18,
+  electricColor = "#fde047",
+  boltSize: _boltSize,
 }: {
   value: number;
   initialFrom?: number;
   duration?: number;
   sx?: SxProps<Theme>;
+  electricColor?: string;
+  /** deprecated; kept for call-site compatibility */
   boltSize?: number;
 }) {
   const reduce = useReducedMotion();
-  // startRef seeds the FROM of the count-up. Seeding it with `initialFrom` makes
-  // the first mount animate initialFrom -> value (e.g. last-seen -> new total).
   const startRef = useRef<number>(initialFrom ?? value);
-  // display inits to `value` (NOT initialFrom) so SSR/first paint matches and there's
-  // no hydration mismatch; the mount effect then tweens down-and-up from initialFrom.
-  const [display, setDisplay] = useState<number>(Math.round(value));
-  const [zap, setZap] = useState(0);
+  const [display, setDisplay] = useState<number>(Math.round(value)); // SSR-safe: = value
+  const [electric, setElectric] = useState(false);
 
   useEffect(() => {
     const from = startRef.current;
     startRef.current = value;
-    if (value === from) return;
-    if (value > from) setZap((z) => z + 1); // lightning only on an increase
+    if (value === from) {
+      setDisplay(Math.round(value));
+      return;
+    }
     if (reduce) {
       setDisplay(Math.round(value));
       return;
     }
+    const increased = value > from;
     const controls = animate(from, value, {
       duration,
       ease: [0.22, 1, 0.36, 1],
       onUpdate: (v) => setDisplay(Math.round(v)),
     });
-    return () => controls.stop();
+    if (!increased) {
+      return () => controls.stop();
+    }
+    setElectric(true);
+    const t = setTimeout(() => setElectric(false), Math.max(1100, duration * 1000 + 350));
+    return () => {
+      controls.stop();
+      clearTimeout(t);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
-  return (
-    <Box component="span" sx={{ position: "relative", display: "inline-flex", alignItems: "center", ...sx }}>
-      <AnimatePresence>
-        {zap > 0 && (
-          <motion.span
-            key={zap}
-            initial={{ scale: 0.3, opacity: 0, rotate: -22 }}
-            animate={{ scale: [0.3, 1.35, 1], opacity: [0, 1, 0], rotate: [-22, 8, 0] }}
-            transition={{ duration: 0.75, ease: "easeOut" }}
-            style={{
-              position: "absolute",
-              left: -(boltSize + 2),
-              top: "50%",
-              marginTop: -boltSize / 2,
-              color: "#f59e0b",
-              display: "inline-flex",
-              filter: "drop-shadow(0 0 6px rgba(245,158,11,0.7))",
-              pointerEvents: "none",
-            }}
-          >
-            <Icon icon="mdi:lightning-bolt" width={boltSize} />
-          </motion.span>
-        )}
-      </AnimatePresence>
-      <Box component="span" sx={{ fontVariantNumeric: "tabular-nums" }}>
-        {display}
-      </Box>
+  const number = (
+    <Box component="span" sx={{ fontVariantNumeric: "tabular-nums", ...sx }}>
+      {display}
     </Box>
+  );
+
+  if (!electric) return number;
+
+  return (
+    <ElectricBorder
+      color={electricColor}
+      speed={2}
+      chaos={0.2}
+      borderRadius={12}
+      className="inline-block align-middle"
+      style={{ borderRadius: 12 }}
+    >
+      <Box component="span" sx={{ display: "inline-block", px: 0.5 }}>
+        {number}
+      </Box>
+    </ElectricBorder>
   );
 }

--- a/components/common/ElectricBorder.tsx
+++ b/components/common/ElectricBorder.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+// Animated glowing "electric" border. Inspired by @BalintFerenczy
+// (https://codepen.io/BalintFerenczy/pen/KwdoyEN) via react-bits.
+// NOTE: runs a requestAnimationFrame canvas loop while mounted - only mount it
+// during transient celebrations (not permanently) to keep the platform snappy.
+
+import React, { useEffect, useRef, useCallback, CSSProperties, ReactNode } from "react";
+
+function hexToRgba(hex: string, alpha: number = 1): string {
+  if (!hex) return `rgba(0,0,0,${alpha})`;
+  let h = hex.replace("#", "");
+  if (h.length === 3) {
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  const int = parseInt(h.slice(0, 6), 16);
+  const r = (int >> 16) & 255;
+  const g = (int >> 8) & 255;
+  const b = int & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+interface ElectricBorderProps {
+  children?: ReactNode;
+  color?: string;
+  speed?: number;
+  chaos?: number;
+  borderRadius?: number;
+  className?: string;
+  style?: CSSProperties;
+}
+
+const ElectricBorder: React.FC<ElectricBorderProps> = ({
+  children,
+  color = "#5227FF",
+  speed = 1,
+  chaos = 0.12,
+  borderRadius = 24,
+  className,
+  style,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const animationRef = useRef<number | null>(null);
+  const timeRef = useRef(0);
+  const lastFrameTimeRef = useRef(0);
+
+  const random = useCallback((x: number): number => {
+    return (Math.sin(x * 12.9898) * 43758.5453) % 1;
+  }, []);
+
+  const noise2D = useCallback(
+    (x: number, y: number): number => {
+      const i = Math.floor(x);
+      const j = Math.floor(y);
+      const fx = x - i;
+      const fy = y - j;
+
+      const a = random(i + j * 57);
+      const b = random(i + 1 + j * 57);
+      const c = random(i + (j + 1) * 57);
+      const d = random(i + 1 + (j + 1) * 57);
+
+      const ux = fx * fx * (3.0 - 2.0 * fx);
+      const uy = fy * fy * (3.0 - 2.0 * fy);
+
+      return a * (1 - ux) * (1 - uy) + b * ux * (1 - uy) + c * (1 - ux) * uy + d * ux * uy;
+    },
+    [random],
+  );
+
+  const octavedNoise = useCallback(
+    (
+      x: number,
+      octaves: number,
+      lacunarity: number,
+      gain: number,
+      baseAmplitude: number,
+      baseFrequency: number,
+      time: number,
+      seed: number,
+      baseFlatness: number,
+    ): number => {
+      let y = 0;
+      let amplitude = baseAmplitude;
+      let frequency = baseFrequency;
+
+      for (let i = 0; i < octaves; i++) {
+        let octaveAmplitude = amplitude;
+        if (i === 0) {
+          octaveAmplitude *= baseFlatness;
+        }
+        y += octaveAmplitude * noise2D(frequency * x + seed * 100, time * frequency * 0.3);
+        frequency *= lacunarity;
+        amplitude *= gain;
+      }
+
+      return y;
+    },
+    [noise2D],
+  );
+
+  const getCornerPoint = useCallback(
+    (
+      centerX: number,
+      centerY: number,
+      radius: number,
+      startAngle: number,
+      arcLength: number,
+      progress: number,
+    ): { x: number; y: number } => {
+      const angle = startAngle + progress * arcLength;
+      return {
+        x: centerX + radius * Math.cos(angle),
+        y: centerY + radius * Math.sin(angle),
+      };
+    },
+    [],
+  );
+
+  const getRoundedRectPoint = useCallback(
+    (
+      t: number,
+      left: number,
+      top: number,
+      width: number,
+      height: number,
+      radius: number,
+    ): { x: number; y: number } => {
+      const straightWidth = width - 2 * radius;
+      const straightHeight = height - 2 * radius;
+      const cornerArc = (Math.PI * radius) / 2;
+      const totalPerimeter = 2 * straightWidth + 2 * straightHeight + 4 * cornerArc;
+      const distance = t * totalPerimeter;
+
+      let accumulated = 0;
+
+      if (distance <= accumulated + straightWidth) {
+        const progress = (distance - accumulated) / straightWidth;
+        return { x: left + radius + progress * straightWidth, y: top };
+      }
+      accumulated += straightWidth;
+
+      if (distance <= accumulated + cornerArc) {
+        const progress = (distance - accumulated) / cornerArc;
+        return getCornerPoint(left + width - radius, top + radius, radius, -Math.PI / 2, Math.PI / 2, progress);
+      }
+      accumulated += cornerArc;
+
+      if (distance <= accumulated + straightHeight) {
+        const progress = (distance - accumulated) / straightHeight;
+        return { x: left + width, y: top + radius + progress * straightHeight };
+      }
+      accumulated += straightHeight;
+
+      if (distance <= accumulated + cornerArc) {
+        const progress = (distance - accumulated) / cornerArc;
+        return getCornerPoint(left + width - radius, top + height - radius, radius, 0, Math.PI / 2, progress);
+      }
+      accumulated += cornerArc;
+
+      if (distance <= accumulated + straightWidth) {
+        const progress = (distance - accumulated) / straightWidth;
+        return { x: left + width - radius - progress * straightWidth, y: top + height };
+      }
+      accumulated += straightWidth;
+
+      if (distance <= accumulated + cornerArc) {
+        const progress = (distance - accumulated) / cornerArc;
+        return getCornerPoint(left + radius, top + height - radius, radius, Math.PI / 2, Math.PI / 2, progress);
+      }
+      accumulated += cornerArc;
+
+      if (distance <= accumulated + straightHeight) {
+        const progress = (distance - accumulated) / straightHeight;
+        return { x: left, y: top + height - radius - progress * straightHeight };
+      }
+      accumulated += straightHeight;
+
+      const progress = (distance - accumulated) / cornerArc;
+      return getCornerPoint(left + radius, top + radius, radius, Math.PI, Math.PI / 2, progress);
+    },
+    [getCornerPoint],
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const octaves = 10;
+    const lacunarity = 1.6;
+    const gain = 0.7;
+    const amplitude = chaos;
+    const frequency = 10;
+    const baseFlatness = 0;
+    const displacement = 60;
+    const borderOffset = 60;
+
+    const updateSize = () => {
+      const rect = container.getBoundingClientRect();
+      const width = rect.width + borderOffset * 2;
+      const height = rect.height + borderOffset * 2;
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.scale(dpr, dpr);
+
+      return { width, height };
+    };
+
+    let { width, height } = updateSize();
+    let lastDpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    const drawElectricBorder = (currentTime: number) => {
+      if (!canvas || !ctx) return;
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      if (dpr !== lastDpr) {
+        lastDpr = dpr;
+        const newSize = updateSize();
+        width = newSize.width;
+        height = newSize.height;
+      }
+
+      const deltaTime = (currentTime - lastFrameTimeRef.current) / 1000;
+      timeRef.current += deltaTime * speed;
+      lastFrameTimeRef.current = currentTime;
+
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.scale(dpr, dpr);
+
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1;
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
+
+      const scale = displacement;
+      const left = borderOffset;
+      const top = borderOffset;
+      const borderWidth = width - 2 * borderOffset;
+      const borderHeight = height - 2 * borderOffset;
+      const maxRadius = Math.min(borderWidth, borderHeight) / 2;
+      const radius = Math.min(borderRadius, maxRadius);
+
+      const approximatePerimeter = 2 * (borderWidth + borderHeight) + 2 * Math.PI * radius;
+      const sampleCount = Math.floor(approximatePerimeter / 2);
+
+      ctx.beginPath();
+
+      for (let i = 0; i <= sampleCount; i++) {
+        const progress = i / sampleCount;
+
+        const point = getRoundedRectPoint(progress, left, top, borderWidth, borderHeight, radius);
+
+        const xNoise = octavedNoise(
+          progress * 8,
+          octaves,
+          lacunarity,
+          gain,
+          amplitude,
+          frequency,
+          timeRef.current,
+          0,
+          baseFlatness,
+        );
+        const yNoise = octavedNoise(
+          progress * 8,
+          octaves,
+          lacunarity,
+          gain,
+          amplitude,
+          frequency,
+          timeRef.current,
+          1,
+          baseFlatness,
+        );
+
+        const displacedX = point.x + xNoise * scale;
+        const displacedY = point.y + yNoise * scale;
+
+        if (i === 0) {
+          ctx.moveTo(displacedX, displacedY);
+        } else {
+          ctx.lineTo(displacedX, displacedY);
+        }
+      }
+
+      ctx.closePath();
+      ctx.stroke();
+
+      animationRef.current = requestAnimationFrame(drawElectricBorder);
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      const newSize = updateSize();
+      width = newSize.width;
+      height = newSize.height;
+    });
+    resizeObserver.observe(container);
+
+    animationRef.current = requestAnimationFrame(drawElectricBorder);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+      resizeObserver.disconnect();
+    };
+  }, [color, speed, chaos, borderRadius, octavedNoise, getRoundedRectPoint]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative overflow-visible isolate ${className ?? ""}`}
+      style={{ "--electric-border-color": color, borderRadius, ...style } as CSSProperties}
+    >
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none z-[2]">
+        <canvas ref={canvasRef} className="block" />
+      </div>
+      <div className="absolute inset-0 rounded-[inherit] pointer-events-none z-0">
+        <div
+          className="absolute inset-0 rounded-[inherit] pointer-events-none"
+          style={{ border: `2px solid ${hexToRgba(color, 0.6)}`, filter: "blur(1px)" }}
+        />
+        <div
+          className="absolute inset-0 rounded-[inherit] pointer-events-none"
+          style={{ border: `2px solid ${color}`, filter: "blur(4px)" }}
+        />
+        <div
+          className="absolute inset-0 rounded-[inherit] pointer-events-none -z-[1] scale-110 opacity-30"
+          style={{
+            filter: "blur(32px)",
+            background: `linear-gradient(-30deg, ${color}, transparent, ${color})`,
+          }}
+        />
+      </div>
+      <div className="relative rounded-[inherit] z-[1]">{children}</div>
+    </div>
+  );
+};
+
+export default ElectricBorder;

--- a/components/common/PointsPrimer.tsx
+++ b/components/common/PointsPrimer.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { primePointsTotal } from "@/lib/xp/pointsWatcher";
+
+/**
+ * Seeds the unified points-total baseline once on load, so the learner's FIRST
+ * earn of the session already animates (the watcher has a value to diff against).
+ * Unauthenticated loads (e.g. the login page) just get a silently-ignored 401.
+ */
+export function PointsPrimer() {
+  useEffect(() => {
+    void primePointsTotal();
+  }, []);
+  return null;
+}

--- a/components/common/XpCelebrationOverlay.tsx
+++ b/components/common/XpCelebrationOverlay.tsx
@@ -4,16 +4,17 @@ import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Box, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
+import ElectricBorder from "@/components/common/ElectricBorder";
 import { useXpCelebration } from "@/lib/xp/xpCelebration";
+import { playXpSound } from "@/lib/xp/xpSound";
 
-const HOLD_MS = 1500;
-// Radial spark spokes (fixed angles => deterministic, SSR-safe).
-const SPARKS = Array.from({ length: 12 }, (_, i) => (i * 360) / 12);
+const HOLD_MS = 2600; // bigger + lingers (was a small, fast pill)
+const SPARKS = Array.from({ length: 16 }, (_, i) => (i * 360) / 16);
 
 /**
- * Global Duolingo-style "+N XP" lightning burst. Store-driven (celebrateXp),
- * mounted once in app/layout so any earn can fire it from anywhere. Non-blocking
- * (pointer-events: none) and self-dismissing.
+ * Global Duolingo-style "+N points earned" celebration: a bold card wrapped in an
+ * animated ElectricBorder, a lightning zap, radial sparks, and a short chime.
+ * Store-driven (celebrateXp), mounted once in app/layout, non-blocking, self-dismissing.
  */
 export function XpCelebrationOverlay() {
   const { amount, token } = useXpCelebration();
@@ -22,6 +23,7 @@ export function XpCelebrationOverlay() {
   useEffect(() => {
     if (token === 0 || amount <= 0) return;
     setShown({ amount, token });
+    playXpSound();
     const t = setTimeout(() => setShown(null), HOLD_MS);
     return () => clearTimeout(t);
   }, [token, amount]);
@@ -34,77 +36,86 @@ export function XpCelebrationOverlay() {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
-          style={{ position: "fixed", inset: 0, zIndex: 2300, pointerEvents: "none" }}
+          transition={{ duration: 0.25 }}
+          style={{ position: "fixed", inset: 0, zIndex: 2300, pointerEvents: "none", display: "grid", placeItems: "center" }}
           aria-hidden
         >
+          {/* soft backdrop dim to make the card pop */}
+          <Box sx={{ position: "absolute", inset: 0, background: "radial-gradient(circle at 50% 45%, rgba(20,6,31,0.5), rgba(10,4,20,0.16) 55%, transparent 72%)" }} />
+
           {/* ambient glow */}
           <motion.div
-            initial={{ scale: 0.2, opacity: 0.85 }}
-            animate={{ scale: [0.2, 1.7, 1.4], opacity: [0.85, 0.45, 0] }}
-            transition={{ duration: 0.95, ease: "easeOut" }}
+            initial={{ scale: 0.3, opacity: 0.8 }}
+            animate={{ scale: [0.3, 1.8, 1.5], opacity: [0.8, 0.4, 0] }}
+            transition={{ duration: 1.1, ease: "easeOut" }}
             style={{
-              position: "absolute", left: "50%", top: "50%", marginLeft: -150, marginTop: -150,
-              width: 300, height: 300, borderRadius: "50%",
-              background: "radial-gradient(circle, rgba(250,204,21,0.55) 0%, rgba(168,85,247,0.28) 45%, transparent 70%)",
+              position: "absolute", left: "50%", top: "50%", marginLeft: -190, marginTop: -190,
+              width: 380, height: 380, borderRadius: "50%",
+              background: "radial-gradient(circle, rgba(250,204,21,0.5) 0%, rgba(168,85,247,0.28) 45%, transparent 70%)",
             }}
           />
-          {/* white flash */}
-          <motion.div
-            initial={{ scale: 0.4, opacity: 0.75 }}
-            animate={{ scale: 1.3, opacity: 0 }}
-            transition={{ duration: 0.35, ease: "easeOut" }}
-            style={{
-              position: "absolute", left: "50%", top: "50%", marginLeft: -95, marginTop: -95,
-              width: 190, height: 190, borderRadius: "50%",
-              background: "radial-gradient(circle, rgba(255,255,255,0.9), transparent 60%)",
-            }}
-          />
+
           {/* radial sparks (opacity-only anim so the static radial transform holds) */}
           {SPARKS.map((deg, i) => (
             <motion.div
               key={i}
               initial={{ opacity: 0 }}
               animate={{ opacity: [0, 1, 0] }}
-              transition={{ duration: 0.55, delay: 0.05 + (i % 4) * 0.03, ease: "easeOut" }}
+              transition={{ duration: 0.7, delay: 0.06 + (i % 4) * 0.03, ease: "easeOut" }}
               style={{
                 position: "absolute", left: "50%", top: "50%",
-                width: 3, height: 44, borderRadius: 2,
+                width: 4, height: 60, borderRadius: 2,
                 background: "linear-gradient(#fef08a, #f59e0b)",
-                transform: `translate(-50%, -50%) rotate(${deg}deg) translateY(-66px)`,
+                transform: `translate(-50%, -50%) rotate(${deg}deg) translateY(-128px)`,
                 transformOrigin: "center",
               }}
             />
           ))}
-          {/* bolt + XP (centered via framer x/y -50% so scale/rotate compose cleanly) */}
+
+          {/* the card */}
           <motion.div
-            initial={{ scale: 0, rotate: -22, opacity: 0 }}
-            animate={{ scale: [0, 1.25, 1], rotate: [-22, 8, 0], opacity: 1 }}
-            transition={{ type: "spring", stiffness: 420, damping: 15 }}
-            style={{
-              position: "absolute", left: "50%", top: "50%", x: "-50%", y: "-50%",
-              display: "flex", flexDirection: "column", alignItems: "center", gap: 8,
-            }}
+            initial={{ scale: 0.4, y: 22, opacity: 0 }}
+            animate={{ scale: 1, y: 0, opacity: 1 }}
+            exit={{ scale: 0.7, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 280, damping: 18 }}
+            style={{ position: "relative" }}
           >
-            <Box
-              sx={{
-                width: 96, height: 96, borderRadius: "30%", display: "grid", placeItems: "center",
-                background: "linear-gradient(135deg, #fde047 0%, #f59e0b 100%)",
-                boxShadow: "0 14px 34px -8px rgba(245,158,11,0.75), 0 0 0 7px rgba(250,204,21,0.16)",
-              }}
-            >
-              <Icon icon="mdi:lightning-bolt" width={56} color="#fff" />
-            </Box>
-            <motion.div initial={{ y: 12, opacity: 0 }} animate={{ y: 0, opacity: 1 }} transition={{ delay: 0.12 }}>
-              <Typography
+            <ElectricBorder color="#fde047" speed={1.6} chaos={0.16} borderRadius={28} style={{ borderRadius: 28 }}>
+              <Box
                 sx={{
-                  fontWeight: 900, fontSize: "1.85rem", color: "#fff", letterSpacing: "-0.02em",
-                  textShadow: "0 2px 12px rgba(245,158,11,0.85)",
+                  borderRadius: "28px",
+                  px: { xs: 4, sm: 6 },
+                  py: { xs: 3.5, sm: 4.5 },
+                  textAlign: "center",
+                  minWidth: { xs: 236, sm: 300 },
+                  background: "radial-gradient(130% 120% at 50% 0%, #2a1150 0%, #14061f 55%, #0f0518 100%)",
                 }}
               >
-                +{shown.amount} XP
-              </Typography>
-            </motion.div>
+                <motion.div
+                  initial={{ scale: 0, rotate: -20 }}
+                  animate={{ scale: [0, 1.3, 1], rotate: [-20, 8, 0] }}
+                  transition={{ type: "spring", stiffness: 380, damping: 14 }}
+                  style={{ display: "inline-flex", marginBottom: 12 }}
+                >
+                  <Box
+                    sx={{
+                      width: 78, height: 78, borderRadius: "26%", display: "grid", placeItems: "center",
+                      background: "linear-gradient(135deg, #fde047, #f59e0b)",
+                      boxShadow: "0 16px 42px -10px rgba(245,158,11,0.85)",
+                    }}
+                  >
+                    <Icon icon="mdi:lightning-bolt" width={46} color="#fff" />
+                  </Box>
+                </motion.div>
+
+                <Typography sx={{ fontWeight: 900, fontSize: { xs: "3rem", sm: "3.6rem" }, lineHeight: 1, color: "#fff", letterSpacing: "-0.02em", textShadow: "0 2px 20px rgba(250,204,21,0.85)" }}>
+                  +{shown.amount}
+                </Typography>
+                <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", letterSpacing: "0.24em", color: "rgba(253,224,71,0.92)", mt: 1.25 }}>
+                  POINTS EARNED
+                </Typography>
+              </Box>
+            </ElectricBorder>
           </motion.div>
         </motion.div>
       )}

--- a/components/community/XPGainProvider.tsx
+++ b/components/community/XPGainProvider.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Box, Typography } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { invalidateLearnerDashboard } from "@/lib/services/adaptive-journey.service";
+import { noteKnownEarn } from "@/lib/xp/pointsWatcher";
 
 interface XPGain {
   id: string;
@@ -35,10 +36,11 @@ export function XPGainProvider({ children }: { children: React.ReactNode }) {
 
   const showXPGain = useCallback((delta: number, icon: string, label?: string) => {
     if (delta <= 0) return;
-    // Community points now fold into the unified "total points", so a community
-    // earn should refresh the dashboard's cached payload - then its Total Points
-    // card animates old -> new (with the lightning bolt) on the next visit.
+    // Community points fold into the unified "total points": bust the dashboard
+    // cache (so its Total Points card animates old -> new next visit) and fire the
+    // "+N points" lightning celebration right here with the known delta.
     invalidateLearnerDashboard();
+    noteKnownEarn(delta);
     const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     setGains((prev) => [...prev, { id, delta, icon, label }]);
     // Auto-dismiss faster - feels less like a notification, more like haptic feedback.

--- a/hooks/useAdaptiveSession.ts
+++ b/hooks/useAdaptiveSession.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { adaptiveQuizService } from "@/lib/services/adaptive-quiz.service";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
-import { celebrateXp } from "@/lib/xp/xpCelebration";
 import type {
   AdaptiveQuestion,
   AdaptiveSessionDetail,
@@ -178,12 +177,9 @@ export function useAdaptiveSession({
         };
       });
       resetForNextQuestion();
-      // Finishing the quiz counts as a completion — celebrate the session XP + streak.
-      if (result.session_complete) {
-        const totalXp = sessionPoints + (result.points_earned ?? 0);
-        celebrateXp(totalXp);
-        notifyContentCompleted();
-      }
+      // Finishing the quiz counts as a completion — notifyContentCompleted polls the
+      // unified points total and fires the "+N points" celebration (one path, every module).
+      if (result.session_complete) notifyContentCompleted();
       return result;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to submit answer");

--- a/lib/services/adaptive-journey.service.ts
+++ b/lib/services/adaptive-journey.service.ts
@@ -64,6 +64,12 @@ export const adaptiveJourneyService = {
     return data;
   },
 
+  /** Cheap unified total points (adaptive wallets + community XP) for delta-detecting earns. */
+  async getLearnerPointsTotal(): Promise<number> {
+    const { data } = await apiClient.get<{ total: number }>(`${BASE}/learner/points-total/`);
+    return data?.total ?? 0;
+  },
+
   async getLeaderboardStreaks(period: LeaderboardPeriod = "all"): Promise<LeaderboardStreaks> {
     const { data } = await apiClient.get<LeaderboardStreaks>(
       `${BASE}/learner/leaderboard-streaks/`, { params: { period } },

--- a/lib/streak/streakCelebration.ts
+++ b/lib/streak/streakCelebration.ts
@@ -14,6 +14,7 @@
 import { useSyncExternalStore } from "react";
 import { profileService } from "@/lib/services/profile.service";
 import { invalidateStreakCache } from "@/lib/hooks/useLeaderboardAndStreak";
+import { checkPointsAndCelebrate } from "@/lib/xp/pointsWatcher";
 
 export interface StreakCelebrationState {
   celebrating: boolean;
@@ -93,6 +94,9 @@ export function dismissCelebration() {
  */
 export function notifyContentCompleted() {
   void reportContentCompleted();
+  // Any completion may have awarded points (article/video/quiz/coding/...); poll
+  // the unified total and celebrate the increase - one chokepoint, every module.
+  void checkPointsAndCelebrate();
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent("submodule-complete"));
   }

--- a/lib/xp/pointsWatcher.ts
+++ b/lib/xp/pointsWatcher.ts
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * Detects points increases ANYWHERE they're awarded and fires the "+N points"
+ * celebration - so it plays for articles, videos, quizzes, coding, community,
+ * and any future module, without each earn endpoint needing to return a delta.
+ *
+ * It polls the cheap unified total (adaptive wallets + community XP) after a
+ * completion and celebrates the difference vs the last value we knew.
+ */
+import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import { celebrateXp } from "@/lib/xp/xpCelebration";
+
+let lastKnown: number | null = null;
+let inFlight = false;
+
+/** Seed the baseline without celebrating (call once on app load). */
+export async function primePointsTotal(): Promise<void> {
+  try {
+    const total = await adaptiveJourneyService.getLearnerPointsTotal();
+    if (typeof total === "number") lastKnown = total;
+  } catch {
+    /* non-critical */
+  }
+}
+
+/** Fetch the unified total; if it grew since we last knew, celebrate the delta. */
+export async function checkPointsAndCelebrate(): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    const total = await adaptiveJourneyService.getLearnerPointsTotal();
+    if (typeof total !== "number") return;
+    if (lastKnown != null && total > lastKnown) {
+      celebrateXp(total - lastKnown);
+    }
+    lastKnown = total; // also primes if it was null
+  } catch {
+    /* non-critical */
+  } finally {
+    inFlight = false;
+  }
+}
+
+/**
+ * For earns where the delta is already known (e.g. a community action returns
+ * the IP amount): celebrate immediately AND keep `lastKnown` in sync so a later
+ * total-based check doesn't double-count the same points.
+ */
+export function noteKnownEarn(delta: number): void {
+  if (!Number.isFinite(delta) || delta <= 0) return;
+  celebrateXp(delta);
+  if (lastKnown != null) lastKnown += delta;
+}

--- a/lib/xp/xpSound.ts
+++ b/lib/xp/xpSound.ts
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Tiny synthesized "points earned" chime - a short bright ascending arpeggio,
+ * played via the Web Audio API so there's no audio asset to bundle/host. Best
+ * effort: guarded for SSR, autoplay policy, and unsupported browsers.
+ */
+let ctx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  try {
+    if (!ctx) {
+      const AC =
+        window.AudioContext ||
+        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (!AC) return null;
+      ctx = new AC();
+    }
+    return ctx;
+  } catch {
+    return null;
+  }
+}
+
+export function playXpSound() {
+  const ac = getCtx();
+  if (!ac) return;
+  try {
+    if (ac.state === "suspended") void ac.resume();
+    const now = ac.currentTime;
+    // A5 -> D6 -> G6, quick and bright (Duolingo-ish "ding").
+    const notes = [
+      { f: 880, t: 0 },
+      { f: 1174.66, t: 0.08 },
+      { f: 1567.98, t: 0.16 },
+    ];
+    const master = ac.createGain();
+    master.gain.value = 0.13;
+    master.connect(ac.destination);
+    for (const n of notes) {
+      const osc = ac.createOscillator();
+      const g = ac.createGain();
+      osc.type = "triangle";
+      osc.frequency.value = n.f;
+      const start = now + n.t;
+      g.gain.setValueAtTime(0.0001, start);
+      g.gain.exponentialRampToValueAtTime(1, start + 0.02);
+      g.gain.exponentialRampToValueAtTime(0.0001, start + 0.24);
+      osc.connect(g);
+      g.connect(master);
+      osc.start(start);
+      osc.stop(start + 0.26);
+    }
+  } catch {
+    /* best-effort - never throw from a celebration */
+  }
+}


### PR DESCRIPTION
## What
Makes the points-earned animation fire for **every** earn (not just quiz/coding) and gives it a bold, longer, **electric** look with a Duolingo-style chime.

### Everywhere points are awarded
- New **`pointsWatcher`** polls a cheap unified total (**BE #412** = adaptive wallets + community XP) from the single **`notifyContentCompleted`** chokepoint — which **article / video / quiz / coding** all call — plus from **community** earns (known delta). So **reading an article now celebrates too** (the reported gap).
- Removed the per-flow explicit `celebrateXp` for quiz/coding (the watcher handles them → no double-fire). **`PointsPrimer`** seeds the baseline on load so the **first** earn animates.

### Bigger, better celebration
- **`XpCelebrationOverlay`** is now a bold **card** — lightning zap, radial sparks, ambient glow, "+N / POINTS EARNED" — wrapped in an animated **ElectricBorder**, held **~2.6s** (was a tiny, fast pill), with a synthesized **chime** (`xpSound`, Web Audio — no asset bundled).
- The **increasing number** (`AnimatedPointsCounter`, in the live quiz HUD + dashboard total) now wraps itself in an **ElectricBorder for the duration of the count-up**, then drops it.

### Perf
`ElectricBorder` runs a canvas rAF loop, so it's **only mounted during the transient celebration / count-up — never idle**. (If it still feels heavy, easy to gate further or remove.)

New `ElectricBorder` component (react-bits, per the provided code). Depends on **BE #412**; degrades gracefully if the endpoint is absent (no celebration, no error).

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)