### PR TITLE
fix(guide): keep the tour tooltip fully on-screen (was clipping off the bottom)

### DIFF
--- a/components/community/TourProvider.tsx
+++ b/components/community/TourProvider.tsx
@@ -368,7 +368,24 @@ function TourOverlay({
   const accent = step.color ?? "#a78bfa";
   const isLast = stepIdx === totalSteps - 1;
 
-  // Compute tooltip position relative to highlight (or centered if no target).
+  // Measure the tooltip card's REAL height so positioning never assumes a fixed size (long
+  // narration + controls make it much taller than the old hardcoded 200px, which pushed the
+  // card off-screen for low/edge targets - the "can't see step 7/8" bug).
+  const tipRef = useRef<HTMLDivElement | null>(null);
+  const [cardH, setCardH] = useState(260);
+  useEffect(() => {
+    const el = tipRef.current;
+    if (!el) return;
+    const measure = () => setCardH(el.offsetHeight || 260);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [stepIdx]);
+
+  // Compute tooltip position relative to highlight (or centered if no target). Places the card
+  // beside the target where it fits, and ALWAYS clamps it fully inside the viewport using the
+  // measured height - so no step's card can ever render off-screen, on any page.
   const tooltipPos = useMemo(() => {
     if (!rect) return null;
     const padded = {
@@ -380,38 +397,32 @@ function TourOverlay({
     const placement = step.placement ?? "bottom";
     const TIP_W = 360;
     const TIP_GAP = 14;
+    const MARGIN = 16;
     const vw = window.innerWidth;
     const vh = window.innerHeight;
 
-    // Auto-flip if the chosen placement would push the tooltip off-screen.
-    if (placement === "bottom" && padded.top + padded.height + TIP_GAP + 220 > vh) {
-      return {
-        top: Math.max(20, padded.top - TIP_GAP - 200),
-        left: Math.min(vw - TIP_W - 20, Math.max(20, padded.left + padded.width / 2 - TIP_W / 2)),
-        arrowOn: "bottom" as const,
-      };
-    }
-    if (placement === "top" && padded.top - TIP_GAP - 200 < 0) {
-      return {
-        top: padded.top + padded.height + TIP_GAP,
-        left: Math.min(vw - TIP_W - 20, Math.max(20, padded.left + padded.width / 2 - TIP_W / 2)),
-        arrowOn: "top" as const,
-      };
-    }
+    const below = padded.top + padded.height + TIP_GAP; // card top if placed below the target
+    const above = padded.top - TIP_GAP - cardH; //          card top if placed above the target
+    const fitsBelow = below + cardH + MARGIN <= vh;
+    const fitsAbove = above >= MARGIN;
+
+    let top: number;
+    let arrowOn: "top" | "bottom";
     if (placement === "top") {
-      return {
-        top: Math.max(20, padded.top - TIP_GAP - 200),
-        left: Math.min(vw - TIP_W - 20, Math.max(20, padded.left + padded.width / 2 - TIP_W / 2)),
-        arrowOn: "bottom" as const,
-      };
+      if (fitsAbove) { top = above; arrowOn = "bottom"; }
+      else { top = below; arrowOn = "top"; }
+    } else {
+      // bottom (default) — and left/right fall back to below/above too
+      if (fitsBelow) { top = below; arrowOn = "top"; }
+      else if (fitsAbove) { top = above; arrowOn = "bottom"; }
+      else { top = MARGIN; arrowOn = "top"; } // neither side fits (huge target) — clamp handles it
     }
-    // default: bottom
-    return {
-      top: padded.top + padded.height + TIP_GAP,
-      left: Math.min(vw - TIP_W - 20, Math.max(20, padded.left + padded.width / 2 - TIP_W / 2)),
-      arrowOn: "top" as const,
-    };
-  }, [rect, step.placement]);
+
+    // Final clamp: keep the whole card in view regardless of placement, target position, or content.
+    top = Math.min(Math.max(MARGIN, top), Math.max(MARGIN, vh - cardH - MARGIN));
+    const left = Math.min(vw - TIP_W - MARGIN, Math.max(MARGIN, padded.left + padded.width / 2 - TIP_W / 2));
+    return { top, left, arrowOn };
+  }, [rect, step.placement, cardH]);
 
   // The cutout polygon - outer rect minus inner rect = mask.
   const clipPath = useMemo(() => {
@@ -481,6 +492,7 @@ function TourOverlay({
       <AnimatePresence mode="wait">
         <Box
           key={stepIdx}
+          ref={tipRef}
           component={motion.div}
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -490,13 +502,17 @@ function TourOverlay({
             position: "absolute",
             width: 360,
             maxWidth: "calc(100vw - 32px)",
+            // Never exceed the viewport: if the card is somehow taller than the screen it scrolls
+            // internally instead of clipping off the bottom.
+            maxHeight: "calc(100vh - 32px)",
             backgroundColor: "#0f172a",
             color: "#e2e8f0",
             borderRadius: "14px",
             border: `1px solid ${accent}66`,
             boxShadow: `0 20px 60px rgba(0,0,0,0.5), 0 0 0 1px ${accent}33`,
             pointerEvents: "auto",
-            overflow: "hidden",
+            overflowY: "auto",
+            overflowX: "hidden",
             ...(tooltipPos
               ? { top: tooltipPos.top, left: tooltipPos.left }
               : {


### PR DESCRIPTION
## Bug
In the platform (and page) guided tours, some steps' tooltip card rendered **off the bottom of the viewport** — you couldn't read what step 7/8 was showing.

## Cause
`TourProvider`'s tooltip positioning assumed a **fixed 200px card height** for its auto-flip and only clamped the *top* edge. A tall card (long narration + controls) or a low/edge target pushed the card below the fold with no bottom clamp.

## Fix (shared TourProvider → applies to every tour)
- **Measure the card's real height** (ResizeObserver) instead of assuming 200px.
- Place it on whichever side actually fits (below / above), then **always clamp the final position fully inside the viewport** using the measured height.
- `maxHeight: calc(100vh - 32px)` + internal scroll as a last resort, so a card taller than the screen never clips.

This is a single fix in the shared component, so the community tour, the dashboard/platform tour, and all 24 per-page tours are covered — "not repeated anywhere."

## Verification
- `tsc --noEmit` clean. Netlify deploy-preview must go green; then take the platform tour and confirm every step's card is fully visible (incl. low targets like the leaderboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)