### PR TITLE
fix(quiz): render HTML in MCQ questions & options (code blocks, tables)

### DIFF
--- a/components/adaptive-quiz/mid/QuestionCard.tsx
+++ b/components/adaptive-quiz/mid/QuestionCard.tsx
@@ -3,6 +3,7 @@
 import { Box, ButtonBase, Chip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { ConfidenceInput } from "./ConfidenceInput";
+import RichHtml from "@/components/common/RichHtml";
 import { prettySkill } from "@/lib/utils/skill-label.utils";
 import type {
   AdaptiveQuestion,
@@ -122,17 +123,16 @@ export function QuestionCard({
         </ButtonBase>
       </Box>
 
-      {/* Question text */}
-      <Typography
+      {/* Question text — rendered as HTML so <pre><code> code blocks / tables render correctly. */}
+      <RichHtml
+        html={question.question_text}
         sx={{
           fontSize: { xs: "1.05rem", md: "1.2rem" },
           fontWeight: 600,
           lineHeight: 1.45,
           color: "text.primary",
         }}
-      >
-        {question.question_text}
-      </Typography>
+      />
 
       {/* Options */}
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
@@ -184,7 +184,8 @@ export function QuestionCard({
               >
                 {opt.id}
               </Box>
-              <Typography
+              <RichHtml
+                html={opt.value}
                 sx={{
                   flex: 1,
                   fontSize: "0.95rem",
@@ -192,9 +193,7 @@ export function QuestionCard({
                   color: "text.primary",
                   lineHeight: 1.5,
                 }}
-              >
-                {opt.value}
-              </Typography>
+              />
             </ButtonBase>
           );
         })}

--- a/components/adaptive-quiz/results/PerQuestionRationaleCard.tsx
+++ b/components/adaptive-quiz/results/PerQuestionRationaleCard.tsx
@@ -2,6 +2,7 @@
 
 import { Box, ButtonBase, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
+import RichHtml from "@/components/common/RichHtml";
 import { AIPill } from "../shared/AIPill";
 import type {
   AdaptiveAINarration,
@@ -48,9 +49,7 @@ export function PerQuestionRationaleCard({
         <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.14em", textTransform: "uppercase", color: "text.secondary", mb: 0.5 }}>
           Question {response.order_index + 1}
         </Typography>
-        <Typography sx={{ fontSize: "0.98rem", fontWeight: 700, lineHeight: 1.45, mb: 1.5 }}>
-          {mcq.question_text}
-        </Typography>
+        <RichHtml html={mcq.question_text} sx={{ fontSize: "0.98rem", fontWeight: 700, lineHeight: 1.45, mb: 1.5 }} />
         <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
           {mcq.options.map((opt) => {
             const isCorrect = opt.id === mcq.correct_option;
@@ -89,7 +88,7 @@ export function PerQuestionRationaleCard({
                 >
                   {opt.id}
                 </Box>
-                <Typography sx={{ fontSize: "0.86rem", flex: 1 }}>{opt.value}</Typography>
+                <RichHtml html={opt.value} sx={{ fontSize: "0.86rem", flex: 1 }} />
                 {isCorrect && <Icon icon="mdi:check-circle" width={18} style={{ color: "#10b981" }} />}
                 {isPicked && !isCorrect && <Icon icon="mdi:close-circle" width={18} style={{ color: "#ef4444" }} />}
               </Box>

--- a/components/assessment/result/QuizResponsesSection.tsx
+++ b/components/assessment/result/QuizResponsesSection.tsx
@@ -9,6 +9,7 @@ import {
   Chip,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import RichHtml from "@/components/common/RichHtml";
 import type { QuizResponseItem } from "@/lib/services/assessment.service";
 
 interface QuizResponsesSectionProps {
@@ -262,9 +263,7 @@ export function QuizResponsesSection({ quizResponses }: QuizResponsesSectionProp
                 />
               ) : null}
             </Box>
-            <Typography variant="body1" sx={{ fontWeight: 500, color: "var(--font-primary)", lineHeight: 1.6 }}>
-              {q.question_text}
-            </Typography>
+            <RichHtml html={q.question_text} sx={{ fontWeight: 500, color: "var(--font-primary)", lineHeight: 1.6 }} />
           </Box>
         </Box>
 
@@ -302,8 +301,8 @@ export function QuizResponsesSection({ quizResponses }: QuizResponsesSectionProp
                   gap: 1,
                 }}
               >
-                <Typography sx={{ color: "var(--font-primary)", fontWeight: isSelected || isCorrectOpt ? 500 : 400 }}>
-                  <strong>{opt.id}.</strong> {opt.label}
+                <Typography component="div" sx={{ color: "var(--font-primary)", fontWeight: isSelected || isCorrectOpt ? 500 : 400, display: "flex", gap: 0.5 }}>
+                  <strong>{opt.id}.</strong> <RichHtml inline html={opt.label} />
                 </Typography>
                 <Box sx={{ display: "flex", gap: 1 }}>
                   {isCorrectOpt && (

--- a/components/common/RichHtml.tsx
+++ b/components/common/RichHtml.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React from "react";
+import { Box, BoxProps } from "@mui/material";
+
+/**
+ * Renders platform-authored HTML content (question stems, options, explanations) as real HTML —
+ * so `<pre><code>` code blocks, tables, `<sup>/<sub>` math, and `<img>` graphs render instead of
+ * showing raw tags with collapsed whitespace.
+ *
+ * Content is platform/verified-generated, but we still strip the obvious injection vectors
+ * (script/style tags, inline on* handlers, javascript: URLs) as defense-in-depth for imported banks.
+ * `inline` renders in a span (for option labels); default renders a block with code/table/img styling.
+ */
+function sanitizeHtml(html: string): string {
+  if (!html) return "";
+  return html
+    .replace(/<\s*(script|style|iframe|object|embed)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi, "")
+    .replace(/<\s*(script|style|iframe|object|embed)\b[^>]*\/?\s*>/gi, "")
+    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "")
+    .replace(/(href|src)\s*=\s*("\s*javascript:[^"]*"|'\s*javascript:[^']*')/gi, '$1="#"');
+}
+
+const BLOCK_SX = {
+  // Code blocks — the main fix: preserve newlines + monospace + horizontal scroll instead of a
+  // collapsed one-liner of raw <pre><code>.
+  "& pre": {
+    my: 1,
+    p: 1.5,
+    borderRadius: 2,
+    bgcolor: "rgba(99,102,241,0.06)",
+    border: "1px solid",
+    borderColor: "rgba(99,102,241,0.15)",
+    overflowX: "auto",
+    fontSize: "0.9em",
+    lineHeight: 1.55,
+    whiteSpace: "pre",
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+  },
+  "& code": {
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+    fontSize: "0.9em",
+    px: 0.5,
+    py: 0.1,
+    borderRadius: 1,
+    bgcolor: "rgba(99,102,241,0.08)",
+  },
+  "& pre code": { p: 0, bgcolor: "transparent", fontSize: "1em" },
+  "& table": {
+    borderCollapse: "collapse",
+    my: 1,
+    "& td, & th": { border: "1px solid", borderColor: "divider", px: 1, py: 0.5, textAlign: "left" },
+    "& th": { bgcolor: "rgba(0,0,0,0.03)", fontWeight: 700 },
+  },
+  "& img": { maxWidth: "100%", height: "auto", borderRadius: 1, my: 1 },
+  "& p": { my: 0.5 },
+  "& ul, & ol": { pl: 3, my: 0.5 },
+} as const;
+
+const INLINE_SX = {
+  display: "inline",
+  "& code": {
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+    fontSize: "0.92em",
+    px: 0.5,
+    borderRadius: 1,
+    bgcolor: "rgba(99,102,241,0.08)",
+  },
+  "& pre": { display: "inline", whiteSpace: "pre-wrap", fontFamily: "ui-monospace, monospace" },
+} as const;
+
+export interface RichHtmlProps extends Omit<BoxProps, "children" | "dangerouslySetInnerHTML"> {
+  html?: string | null;
+  inline?: boolean;
+}
+
+export default function RichHtml({ html, inline = false, sx, ...rest }: RichHtmlProps) {
+  return (
+    <Box
+      component={inline ? "span" : "div"}
+      {...rest}
+      dangerouslySetInnerHTML={{ __html: sanitizeHtml(html || "") }}
+      sx={{ ...(inline ? INLINE_SX : BLOCK_SX), ...sx }}
+    />
+  );
+}

--- a/components/quiz/QuestionTitle.tsx
+++ b/components/quiz/QuestionTitle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Typography } from "@mui/material";
+import RichHtml from "@/components/common/RichHtml";
 
 /** Check if string contains HTML tags so we can render with dangerouslySetInnerHTML */
 function hasHtml(str: unknown): str is string {
@@ -30,15 +31,7 @@ export function QuestionTitle({ question, compact }: QuestionTitleProps) {
       }}
     >
       {hasHtml(question) ? (
-        <Box
-          component="div"
-          sx={{
-            ...titleSx,
-            "& p": { margin: "0 0 0.5em 0" },
-            "& p:last-child": { marginBottom: 0 },
-          }}
-          dangerouslySetInnerHTML={{ __html: question }}
-        />
+        <RichHtml html={question} sx={titleSx} />
       ) : (
         <Typography variant="h6" sx={{ ...titleSx, whiteSpace: "pre-wrap" }}>
           {question}


### PR DESCRIPTION
MCQ question stems with `<pre><code>` code blocks rendered as raw text with collapsed newlines on the adaptive-quiz surfaces (the reported "total = 20 total -= 5..." one-liner). Adds a reusable sanitized HTML renderer (`components/common/RichHtml.tsx`) with code-block/table/image styling, applied across every MCQ render site: adaptive quiz live (QuestionCard), adaptive quiz results (PerQuestionRationaleCard), assessment results (QuizResponsesSection), and the shared QuestionTitle (assessment take-flow + course quiz). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)