### PR TITLE
feat(tickets): video attachments — upload + inline playback

### DIFF
--- a/app/admin/tickets/[id]/page.tsx
+++ b/app/admin/tickets/[id]/page.tsx
@@ -28,8 +28,10 @@ import { uploadFile } from "@/lib/services/file-upload.service";
 import { ticketService, Ticket } from "@/lib/services/ticket.service";
 
 const MAX_ATTACHMENTS = 5;
+const MAX_FILE_MB = 50; // matches the backend cap for the report_issue module (images + video)
 const ACCEPTED_TYPES =
-  "image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf";
+  "image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf," +
+  "video/mp4,video/webm,video/quicktime,video/x-msvideo,video/x-matroska,video/3gpp";
 
 function formatDateTime(iso: string | null): string {
   if (!iso) return "-";
@@ -92,7 +94,12 @@ export default function AdminTicketDetailPage() {
 
   const handleAddFiles = (incoming: FileList | null) => {
     if (!incoming) return;
-    const additions = Array.from(incoming);
+    const all = Array.from(incoming);
+    const additions = all.filter((f) => f.size <= MAX_FILE_MB * 1024 * 1024);
+    if (additions.length < all.length) {
+      showToast(`Each file must be ${MAX_FILE_MB}MB or smaller.`, "warning");
+    }
+    if (additions.length === 0) return;
     setFiles((prev) => {
       const room = MAX_ATTACHMENTS - prev.length;
       if (room <= 0) {
@@ -166,7 +173,8 @@ export default function AdminTicketDetailPage() {
         const uploads = await Promise.all(
           files.map((file) => uploadFile(clientId, file, "report_issue")),
         );
-        attachmentUrls = uploads.map((u) => u.url).filter(Boolean);
+        // Prefer the S3 object key so the backend re-signs a fresh URL on read (no expiry).
+        attachmentUrls = uploads.map((u) => u.storage_path || u.url).filter(Boolean);
         setUploading(false);
       }
 
@@ -520,7 +528,7 @@ export default function AdminTicketDetailPage() {
                       ? "Uploading attachments..."
                       : files.length > 0
                         ? `${files.length} file${files.length === 1 ? "" : "s"} attached - click to add more`
-                        : `Attach images / docs for the user (optional, up to ${MAX_ATTACHMENTS})`}
+                        : `Attach images, docs or a video for the user (optional, up to ${MAX_ATTACHMENTS}, ${MAX_FILE_MB}MB each)`}
                   </Typography>
                 </Box>
 

--- a/components/common/ReportIssueDialog.tsx
+++ b/components/common/ReportIssueDialog.tsx
@@ -35,8 +35,10 @@ interface ReportIssueDialogProps {
 }
 
 const MAX_ATTACHMENTS = 5;
+const MAX_FILE_MB = 50; // matches the backend cap for the report_issue module (images + video)
 const ACCEPTED_TYPES =
-  "image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf";
+  "image/png,image/jpeg,image/jpg,image/gif,image/webp,application/pdf," +
+  "video/mp4,video/webm,video/quicktime,video/x-msvideo,video/x-matroska,video/3gpp";
 
 export function ReportIssueDialog({
   open,
@@ -55,7 +57,12 @@ export function ReportIssueDialog({
 
   const handleAddFiles = (incoming: FileList | null) => {
     if (!incoming) return;
-    const additions = Array.from(incoming);
+    const all = Array.from(incoming);
+    const additions = all.filter((f) => f.size <= MAX_FILE_MB * 1024 * 1024);
+    if (additions.length < all.length) {
+      showToast(`Each file must be ${MAX_FILE_MB}MB or smaller.`, "warning");
+    }
+    if (additions.length === 0) return;
     setFiles((prev) => {
       const room = MAX_ATTACHMENTS - prev.length;
       if (room <= 0) {
@@ -89,7 +96,9 @@ export function ReportIssueDialog({
         const uploads = await Promise.all(
           files.map((file) => uploadFile(clientId, file, "report_issue")),
         );
-        attachmentUrls = uploads.map((u) => u.url).filter(Boolean);
+        // Prefer the S3 object key (storage_path): the backend re-signs a fresh URL from it on
+        // read, so the attachment never expires the way a stored presigned URL does.
+        attachmentUrls = uploads.map((u) => u.storage_path || u.url).filter(Boolean);
         setUploading(false);
       }
 
@@ -309,7 +318,7 @@ export function ReportIssueDialog({
                   ? "Uploading attachments..."
                   : files.length > 0
                     ? `${files.length} file${files.length === 1 ? "" : "s"} attached - click to add more`
-                    : `Attach screenshots / docs (optional, up to ${MAX_ATTACHMENTS})`}
+                    : `Attach screenshots, docs or a video (optional, up to ${MAX_ATTACHMENTS}, ${MAX_FILE_MB}MB each)`}
               </Typography>
             </Box>
           </Box>

--- a/components/tickets/AttachmentList.tsx
+++ b/components/tickets/AttachmentList.tsx
@@ -6,6 +6,7 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import {
   attachmentLabel,
   isImageAttachment,
+  isVideoAttachment,
 } from "./attachment-utils";
 import { AttachmentPreviewDialog } from "./AttachmentPreviewDialog";
 
@@ -45,9 +46,11 @@ export function AttachmentList({ urls, heading, dense = false }: Props) {
           if (!u) return null;
           const label = attachmentLabel(u, i);
           const isImage = isImageAttachment(u);
+          const isVideo = isVideoAttachment(u);
+          const canPreview = isImage || isVideo;
 
           const handleActivate = (e: React.MouseEvent | React.KeyboardEvent) => {
-            if (isImage) {
+            if (canPreview) {
               e.preventDefault();
               setPreview({ url: u, label });
             }
@@ -56,8 +59,8 @@ export function AttachmentList({ urls, heading, dense = false }: Props) {
           return (
             <Box
               key={`${u}-${i}`}
-              component={isImage ? "div" : "a"}
-              {...(isImage
+              component={canPreview ? "div" : "a"}
+              {...(canPreview
                 ? {
                     role: "button",
                     tabIndex: 0,
@@ -105,11 +108,11 @@ export function AttachmentList({ urls, heading, dense = false }: Props) {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  backgroundColor: isImage
+                  backgroundColor: canPreview
                     ? "var(--info-surface)"
                     : "var(--surface)",
                   border: "1px solid",
-                  borderColor: isImage
+                  borderColor: canPreview
                     ? "var(--info-border)"
                     : "var(--border-default)",
                 }}
@@ -128,6 +131,12 @@ export function AttachmentList({ urls, heading, dense = false }: Props) {
                       (e.currentTarget as HTMLImageElement).style.display =
                         "none";
                     }}
+                  />
+                ) : isVideo ? (
+                  <IconWrapper
+                    icon="mdi:play-circle"
+                    size={22}
+                    color="var(--info-accent)"
                   />
                 ) : (
                   <IconWrapper
@@ -155,12 +164,22 @@ export function AttachmentList({ urls, heading, dense = false }: Props) {
                   variant="caption"
                   sx={{ color: "var(--font-secondary)", fontSize: "0.7rem" }}
                 >
-                  {isImage ? "Image · click to preview" : "Document · opens in new tab"}
+                  {isImage
+                    ? "Image · click to preview"
+                    : isVideo
+                      ? "Video · click to play"
+                      : "Document · opens in new tab"}
                 </Typography>
               </Box>
 
               <IconWrapper
-                icon={isImage ? "mdi:eye-outline" : "mdi:open-in-new"}
+                icon={
+                  isVideo
+                    ? "mdi:play-circle-outline"
+                    : isImage
+                      ? "mdi:eye-outline"
+                      : "mdi:open-in-new"
+                }
                 size={18}
                 color="var(--font-secondary)"
               />

--- a/components/tickets/AttachmentPreviewDialog.tsx
+++ b/components/tickets/AttachmentPreviewDialog.tsx
@@ -10,6 +10,7 @@ import {
   Stack,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { isVideoAttachment } from "./attachment-utils";
 
 interface Props {
   open: boolean;
@@ -19,6 +20,7 @@ interface Props {
 }
 
 export function AttachmentPreviewDialog({ open, url, label, onClose }: Props) {
+  const isVideo = !!url && isVideoAttachment(url);
   return (
     <Dialog
       open={open && !!url}
@@ -137,18 +139,34 @@ export function AttachmentPreviewDialog({ open, url, label, onClose }: Props) {
           }}
         >
           {url ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={url}
-              alt={label}
-              style={{
-                maxWidth: "100%",
-                maxHeight: "78vh",
-                objectFit: "contain",
-                borderRadius: 8,
-                boxShadow: "0 12px 32px rgba(0,0,0,0.45)",
-              }}
-            />
+            isVideo ? (
+              <video
+                src={url}
+                controls
+                autoPlay
+                playsInline
+                style={{
+                  maxWidth: "100%",
+                  maxHeight: "78vh",
+                  borderRadius: 8,
+                  boxShadow: "0 12px 32px rgba(0,0,0,0.45)",
+                  backgroundColor: "#000",
+                }}
+              />
+            ) : (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={url}
+                alt={label}
+                style={{
+                  maxWidth: "100%",
+                  maxHeight: "78vh",
+                  objectFit: "contain",
+                  borderRadius: 8,
+                  boxShadow: "0 12px 32px rgba(0,0,0,0.45)",
+                }}
+              />
+            )
           ) : null}
         </Box>
       </DialogContent>

--- a/components/tickets/attachment-utils.ts
+++ b/components/tickets/attachment-utils.ts
@@ -8,6 +8,18 @@ const IMAGE_EXTS = new Set([
   "svg",
 ]);
 
+const VIDEO_EXTS = new Set([
+  "mp4",
+  "webm",
+  "mov",
+  "m4v",
+  "mpeg",
+  "mpg",
+  "avi",
+  "mkv",
+  "3gp",
+]);
+
 const HEX_HASH_RE = /^[a-f0-9]{16,}$/i;
 
 function safeBasename(url: string): { basename: string; ext: string; stem: string } {
@@ -28,9 +40,9 @@ function safeBasename(url: string): { basename: string; ext: string; stem: strin
 export function attachmentLabel(url: string, index: number): string {
   const { basename, ext, stem } = safeBasename(url);
   if (!basename || HEX_HASH_RE.test(stem)) {
-    return isImageAttachment(url)
-      ? `Screenshot ${index + 1}`
-      : `Attachment ${index + 1}`;
+    if (isImageAttachment(url)) return `Screenshot ${index + 1}`;
+    if (isVideoAttachment(url)) return `Video ${index + 1}`;
+    return `Attachment ${index + 1}`;
   }
   if (basename.length > 42) {
     const tail = ext ? `.${ext}` : "";
@@ -42,4 +54,9 @@ export function attachmentLabel(url: string, index: number): string {
 export function isImageAttachment(url: string): boolean {
   const { ext } = safeBasename(url);
   return IMAGE_EXTS.has(ext);
+}
+
+export function isVideoAttachment(url: string): boolean {
+  const { ext } = safeBasename(url);
+  return VIDEO_EXTS.has(ext);
 }

--- a/lib/services/file-upload.service.ts
+++ b/lib/services/file-upload.service.ts
@@ -15,6 +15,9 @@ export type CertificateUploadTier = "participation" | "excellence";
 export interface FileUploadResponse {
   id: number;
   url: string;
+  /** The S3 object key. Prefer this over `url` when attaching to a record: the backend re-signs a
+   *  fresh presigned URL from the key on read, so a stored key never expires the way a URL does. */
+  storage_path?: string;
   filename: string;
   module: string;
   created_at: string;
@@ -148,9 +151,16 @@ async function postUploadFormData(
   const meta = pickMetadataRecord(top, url);
   const m = readIdFilenameModuleCreated(meta);
 
+  const rawStoragePath = meta.storage_path ?? top.storage_path;
+  const storagePath =
+    typeof rawStoragePath === "string" && rawStoragePath.trim()
+      ? rawStoragePath.trim()
+      : undefined;
+
   return {
     id: m.id,
     url,
+    storage_path: storagePath,
     filename: m.filename || file.name || "upload.jpg",
     module: m.module || fallbackModule,
     created_at: m.created_at || new Date().toISOString(),


### PR DESCRIPTION
Pairs with backend **#426** (`report_issue` accepts video @ 50MB; ticket attachments re-signed on read so they never render broken).

## Upload
- **Student report-issue dialog** + **admin resolve form**: the file picker now accepts video (mp4/webm/mov/…), with a **50MB-per-file** client guard matching the backend cap, and updated helper copy.
- Attachments are now sent as the upload's **S3 object key** (`storage_path`) rather than the presigned URL, so the backend re-signs a fresh, non-expiring URL on read (the fix for "images show broken on the admin side"). The upload response surfaces `storage_path`.

## Rendering
- `isVideoAttachment()` + a **play-badge thumbnail** in `AttachmentList` (click to play) and a `<video controls>` branch in the preview dialog. Images unchanged; other files still open in a new tab.

## Verify
- `tsc --noEmit` clean.
- End-to-end: attach a short screen recording on a ticket → it uploads, shows a play badge, and plays inline for the admin; older tickets' images render again (backend re-sign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)