### PR TITLE
feat(guide): platform-wide "Guide" button in the top nav

### DIFF
--- a/components/common/PageGuide.tsx
+++ b/components/common/PageGuide.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Button, Dialog, DialogContent, IconButton, Tooltip, Typography } from "@mui/material";
+import { Box, Button, ButtonBase, Dialog, DialogContent, IconButton, Tooltip, Typography } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useTour } from "@/components/community/TourProvider";
 import type { PageGuideContent } from "@/lib/guide/registry";
@@ -13,7 +13,19 @@ import type { PageGuideContent } from "@/lib/guide/registry";
  * that have data-tour-id targets. Generalizes the old CommunityHelpButton so a
  * single component + one content registry powers the guide on every page.
  */
-export function PageGuide({ content }: { content: PageGuideContent }) {
+export function PageGuide({
+  content,
+  variant = "hero",
+  label,
+  tooltip = "Guide to this page",
+}: {
+  content: PageGuideContent;
+  /** "hero" = translucent-white icon for the dark page header; "nav" = light pill for the top nav. */
+  variant?: "hero" | "nav";
+  /** Optional pill label (nav variant), hidden on xs. */
+  label?: string;
+  tooltip?: string;
+}) {
   const [open, setOpen] = useState(false);
   const { startTour } = useTour();
   const hasTour = !!content.tourSteps && content.tourSteps.length > 0;
@@ -40,26 +52,66 @@ export function PageGuide({ content }: { content: PageGuideContent }) {
 
   return (
     <>
-      <Tooltip title="Guide to this page">
-        <IconButton
-          onClick={() => setOpen(true)}
-          size="small"
-          aria-label="Page guide"
-          sx={{
-            width: 38,
-            height: 38,
-            color: "#fff",
-            border: "1px solid rgba(255,255,255,0.22)",
-            backgroundColor: "rgba(255,255,255,0.12)",
-            transition: "all 0.15s",
-            "&:hover": {
-              backgroundColor: "rgba(255,255,255,0.22)",
-              borderColor: "rgba(255,255,255,0.4)",
-            },
-          }}
-        >
-          <IconWrapper icon="mdi:help-circle-outline" size={20} />
-        </IconButton>
+      <Tooltip title={tooltip}>
+        {variant === "nav" ? (
+          <ButtonBase
+            onClick={() => setOpen(true)}
+            aria-label={tooltip}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: label ? 2 : 1,
+              py: 1,
+              borderRadius: 2,
+              backgroundColor: "var(--surface-indigo-light)",
+              border: "1px solid",
+              borderColor: "var(--primary-200)",
+              boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
+              transition: "all 0.2s ease",
+              "&:hover": {
+                backgroundColor: "var(--primary-100)",
+                boxShadow: "0 2px 6px rgba(0,0,0,0.15)",
+                transform: "translateY(-1px)",
+              },
+            }}
+          >
+            <IconWrapper icon="mdi:compass-outline" size={16} color="var(--primary-700)" />
+            {label && (
+              <Typography
+                variant="body2"
+                sx={{
+                  display: { xs: "none", sm: "block" },
+                  fontSize: "0.875rem",
+                  fontWeight: 600,
+                  color: "var(--primary-700)",
+                }}
+              >
+                {label}
+              </Typography>
+            )}
+          </ButtonBase>
+        ) : (
+          <IconButton
+            onClick={() => setOpen(true)}
+            size="small"
+            aria-label={tooltip}
+            sx={{
+              width: 38,
+              height: 38,
+              color: "#fff",
+              border: "1px solid rgba(255,255,255,0.22)",
+              backgroundColor: "rgba(255,255,255,0.12)",
+              transition: "all 0.15s",
+              "&:hover": {
+                backgroundColor: "rgba(255,255,255,0.22)",
+                borderColor: "rgba(255,255,255,0.4)",
+              },
+            }}
+          >
+            <IconWrapper icon="mdi:help-circle-outline" size={20} />
+          </IconButton>
+        )}
       </Tooltip>
 
       <Dialog

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -35,6 +35,8 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useLeaderboardAndStreak } from "@/lib/hooks/useLeaderboardAndStreak";
 import { useStreakCelebration, primeNavStreak } from "@/lib/streak/streakCelebration";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { PageGuide } from "@/components/common/PageGuide";
+import { PLATFORM_GUIDE } from "@/lib/guide/registry";
 import { Settings, ShieldCheck } from "lucide-react";
 import { LanguageSelect } from "@/components/common/LanguageSelect";
 import { useTranslation } from "react-i18next";
@@ -965,6 +967,16 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
             </Popover>
           </Box>
           </React.Fragment>
+          )}
+
+          {/* Platform guide - a bird's-eye "what can I do here" overview, always available */}
+          {isAuthenticated && (
+            <PageGuide
+              content={PLATFORM_GUIDE}
+              variant="nav"
+              label="Guide"
+              tooltip="Take a platform guide"
+            />
           )}
 
           {/* Language selector - only for client id 28 */}

--- a/lib/guide/registry.ts
+++ b/lib/guide/registry.ts
@@ -31,6 +31,66 @@ export interface PageGuideContent {
   tourSteps?: TourStep[];
 }
 
+/**
+ * The platform-wide guide, opened from the "Guide" button in the top nav - a
+ * bird's-eye overview of what AI Linc offers and where to find each area.
+ */
+export const PLATFORM_GUIDE: PageGuideContent = {
+  headerTitle: "Welcome to AI Linc",
+  headerSubtitle: "Your learning platform at a glance - here's what you can do and where to find it.",
+  features: [
+    {
+      icon: "mdi:book-education-outline",
+      color: "#6366f1",
+      title: "Learn with adaptive courses",
+      text: "Take courses that adjust to your level - articles, quizzes, coding, and videos with instant feedback.",
+    },
+    {
+      icon: "mdi:clipboard-text-outline",
+      color: "#0ea5e9",
+      title: "Sit assessments",
+      text: "Take quizzes and proctored tests assigned by your courses, then review your scored results.",
+    },
+    {
+      icon: "mdi:account-voice",
+      color: "#a78bfa",
+      title: "Practice mock interviews",
+      text: "Run AI-driven interviews and get instant, rubric-based feedback to sharpen your answers.",
+    },
+    {
+      icon: "mdi:video",
+      color: "#22c55e",
+      title: "Join live sessions",
+      text: "Attend live classes and webinars, or catch up later with recordings and AI recaps.",
+    },
+    {
+      icon: "mdi:forum",
+      color: "#ec4899",
+      title: "Connect in the community",
+      text: "Ask questions, share resources, join live rooms, and earn IP with your cohort.",
+    },
+    {
+      icon: "mdi:briefcase-outline",
+      color: "#f59e0b",
+      title: "Explore jobs",
+      text: "Browse and apply to roles curated for you from the Jobs board.",
+    },
+    {
+      icon: "mdi:trophy-outline",
+      color: "#fbbf24",
+      title: "Points, streaks & scorecard",
+      text: "Earn points for everything you do, keep your daily streak alive, and track your skills on your scorecard.",
+    },
+    {
+      icon: "mdi:account-circle-outline",
+      color: "#6366f1",
+      title: "Profile & resume",
+      text: "Build your profile and resume, and personalize your settings from the profile menu.",
+    },
+  ],
+  tip: "Look for the '?' in any page's header for a guide specific to that page.",
+};
+
 // The community page keeps its rich guided tour: the steps target data-tour-id
 // attributes already present on app/community/page.tsx.
 const COMMUNITY_TOUR_STEPS: TourStep[] = [


### PR DESCRIPTION
## What

Beside **Today's Leaders**, a new **"Guide"** button opens a bird's-eye overview of the whole platform — what AI Linc offers (Learn, Assessments, Mock interviews, Live sessions, Community, Jobs, Points/streaks/scorecard, Profile) and where to find each area — and points users at the per-page "?" for detail.

Phase 2 of the guide feature (Phase 1 = per-page "?" guides, #1086).

## How
- Reuses the same `PageGuide` component with a new `variant="nav"` trigger — a light nav pill matching the leaderboard/streak pills (label hidden on xs). One guide component, one content source.
- The overview lives in the registry as `PLATFORM_GUIDE`.
- Rendered in `AppBar` right after the leaderboard/streak cluster, so it's **always available to authenticated users**, independent of the `no_leaderboard_view` tenant flag.

## Verification
- `tsc --noEmit` clean (0 errors).
- Netlify deploy-preview must go green before merge (Turbopack tolerates the pre-existing `statusLabel` file, as #1085/#1086 proved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)