### PR TITLE
feat(courses): adaptive is the primary 'Courses' surface (Phase 2)

### DIFF
--- a/components/courses/CoursesNavTabs.tsx
+++ b/components/courses/CoursesNavTabs.tsx
@@ -14,33 +14,33 @@ interface TabDef {
 }
 
 /**
- * Prominent section switcher for the Courses area: "Courses" (legacy) and
- * "Adaptive courses" (the adaptive library page). Rendered as a clear segmented
- * control so the section is obvious - each tab is its own route. The Adaptive
- * tab only appears when the tenant has the adaptive feature.
+ * Prominent section switcher for the Courses area. When the tenant has the
+ * adaptive feature, ADAPTIVE is the primary "Courses" experience (listed first)
+ * and the legacy structured catalogue is demoted to "Classic courses" — the
+ * courses→adaptive migration. When adaptive is off, the legacy catalogue keeps
+ * the "Courses" name (and there's nothing to switch, so the control hides).
  */
 export function CoursesNavTabs({ active }: { active: "courses" | "adaptive" }) {
   const { push, prefetch } = useInstantNavigation();
   const adaptiveOn = useIsAdaptiveQuizEnabled();
 
-  const tabs: TabDef[] = [
-    {
-      key: "courses",
-      label: "Courses",
-      sub: "Structured & self-paced",
-      icon: "mdi:book-open-page-variant-outline",
-      href: "/courses",
-    },
-  ];
-  if (adaptiveOn) {
-    tabs.push({
-      key: "adaptive",
-      label: "Adaptive courses",
-      sub: "AI-personalised in real time",
-      icon: "mdi:book-education-outline",
-      href: "/adaptive-courses",
-    });
-  }
+  const legacyTab: TabDef = {
+    key: "courses",
+    label: adaptiveOn ? "Classic courses" : "Courses",
+    sub: "Structured & self-paced",
+    icon: "mdi:book-open-page-variant-outline",
+    href: "/courses",
+  };
+  const adaptiveTab: TabDef = {
+    key: "adaptive",
+    label: "Courses",
+    sub: "AI-personalised in real time",
+    icon: "mdi:book-education-outline",
+    href: "/adaptive-courses",
+  };
+
+  // Adaptive first (it's the primary "Courses" now); legacy demoted after it.
+  const tabs: TabDef[] = adaptiveOn ? [adaptiveTab, legacyTab] : [legacyTab];
 
   // Nothing to switch between with a single section.
   if (tabs.length < 2) return null;

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -368,14 +368,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
       featureName: "dashboard", // Regular dashboard, not admin
       descKey: "navDesc.dashboard",
     },
-    {
-      label: "Courses",
-      labelKey: "nav.courses",
-      path: "/courses",
-      icon: "mdi:book-open-variant",
-      featureName: "course",
-      descKey: "navDesc.courses",
-    },
+    // Adaptive is the primary courses experience now (courses→adaptive migration), so it
+    // leads; the legacy structured catalogue follows. Labels stay feature-scoped via i18n so
+    // a traditional-only tenant (no adaptive_quiz) still sees its catalogue as "Courses".
     {
       label: "Adaptive Courses",
       labelKey: "nav.adaptiveCourses",
@@ -383,6 +378,14 @@ export const Sidebar: React.FC<SidebarProps> = ({
       icon: "mdi:book-education-outline",
       featureName: "adaptive_quiz",
       descKey: "navDesc.adaptiveCourses",
+    },
+    {
+      label: "Courses",
+      labelKey: "nav.courses",
+      path: "/courses",
+      icon: "mdi:book-open-variant",
+      featureName: "course",
+      descKey: "navDesc.courses",
     },
     {
       label: "Assessments",


### PR DESCRIPTION
## What (Phase 2 of courses→adaptive)
When the tenant has the adaptive feature, **adaptive becomes the primary "Courses"** and the legacy structured catalogue is demoted to **"Classic courses"**:
- **CoursesNavTabs** — adaptive tab is first + labelled **"Courses"**; legacy tab becomes **"Classic courses"**. Gated on the adaptive feature, so a traditional-only tenant keeps its catalogue named "Courses".
- **Sidebar** — the Adaptive Courses entry leads (above the legacy Courses entry). Labels stay feature-scoped via i18n, so traditional-only tenants are unaffected.

## Safe by construction
Everything is conditional on the adaptive feature, so no tenant config regresses:
- adaptive+legacy tenant → "Courses" (adaptive) + "Classic courses"
- traditional-only tenant → unchanged ("Courses")

## Deferred (needs conditional per-tenant i18n, follow-up)
Renaming the *sidebar entry* label itself to "Courses"/"Classic" and switching the default landing route. Flagged rather than done, to avoid a blanket i18n change that would confuse traditional-only tenants.

`npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)