### PR TITLE
fix(coding): custom input runs the student's input, not preloaded test cases

### DIFF
--- a/components/assessment/AssessmentCodingLayout.tsx
+++ b/components/assessment/AssessmentCodingLayout.tsx
@@ -521,7 +521,7 @@ export function AssessmentCodingLayout({
 
       const languageId = getLanguageId(selectedLanguage);
 
-      const result = await assessmentService.runCodeInAssessment(
+      const result = await assessmentService.runCustomTestCaseInAssessment(
         slug,
         questionId,
         code,
@@ -529,8 +529,9 @@ export function AssessmentCodingLayout({
         customInput
       );
 
-      // Mark as custom input result
-      setTestResults({ ...result, custom_input: true });
+      // Mark as custom input result. The custom endpoint returns the stdout under `output`;
+      // mirror it to `actual_output` so the results panel (which reads actual_output) shows it.
+      setTestResults({ ...result, actual_output: result?.actual_output ?? result?.output, custom_input: true });
 
       if (result.stderr || result.compile_output) {
         showToast("Code executed with errors", "warning");

--- a/components/coding/CodingProblemLayout.tsx
+++ b/components/coding/CodingProblemLayout.tsx
@@ -479,8 +479,9 @@ export function CodingProblemLayout({
       setRunningCustomInput(true);
       const languageId = getLanguageId(selectedLanguage);
 
-      // Use the runCode endpoint with custom input
-      const result = await coursesService.runCode(
+      // Use the dedicated custom-input endpoint (runCode ignores stdin and returns the
+      // problem's preloaded test-case outputs).
+      const result = await coursesService.runCustomInput(
         courseId,
         contentId,
         code,

--- a/lib/services/assessment.service.ts
+++ b/lib/services/assessment.service.ts
@@ -586,6 +586,25 @@ export const assessmentService = {
     return response.data;
   },
 
+  // Assessment Coding Problem: Run against the student's OWN custom input.
+  // Must hit /run-custom-testcase/ with the input under key `input` — /run-code/ ignores stdin
+  // and only runs the problem's stored sample cases (returned the "preloaded outputs" bug).
+  runCustomTestCaseInAssessment: async (
+    slug: string,
+    questionId: number,
+    sourceCode: string,
+    languageId: number,
+    customInput: string,
+  ): Promise<any> => {
+    const endpoint = `/assessment/api/client/${config.clientId}/run-custom-testcase/${slug}/${questionId}/`;
+    const response = await apiClient.post(endpoint, {
+      source_code: sourceCode,
+      language_id: languageId,
+      input: customInput,
+    });
+    return response.data;
+  },
+
   // Assessment Coding Problem: Submit Code
   submitCodeInAssessment: async (
     slug: string,

--- a/lib/services/courses.service.ts
+++ b/lib/services/courses.service.ts
@@ -433,6 +433,25 @@ export const coursesService = {
     return response.data;
   },
 
+  // Coding Problem: Run against the student's OWN custom input (not the stored test cases).
+  // Must hit sub_type=customRunCode and send the input under key `input` — the runCode branch
+  // ignores stdin and only runs the problem's preloaded test cases.
+  runCustomInput: async (
+    courseId: number,
+    contentId: number,
+    sourceCode: string,
+    languageId: number,
+    customInput: string
+  ): Promise<any> => {
+    const endpoint = `/activity/clients/${config.clientId}/courses/${courseId}/content/${contentId}/?activity_type=CodingProblem&sub_type=customRunCode`;
+    const response = await apiClient.post(endpoint, {
+      source_code: sourceCode,
+      language_id: languageId,
+      input: customInput,
+    });
+    return response.data;
+  },
+
   // Coding Problem: Submit Code
   submitCode: async (
     courseId: number,


### PR DESCRIPTION
The **Run custom input** button was calling the `runCode`/`run-code` endpoint (which judges the problem's stored `test_cases[:2]` and never reads stdin) and sending the input under key `stdin`, while the custom endpoints read `input`. So the input was dropped twice → the panel showed the **preloaded test-case outputs**.

- **Course**: new `coursesService.runCustomInput` → `sub_type=customRunCode` with `{ input }`.
- **Assessment**: new `runCustomTestCaseInAssessment` → `/run-custom-testcase/` with `{ input }` (mirrors its `output` onto `actual_output` for the results panel).

Backs the BE endpoints that already read `input`. tsc clean. Part of the coding-bug RCA (companion BE fix ai-linc-backend#423). 🤖 Generated with Claude Code