### PR TITLE
feat(coding): wire up C# in the editor (Monaco mode + fallback + default pref)

### DIFF
--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -42,7 +42,7 @@ function isUnsuitableTemplate(tpl: string | undefined): boolean {
 }
 
 // Preference order when several languages are suitable - pick the most natural for a general problem.
-const LANGUAGE_PREFERENCE = ["python", "java", "cpp", "c", "javascript", "typescript", "go", "csharp", "ruby", "sql"];
+const LANGUAGE_PREFERENCE = ["python", "java", "cpp", "c", "javascript", "typescript", "go", "c#", "ruby", "sql"];
 
 /** The language a problem is best answered in: the first SUITABLE template by preference order
  *  (falls back to the first template only if every language is stubbed). */

--- a/components/coding/utils/languageUtils.ts
+++ b/components/coding/utils/languageUtils.ts
@@ -10,6 +10,7 @@ export const LANGUAGE_ID_MAPPING: Record<string, number> = {
   c: 50,
   sql: 82,
   'c#': 51,
+  csharp: 51,
 };
 
 // Map language names to Monaco Editor language identifiers
@@ -25,7 +26,8 @@ export const MONACO_LANGUAGE_MAPPING: Record<string, string> = {
   java: "java",
   c: "c",
   sql: "sql",
-  'c#': "c#",
+  'c#': "csharp",
+  csharp: "csharp",
 };
 
 // Map display names
@@ -42,6 +44,7 @@ export const LANGUAGE_DISPLAY_NAMES: Record<string, string> = {
   c: "C",
   sql: "SQL",
   'c#': "C#",
+  csharp: "C#",
 };
 
 export type LanguageOption = {
@@ -92,7 +95,7 @@ export function getAvailableLanguages(templateCode: Record<string, string> | und
  * interview/competitive languages. An AI-generated problem can arrive with an empty
  * template_code ({}), which would otherwise leave the editor with no selectable language
  * and no way to type. This keeps the IDE usable (Judge0 + Monaco both key off the value). */
-const DEFAULT_FALLBACK_LANGUAGE_KEYS = ["python", "java", "cpp", "c", "javascript"];
+const DEFAULT_FALLBACK_LANGUAGE_KEYS = ["python", "java", "cpp", "c", "javascript", "c#"];
 
 export function getAvailableLanguagesOrDefault(
   templateCode: Record<string, string> | undefined


### PR DESCRIPTION
Pairs with backend ai-linc-backend#416. C# executes on Judge0 (verified id 51 = Mono, Accepted on prod). These are the FE gaps:

- **Monaco mode (the load-bearing bug)**: `MONACO_LANGUAGE_MAPPING['c#']` was `"c#"`, but Monaco's registered id is `"csharp"` — so C# rendered as **plaintext with no syntax highlighting**. Fixed to `"csharp"` (flows into every editor via `getMonacoLanguage`).
- Add `"c#"` to `DEFAULT_FALLBACK_LANGUAGE_KEYS` so assessment problems with empty `template_code` still offer C#.
- Normalize the adaptive default-language preference key `"csharp" → "c#"` (the canonical key across the id/label/monaco maps + BE `template_code`).
- **Defense-in-depth**: `"csharp"` alias rows in the id/monaco/display maps so a surface emitting `"csharp"` resolves to id 51 (not the `getLanguageId → 71` Python fallback).

Learner pickers are template-driven, so C# appears once BE ships `template_code["c#"]` (#416's force-inject + backfill command cover new + existing problems).

## Verification
- `tsc --noEmit` clean. Netlify deploy-preview must go green.
- After BE #416 deploy + backfill: open an adaptive/assessment coding problem → C# in the picker, **syntax highlighting**, run/submit a real C# solution → correct verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)