### PR TITLE
feat(admin): adaptive-course pickers in the jobs + interview-template forms (Phase 3b/3c FE)

### DIFF
--- a/app/admin/admin-mock-interview/templates/page.tsx
+++ b/app/admin/admin-mock-interview/templates/page.tsx
@@ -27,6 +27,7 @@ import { MainLayout } from "@/components/layout/MainLayout";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { adminCoursesService } from "@/lib/services/admin/admin-courses.service";
+import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
 import adminMockInterviewService, {
   type InterviewTemplate,
   type InterviewTemplateCreatePayload,
@@ -82,6 +83,7 @@ interface DraftTemplate {
   description: string;
   is_active: boolean;
   course_ids: number[];
+  adaptive_course_ids: number[];
   num_coding_questions: number;
   num_mcq_questions: number;
   result_release_mode: InterviewResultReleaseMode;
@@ -98,6 +100,7 @@ const EMPTY_DRAFT: DraftTemplate = {
   description: "",
   is_active: true,
   course_ids: [],
+  adaptive_course_ids: [],
   num_coding_questions: 2,
   num_mcq_questions: 1,
   result_release_mode: "manual",
@@ -116,6 +119,7 @@ function toDraft(t: InterviewTemplate): DraftTemplate {
     description: t.description || "",
     is_active: t.is_active,
     course_ids: t.course_ids,
+    adaptive_course_ids: t.adaptive_course_ids ?? [],
     num_coding_questions: t.num_coding_questions ?? 2,
     num_mcq_questions: t.num_mcq_questions ?? 1,
     result_release_mode: t.result_release_mode ?? "manual",
@@ -141,6 +145,7 @@ export default function AdminInterviewTemplatesPage() {
 
   const [templates, setTemplates] = useState<InterviewTemplate[]>([]);
   const [courses, setCourses] = useState<Array<{ id: number; title: string }>>([]);
+  const [adaptiveCourses, setAdaptiveCourses] = useState<Array<{ id: number; title: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [selectedTemplate, setSelectedTemplate] = useState<InterviewTemplate | null>(
     null
@@ -167,11 +172,17 @@ export default function AdminInterviewTemplatesPage() {
   const loadAll = useCallback(async () => {
     setLoading(true);
     try {
-      const [tmpls, coursesData] = await Promise.all([
+      const [tmpls, coursesData, adaptiveData] = await Promise.all([
         adminMockInterviewService.listTemplates(),
         adminCoursesService.getCourses().catch(() => []),
+        adminAdaptiveCourseService.listCourses().catch(() => []),
       ]);
       setTemplates(tmpls);
+      setAdaptiveCourses(
+        (adaptiveData ?? [])
+          .filter((c) => c.is_published)
+          .map((c) => ({ id: c.id, title: c.title }))
+      );
       const rawList = Array.isArray(coursesData)
         ? coursesData
         : Array.isArray((coursesData as { results?: unknown[] })?.results)
@@ -207,6 +218,12 @@ export default function AdminInterviewTemplatesPage() {
     courses.forEach((c) => m.set(c.id, c.title));
     return m;
   }, [courses]);
+
+  const adaptiveCourseById = useMemo(() => {
+    const m = new Map<number, string>();
+    adaptiveCourses.forEach((c) => m.set(c.id, c.title));
+    return m;
+  }, [adaptiveCourses]);
 
   const resetForm = () => {
     setSelectedTemplate(null);
@@ -264,6 +281,7 @@ export default function AdminInterviewTemplatesPage() {
         description: draft.description.trim(),
         is_active: draft.is_active,
         course_ids: draft.course_ids,
+        adaptive_course_ids: draft.adaptive_course_ids,
         num_coding_questions: draft.num_coding_questions,
         num_mcq_questions: draft.num_mcq_questions,
         result_release_mode: draft.result_release_mode,
@@ -1048,6 +1066,47 @@ export default function AdminInterviewTemplatesPage() {
                       <MenuItem disabled>No courses available</MenuItem>
                     ) : (
                       courses.map((c) => (
+                        <MenuItem key={c.id} value={c.id}>
+                          {c.title}
+                        </MenuItem>
+                      ))
+                    )}
+                  </Select>
+                </FormControl>
+                <FormControl fullWidth size="small" sx={{ mt: 1.5 }}>
+                  <InputLabel>Adaptive courses</InputLabel>
+                  <Select
+                    multiple
+                    label="Adaptive courses"
+                    value={draft.adaptive_course_ids}
+                    input={<OutlinedInput label="Adaptive courses" />}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      const ids = Array.isArray(value) ? (value as number[]) : [Number(value)];
+                      setDraft((d) => ({ ...d, adaptive_course_ids: ids }));
+                    }}
+                    renderValue={(selected) => {
+                      const ids = selected as number[];
+                      if (ids.length === 0) {
+                        return (
+                          <Typography variant="body2" sx={{ color: "var(--font-tertiary)", fontStyle: "italic" }}>
+                            Not mapped yet
+                          </Typography>
+                        );
+                      }
+                      return (
+                        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                          {ids.map((id) => (
+                            <Chip key={id} label={adaptiveCourseById.get(id) || `#${id}`} size="small" />
+                          ))}
+                        </Box>
+                      );
+                    }}
+                  >
+                    {adaptiveCourses.length === 0 ? (
+                      <MenuItem disabled>No adaptive courses available</MenuItem>
+                    ) : (
+                      adaptiveCourses.map((c) => (
                         <MenuItem key={c.id} value={c.id}>
                           {c.title}
                         </MenuItem>

--- a/components/admin/jobs-v2/JobCreateEditPage.tsx
+++ b/components/admin/jobs-v2/JobCreateEditPage.tsx
@@ -29,6 +29,7 @@ import type {
   JobQuestionV2,
 } from "@/lib/services/admin/admin-jobs-v2.service";
 import { adminJobsV2Service } from "@/lib/services/admin/admin-jobs-v2.service";
+import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
 import type { JobV2 } from "@/lib/services/jobs-v2.service";
 import { formatJobPassoutYear } from "@/lib/services/jobs-v2.service";
 import { CreateJobIllustration } from "@/components/jobs-v2/illustrations";
@@ -89,6 +90,7 @@ const emptyPayload: JobCreateUpdatePayload = {
   min_graduation_percentage: null,
   college_mappings: [],
   course_ids: [],
+  adaptive_course_ids: [],
   assigned_student_ids: [],
   question_ids: [],
 };
@@ -225,6 +227,24 @@ export function JobCreateEditPage({
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [formData, setFormData] = useState<JobCreateUpdatePayload>(emptyPayload);
   const [submitting, setSubmitting] = useState(false);
+  // Adaptive courses (courses→adaptive) fetched here so both the new + edit pages get the picker.
+  const [adaptiveCourses, setAdaptiveCourses] = useState<CourseOption[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    adminAdaptiveCourseService
+      .listCourses()
+      .then((list) => {
+        if (!cancelled) {
+          setAdaptiveCourses(
+            list.filter((c) => c.is_published).map((c) => ({ id: c.id, title: c.title }))
+          );
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // Kept alongside formData.assigned_student_ids (the wire format) because the chips need the
   // name/email the picker resolved - the payload only carries ids.
   const [assignedStudents, setAssignedStudents] = useState<SelectedStudent[]>([]);
@@ -247,6 +267,7 @@ export function JobCreateEditPage({
       const data = initialData as {
         college_mappings?: Array<{ college_name: string; department?: string; batch?: string }>;
         courses?: Array<{ id: number }>;
+        adaptive_courses?: Array<{ id: number }>;
         question_ids?: number[];
         application_deadline?: string;
       };
@@ -300,6 +321,7 @@ export function JobCreateEditPage({
           batch: m.batch,
         })),
         course_ids: (data.courses ?? []).map((c) => c.id),
+        adaptive_course_ids: (data.adaptive_courses ?? []).map((c) => c.id),
         assigned_student_ids: (initialData.assigned_students ?? []).map((s) => s.id),
         question_ids: data.question_ids ?? [],
       });
@@ -419,6 +441,7 @@ export function JobCreateEditPage({
         company_logo: formData.company_logo.trim(),
         mandatory_skills: formData.key_skills ?? [],
         course_ids: formData.course_ids ?? [],
+        adaptive_course_ids: formData.adaptive_course_ids ?? [],
         // Always sent, even when empty: [] is how the admin clears a curated list.
         assigned_student_ids: formData.assigned_student_ids ?? [],
         question_ids: formData.question_ids ?? [],
@@ -938,6 +961,49 @@ export function JobCreateEditPage({
                       }
                       sx={inputSx}
                     />
+                  )}
+                  renderTags={(value, getTagProps) =>
+                    value.map((option, index) => (
+                      <Chip
+                        label={option?.title ?? option?.name ?? `Course ${option?.id}`}
+                        {...getTagProps({ index })}
+                        key={option?.id ?? index}
+                        size="small"
+                        onDelete={getTagProps({ index }).onDelete}
+                      />
+                    ))
+                  }
+                />
+              </Box>
+              <Box sx={{ mt: 2.5 }}>
+                <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 700, color: "var(--font-primary)" }}>
+                  Adaptive courses
+                </Typography>
+                <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+                  If set, students enrolled in any of these adaptive courses also see this job
+                </Typography>
+                <Autocomplete
+                  multiple
+                  options={adaptiveCourses}
+                  getOptionLabel={(option: CourseOption) =>
+                    option?.title ?? option?.name ?? `Course ${option?.id ?? ""}`
+                  }
+                  isOptionEqualToValue={(option: CourseOption, value: CourseOption) =>
+                    option?.id === value?.id
+                  }
+                  value={(formData.adaptive_course_ids ?? [])
+                    .map((id) => adaptiveCourses.find((c) => Number(c?.id) === Number(id)))
+                    .filter(Boolean) as CourseOption[]}
+                  onChange={(_, newValue: CourseOption[]) => {
+                    handleChange("adaptive_course_ids", newValue.map((c) => c.id));
+                  }}
+                  renderOption={(props, option: CourseOption) => (
+                    <li {...props} key={option?.id ?? props.id}>
+                      {option?.title ?? option?.name ?? `Course ${option?.id}`}
+                    </li>
+                  )}
+                  renderInput={(params) => (
+                    <TextField {...params} size="small" label="Select adaptive courses" sx={inputSx} />
                   )}
                   renderTags={(value, getTagProps) =>
                     value.map((option, index) => (

--- a/lib/services/admin/admin-jobs-v2.service.ts
+++ b/lib/services/admin/admin-jobs-v2.service.ts
@@ -46,6 +46,8 @@ export interface JobCreateUpdatePayload {
     batch?: string;
   }>;
   course_ids?: number[];
+  /** Adaptive course ids the job targets (courses→adaptive). Their enrollees also see the job. */
+  adaptive_course_ids?: number[];
   /** UserProfile ids of individually curated learners. Only they see the job. [] clears. */
   assigned_student_ids?: number[];
   question_ids?: number[];

--- a/lib/services/admin/admin-mock-interview.service.ts
+++ b/lib/services/admin/admin-mock-interview.service.ts
@@ -527,6 +527,7 @@ export interface InterviewTemplate {
   description: string;
   is_active: boolean;
   course_ids: number[];
+  adaptive_course_ids?: number[];
   courses: Array<{ id: number; title: string }>;
   attempt_count: number;
   num_coding_questions: number;
@@ -549,6 +550,7 @@ export interface InterviewTemplateCreatePayload {
   description?: string;
   is_active?: boolean;
   course_ids?: number[];
+  adaptive_course_ids?: number[];
   num_coding_questions?: number;
   num_mcq_questions?: number;
   result_release_mode?: InterviewResultReleaseMode;


### PR DESCRIPTION
## What
Completes the FE for courses→adaptive Phase 3b/3c (the BE already accepts `adaptive_course_ids` on both).

- **Jobs form** (`JobCreateEditPage`) — an **"Adaptive courses"** multi-select beside the course picker; loads published adaptive courses and round-trips `adaptive_course_ids` on create/edit. Enrollees of the picked adaptive courses then see the job.
- **Interview-template form** — an **"Adaptive courses"** Select beside "Map to course(s)"; round-trips `adaptive_course_ids`. Enrollees see the interview as pending.

Service types gain `adaptive_course_ids` on the create/update payloads + the read shapes. `npx tsc --noEmit` clean.

This is the last piece of the courses→adaptive migration FE — admins can now tag adaptive courses to jobs and interviews from the UI (previously API-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)