### PR TITLE
feat(adaptive-courses): auto-enroll toggle in the course builder (Phase 1)

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -211,6 +211,23 @@ export default function AdminAdaptiveCourseDetailPage() {
     }
   }
 
+  async function handleToggleAutoEnroll() {
+    if (!course) return;
+    const next = !course.auto_enroll;
+    try {
+      const res = await adminAdaptiveCourseService.updateCourse(course.id, { auto_enroll: next });
+      setCourse({ ...course, auto_enroll: res.auto_enroll });
+      showToast(
+        res.auto_enroll
+          ? `Auto-enroll on: every student of this tenant is enrolled${course.is_published ? " now." : " once you publish."}`
+          : "Auto-enroll off: enroll students manually or via a cohort.",
+        "success"
+      );
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't update auto-enroll", "error");
+    }
+  }
+
   async function handlePublish() {
     if (!course) return;
     try {
@@ -379,6 +396,18 @@ export default function AdminAdaptiveCourseDetailPage() {
                     >
                       <Icon icon={course.content_locked ? "mdi:lock-outline" : "mdi:lock-open-variant-outline"} width={16} />
                       {course.content_locked ? "Content locked" : "Content unlocked"}
+                    </ButtonBase>
+                    <ButtonBase
+                      onClick={() => void handleToggleAutoEnroll()}
+                      sx={pillBtnSx("outline")}
+                      title={
+                        course.auto_enroll
+                          ? "Every student of this tenant is auto-enrolled. Click to make enrollment admin/cohort-managed instead."
+                          : "Enrollment is admin/cohort-managed. Click to auto-enroll every student of this tenant."
+                      }
+                    >
+                      <Icon icon={course.auto_enroll ? "mdi:account-multiple-check" : "mdi:account-multiple-outline"} width={16} />
+                      {course.auto_enroll ? "Auto-enroll on" : "Auto-enroll off"}
                     </ButtonBase>
                     <ButtonBase onClick={() => void handlePublish()} sx={pillBtnSx(course.is_published ? "outline" : "solid")}>
                       <Icon icon={course.is_published ? "mdi:eye-off-outline" : "mdi:earth"} width={16} />

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -284,6 +284,9 @@ export interface AdminAdaptiveCourseListItem {
   duration_weeks: number;
   difficulty_levels: string[];
   is_published: boolean;
+  /** When true, every active student of the tenant is auto-enrolled (existing on toggle/publish,
+   *  new students on signup), so the course appears in their courses without an admin acting. */
+  auto_enroll: boolean;
   /** Weekly cohort gate. False = every week open + full XP (admin toggle). */
   content_locked: boolean;
   module_count: number;
@@ -541,10 +544,10 @@ export const adminAdaptiveCourseService = {
     return data;
   },
 
-  /** Edit course fields (title/description/content lock). Returns the updated detail. */
+  /** Edit course fields (title/description/content lock/auto-enroll). Returns the updated detail. */
   async updateCourse(
     courseId: number,
-    payload: { title?: string; description?: string; content_locked?: boolean },
+    payload: { title?: string; description?: string; content_locked?: boolean; auto_enroll?: boolean },
   ): Promise<AdminAdaptiveCourseDetail> {
     const { data } = await apiClient.patch<AdminAdaptiveCourseDetail>(
       `${BASE}/courses/${courseId}/`,


### PR DESCRIPTION
## What
Adds an **Auto-enroll on/off** toggle to the adaptive course builder header (beside content-lock / publish).

- **On** → every active student of the tenant is enrolled automatically (existing students immediately or on publish; new students on signup), so the course shows up in their courses with no admin action.
- **Off** → enrollment stays admin/cohort-managed (today's behavior).

Backs BE ai-linc-backend#418 (`AdaptiveCourse.auto_enroll`): PATCHes `{ auto_enroll }` via `updateCourse`, updates local state, and toasts the effect (noting it applies on publish for a draft).

Part of the courses→adaptive migration (Phase 1: the enrollment unblock — adaptive was default-deny with no self-serve enroll).

## Verification
`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)