### PR TITLE
feat(courses): student self-enroll catalog + admin open-to-self-enroll toggle

### DIFF
--- a/app/adaptive-courses/catalog/loading.tsx
+++ b/app/adaptive-courses/catalog/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer - renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition; the page's own skeleton takes over while its API loads.
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/adaptive-courses/catalog/page.tsx
+++ b/app/adaptive-courses/catalog/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Box, Chip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
   adaptiveCourseService,
@@ -18,7 +18,7 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { useToast } from "@/components/common/Toast";
 
 export default function AdaptiveCourseCatalogPage() {
-  const { push, prefetch } = useInstantNavigation();
+  const { push } = useInstantNavigation();
   const { showToast } = useToast();
   const featureOn = useIsAdaptiveQuizEnabled();
   const [loading, setLoading] = useState(true);
@@ -155,8 +155,8 @@ export default function AdaptiveCourseCatalogPage() {
               <CatalogCourseCard
                 course={course}
                 enrolling={enrollingId === course.id}
+                disabled={enrollingId !== null && enrollingId !== course.id}
                 onEnroll={() => void handleEnroll(course)}
-                onPreview={() => push(`/adaptive-courses/${course.id}`)}
               />
             </Reveal>
           ))}

--- a/app/adaptive-courses/catalog/page.tsx
+++ b/app/adaptive-courses/catalog/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import {
+  adaptiveCourseService,
+  type AdaptiveCourseListItem,
+} from "@/lib/services/adaptive-course.service";
+import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
+import { SearchFilterBar } from "@/components/common/list";
+import { Reveal } from "@/components/scorecard/shared";
+import { CatalogCourseCard } from "@/components/courses/CatalogCourseCard";
+import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { useToast } from "@/components/common/Toast";
+
+export default function AdaptiveCourseCatalogPage() {
+  const { push, prefetch } = useInstantNavigation();
+  const { showToast } = useToast();
+  const featureOn = useIsAdaptiveQuizEnabled();
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState<AdaptiveCourseListItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [enrollingId, setEnrollingId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!featureOn) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await adaptiveCourseService.getCatalog();
+        if (!cancelled) setItems(list);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load the course catalog.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [featureOn]);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (c) =>
+        c.title.toLowerCase().includes(q) ||
+        (c.description || "").toLowerCase().includes(q) ||
+        (c.target_audience || "").toLowerCase().includes(q),
+    );
+  }, [items, query]);
+
+  async function handleEnroll(course: AdaptiveCourseListItem) {
+    if (enrollingId !== null) return;
+    setEnrollingId(course.id);
+    try {
+      await adaptiveCourseService.selfEnroll(course.id);
+      // Drop it from the catalog (it now lives in "My courses") and route the learner in.
+      setItems((prev) => prev.filter((c) => c.id !== course.id));
+      showToast(`You're enrolled in "${course.title}".`, "success");
+      push(`/adaptive-courses/${course.id}`);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't enroll in that course.", "error");
+    } finally {
+      setEnrollingId(null);
+    }
+  }
+
+  if (!featureOn) {
+    return (
+      <PageShell>
+        <Box sx={{ py: 8, textAlign: "center" }}>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            {"Adaptive Course isn't enabled for this organisation."}
+          </Typography>
+          <Typography sx={{ color: "text.secondary", mt: 1 }}>
+            {'Ask your administrator to switch on the "Adaptive Quiz" feature.'}
+          </Typography>
+        </Box>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Learn"
+        title="Browse courses"
+        description="Courses your organisation has opened for you to join. Enroll in one and it moves into My courses instantly."
+        accent="purple"
+        icon="mdi:compass-outline"
+        action={
+          <HeaderActionButton icon="mdi:book-education-outline" variant="ghost" onClick={() => push("/adaptive-courses")}>
+            My courses
+          </HeaderActionButton>
+        }
+      />
+
+      {loading && <AdaptiveCourseListSkeleton />}
+
+      {error && (
+        <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>
+          {error}
+        </Typography>
+      )}
+
+      {!loading && !error && items.length === 0 && <CatalogEmptyState onBack={() => push("/adaptive-courses")} />}
+
+      {!loading && !error && items.length > 0 && (
+        <Box sx={{ mb: 2.5 }}>
+          <SearchFilterBar
+            search={query}
+            onSearchChange={setQuery}
+            searchPlaceholder="Search available courses…"
+          />
+        </Box>
+      )}
+
+      {!loading && !error && items.length > 0 && visible.length === 0 && (
+        <Box
+          sx={{
+            p: { xs: 3, md: 5 },
+            borderRadius: 4,
+            textAlign: "center",
+            bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+            border: "1px dashed color-mix(in srgb, var(--border-default) 90%, transparent)",
+          }}
+        >
+          <Icon icon="mdi:magnify-close" width={44} style={{ color: "#a855f7" }} />
+          <Typography sx={{ fontWeight: 800, mt: 1.5, fontSize: "1.05rem" }}>No courses match your search.</Typography>
+          <Chip label="Clear search" onClick={() => setQuery("")} sx={{ mt: 1.75, fontWeight: 700, cursor: "pointer" }} />
+        </Box>
+      )}
+
+      {!loading && visible.length > 0 && (
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+            gap: 2,
+            alignItems: "stretch",
+          }}
+        >
+          {visible.map((course, idx) => (
+            <Reveal key={course.id} delay={Math.min(idx, 8) * 0.06}>
+              <CatalogCourseCard
+                course={course}
+                enrolling={enrollingId === course.id}
+                onEnroll={() => void handleEnroll(course)}
+                onPreview={() => push(`/adaptive-courses/${course.id}`)}
+              />
+            </Reveal>
+          ))}
+        </Box>
+      )}
+    </PageShell>
+  );
+}
+
+function CatalogEmptyState({ onBack }: { onBack: () => void }) {
+  return (
+    <Box
+      sx={{
+        p: { xs: 3, md: 5 },
+        borderRadius: 4,
+        textAlign: "center",
+        bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+        border: "1px dashed color-mix(in srgb, var(--border-default) 90%, transparent)",
+      }}
+    >
+      <Icon icon="mdi:compass-off-outline" width={48} style={{ color: "#a855f7" }} />
+      <Typography sx={{ fontWeight: 800, mt: 1.5, fontSize: "1.1rem" }}>
+        No courses are open to join right now.
+      </Typography>
+      <Typography sx={{ color: "text.secondary", mt: 0.75, maxWidth: 520, mx: "auto", lineHeight: 1.5 }}>
+        {"When your organisation opens a course for self-enrollment, it'll show up here. You may already be enrolled in others."}
+      </Typography>
+      <Chip label="Back to my courses" onClick={onBack} sx={{ mt: 2, fontWeight: 700, cursor: "pointer" }} />
+    </Box>
+  );
+}

--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/services/adaptive-course.service";
 import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
 import { PageShell } from "@/components/common/PageShell";
-import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { ViewToggle, SegmentedTabs, SearchFilterBar, type ListView } from "@/components/common/list";
 import { KpiRail, Reveal } from "@/components/scorecard/shared";
 import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
@@ -133,6 +133,11 @@ export default function AdaptiveCourseListPage() {
         description="AI-personalised courses that adapt to your level in real time - practice, get instant feedback, and level up."
         accent="purple"
         icon="mdi:book-education-outline"
+        action={
+          <HeaderActionButton icon="mdi:compass-outline" onClick={() => push("/adaptive-courses/catalog")}>
+            Browse courses
+          </HeaderActionButton>
+        }
       />
 
       {items.length > 0 && (
@@ -156,7 +161,9 @@ export default function AdaptiveCourseListPage() {
             </Typography>
           )}
 
-          {!loading && !error && items.length === 0 && <EmptyState />}
+          {!loading && !error && items.length === 0 && (
+            <EmptyState onBrowse={() => push("/adaptive-courses/catalog")} />
+          )}
 
           {!loading && !error && items.length > 0 && (
             <Box sx={{ mb: 2.5 }}>
@@ -319,7 +326,7 @@ function AdaptiveCourseRow({
   );
 }
 
-function EmptyState() {
+function EmptyState({ onBrowse }: { onBrowse: () => void }) {
   return (
     <Box
       sx={{
@@ -335,8 +342,14 @@ function EmptyState() {
         {"You're not enrolled in any adaptive course yet."}
       </Typography>
       <Typography sx={{ color: "text.secondary", mt: 0.75, maxWidth: 520, mx: "auto", lineHeight: 1.5 }}>
-        {"Adaptive courses appear here once your instructor enrolls you. Check back soon - or reach out to your instructor if you're expecting access."}
+        {"Browse the courses your organisation has opened for you to join - or check back once your instructor enrolls you."}
       </Typography>
+      <Chip
+        label="Browse courses"
+        icon={<Icon icon="mdi:compass-outline" width={18} />}
+        onClick={onBrowse}
+        sx={{ mt: 2, fontWeight: 700, cursor: "pointer", px: 0.5 }}
+      />
     </Box>
   );
 }

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -228,6 +228,23 @@ export default function AdminAdaptiveCourseDetailPage() {
     }
   }
 
+  async function handleToggleSelfEnroll() {
+    if (!course) return;
+    const next = !course.self_enroll_enabled;
+    try {
+      const res = await adminAdaptiveCourseService.updateCourse(course.id, { self_enroll_enabled: next });
+      setCourse({ ...course, self_enroll_enabled: res.self_enroll_enabled });
+      showToast(
+        res.self_enroll_enabled
+          ? `Self-enroll on: students can find and join this course themselves${course.is_published ? "." : " once you publish."}`
+          : "Self-enroll off: the course is no longer listed for students to join.",
+        "success"
+      );
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't update self-enroll", "error");
+    }
+  }
+
   async function handlePublish() {
     if (!course) return;
     try {
@@ -408,6 +425,18 @@ export default function AdminAdaptiveCourseDetailPage() {
                     >
                       <Icon icon={course.auto_enroll ? "mdi:account-multiple-check" : "mdi:account-multiple-outline"} width={16} />
                       {course.auto_enroll ? "Auto-enroll on" : "Auto-enroll off"}
+                    </ButtonBase>
+                    <ButtonBase
+                      onClick={() => void handleToggleSelfEnroll()}
+                      sx={pillBtnSx("outline")}
+                      title={
+                        course.self_enroll_enabled
+                          ? "Students can find this course in the catalog and enroll themselves. Click to remove it from the catalog."
+                          : "The course isn't self-enrollable. Click to let students find and join it themselves from the catalog."
+                      }
+                    >
+                      <Icon icon={course.self_enroll_enabled ? "mdi:account-plus" : "mdi:account-plus-outline"} width={16} />
+                      {course.self_enroll_enabled ? "Self-enroll on" : "Self-enroll off"}
                     </ButtonBase>
                     <ButtonBase onClick={() => void handlePublish()} sx={pillBtnSx(course.is_published ? "outline" : "solid")}>
                       <Icon icon={course.is_published ? "mdi:eye-off-outline" : "mdi:earth"} width={16} />

--- a/components/courses/CatalogCourseCard.tsx
+++ b/components/courses/CatalogCourseCard.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { AdaptiveCourseListItem } from "@/lib/services/adaptive-course.service";
+
+/** A course card for the self-enroll catalog. Mirrors AdaptiveCourseCard's visuals but the root is
+ *  a plain Box (not a ButtonBase) so it can carry a real <button> Enroll action — a button nested
+ *  inside a ButtonBase is invalid. The whole preview area opens the course; the footer enrolls. */
+export function CatalogCourseCard({
+  course,
+  enrolling,
+  onEnroll,
+  onPreview,
+}: {
+  course: AdaptiveCourseListItem;
+  enrolling: boolean;
+  onEnroll: () => void;
+  onPreview?: () => void;
+}) {
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+        borderRadius: 3,
+        p: 2.5,
+        bgcolor: "var(--card-bg, #fff)",
+        border: "1px solid var(--border-default, #ececf1)",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.04), 0 10px 26px -22px rgba(16,24,40,0.18)",
+        transition: "transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease",
+        "&:hover": {
+          transform: "translateY(-3px)",
+          borderColor: "color-mix(in srgb, #6366f1 40%, transparent)",
+          boxShadow: "0 20px 40px -26px rgba(99, 102, 241, 0.45)",
+        },
+      }}
+    >
+      {/* Image band (fallback gradient) — clickable to preview the course. */}
+      <Box
+        onClick={onPreview}
+        sx={{
+          width: "100%",
+          aspectRatio: "16 / 9",
+          borderRadius: 2.5,
+          overflow: "hidden",
+          mb: 1.5,
+          flexShrink: 0,
+          cursor: onPreview ? "pointer" : "default",
+          background:
+            "linear-gradient(135deg, color-mix(in srgb, #6366f1 14%, transparent), color-mix(in srgb, #a855f7 12%, transparent))",
+        }}
+      >
+        {course.card_image_url && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={course.card_image_url}
+            alt={course.title}
+            loading="lazy"
+            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+          />
+        )}
+      </Box>
+
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.5 }}>
+        <Box
+          sx={{
+            width: 44,
+            height: 44,
+            borderRadius: 3,
+            flexShrink: 0,
+            display: "grid",
+            placeItems: "center",
+            color: "white",
+            background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
+            boxShadow: "0 14px 26px -14px rgba(168, 85, 247, 0.6)",
+          }}
+        >
+          <Icon icon="mdi:book-education-outline" width={22} />
+        </Box>
+        <Box
+          component="span"
+          sx={{
+            px: 1,
+            py: 0.3,
+            borderRadius: 999,
+            fontSize: "0.65rem",
+            fontWeight: 800,
+            letterSpacing: 0.4,
+            textTransform: "uppercase",
+            color: "#a855f7",
+            bgcolor: "color-mix(in srgb, #a855f7 14%, transparent)",
+          }}
+        >
+          Adaptive
+        </Box>
+      </Box>
+
+      <Typography
+        onClick={onPreview}
+        sx={{
+          fontWeight: 800,
+          fontSize: "1.05rem",
+          lineHeight: 1.3,
+          cursor: onPreview ? "pointer" : "default",
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+        }}
+      >
+        {course.title}
+      </Typography>
+      <Typography
+        sx={{
+          color: "text.secondary",
+          mt: 0.75,
+          fontSize: "0.86rem",
+          lineHeight: 1.5,
+          minHeight: "2.6em",
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+        }}
+      >
+        {course.description || ""}
+      </Typography>
+
+      <Box sx={{ display: "flex", gap: 1.5, columnGap: 2, mt: "auto", pt: 2, flexWrap: "wrap" }}>
+        <Metric icon="mdi:view-module-outline" label="modules" value={course.module_count} />
+        <Metric icon="mdi:book-open-variant" label="articles" value={course.article_count} />
+        <Metric icon="mdi:tune-vertical" label="quizzes" value={course.quiz_count} />
+        {(course.coding_count ?? 0) > 0 && (
+          <Metric icon="mdi:robot-happy-outline" label="coding" value={course.coding_count ?? 0} />
+        )}
+      </Box>
+
+      {/* Enroll action pinned to the bottom so every card lines up. */}
+      <Button
+        onClick={onEnroll}
+        disabled={enrolling}
+        variant="contained"
+        disableElevation
+        startIcon={
+          enrolling ? (
+            <CircularProgress size={16} sx={{ color: "inherit" }} />
+          ) : (
+            <Icon icon="mdi:account-plus" width={18} />
+          )
+        }
+        sx={{
+          mt: 2,
+          borderRadius: 2,
+          textTransform: "none",
+          fontWeight: 800,
+          background: "linear-gradient(135deg, #6366f1 0%, #a855f7 60%, #ec4899 100%)",
+          "&:hover": { background: "linear-gradient(135deg, #5457e5 0%, #9333ea 60%, #db2777 100%)" },
+          "&.Mui-disabled": { color: "rgba(255,255,255,0.85)", opacity: 0.7 },
+        }}
+      >
+        {enrolling ? "Enrolling…" : "Enroll"}
+      </Button>
+    </Box>
+  );
+}
+
+function Metric({ icon, label, value }: { icon: string; label: string; value: number }) {
+  return (
+    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.6 }}>
+      <Icon icon={icon} width={16} style={{ color: "#6366f1" }} />
+      <Typography component="span" sx={{ fontWeight: 800, fontSize: "0.85rem" }}>
+        {value}
+      </Typography>
+      <Typography component="span" sx={{ color: "text.secondary", fontSize: "0.78rem" }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+}

--- a/components/courses/CatalogCourseCard.tsx
+++ b/components/courses/CatalogCourseCard.tsx
@@ -6,17 +6,19 @@ import type { AdaptiveCourseListItem } from "@/lib/services/adaptive-course.serv
 
 /** A course card for the self-enroll catalog. Mirrors AdaptiveCourseCard's visuals but the root is
  *  a plain Box (not a ButtonBase) so it can carry a real <button> Enroll action — a button nested
- *  inside a ButtonBase is invalid. The whole preview area opens the course; the footer enrolls. */
+ *  inside a ButtonBase is invalid. Enroll-only: the course detail page is enrollment-gated (a
+ *  non-enrolled learner would hit its 403), so the card intentionally offers no "open" affordance. */
 export function CatalogCourseCard({
   course,
   enrolling,
+  disabled,
   onEnroll,
-  onPreview,
 }: {
   course: AdaptiveCourseListItem;
   enrolling: boolean;
+  /** True while a sibling card's enroll is in flight — greys this one out to prevent double-submit. */
+  disabled?: boolean;
   onEnroll: () => void;
-  onPreview?: () => void;
 }) {
   return (
     <Box
@@ -39,9 +41,8 @@ export function CatalogCourseCard({
         },
       }}
     >
-      {/* Image band (fallback gradient) — clickable to preview the course. */}
+      {/* Image band (fallback gradient). */}
       <Box
-        onClick={onPreview}
         sx={{
           width: "100%",
           aspectRatio: "16 / 9",
@@ -49,7 +50,6 @@ export function CatalogCourseCard({
           overflow: "hidden",
           mb: 1.5,
           flexShrink: 0,
-          cursor: onPreview ? "pointer" : "default",
           background:
             "linear-gradient(135deg, color-mix(in srgb, #6366f1 14%, transparent), color-mix(in srgb, #a855f7 12%, transparent))",
         }}
@@ -100,12 +100,10 @@ export function CatalogCourseCard({
       </Box>
 
       <Typography
-        onClick={onPreview}
         sx={{
           fontWeight: 800,
           fontSize: "1.05rem",
           lineHeight: 1.3,
-          cursor: onPreview ? "pointer" : "default",
           display: "-webkit-box",
           WebkitLineClamp: 2,
           WebkitBoxOrient: "vertical",
@@ -142,7 +140,7 @@ export function CatalogCourseCard({
       {/* Enroll action pinned to the bottom so every card lines up. */}
       <Button
         onClick={onEnroll}
-        disabled={enrolling}
+        disabled={enrolling || disabled}
         variant="contained"
         disableElevation
         startIcon={

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -140,6 +140,8 @@ export interface AdaptiveCourseListItem {
   video_count?: number;
   /** AI/admin card thumbnail; null when absent or hidden by the admin. */
   card_image_url?: string | null;
+  /** True when the admin has opened this course to student self-enrollment (catalog listing). */
+  self_enroll_enabled?: boolean;
   updated_at: string;
 }
 
@@ -216,6 +218,22 @@ export interface SubmodulePointsBreakdown {
 export const adaptiveCourseService = {
   async listCourses(): Promise<AdaptiveCourseListItem[]> {
     const { data } = await apiClient.get<AdaptiveCourseListItem[]>(`${BASE}/courses/`);
+    return data;
+  },
+
+  /** Courses the student can join themselves: published + admin-opened (self_enroll_enabled),
+   *  minus the ones they're already enrolled in. Powers the "Browse courses" catalog. */
+  async getCatalog(): Promise<AdaptiveCourseListItem[]> {
+    const { data } = await apiClient.get<AdaptiveCourseListItem[]>(`${BASE}/courses/catalog/`);
+    return data;
+  },
+
+  /** Enroll the current student into a self-enrollable course. Idempotent server-side. */
+  async selfEnroll(courseId: number): Promise<{ course_id: number; enrolled: boolean; already_enrolled: boolean }> {
+    const { data } = await apiClient.post<{ course_id: number; enrolled: boolean; already_enrolled: boolean }>(
+      `${BASE}/courses/${courseId}/enroll/`,
+      {},
+    );
     return data;
   },
 

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -287,6 +287,9 @@ export interface AdminAdaptiveCourseListItem {
   /** When true, every active student of the tenant is auto-enrolled (existing on toggle/publish,
    *  new students on signup), so the course appears in their courses without an admin acting. */
   auto_enroll: boolean;
+  /** When true, the published course is listed in the learner catalog and any active student of
+   *  the tenant may enroll themselves (a pull, distinct from auto_enroll's push). */
+  self_enroll_enabled: boolean;
   /** Weekly cohort gate. False = every week open + full XP (admin toggle). */
   content_locked: boolean;
   module_count: number;
@@ -547,7 +550,7 @@ export const adminAdaptiveCourseService = {
   /** Edit course fields (title/description/content lock/auto-enroll). Returns the updated detail. */
   async updateCourse(
     courseId: number,
-    payload: { title?: string; description?: string; content_locked?: boolean; auto_enroll?: boolean },
+    payload: { title?: string; description?: string; content_locked?: boolean; auto_enroll?: boolean; self_enroll_enabled?: boolean },
   ): Promise<AdminAdaptiveCourseDetail> {
     const { data } = await apiClient.patch<AdminAdaptiveCourseDetail>(
       `${BASE}/courses/${courseId}/`,


### PR DESCRIPTION
Pairs with backend #424 (`self_enroll_enabled` + catalog/self-enroll endpoints).

## Admin builder
- New **"Self-enroll on/off"** pill next to Auto-enroll in the adaptive-course builder header. PATCHes `self_enroll_enabled` via `updateCourse`. Distinct from auto-enroll (push): this lists the published course in the learner catalog for students to opt into — **no back-fill**.

## Learner
- New **`/adaptive-courses/catalog`** route ("Browse courses"): lists self-enrollable courses as cards with an **Enroll** button. Enrolling calls `selfEnroll`, drops the card, toasts, and routes into the course. Search + empty states + route shimmer.
- **"Browse courses"** CTA added to the course-list header; the no-courses empty state now invites browsing instead of only "wait for your instructor".
- `adaptiveCourseService.getCatalog()` + `selfEnroll()`; `self_enroll_enabled` on the learner course type.
- `CatalogCourseCard` mirrors `AdaptiveCourseCard` visuals but roots on a `Box` (not `ButtonBase`) so it can carry a real Enroll `<button>`.

## Safety / verification
- `tsc --noEmit` clean.
- Enrollment is enforced **server-side** (the endpoint rejects any course not published + flagged + in the student's tenant scope); the FE only surfaces what the catalog returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)