### PR TITLE
fix(adaptive): coding editor persistence + reliable video check-in scoring

### DIFF
--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -56,7 +56,7 @@ export function VideoCompanion({ configId }: { configId: number }) {
 
   // Destructure the controller into stable locals - passing `setIframe` to a ref taints the
   // whole object for the react-hooks/refs rule, so we never read `ctl.<member>` during render.
-  const { setIframe, currentTime, duration, playbackRate, rewinds, play, pause, seekTo, setRate } =
+  const { setIframe, currentTime, duration, playbackRate, rewinds, endedTick, play, pause, seekTo, setRate } =
     useVimeoController();
 
   // Real watched-coverage tracking: each whole second actually PLAYED (not skipped) is marked, so
@@ -87,13 +87,13 @@ export function VideoCompanion({ configId }: { configId: number }) {
   // --- Check-in auto-pause ---------------------------------------------------
   useEffect(() => {
     if (!companion || activeCheckIn) return;
-    const due = companion.check_ins.find(
-      (c) =>
-        currentTime >= c.timestamp_seconds &&
-        currentTime <= c.timestamp_seconds + 4 &&
-        !shownRef.current.has(c.id) &&
-        !answered.has(c.id)
-    );
+    // Fire the FIRST un-shown, un-answered check-in whose timestamp has been reached. (Previously a
+    // tight 4-second window meant a coarse/seeked timeupdate tick could jump past a marker and drop
+    // it forever - the "7/8 checks" symptom.) The shown/answered guards + backward-seek can't re-fire
+    // an already-handled one.
+    const due = companion.check_ins
+      .filter((c) => !shownRef.current.has(c.id) && !answered.has(c.id) && currentTime >= c.timestamp_seconds)
+      .sort((a, b) => a.timestamp_seconds - b.timestamp_seconds)[0];
     if (due) {
       shownRef.current.add(due.id);
       pause();
@@ -162,24 +162,47 @@ export function VideoCompanion({ configId }: { configId: number }) {
     return () => clearInterval(t);
   }, [sessionId, watchMode]);
 
-  // On unmount: flush the FINAL coverage/speed, THEN end + score (so the award reflects everything
-  // watched, including the last stretch the periodic sync may not have sent yet).
-  useEffect(() => {
-    return () => {
-      if (!sessionId) return;
-      adaptiveVideoService
-        .sync(sessionId, {
-          current_timestamp: prevTimeRef.current,
-          completeness_pct: coverageRef.current,
-          max_speed: maxSpeedRef.current,
-          rewinds: rewindsRef.current.length ? rewindsRef.current : undefined,
-        })
-        .catch(() => {})
-        .finally(() => {
-          adaptiveVideoService.endSession(sessionId).then(() => notifyContentCompleted()).catch(() => {});
-        });
-    };
+  // Flush the FINAL coverage/speed, THEN end + score (so the award reflects everything watched,
+  // including the last stretch the periodic sync may not have sent yet). Server-side this is
+  // idempotent + monotonic (upgradeable award keyed on video:<config.id>), so firing it from
+  // several triggers is safe and never lowers a prior award.
+  const endAndScore = useCallback(() => {
+    if (!sessionId) return;
+    adaptiveVideoService
+      .sync(sessionId, {
+        current_timestamp: prevTimeRef.current,
+        completeness_pct: coverageRef.current,
+        max_speed: maxSpeedRef.current,
+        rewinds: rewindsRef.current.length ? rewindsRef.current : undefined,
+      })
+      .catch(() => {})
+      .finally(() => {
+        adaptiveVideoService.endSession(sessionId).then(() => notifyContentCompleted()).catch(() => {});
+      });
   }, [sessionId]);
+  const endRef = useRef(endAndScore);
+  useEffect(() => {
+    endRef.current = endAndScore;
+  }, [endAndScore]);
+
+  // Score the watch the moment the video REACHES THE END - not only on navigation-away unmount,
+  // which is what left a completed watch stuck at 0/25 (the ScoreEvent never fired).
+  useEffect(() => {
+    if (endedTick > 0) endRef.current();
+  }, [endedTick]);
+
+  // Also flush on page hide/close (tab close / hard navigation), where the unmount cleanup's async
+  // request would otherwise be dropped.
+  useEffect(() => {
+    const flush = () => endRef.current();
+    window.addEventListener("pagehide", flush);
+    return () => window.removeEventListener("pagehide", flush);
+  }, []);
+
+  // Unmount fallback (SPA navigation away before the video ends).
+  useEffect(() => {
+    return () => endRef.current();
+  }, []);
 
   // --- Handlers --------------------------------------------------------------
   const onAnswer = useCallback(

--- a/components/adaptive-video/useVimeoController.ts
+++ b/components/adaptive-video/useVimeoController.ts
@@ -18,6 +18,9 @@ export interface VimeoController {
   playbackRate: number;
   /** Backwards seeks observed this watch - {from, to}. */
   rewinds: { from: number; to: number }[];
+  /** Bumps each time the video fires "ended" - lets the consumer score the watch on real
+   *  completion, not only on unmount/navigation. */
+  endedTick: number;
   play: () => void;
   pause: () => void;
   seekTo: (seconds: number) => void;
@@ -37,6 +40,7 @@ export function useVimeoController(): VimeoController {
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackRate, setPlaybackRate] = useState(1);
   const [rewinds, setRewinds] = useState<{ from: number; to: number }[]>([]);
+  const [endedTick, setEndedTick] = useState(0);
   const lastTimeRef = useRef(0);
 
   // Callback ref: store the node and register the Vimeo listeners once it loads. Doing the setup
@@ -79,8 +83,11 @@ export function useVimeoController(): VimeoController {
           setIsPlaying(true);
           break;
         case "pause":
+          setIsPlaying(false);
+          break;
         case "ended":
           setIsPlaying(false);
+          setEndedTick((t) => t + 1);
           break;
         case "timeupdate": {
           const s = payload?.seconds ?? 0;
@@ -115,5 +122,5 @@ export function useVimeoController(): VimeoController {
     setPlaybackRate(rate);
   }, []);
 
-  return { setIframe, currentTime, duration, isPlaying, playbackRate, rewinds, play, pause, seekTo, setRate };
+  return { setIframe, currentTime, duration, isPlaying, playbackRate, rewinds, endedTick, play, pause, seekTo, setRate };
 }

--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -54,6 +54,40 @@ function pickDefaultLanguage(templateCode: Record<string, string>): string {
   return pool[0];
 }
 
+// Per-language editor drafts persisted locally so typed code survives a refresh AND a language
+// switch (the adaptive flow only persisted code to the server on Run/Submit). Keyed by problem +
+// language, plus the last-used language per problem so a reload restores the right dropdown.
+const draftKey = (pid: number, lang: string) => `adaptiveCoding:draft:${pid}:${lang}`;
+const langKey = (pid: number) => `adaptiveCoding:lang:${pid}`;
+function readDraft(pid: number, lang: string): string | null {
+  try {
+    return typeof window !== "undefined" ? localStorage.getItem(draftKey(pid, lang)) : null;
+  } catch {
+    return null;
+  }
+}
+function writeDraft(pid: number, lang: string, code: string) {
+  try {
+    if (typeof window !== "undefined") localStorage.setItem(draftKey(pid, lang), code ?? "");
+  } catch {
+    /* quota / private mode - drafts are best-effort */
+  }
+}
+function readLangPref(pid: number): string | null {
+  try {
+    return typeof window !== "undefined" ? localStorage.getItem(langKey(pid)) : null;
+  } catch {
+    return null;
+  }
+}
+function writeLangPref(pid: number, lang: string) {
+  try {
+    if (typeof window !== "undefined") localStorage.setItem(langKey(pid), lang);
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * Student-facing AI Coding Mentor solver. Reuses the Monaco editor + language
  * utils, but routes Run/Submit/Hint at the adaptive-coding endpoints so every
@@ -120,24 +154,36 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
         const existing = await adaptiveCodingService.getActiveSession(configId, problemId);
         if (cancelled) return;
         setProblem(prob);
+        // Priority for language: local last-used -> server session language -> best default.
+        const savedLang = readLangPref(problemId);
+        const pickLang = (serverLang?: string | null) => {
+          if (savedLang && langs.includes(savedLang)) return savedLang;
+          if (serverLang && langs.includes(serverLang)) return serverLang;
+          return pickDefaultLanguage(prob.template_code);
+        };
+        // Priority for code: local draft for that language -> server last_source (only if it was
+        // that language) -> the language's starter template.
+        const codeFor = (lang: string, serverSource?: string | null, serverLang?: string | null) => {
+          const draft = readDraft(problemId, lang);
+          if (draft !== null) return draft;
+          if (serverSource && lang === serverLang) return serverSource;
+          return prob.template_code[lang] || "";
+        };
         if (existing) {
           setSessionData(existing);
           setSessionId(existing.id);
-          const lang = existing.language && langs.includes(existing.language)
-            ? existing.language
-            : pickDefaultLanguage(prob.template_code);
+          const lang = pickLang(existing.language);
           setLanguage(lang);
-          setCode(existing.last_source || prob.template_code[lang] || "");
+          setCode(codeFor(lang, existing.last_source, existing.language));
           setHintsRevealed(existing.hints_revealed);
           setSolvedAlready(existing.passed || existing.status === "completed");
           setStarted(existing.status === "active");  // live timer only while active
           setAllowClipboard(Boolean(existing.allow_clipboard));
           applySubmissionRecord(existing.latest_submission);
         } else {
-          // No session yet - default to the language the problem is best answered in (not a stub).
-          const lang = pickDefaultLanguage(prob.template_code);
+          const lang = pickLang();
           setLanguage(lang);
-          setCode(prob.template_code[lang] || "");
+          setCode(codeFor(lang));
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load this problem.");
@@ -178,11 +224,28 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
   }, []);
 
   function handleLanguageChange(next: string) {
+    if (next === language) return;
+    // Stash the current language's work before switching, then restore the target language's
+    // draft if it has one - never blow away typed code with the fresh template.
+    writeDraft(problemId, language, code);
+    writeLangPref(problemId, next);
+    const draft = readDraft(problemId, next);
     setLanguage(next);
-    setCode(problem?.template_code[next] ?? "");
+    setCode(draft !== null ? draft : problem?.template_code[next] ?? "");
     setTestResults(null);
     resetMentorState();
   }
+
+  // Autosave the working draft locally (debounced) so a refresh or a language switch never loses
+  // typed code - the server only persists on Run/Submit.
+  useEffect(() => {
+    if (!problem) return;
+    const t = setTimeout(() => {
+      writeDraft(problemId, language, code);
+      writeLangPref(problemId, language);
+    }, 700);
+    return () => clearTimeout(t);
+  }, [code, language, problem, problemId]);
 
   async function handleRun() {
     if (!sessionId || running || submitting || solvedAlready) return;
@@ -359,7 +422,20 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
 
         <CodingMasteryPanel refreshKey={masteryRefresh} />
 
-        <AdaptiveCodingSubmissions problemId={problemId} refreshKey={masteryRefresh} />
+        <AdaptiveCodingSubmissions
+          problemId={problemId}
+          refreshKey={masteryRefresh}
+          onRestore={(src, lang) => {
+            // Stash the current work, then load the chosen submission back into the editor.
+            writeDraft(problemId, language, code);
+            const l = lang && problem?.template_code?.[lang] != null ? lang : language;
+            if (l !== language) writeLangPref(problemId, l);
+            setLanguage(l);
+            setCode(src);
+            resetMentorState();
+            showToast("Loaded that submission into the editor.", "success");
+          }}
+        />
       </Box>
 
       {/* Right - editor + live timer/points HUD + toolbar (the ready gate is shown earlier, before

--- a/components/coding/AdaptiveCodingSubmissions.tsx
+++ b/components/coding/AdaptiveCodingSubmissions.tsx
@@ -20,9 +20,12 @@ import {
 export function AdaptiveCodingSubmissions({
   problemId,
   refreshKey = 0,
+  onRestore,
 }: {
   problemId: number;
   refreshKey?: number;
+  /** Load a past submission's code (+ language) back into the editor. */
+  onRestore?: (source: string, language: string) => void;
 }) {
   const [items, setItems] = useState<CodingSubmissionHistoryItem[] | null>(null);
   const [expandedId, setExpandedId] = useState<number | null>(null);
@@ -96,6 +99,7 @@ export function AdaptiveCodingSubmissions({
             index={items.length - i}
             expanded={expandedId === s.id}
             onToggle={() => setExpandedId((cur) => (cur === s.id ? null : s.id))}
+            onRestore={onRestore}
           />
         ))}
       </Box>
@@ -108,11 +112,13 @@ function SubmissionRow({
   index,
   expanded,
   onToggle,
+  onRestore,
 }: {
   sub: CodingSubmissionHistoryItem;
   index: number;
   expanded: boolean;
   onToggle: () => void;
+  onRestore?: (source: string, language: string) => void;
 }) {
   const color = sub.all_passed ? "#10b981" : "#ef4444";
   const verdict = sub.all_passed ? "Accepted" : `${sub.passed_count}/${sub.total_count} passed`;
@@ -224,6 +230,32 @@ function SubmissionRow({
           >
             {sub.source || "-"}
           </Box>
+          {onRestore && sub.source && (
+            <Box sx={{ mt: 1, display: "flex", justifyContent: "flex-end" }}>
+              <Box
+                component="button"
+                onClick={() => onRestore(sub.source, sub.language)}
+                sx={{
+                  all: "unset",
+                  cursor: "pointer",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.4,
+                  px: 1,
+                  py: 0.5,
+                  borderRadius: 1.5,
+                  fontSize: "0.75rem",
+                  fontWeight: 800,
+                  color: "#6366f1",
+                  border: "1px solid color-mix(in srgb, #6366f1 40%, transparent)",
+                  "&:hover": { background: "color-mix(in srgb, #6366f1 10%, transparent)" },
+                }}
+              >
+                <Icon icon="mdi:pencil-box-outline" width={15} />
+                Load into editor
+              </Box>
+            </Box>
+          )}
         </Box>
       </Collapse>
     </Box>


### PR DESCRIPTION
Pairs with backend ai-linc-backend#415. Fixes the two reported learner bugs.

## Bug A — coding editor lost code + reset language on refresh/switch
- **Per-language drafts in localStorage** (`adaptiveCoding:draft:<problem>:<lang>` + `…:lang:<problem>`), autosaved (debounced) on every edit — typed code survives a **refresh** even without Run/Submit.
- **Switching language no longer wipes the editor**: stash the current language's draft, restore the target language's draft (else its template).
- **On load, restore the last-used language + its draft** (local → server session → default) instead of always defaulting to Python.
- **Submissions restorable**: a "Load into editor" button pulls a past submission's source + language back into Monaco.

## Bug B — video check-in score stuck at 0/25
- **Score on the video "ended" event** (new `endedTick`) + a `pagehide` flush — not only on React unmount, which is why a completed watch never emitted the ScoreEvent (→ 0/25). `end_session` is idempotent/monotonic, so multiple triggers are safe.
- **Fix the dropped check-in ("7/8")**: the auto-pause fired only inside a tight 4-second window, so a coarse/seeked tick could skip a marker forever. Now fire the first un-shown, un-answered check-in whose timestamp has been reached.

(The BE half makes answering the check-ins actually move the 25-point award and keeps the coding language authoritative after run/submit.)

## Verification
- `tsc --noEmit` clean. Netlify deploy-preview must go green.
- Manual: type Java → refresh → Java + code restored; switch languages → each keeps its draft; load a past submission; watch a video to the end → score fires and reflects check-in accuracy; all 8 check-ins fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)