### PR TITLE
fix(coding): consistent language set in adaptive editor (C++/TypeScript in, SQL out)

### DIFF
--- a/components/coding/AdaptiveCodingSolve.tsx
+++ b/components/coding/AdaptiveCodingSolve.tsx
@@ -10,7 +10,8 @@ import { AdaptiveCodingSubmissions } from "@/components/coding/AdaptiveCodingSub
 import { useToast } from "@/components/common/Toast";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import {
-  getAvailableLanguages,
+  getCodingLanguages,
+  starterCodeFor,
   getLanguageId,
   getMonacoLanguage,
 } from "@/components/coding/utils/languageUtils";
@@ -35,23 +36,22 @@ interface AdaptiveCodingSolveProps {
   onBack?: () => void;
 }
 
-/** Languages a problem can't be solved in are stubbed with a "not suitable" comment (e.g. SQL for an
- *  array problem), so we never default to or even offer them. */
+/** Languages a problem can't be solved in are stubbed with a placeholder comment (e.g. SQL for an
+ *  array problem: "SQL version not applicable…" / "not suitable…"), so we never default to them. */
 function isUnsuitableTemplate(tpl: string | undefined): boolean {
-  return /not suitable/i.test(tpl ?? "");
+  return /not\s+(suitable|applicable)/i.test(tpl ?? "");
 }
 
 // Preference order when several languages are suitable - pick the most natural for a general problem.
-const LANGUAGE_PREFERENCE = ["python", "java", "cpp", "c", "javascript", "typescript", "go", "c#", "ruby", "sql"];
+const LANGUAGE_PREFERENCE = ["python", "java", "cpp", "javascript", "typescript", "c#"];
 
-/** The language a problem is best answered in: the first SUITABLE template by preference order
- *  (falls back to the first template only if every language is stubbed). */
-function pickDefaultLanguage(templateCode: Record<string, string>): string {
-  const langs = Object.keys(templateCode);
-  const suitable = langs.filter((l) => !isUnsuitableTemplate(templateCode[l]));
-  const pool = suitable.length ? suitable : langs;
+/** The language a problem is best answered in: among the OFFERED languages, the first (by
+ *  preference) that has a real template, else the first offered. */
+function pickDefaultLanguage(templateCode: Record<string, string>, offered: string[]): string {
+  const suitable = offered.filter((l) => !isUnsuitableTemplate(templateCode[l]));
+  const pool = suitable.length ? suitable : offered;
   for (const p of LANGUAGE_PREFERENCE) if (pool.includes(p)) return p;
-  return pool[0];
+  return pool[0] ?? "python";
 }
 
 // Per-language editor drafts persisted locally so typed code survives a refresh AND a language
@@ -124,11 +124,14 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
   const [masteryRefresh, setMasteryRefresh] = useState(0);
   const [allowClipboard, setAllowClipboard] = useState(false);
 
-  const availableLanguages = useMemo(() => {
-    const all = getAvailableLanguages(problem?.template_code);
-    const suitable = all.filter((l) => !isUnsuitableTemplate(problem?.template_code?.[l.value]));
-    return suitable.length ? suitable : all;  // never offer the "not suitable" stubs
-  }, [problem?.template_code]);
+  // Offer a consistent algorithmic language set (Python/JS/TS/Java/C++/C#) rather than only the
+  // languages this problem happened to be generated with — so C++/TypeScript are always available
+  // and SQL never shows on a non-SQL problem. Every option runs on Judge0; the editor seeds from
+  // the problem's own template when present, else a minimal stub (see starterCodeFor).
+  const availableLanguages = useMemo(
+    () => getCodingLanguages(problem?.template_code),
+    [problem?.template_code],
+  );
 
   // Rehydrate the UI from a persisted submission (re-entry / reload).
   const applySubmissionRecord = useCallback((record: CodingSubmissionRecord | null | undefined) => {
@@ -150,7 +153,9 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
     (async () => {
       try {
         const prob = await adaptiveCodingService.getProblem(problemId);
-        const langs = Object.keys(prob.template_code);
+        // Selectable languages = the curated set actually offered in the dropdown (not just the
+        // languages the problem was generated with), so a saved "cpp"/"typescript" is honored.
+        const langs = getCodingLanguages(prob.template_code).map((l) => l.value);
         const existing = await adaptiveCodingService.getActiveSession(configId, problemId);
         if (cancelled) return;
         setProblem(prob);
@@ -159,15 +164,15 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
         const pickLang = (serverLang?: string | null) => {
           if (savedLang && langs.includes(savedLang)) return savedLang;
           if (serverLang && langs.includes(serverLang)) return serverLang;
-          return pickDefaultLanguage(prob.template_code);
+          return pickDefaultLanguage(prob.template_code, langs);
         };
         // Priority for code: local draft for that language -> server last_source (only if it was
-        // that language) -> the language's starter template.
+        // that language) -> the language's starter template (or a stub if it has none).
         const codeFor = (lang: string, serverSource?: string | null, serverLang?: string | null) => {
           const draft = readDraft(problemId, lang);
           if (draft !== null) return draft;
           if (serverSource && lang === serverLang) return serverSource;
-          return prob.template_code[lang] || "";
+          return starterCodeFor(lang, prob.template_code);
         };
         if (existing) {
           setSessionData(existing);
@@ -231,7 +236,7 @@ export function AdaptiveCodingSolve({ configId, problemId, onBack }: AdaptiveCod
     writeLangPref(problemId, next);
     const draft = readDraft(problemId, next);
     setLanguage(next);
-    setCode(draft !== null ? draft : problem?.template_code[next] ?? "");
+    setCode(draft !== null ? draft : starterCodeFor(next, problem?.template_code));
     setTestResults(null);
     resetMentorState();
   }

--- a/components/coding/utils/languageUtils.ts
+++ b/components/coding/utils/languageUtils.ts
@@ -109,6 +109,58 @@ export function getAvailableLanguagesOrDefault(
   }));
 }
 
+/**
+ * The languages offered in the coding editor, as a CONSISTENT algorithmic set — so the dropdown
+ * doesn't depend on which languages a given problem happened to be generated with (some arrived
+ * with SQL + C# but no C++/TypeScript). SQL is offered only for a genuine SQL problem (its
+ * template_code is SQL-only). Every language here runs on Judge0 (see LANGUAGE_ID_MAPPING).
+ */
+const CODING_LANGUAGE_KEYS = ["python", "javascript", "typescript", "java", "cpp", "c#"];
+
+/** Minimal per-language starter skeletons (mirrors the backend defaults) — used when a problem
+ *  has no, or an unusable, template for a language the learner selects. */
+export const DEFAULT_CODE_STUBS: Record<string, string> = {
+  python: "# Write your solution here\n",
+  javascript: "// Write your solution here\n",
+  typescript: "// Write your solution here\n",
+  java:
+    "public class Main {\n    public static void main(String[] args) {\n        // Write your solution here\n    }\n}\n",
+  cpp:
+    "#include <bits/stdc++.h>\nusing namespace std;\n\nint main() {\n    // Write your solution here\n    return 0;\n}\n",
+  "c#":
+    "using System;\n\nclass Program {\n    static void Main() {\n        // Write your solution here\n    }\n}\n",
+  c: "#include <stdio.h>\n\nint main() {\n    // Write your solution here\n    return 0;\n}\n",
+  sql: "-- Write your SQL query here\n",
+};
+
+/** True when a stored template is a placeholder for a language the problem can't be solved in
+ *  ("SQL version not applicable…", "not suitable…") rather than real starter code. */
+export function isPlaceholderTemplate(tpl: string | undefined): boolean {
+  return /not\s+(suitable|applicable)/i.test(tpl ?? "");
+}
+
+/** Languages to show in the coding editor for a problem (curated set; SQL only for SQL problems). */
+export function getCodingLanguages(templateCode?: Record<string, string>): LanguageOption[] {
+  const keys = templateCode ? Object.keys(templateCode).map((k) => k.toLowerCase()) : [];
+  const isSqlOnly = keys.length > 0 && keys.every((k) => k === "sql");
+  const wanted = isSqlOnly ? ["sql"] : CODING_LANGUAGE_KEYS;
+  return wanted
+    .filter((k) => k in LANGUAGE_DISPLAY_NAMES)
+    .map((lang) => ({
+      value: lang,
+      label: LANGUAGE_DISPLAY_NAMES[lang] || lang,
+      monacoLanguage: MONACO_LANGUAGE_MAPPING[lang] || lang,
+    }));
+}
+
+/** Starter code to seed the editor with: the problem's own template when it's real, else a stub. */
+export function starterCodeFor(lang: string, templateCode?: Record<string, string>): string {
+  const key = (lang || "").toLowerCase();
+  const tpl = templateCode?.[lang] ?? templateCode?.[key];
+  if (tpl && !isPlaceholderTemplate(tpl)) return tpl;
+  return DEFAULT_CODE_STUBS[lang] ?? DEFAULT_CODE_STUBS[key] ?? "";
+}
+
 // Get Judge0 language ID
 export function getLanguageId(language: string): number {
   return LANGUAGE_ID_MAPPING[language] || LANGUAGE_ID_MAPPING[MONACO_LANGUAGE_MAPPING[language]] || 71;


### PR DESCRIPTION
Fixes the adaptive-coding editor showing **SQL on a non-SQL problem** and **missing C++/TypeScript** (see screenshot in the linked issue).

## Root cause
`AdaptiveCodingSolve` built the language dropdown from the problem's `template_code` keys, which were generated as `{python, java, sql, c#}`. The "unsuitable" filter also only matched `"not suitable"`, not the actual `"not applicable"` SQL placeholder, so SQL leaked in.

## Fix
- **`getCodingLanguages()`**: a curated algorithmic set (Python/JS/TS/Java/C++/C#) offered regardless of which languages a problem carries; SQL only for a genuine SQL-only problem. Every option maps to a Judge0 language id, so Run/Submit work end to end.
- **`starterCodeFor()`**: seeds the editor from the problem's own template when real, else a minimal per-language stub — so C++/TypeScript on an older problem opens a usable skeleton.
- Placeholder filter broadened to `"not applicable"`; language default/preference cleaned up.
- Fixes **existing** problems without regeneration.

Pairs with backend `fix/coding-language-set` (generates the same curated set for new problems). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)