### PR TITLE
feat(guide): tour on every page + Guide button left of Today's Leaders

### DIFF
--- a/components/common/PageGuide.tsx
+++ b/components/common/PageGuide.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Box, Button, ButtonBase, Dialog, DialogContent, IconButton, Tooltip, Typography } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useTour } from "@/components/community/TourProvider";
-import type { PageGuideContent } from "@/lib/guide/registry";
+import { buildTour, type PageGuideContent } from "@/lib/guide/registry";
 
 /**
  * The one page-guide "?" used across every module header. Opens a modal that
@@ -28,7 +28,10 @@ export function PageGuide({
 }) {
   const [open, setOpen] = useState(false);
   const { startTour } = useTour();
-  const hasTour = !!content.tourSteps && content.tourSteps.length > 0;
+  // Every page can be toured: pages with explicit tourSteps use them, the rest get a
+  // narrated walkthrough synthesized from their features.
+  const tourSteps = buildTour(content);
+  const hasTour = tourSteps.length > 0;
 
   // 0.1s of silent WAV, base64. Playing it from inside the click handler primes
   // the browser's autoplay gate so the tour's TTS narration then plays without a
@@ -47,7 +50,7 @@ export function PageGuide({
     }
     setOpen(false);
     // Brief delay so the modal exit animation runs before the spotlight measures.
-    window.setTimeout(() => startTour(content.tourSteps!), 220);
+    window.setTimeout(() => startTour(tourSteps), 220);
   };
 
   return (
@@ -240,7 +243,7 @@ export function PageGuide({
                   "&:hover": { filter: "brightness(0.92)", boxShadow: "none" },
                 }}
               >
-                Start the tour
+                Take a tour
               </Button>
             )}
           </Box>

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -409,6 +409,16 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
               </Box>
             </>
           )}
+          {/* Platform guide - "what can I do here" overview + platform tour; sits
+              left of Today's Leaders and stays available regardless of the flag. */}
+          {isAuthenticated && (
+            <PageGuide
+              content={PLATFORM_GUIDE}
+              variant="nav"
+              label="Guide"
+              tooltip="Take a platform guide"
+            />
+          )}
           {/* Daily Progress Leaderboard - hidden when no_leaderboard_view */}
           {!hideLeaderboardView && (
           <React.Fragment>
@@ -967,16 +977,6 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
             </Popover>
           </Box>
           </React.Fragment>
-          )}
-
-          {/* Platform guide - a bird's-eye "what can I do here" overview, always available */}
-          {isAuthenticated && (
-            <PageGuide
-              content={PLATFORM_GUIDE}
-              variant="nav"
-              label="Guide"
-              tooltip="Take a platform guide"
-            />
           )}
 
           {/* Language selector - only for client id 28 */}

--- a/lib/guide/registry.ts
+++ b/lib/guide/registry.ts
@@ -1402,3 +1402,32 @@ export function resolveGuide(pathname: string | null | undefined): PageGuideCont
   }
   return best?.guide;
 }
+
+/**
+ * The guided tour for a page. Pages with explicit tourSteps (e.g. community, which
+ * anchors to data-tour-id targets on the page) use those; every other page gets a
+ * narrated walkthrough synthesized from its features - an intro card, one card per
+ * feature, and an outro - so "Take a tour" works on every page and the platform guide.
+ */
+export function buildTour(content: PageGuideContent): TourStep[] {
+  if (content.tourSteps && content.tourSteps.length > 0) return content.tourSteps;
+  const intro: TourStep = {
+    title: content.headerTitle,
+    narration: content.headerSubtitle,
+    icon: "mdi:compass-outline",
+    color: "#a78bfa",
+  };
+  const featureSteps: TourStep[] = content.features.map((f) => ({
+    title: f.title,
+    narration: f.text,
+    icon: f.icon,
+    color: f.color,
+  }));
+  const outro: TourStep = {
+    title: "You're all set",
+    narration: content.tip ?? "That's the tour. Explore the page - and open this guide any time from the header.",
+    icon: "mdi:rocket-launch-outline",
+    color: "#a78bfa",
+  };
+  return [intro, ...featureSteps, outro];
+}


### PR DESCRIPTION
## What

Follow-up to the guide feature (#1086/#1087):

1. **Guide button moved left of Today's Leaders** in the top nav (was on the right of the streak chip), and it stays visible regardless of the `no_leaderboard_view` flag.
2. **"Take a tour" on every page** — and on the platform guide. Pages with explicit `tourSteps` (community, anchored to `data-tour-id` targets) keep their richer spotlight tour; every other page gets a **narrated walkthrough synthesized from its features** (intro → one card per feature → outro) via `buildTour()`. So the tour is essential/available everywhere, as requested.
3. Tour button relabeled **"Take a tour"**.

No new `data-tour-id` anchors were needed — the synthesized tour uses centered narration cards (the TourProvider already supports target-less steps), with voice + word-by-word reveal.

## Verification
- `tsc --noEmit` clean (0 errors).
- Netlify deploy-preview must go green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)