### PR TITLE
feat(community): remove the Live Rooms strip from the community feed

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -30,8 +30,6 @@ import { BountySection } from "@/components/community/BountySection";
 import { MilestoneWidget } from "@/components/community/MilestoneWidget";
 import { ShareDialog } from "@/components/community/ShareDialog";
 import { ReportDialog } from "@/components/community/ReportDialog";
-import { LiveRoomsStrip } from "@/components/community/LiveRoomsStrip";
-import { CreateRoomDialog } from "@/components/community/CreateRoomDialog";
 import { useXPGain } from "@/components/community/XPGainProvider";
 import { useAuth } from "@/lib/auth/auth-context";
 import {
@@ -148,14 +146,6 @@ export default function CommunityPage() {
   const [selectedTag, setSelectedTag] = useState<{ id?: number; name: string } | null>(null);
   const [shareTarget, setShareTarget] = useState<{ id: number; title: string } | null>(null);
   const [reportTarget, setReportTarget] = useState<{ id: number } | null>(null);
-  const [createRoomOpen, setCreateRoomOpen] = useState(false);
-
-  // Use auth-context role rather than scraping localStorage - the previous
-  // approach failed for users who hadn't visited /profile in this session.
-  const canCreateRooms = useMemo(
-    () => ["admin", "instructor", "superadmin"].includes(user?.role ?? ""),
-    [user?.role]
-  );
   const threadExtrasRef = useRef<Map<number, ThreadExtras>>(new Map());
   const optimisticVotesRef = useRef<Map<number, "upvote" | "downvote" | null>>(new Map());
   const optimisticBookmarksRef = useRef<Map<number, boolean>>(new Map());
@@ -694,17 +684,8 @@ export default function CommunityPage() {
         {/* Main content */}
         <Box sx={{ flex: 1, minWidth: 0 }}>
 
-        {/* Live rooms / bounty / filters strip */}
+        {/* Bounty / filters strip */}
         <Box sx={{ mb: 4 }}>
-          {/* Live rooms strip (Instagram-style live circles). Hidden when empty
-              unless the viewer can host. */}
-          <Box data-tour-id="tour-live-rooms">
-            <LiveRoomsStrip
-              canCreate={canCreateRooms}
-              onCreateClick={() => setCreateRoomOpen(true)}
-            />
-          </Box>
-
           {/* Bounty Section */}
           <Box data-tour-id="tour-bounties">
             <BountySection bounties={bounties} />
@@ -1003,13 +984,6 @@ export default function CommunityPage() {
             }}
           />
         )}
-
-        {/* Create-room dialog (admin / instructor) */}
-        <CreateRoomDialog
-          open={createRoomOpen}
-          onClose={() => setCreateRoomOpen(false)}
-          onCreated={(room) => router.push(`/community/rooms/${room.id}`)}
-        />
 
         {/* Offer Bounty Dialog */}
         {bountyDialog.open && (

--- a/lib/guide/registry.ts
+++ b/lib/guide/registry.ts
@@ -51,15 +51,6 @@ const COMMUNITY_TOUR_STEPS: TourStep[] = [
     color: "#6366f1",
   },
   {
-    targetId: "tour-live-rooms",
-    title: "Live Rooms",
-    narration:
-      "When admins or instructors go live, you'll see them here as glowing circles, with a pink badge showing how many sessions are live. Tap a circle to join, or click the Live Rooms heading to browse every scheduled and past room.",
-    placement: "bottom",
-    icon: "mdi:broadcast",
-    color: "#ec4899",
-  },
-  {
     targetId: "tour-bounties",
     title: "High-value Bounties",
     narration:
@@ -107,7 +98,7 @@ const COMMUNITY_TOUR_STEPS: TourStep[] = [
 export const PAGE_GUIDES: Record<string, PageGuideContent> = {
   "/community": {
     headerTitle: "What you can do in the Community",
-    headerSubtitle: "Eight tools in one place. Take a 60-second guided tour or browse the list.",
+    headerSubtitle: "Everything in one place. Take a quick guided tour or browse the list.",
     tourSteps: COMMUNITY_TOUR_STEPS,
     features: [
       {
@@ -115,12 +106,6 @@ export const PAGE_GUIDES: Record<string, PageGuideContent> = {
         color: "#6366f1",
         title: "Five post types",
         text: "Question, Poll, Resource, Discussion, Humor - each with its own template.",
-      },
-      {
-        icon: "mdi:broadcast",
-        color: "#ec4899",
-        title: "Live voice/video rooms",
-        text: "Drop into rooms hosted by admins. Camera, mic, screen share, chat.",
       },
       {
         icon: "mdi:fire",


### PR DESCRIPTION
## What

Removes the **Live Rooms** strip (the Instagram-style live circles + "Start" button) from the main community feed, as requested.

- Drops the `LiveRoomsStrip` + `CreateRoomDialog` from `app/community/page.tsx`, plus the now-unused `createRoomOpen` state, `canCreateRooms` memo, and imports.
- Cleans the community page guide (`lib/guide/registry.ts`): removes the "Live voice/video rooms" feature and the "Live Rooms" tour step; updates the subtitle.

The `LiveRoomsStrip` / `CreateRoomDialog` components and the `/community/rooms` route are **left intact** (still used by the rooms browser page) — this only removes the feature from the community feed.

## Verification
- `tsc --noEmit` clean (0 errors).
- Netlify deploy-preview must go green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)