### PR TITLE
feat(instructor): Phase-1 instructor surface (dashboard + drill-downs + admin assign UI)

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -22,6 +22,7 @@ import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
 import { Reveal } from "@/components/scorecard/shared";
+import { InstructorAssignPanel } from "@/components/instructor/InstructorAssignPanel";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { AdaptiveSectionHero } from "@/components/adaptive-quiz/shared/AdaptiveSectionHero";
 import {
@@ -489,7 +490,10 @@ export default function AdminAdaptiveCourseDetailPage() {
               )}
 
               {tab === "students" && (
-                <CourseStudentsPanel courseId={course.id} courseTitle={course.title} />
+                <Stack spacing={2}>
+                  <InstructorAssignPanel scope="course" id={course.id} />
+                  <CourseStudentsPanel courseId={course.id} courseTitle={course.title} />
+                </Stack>
               )}
 
               {tab === "calibration" && (

--- a/app/admin/cohorts/[cohortId]/page.tsx
+++ b/app/admin/cohorts/[cohortId]/page.tsx
@@ -24,6 +24,7 @@ import { CohortRosterTab } from "@/components/admin/cohorts/CohortRosterTab";
 import { CohortAssignmentsTab } from "@/components/admin/cohorts/CohortAssignmentsTab";
 import { CohortScheduleTab } from "@/components/admin/cohorts/CohortScheduleTab";
 import { CohortDetailsTab } from "@/components/admin/cohorts/CohortDetailsTab";
+import { InstructorAssignPanel } from "@/components/instructor/InstructorAssignPanel";
 
 type TabKey = "roster" | "assignments" | "schedule" | "details";
 
@@ -141,7 +142,10 @@ export default function AdminCohortDetailPage() {
             <CohortRosterTab cohortId={cohort.id} cohortName={cohort.name} onChanged={() => void load()} />
           )}
           {tab === "assignments" && (
-            <CohortAssignmentsTab cohortId={cohort.id} artifacts={cohort.artifacts} onChanged={() => void load()} />
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2, p: 2 }}>
+              <InstructorAssignPanel scope="cohort" id={cohort.id} />
+              <CohortAssignmentsTab cohortId={cohort.id} artifacts={cohort.artifacts} onChanged={() => void load()} />
+            </Box>
           )}
           {tab === "schedule" && <CohortScheduleTab cohort={cohort} onSaved={() => void load()} />}
           {tab === "details" && <CohortDetailsTab cohort={cohort} onSaved={() => void load()} />}

--- a/app/instructor/cohorts/[id]/page.tsx
+++ b/app/instructor/cohorts/[id]/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { Box, Chip, Stack, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
+import { instructorService, type CohortRoster } from "@/lib/services/instructor.service";
+import { RosterRow } from "@/components/instructor/RosterRow";
+
+export default function InstructorCohortPage() {
+  const params = useParams();
+  const cohortId = Number(params?.id);
+  const { push } = useInstantNavigation();
+  const [roster, setRoster] = useState<CohortRoster | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!cohortId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await instructorService.getCohortStudents(cohortId);
+        if (!cancelled) setRoster(r);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load this batch.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [cohortId]);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const rows = roster?.results ?? [];
+    if (!q) return rows;
+    return rows.filter((r) => r.name.toLowerCase().includes(q) || r.email.toLowerCase().includes(q));
+  }, [roster, query]);
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Batch"
+        title={roster?.name || "Batch"}
+        description={`${roster?.count ?? 0} student${(roster?.count ?? 0) === 1 ? "" : "s"} in this batch.`}
+        accent="indigo"
+        icon="mdi:account-group"
+        action={
+          <HeaderActionButton icon="mdi:arrow-left" variant="ghost" onClick={() => push("/instructor/dashboard")}>
+            Dashboard
+          </HeaderActionButton>
+        }
+      />
+
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+
+      {!error && (
+        <>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Search students…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            sx={{ maxWidth: 380, mb: 2, "& .MuiOutlinedInput-root": { borderRadius: 2, bgcolor: "var(--surface)" } }}
+            InputProps={{ startAdornment: <Icon icon="mdi:magnify" width={18} style={{ marginRight: 6, opacity: 0.6 }} /> }}
+          />
+
+          {!loading && visible.length === 0 && (
+            <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+              <Typography sx={{ color: "text.secondary" }}>
+                {roster?.count ? "No students match your search." : "No students in this batch yet."}
+              </Typography>
+            </Box>
+          )}
+
+          <Stack spacing={1}>
+            {visible.map((r) => (
+              <RosterRow
+                key={r.student_id}
+                name={r.name}
+                email={r.email}
+                onClick={() => setSelected(r.student_id)}
+                right={<Chip size="small" label={r.status} sx={{ fontWeight: 700, textTransform: "capitalize" }} />}
+              />
+            ))}
+          </Stack>
+        </>
+      )}
+
+      <StudentDetailDrawer studentId={selected} open={selected != null} onClose={() => setSelected(null)} />
+    </PageShell>
+  );
+}

--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import { Box, Chip, LinearProgress, Stack, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { useToast } from "@/components/common/Toast";
+import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
+import { RosterRow } from "@/components/instructor/RosterRow";
+import { instructorService, type CourseStudentRow } from "@/lib/services/instructor.service";
+
+export default function InstructorCoursePage() {
+  const params = useParams();
+  const courseId = Number(params?.id);
+  const { push } = useInstantNavigation();
+  const { showToast } = useToast();
+  const [rows, setRows] = useState<CourseStudentRow[]>([]);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<number | null>(null);
+  const [removing, setRemoving] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    if (!courseId) return;
+    setLoading(true);
+    try {
+      const r = await instructorService.getCourseStudents(courseId);
+      setRows(r.results);
+      setCount(r.count);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't load this course.");
+    } finally {
+      setLoading(false);
+    }
+  }, [courseId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((r) => r.name.toLowerCase().includes(q) || r.email.toLowerCase().includes(q));
+  }, [rows, query]);
+
+  async function handleRemove(studentId: number, name: string) {
+    if (removing != null) return;
+    if (!window.confirm(`Remove ${name || "this student"} from the course?`)) return;
+    setRemoving(studentId);
+    try {
+      await instructorService.unenrollCourseStudents(courseId, [studentId]);
+      setRows((prev) => prev.filter((r) => r.student_id !== studentId));
+      setCount((c) => Math.max(0, c - 1));
+      showToast("Student removed from the course.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't remove the student.", "error");
+    } finally {
+      setRemoving(null);
+    }
+  }
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Course"
+        title="Course students"
+        description={`${count} enrolled student${count === 1 ? "" : "s"}.`}
+        accent="purple"
+        icon="mdi:book-education"
+        action={
+          <HeaderActionButton icon="mdi:arrow-left" variant="ghost" onClick={() => push("/instructor/dashboard")}>
+            Dashboard
+          </HeaderActionButton>
+        }
+      />
+
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+
+      {!error && (
+        <>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder="Search students…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            sx={{ maxWidth: 380, mb: 2, "& .MuiOutlinedInput-root": { borderRadius: 2, bgcolor: "var(--surface)" } }}
+            InputProps={{ startAdornment: <Icon icon="mdi:magnify" width={18} style={{ marginRight: 6, opacity: 0.6 }} /> }}
+          />
+
+          {!loading && visible.length === 0 && (
+            <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+              <Typography sx={{ color: "text.secondary" }}>
+                {count ? "No students match your search." : "No students enrolled yet."}
+              </Typography>
+            </Box>
+          )}
+
+          <Stack spacing={1}>
+            {visible.map((r) => (
+              <RosterRow
+                key={r.student_id}
+                name={r.name}
+                email={r.email}
+                onClick={() => setSelected(r.student_id)}
+                right={
+                  <Stack direction="row" spacing={1.5} alignItems="center">
+                    <Box sx={{ width: 92, display: { xs: "none", sm: "block" } }}>
+                      <LinearProgress
+                        variant="determinate"
+                        value={Math.max(0, Math.min(100, r.progress_percentage || 0))}
+                        sx={{ height: 6, borderRadius: 3 }}
+                      />
+                      <Typography sx={{ fontSize: "0.68rem", color: "text.secondary", mt: 0.25 }}>
+                        {Math.round(r.progress_percentage || 0)}% · {r.completed}/{r.total}
+                      </Typography>
+                    </Box>
+                    <Chip
+                      size="small"
+                      label={removing === r.student_id ? "Removing…" : "Remove"}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void handleRemove(r.student_id, r.name);
+                      }}
+                      disabled={removing === r.student_id}
+                      sx={{ fontWeight: 700, cursor: "pointer", color: "#ef4444",
+                        bgcolor: "color-mix(in srgb, #ef4444 12%, transparent)" }}
+                    />
+                  </Stack>
+                }
+              />
+            ))}
+          </Stack>
+        </>
+      )}
+
+      <StudentDetailDrawer studentId={selected} open={selected != null} onClose={() => setSelected(null)} />
+    </PageShell>
+  );
+}

--- a/app/instructor/dashboard/loading.tsx
+++ b/app/instructor/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/instructor/dashboard/page.tsx
+++ b/app/instructor/dashboard/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { KpiRail, Reveal } from "@/components/scorecard/shared";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import {
+  instructorService,
+  type InstructorOverview,
+  type InstructorCohort,
+  type InstructorCourse,
+} from "@/lib/services/instructor.service";
+
+export default function InstructorDashboardPage() {
+  const { push, prefetch } = useInstantNavigation();
+  const [overview, setOverview] = useState<InstructorOverview | null>(null);
+  const [cohorts, setCohorts] = useState<InstructorCohort[]>([]);
+  const [courses, setCourses] = useState<InstructorCourse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [o, ch, co] = await Promise.all([
+          instructorService.getOverview(),
+          instructorService.getCohorts(),
+          instructorService.getCourses(),
+        ]);
+        if (cancelled) return;
+        setOverview(o);
+        setCohorts(ch);
+        setCourses(co);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load your dashboard.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Teach"
+        title="Instructor dashboard"
+        description={
+          overview?.is_admin_view
+            ? "Admin view — every batch and course in your organisation."
+            : "Your assigned batches and courses, and the students in them."
+        }
+        accent="indigo"
+        icon="mdi:teach"
+      />
+
+      {error && (
+        <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>
+      )}
+
+      {!error && (
+        <>
+          <KpiRail
+            items={[
+              { value: overview?.cohorts ?? 0, label: "My batches", accent: "#6366f1" },
+              { value: overview?.courses ?? 0, label: "My courses", accent: "#a855f7" },
+              { value: overview?.students ?? 0, label: "Students", accent: "#10b981" },
+            ]}
+          />
+
+          <Section title="My batches" icon="mdi:account-group-outline" empty={!loading && cohorts.length === 0}
+            emptyText="No batches assigned yet. An admin can assign you to a cohort.">
+            <CardGrid>
+              {cohorts.map((c, i) => (
+                <Reveal key={c.id} delay={Math.min(i, 8) * 0.05}>
+                  <EntityCard
+                    icon="mdi:account-group"
+                    title={c.name}
+                    subtitle={`${c.member_count} student${c.member_count === 1 ? "" : "s"} · ${c.artifact_count} item${c.artifact_count === 1 ? "" : "s"}`}
+                    chip={c.status}
+                    onOpen={() => push(`/instructor/cohorts/${c.id}`)}
+                    onHover={() => prefetch(`/instructor/cohorts/${c.id}`)}
+                  />
+                </Reveal>
+              ))}
+            </CardGrid>
+          </Section>
+
+          <Section title="My courses" icon="mdi:book-education-outline" empty={!loading && courses.length === 0}
+            emptyText="No courses assigned yet.">
+            <CardGrid>
+              {courses.map((c, i) => (
+                <Reveal key={c.id} delay={Math.min(i, 8) * 0.05}>
+                  <EntityCard
+                    icon="mdi:book-education"
+                    title={c.title}
+                    subtitle={`${c.student_count} student${c.student_count === 1 ? "" : "s"}`}
+                    chip={c.is_published ? "published" : "draft"}
+                    chipColor={c.is_published ? "#10b981" : "#f59e0b"}
+                    onOpen={() => push(`/instructor/courses/${c.id}`)}
+                    onHover={() => prefetch(`/instructor/courses/${c.id}`)}
+                  />
+                </Reveal>
+              ))}
+            </CardGrid>
+          </Section>
+        </>
+      )}
+    </PageShell>
+  );
+}
+
+function Section({
+  title,
+  icon,
+  children,
+  empty,
+  emptyText,
+}: {
+  title: string;
+  icon: string;
+  children: React.ReactNode;
+  empty: boolean;
+  emptyText: string;
+}) {
+  return (
+    <Box sx={{ mt: 3.5 }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+        <Icon icon={icon} width={20} style={{ color: "#6366f1" }} />
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>{title}</Typography>
+      </Stack>
+      {empty ? (
+        <Box
+          sx={{
+            p: { xs: 3, md: 4 },
+            borderRadius: 3,
+            textAlign: "center",
+            bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+            border: "1px dashed color-mix(in srgb, var(--border-default) 90%, transparent)",
+          }}
+        >
+          <Typography sx={{ color: "text.secondary" }}>{emptyText}</Typography>
+        </Box>
+      ) : (
+        children
+      )}
+    </Box>
+  );
+}
+
+function CardGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
+        gap: 2,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function EntityCard({
+  icon,
+  title,
+  subtitle,
+  chip,
+  chipColor = "#6366f1",
+  onOpen,
+  onHover,
+}: {
+  icon: string;
+  title: string;
+  subtitle: string;
+  chip: string;
+  chipColor?: string;
+  onOpen: () => void;
+  onHover?: () => void;
+}) {
+  return (
+    <Box
+      onClick={onOpen}
+      onMouseEnter={onHover}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      sx={{
+        cursor: "pointer",
+        p: 2.25,
+        borderRadius: 3,
+        bgcolor: "var(--card-bg, #fff)",
+        border: "1px solid var(--border-default, #ececf1)",
+        transition: "transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease",
+        "&:hover": {
+          transform: "translateY(-3px)",
+          borderColor: "color-mix(in srgb, #6366f1 40%, transparent)",
+          boxShadow: "0 20px 40px -26px rgba(99,102,241,0.45)",
+        },
+        "&:focus-visible": { outline: "2px solid #6366f1", outlineOffset: 2 },
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 1 }}>
+        <Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: 2.5,
+            display: "grid",
+            placeItems: "center",
+            color: "#fff",
+            flexShrink: 0,
+            background: "linear-gradient(135deg,#6366f1,#a855f7)",
+          }}
+        >
+          <Icon icon={icon} width={20} />
+        </Box>
+        <Box
+          component="span"
+          sx={{
+            px: 1,
+            py: 0.3,
+            borderRadius: 999,
+            fontSize: "0.62rem",
+            fontWeight: 800,
+            letterSpacing: 0.4,
+            textTransform: "uppercase",
+            color: chipColor,
+            bgcolor: `color-mix(in srgb, ${chipColor} 14%, transparent)`,
+          }}
+        >
+          {chip}
+        </Box>
+      </Stack>
+      <Typography sx={{ fontWeight: 800, fontSize: "1rem", lineHeight: 1.3 }} noWrap>
+        {title}
+      </Typography>
+      <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", mt: 0.5 }}>{subtitle}</Typography>
+    </Box>
+  );
+}

--- a/app/instructor/layout.tsx
+++ b/app/instructor/layout.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, CircularProgress } from "@mui/material";
+import { authUtils } from "@/lib/auth/auth-utils";
+import { isScopedAdminRole, isClientOrgAdminRole } from "@/lib/auth/role-utils";
+
+/**
+ * Route guard for the instructor surface. Only teaching roles (instructor / course_manager) and org
+ * admins may enter; everyone else is bounced to the student home. A real guard — the UI never relies
+ * on the backend alone to keep learners out of /instructor.
+ */
+export default function InstructorLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const role = authUtils.getUserRole() ?? "";
+    const ok = isScopedAdminRole(role) || isClientOrgAdminRole(role);
+    setAllowed(ok);
+    if (!ok) router.replace("/dashboard");
+  }, [router]);
+
+  if (allowed !== true) {
+    return (
+      <Box sx={{ display: "grid", placeItems: "center", minHeight: "60vh" }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  return <>{children}</>;
+}

--- a/components/instructor/InstructorAssignPanel.tsx
+++ b/components/instructor/InstructorAssignPanel.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, Button, Chip, CircularProgress, MenuItem, Select, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import { adminInstructorsService, type InstructorRow } from "@/lib/services/admin/admin-instructors.service";
+import { instructorService, type StaffAssignment } from "@/lib/services/instructor.service";
+
+/** Admin panel to assign/unassign instructors on a course or cohort. Reuses the existing approved-
+ *  instructor list for the picker; writes go through the admin-only assignment API. */
+export function InstructorAssignPanel({ scope, id }: { scope: "course" | "cohort"; id: number }) {
+  const { showToast } = useToast();
+  const [staff, setStaff] = useState<StaffAssignment[]>([]);
+  const [instructors, setInstructors] = useState<InstructorRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pick, setPick] = useState<number>(0); // 0 = none selected
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [s, list] = await Promise.all([
+        scope === "course" ? instructorService.listCourseStaff(id) : instructorService.listCohortStaff(id),
+        adminInstructorsService.listInstructors("approved"),
+      ]);
+      setStaff(s);
+      setInstructors(list);
+    } catch {
+      showToast("Couldn't load instructor assignments.", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [scope, id, showToast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const assignedIds = useMemo(() => new Set(staff.map((s) => s.profile_id)), [staff]);
+  const available = useMemo(
+    () => instructors.filter((i) => !assignedIds.has(i.id)),
+    [instructors, assignedIds],
+  );
+
+  async function handleAdd() {
+    if (!pick || busy) return;
+    setBusy(true);
+    try {
+      const row =
+        scope === "course"
+          ? await instructorService.assignCourseStaff(id, { profile_id: pick, role: "instructor" })
+          : await instructorService.assignCohortStaff(id, { profile_id: pick, role: "instructor" });
+      setStaff((prev) => [...prev.filter((s) => s.profile_id !== row.profile_id), row]);
+      setPick(0);
+      showToast("Instructor assigned.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't assign instructor.", "error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleRemove(profileId: number) {
+    setBusy(true);
+    try {
+      if (scope === "course") await instructorService.removeCourseStaff(id, profileId);
+      else await instructorService.removeCohortStaff(id, profileId);
+      setStaff((prev) => prev.filter((s) => s.profile_id !== profileId));
+      showToast("Instructor unassigned.", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't unassign.", "error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Box sx={{ p: 2, borderRadius: 3, border: "1px solid var(--border-default)", bgcolor: "var(--card-bg)" }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
+        <Icon icon="mdi:account-tie-outline" width={20} style={{ color: "#6366f1" }} />
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>Instructors</Typography>
+        <Typography sx={{ color: "text.secondary", fontSize: "0.8rem" }}>
+          — assigned instructors own this {scope}&apos;s students.
+        </Typography>
+      </Stack>
+
+      {loading ? (
+        <Box sx={{ display: "grid", placeItems: "center", py: 3 }}>
+          <CircularProgress size={22} />
+        </Box>
+      ) : (
+        <>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap sx={{ mb: staff.length ? 2 : 0 }}>
+            {staff.map((s) => (
+              <Chip
+                key={s.profile_id}
+                label={s.name || s.email}
+                onDelete={busy ? undefined : () => handleRemove(s.profile_id)}
+                sx={{ fontWeight: 600 }}
+              />
+            ))}
+            {staff.length === 0 && (
+              <Typography sx={{ color: "text.secondary", fontSize: "0.85rem" }}>
+                No instructors assigned yet.
+              </Typography>
+            )}
+          </Stack>
+
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1.5 }}>
+            <Select
+              size="small"
+              value={pick}
+              displayEmpty
+              onChange={(e) => setPick(Number(e.target.value))}
+              sx={{ minWidth: 240, borderRadius: 2, bgcolor: "var(--surface)" }}
+              renderValue={(v) =>
+                !v ? (
+                  <Typography sx={{ color: "text.secondary", fontSize: "0.88rem" }}>Add an instructor…</Typography>
+                ) : (
+                  instructors.find((i) => i.id === v)?.full_name ||
+                  instructors.find((i) => i.id === v)?.email ||
+                  String(v)
+                )
+              }
+            >
+              {available.length === 0 && (
+                <MenuItem disabled value={0}>
+                  {instructors.length ? "All instructors already assigned" : "No approved instructors"}
+                </MenuItem>
+              )}
+              {available.map((i) => (
+                <MenuItem key={i.id} value={i.id} sx={{ fontSize: "0.88rem" }}>
+                  {i.full_name || i.email}
+                </MenuItem>
+              ))}
+            </Select>
+            <Button
+              onClick={() => void handleAdd()}
+              disabled={!pick || busy}
+              variant="contained"
+              disableElevation
+              startIcon={<Icon icon="mdi:plus" width={18} />}
+              sx={{ borderRadius: 2, textTransform: "none", fontWeight: 700,
+                background: "linear-gradient(135deg,#6366f1,#a855f7)" }}
+            >
+              Assign
+            </Button>
+          </Stack>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/components/instructor/RosterRow.tsx
+++ b/components/instructor/RosterRow.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Box, Stack, Typography } from "@mui/material";
+
+/** A single clickable student row shared by the cohort + course rosters. */
+export function RosterRow({
+  name,
+  email,
+  onClick,
+  right,
+}: {
+  name: string;
+  email: string;
+  onClick?: () => void;
+  right?: React.ReactNode;
+}) {
+  return (
+    <Box
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={(e) => {
+        if (onClick && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        p: 1.5,
+        borderRadius: 2,
+        cursor: onClick ? "pointer" : "default",
+        bgcolor: "var(--card-bg)",
+        border: "1px solid var(--border-default)",
+        transition: "border-color .15s, box-shadow .15s",
+        "&:hover": onClick
+          ? { borderColor: "color-mix(in srgb, #6366f1 40%, transparent)", boxShadow: "0 6px 16px -10px rgba(99,102,241,0.35)" }
+          : undefined,
+        "&:focus-visible": { outline: "2px solid #6366f1", outlineOffset: 2 },
+      }}
+    >
+      <Box sx={{ width: 38, height: 38, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center",
+        color: "#fff", fontWeight: 800, background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
+        {(name || email || "?").slice(0, 1).toUpperCase()}
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }} noWrap>{name || "—"}</Typography>
+        <Typography sx={{ color: "text.secondary", fontSize: "0.8rem" }} noWrap>{email}</Typography>
+      </Box>
+      {right && <Box sx={{ flexShrink: 0 }}>{right}</Box>}
+    </Box>
+  );
+}

--- a/components/instructor/StudentDetailDrawer.tsx
+++ b/components/instructor/StudentDetailDrawer.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, CircularProgress, Divider, Drawer, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { instructorService, type InstructorStudentDetail } from "@/lib/services/instructor.service";
+
+/** A right-side drawer showing a student, restricted to what the instructor shares with them
+ *  (server-enforced: only the instructor's own courses/cohorts appear). */
+export function StudentDetailDrawer({
+  studentId,
+  open,
+  onClose,
+}: {
+  studentId: number | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [detail, setDetail] = useState<InstructorStudentDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || studentId == null) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setDetail(null);
+    (async () => {
+      try {
+        const d = await instructorService.getStudent(studentId);
+        if (!cancelled) setDetail(d);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load this student.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, studentId]);
+
+  return (
+    <Drawer anchor="right" open={open} onClose={onClose}
+      PaperProps={{ sx: { width: { xs: "100%", sm: 420 }, p: 2.5 } }}>
+      {loading && (
+        <Box sx={{ display: "grid", placeItems: "center", minHeight: 200 }}>
+          <CircularProgress />
+        </Box>
+      )}
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700 }}>{error}</Typography>}
+      {detail && (
+        <>
+          <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 2 }}>
+            <Box sx={{ width: 48, height: 48, borderRadius: "50%", display: "grid", placeItems: "center",
+              color: "#fff", background: "linear-gradient(135deg,#6366f1,#a855f7)", fontWeight: 800 }}>
+              {(detail.name || detail.email || "?").slice(0, 1).toUpperCase()}
+            </Box>
+            <Box sx={{ minWidth: 0 }}>
+              <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }} noWrap>{detail.name}</Typography>
+              <Typography sx={{ color: "text.secondary", fontSize: "0.85rem" }} noWrap>{detail.email}</Typography>
+              {detail.phone && (
+                <Typography sx={{ color: "text.secondary", fontSize: "0.82rem" }}>{detail.phone}</Typography>
+              )}
+            </Box>
+          </Stack>
+          <Divider sx={{ mb: 2 }} />
+
+          <DetailList
+            icon="mdi:book-education-outline"
+            title="Courses"
+            empty="No shared courses."
+            items={detail.courses.map((c) => ({ id: `c${c.id}`, primary: c.title }))}
+          />
+          <DetailList
+            icon="mdi:account-group-outline"
+            title="Batches"
+            empty="No shared batches."
+            items={detail.cohorts.map((c) => ({ id: `h${c.id}`, primary: c.name, secondary: c.status }))}
+          />
+          <Typography sx={{ mt: 3, fontSize: "0.75rem", color: "text.secondary", opacity: 0.8 }}>
+            You see only the courses and batches you share with this student.
+          </Typography>
+        </>
+      )}
+    </Drawer>
+  );
+}
+
+function DetailList({
+  icon,
+  title,
+  items,
+  empty,
+}: {
+  icon: string;
+  title: string;
+  items: { id: string; primary: string; secondary?: string }[];
+  empty: string;
+}) {
+  return (
+    <Box sx={{ mb: 2.5 }}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+        <Icon icon={icon} width={18} style={{ color: "#6366f1" }} />
+        <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }}>{title}</Typography>
+      </Stack>
+      {items.length === 0 ? (
+        <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", pl: 3.25 }}>{empty}</Typography>
+      ) : (
+        <Stack spacing={0.75}>
+          {items.map((it) => (
+            <Box key={it.id} sx={{ display: "flex", justifyContent: "space-between", alignItems: "center",
+              p: 1, borderRadius: 2, bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
+              border: "1px solid var(--border-default)" }}>
+              <Typography sx={{ fontSize: "0.86rem", fontWeight: 600 }} noWrap>{it.primary}</Typography>
+              {it.secondary && (
+                <Typography sx={{ fontSize: "0.72rem", color: "text.secondary", textTransform: "uppercase", fontWeight: 700 }}>
+                  {it.secondary}
+                </Typography>
+              )}
+            </Box>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/lib/auth/role-utils.ts
+++ b/lib/auth/role-utils.ts
@@ -85,6 +85,7 @@ export function canAccessAdminArea(role: string | undefined | null): boolean {
 
 const DEFAULT_STUDENT_HOME = "/dashboard";
 const DEFAULT_ADMIN_HOME = "/admin/dashboard";
+const INSTRUCTOR_HOME = "/instructor/dashboard";
 
 function pathnameOnly(url: string): string {
   try {
@@ -121,6 +122,14 @@ export function resolvePostLoginPath(
   const canAdmin = canAccessAdminArea(role);
 
   const limitedAdmin = isAdminOnlyRole(role);
+
+  // Instructors land in their dedicated space by default; an explicit in-app redirect is honored.
+  if (isInstructorRole(role)) {
+    if (raw && (isAdminAppPath(pathname) || pathname.startsWith("/instructor"))) {
+      return path;
+    }
+    return INSTRUCTOR_HOME;
+  }
 
   if (!canAdmin) {
     if (isAdminAppPath(pathname)) {

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -1,0 +1,172 @@
+import apiClient from "./api";
+
+/**
+ * Instructor RBAC surface (Phase 1). The dashboard endpoints are assignment-scoped server-side —
+ * an instructor only ever receives their assigned courses/cohorts/students. The admin endpoints
+ * (assign/unassign) are admin-only server-side.
+ */
+const BASE = "/instructor/api";
+
+export interface InstructorOverview {
+  courses: number;
+  cohorts: number;
+  students: number;
+  is_admin_view: boolean;
+}
+
+export interface InstructorCourse {
+  id: number;
+  title: string;
+  slug: string;
+  is_published: boolean;
+  student_count: number;
+  updated_at: string;
+}
+
+export interface InstructorCohort {
+  id: number;
+  name: string;
+  status: string;
+  start_date: string | null;
+  end_date: string | null;
+  member_count: number;
+  artifact_count: number;
+}
+
+export interface CohortStudentRow {
+  student_id: number;
+  name: string;
+  email: string;
+  phone: string;
+  status: string;
+  joined_at: string;
+}
+
+export interface CohortRoster {
+  cohort_id: number;
+  name: string;
+  count: number;
+  results: CohortStudentRow[];
+}
+
+export interface CourseStudentRow {
+  student_id: number;
+  name: string;
+  email: string;
+  phone: string;
+  enrolled_at: string;
+  progress_percentage: number;
+  completed: number;
+  total: number;
+  last_activity: string | null;
+}
+
+export interface CourseRoster {
+  count: number;
+  page: number;
+  page_size: number;
+  results: CourseStudentRow[];
+}
+
+export interface InstructorStudentDetail {
+  student_id: number;
+  name: string;
+  email: string;
+  phone: string;
+  courses: { id: number; title: string; enrolled_at: string }[];
+  cohorts: { id: number; name: string; status: string }[];
+}
+
+/** A staff assignment row (course or cohort). */
+export interface StaffAssignment {
+  id: number;
+  profile_id: number;
+  email: string;
+  name: string;
+  role: string;
+  can_grade: boolean;
+  can_manage_roster: boolean;
+  can_edit_content?: boolean; // course only
+  can_message?: boolean; // cohort only
+  created_at: string;
+}
+
+export interface AssignStaffBody {
+  profile_id: number;
+  role?: string;
+  can_grade?: boolean;
+  can_manage_roster?: boolean;
+  can_edit_content?: boolean;
+  can_message?: boolean;
+}
+
+export const instructorService = {
+  // --- Dashboard (assignment-scoped) ---
+  async getOverview(): Promise<InstructorOverview> {
+    const { data } = await apiClient.get<InstructorOverview>(`${BASE}/overview/`);
+    return data;
+  },
+  async getCourses(): Promise<InstructorCourse[]> {
+    const { data } = await apiClient.get<InstructorCourse[]>(`${BASE}/courses/`);
+    return data;
+  },
+  async getCohorts(): Promise<InstructorCohort[]> {
+    const { data } = await apiClient.get<InstructorCohort[]>(`${BASE}/cohorts/`);
+    return data;
+  },
+  async getCohortStudents(cohortId: number, search?: string): Promise<CohortRoster> {
+    const { data } = await apiClient.get<CohortRoster>(`${BASE}/cohorts/${cohortId}/students/`, {
+      params: search ? { search } : {},
+    });
+    return data;
+  },
+  async getStudent(studentId: number): Promise<InstructorStudentDetail> {
+    const { data } = await apiClient.get<InstructorStudentDetail>(`${BASE}/students/${studentId}/`);
+    return data;
+  },
+
+  // --- Course roster (via the capability-re-gated admin endpoints; an assigned instructor may use these) ---
+  async getCourseStudents(courseId: number, search?: string, page = 1): Promise<CourseRoster> {
+    const { data } = await apiClient.get<CourseRoster>(
+      `/adaptive-quiz/api/admin/courses/${courseId}/students/`,
+      { params: { page, ...(search ? { search } : {}) } },
+    );
+    return data;
+  },
+  async unenrollCourseStudents(courseId: number, studentIds: number[]): Promise<{ succeeded: number }> {
+    const { data } = await apiClient.post(`/adaptive-quiz/api/admin/courses/${courseId}/students/unenroll/`, {
+      student_ids: studentIds,
+    });
+    return data;
+  },
+  async enrollCourseStudents(courseId: number, studentIds: number[]): Promise<{ succeeded: number; skipped: number; missing: number[] }> {
+    const { data } = await apiClient.post(`/adaptive-quiz/api/admin/courses/${courseId}/students/enroll/`, {
+      student_ids: studentIds,
+    });
+    return data;
+  },
+
+  // --- Admin: assignment management (admin-only server-side) ---
+  async listCourseStaff(courseId: number): Promise<StaffAssignment[]> {
+    const { data } = await apiClient.get<StaffAssignment[]>(`${BASE}/admin/courses/${courseId}/staff/`);
+    return data;
+  },
+  async assignCourseStaff(courseId: number, body: AssignStaffBody): Promise<StaffAssignment> {
+    const { data } = await apiClient.post<StaffAssignment>(`${BASE}/admin/courses/${courseId}/staff/`, body);
+    return data;
+  },
+  async removeCourseStaff(courseId: number, profileId: number): Promise<void> {
+    await apiClient.delete(`${BASE}/admin/courses/${courseId}/staff/${profileId}/`);
+  },
+  async listCohortStaff(cohortId: number): Promise<StaffAssignment[]> {
+    const { data } = await apiClient.get<StaffAssignment[]>(`${BASE}/admin/cohorts/${cohortId}/staff/`);
+    return data;
+  },
+  async assignCohortStaff(cohortId: number, body: AssignStaffBody): Promise<StaffAssignment> {
+    const { data } = await apiClient.post<StaffAssignment>(`${BASE}/admin/cohorts/${cohortId}/staff/`, body);
+    return data;
+  },
+  async removeCohortStaff(cohortId: number, profileId: number): Promise<void> {
+    await apiClient.delete(`${BASE}/admin/cohorts/${cohortId}/staff/${profileId}/`);
+  },
+};


### PR DESCRIPTION
Pairs with backend **#434** (capability-based RBAC — merged + deployed). Adds the dedicated **/instructor** space and the admin tooling to assign instructors.

## Instructor surface (`/instructor/*`, route-guarded to teaching/admin roles)
- **`/instructor/dashboard`** — KPIs (my batches / courses / students) + cards for assigned cohorts & courses.
- **`/instructor/cohorts/[id]`** — batch roster + search; click a student → shared-scope detail drawer.
- **`/instructor/courses/[id]`** — course roster with progress + remove-student; student drawer.
- **Student detail drawer** shows only the courses/batches the instructor **shares** with the student (matches the server-enforced privacy boundary).
- Instructors now **land at `/instructor/dashboard`** on login.

## Admin tooling
- **`InstructorAssignPanel`** on the adaptive-course **Students** tab (`scope=course`) and the cohort **Assignments** tab (`scope=cohort`): list current instructors, assign from the approved-instructor list, unassign. Writes go through the admin-only assignment API.

## Notes
- `tsc --noEmit` clean. Scoping is enforced **server-side** (dashboard endpoints are assignment-scoped; assign endpoints are admin-only) — the FE surfaces only what the API returns.
- Follow-ups: a student-picker to **add** students to a course from `/instructor` (BE enroll already re-gated); a `useCapabilities()` hook for finer control visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)