### PR TITLE
feat(instructor): admin code directory + student sees instructor code

### DIFF
--- a/app/adaptive-courses/[courseId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/page.tsx
@@ -1,22 +1,42 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { Box, ButtonBase } from "@mui/material";
+import { Box, ButtonBase, Chip, Stack } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { JourneyBoard } from "@/components/adaptive-journey/JourneyBoard";
+import { adaptiveCourseService } from "@/lib/services/adaptive-course.service";
 
 export default function AdaptiveCourseDetailPage() {
   const { push } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
+  // Assigned instructor(s), shown as the public code (or real name). Fetched with a small course-only
+  // call because JourneyBoard drives the main render off the journey payload, not getCourse.
+  const [instructors, setInstructors] = useState<{ name: string }[]>([]);
+
+  useEffect(() => {
+    if (!Number.isFinite(courseId)) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const course = await adaptiveCourseService.getCourse(courseId);
+        if (!cancelled) setInstructors(course.instructors ?? []);
+      } catch {
+        /* non-fatal — the instructor line is optional decoration */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
 
   // JourneyBoard fetches the journey (which already returns the course) and renders
   // its own loading skeleton, 403 "not enrolled" state, and errors - so there is no
-  // page-level getCourse pre-fetch (that was a redundant round-trip + an extra
-  // skeleton phase on top of the route shimmer and JourneyBoard's own skeleton).
+  // page-level getCourse pre-fetch for the main content (that was a redundant round-trip).
   return (
     <MainLayout fullWidthContent>
       <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
@@ -27,6 +47,23 @@ export default function AdaptiveCourseDetailPage() {
           <Icon icon="mdi:arrow-left" width={18} />
           Back to Adaptive Courses
         </ButtonBase>
+
+        {instructors.length > 0 && (
+          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
+            <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, color: "text.secondary", fontSize: "0.85rem", fontWeight: 600 }}>
+              <Icon icon="mdi:account-tie-outline" width={16} />
+              Instructor{instructors.length > 1 ? "s" : ""}:
+            </Box>
+            {instructors.map((i, idx) => (
+              <Chip
+                key={idx}
+                size="small"
+                label={i.name}
+                sx={{ fontWeight: 700, bgcolor: "color-mix(in srgb, #6366f1 12%, transparent)", color: "#4f46e5" }}
+              />
+            ))}
+          </Stack>
+        )}
 
         <AdaptiveSectionShell meshOpacity={0.18}>
           {Number.isFinite(courseId) && <JourneyBoard courseId={courseId} />}

--- a/app/admin/instructors/page.tsx
+++ b/app/admin/instructors/page.tsx
@@ -39,6 +39,7 @@ import {
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { PageShell } from "@/components/common/PageShell";
+import { InstructorCodeDirectory } from "@/components/admin/instructors/InstructorCodeDirectory";
 import {
   ModulePageHeader,
 } from "@/components/common/ModulePageHeader";
@@ -441,6 +442,22 @@ export default function InstructorsPage() {
         accent="indigo"
         icon="mdi:account-tie"
       />
+
+      {/* Directory: email, assignments, and the public code students see instead of the real name. */}
+      <Box
+        sx={{
+          mb: 3,
+          p: { xs: 2, md: 2.5 },
+          borderRadius: 3,
+          border: "1px solid var(--border-default)",
+          bgcolor: "var(--card-bg)",
+        }}
+      >
+        <Typography sx={{ fontWeight: 800, fontSize: "1rem", mb: 1.5 }}>
+          Instructor codes &amp; assignments
+        </Typography>
+        <InstructorCodeDirectory />
+      </Box>
 
       {/* Status quick-stats (click to switch tab) */}
       <Box

--- a/components/admin/instructors/InstructorCodeDirectory.tsx
+++ b/components/admin/instructors/InstructorCodeDirectory.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useToast } from "@/components/common/Toast";
+import { instructorService, type InstructorDirectoryRow } from "@/lib/services/instructor.service";
+
+/**
+ * Admin directory of instructors: email, assigned courses/cohorts/live-sessions, and an editable
+ * public CODE. When a code is set, students see it instead of the instructor's real name on
+ * course/live-session surfaces (for privacy/professionalism).
+ */
+export function InstructorCodeDirectory() {
+  const { showToast } = useToast();
+  const [rows, setRows] = useState<InstructorDirectoryRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setRows(await instructorService.getInstructorDirectory());
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't load the instructor directory.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "grid", placeItems: "center", py: 5 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+  if (error) {
+    return <Typography sx={{ color: "#ef4444", fontWeight: 700, py: 3 }}>{error}</Typography>;
+  }
+  if (rows.length === 0) {
+    return (
+      <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+        <Typography sx={{ color: "text.secondary" }}>No instructors yet.</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={1.5}>
+      <Typography sx={{ fontSize: "0.85rem", color: "text.secondary" }}>
+        Set a public <b>code</b> to hide an instructor&apos;s real name from students on their course and
+        live-session surfaces. Leave it blank to show the real name.
+      </Typography>
+      {rows.map((row) => (
+        <InstructorCodeRow key={row.profile_id} row={row} onSaved={(code) => {
+          setRows((prev) => prev.map((r) => (r.profile_id === row.profile_id ? { ...r, instructor_code: code } : r)));
+        }} showToast={showToast} />
+      ))}
+    </Stack>
+  );
+}
+
+function InstructorCodeRow({
+  row,
+  onSaved,
+  showToast,
+}: {
+  row: InstructorDirectoryRow;
+  onSaved: (code: string) => void;
+  showToast: (msg: string, sev: "success" | "error") => void;
+}) {
+  const [code, setCode] = useState(row.instructor_code);
+  const [saving, setSaving] = useState(false);
+  const dirty = code.trim() !== row.instructor_code;
+
+  async function save() {
+    if (!dirty || saving) return;
+    setSaving(true);
+    try {
+      const res = await instructorService.setInstructorCode(row.profile_id, code.trim());
+      onSaved(res.instructor_code);
+      setCode(res.instructor_code);
+      showToast(res.instructor_code ? `Code set to "${res.instructor_code}".` : "Code cleared.", "success");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Couldn't save the code.";
+      showToast(msg, "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        p: 2,
+        borderRadius: 3,
+        border: "1px solid var(--border-default)",
+        bgcolor: "var(--card-bg)",
+        display: "flex",
+        flexDirection: { xs: "column", md: "row" },
+        gap: 2,
+        alignItems: { md: "center" },
+      }}
+    >
+      {/* Identity */}
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ minWidth: 0, flex: 1 }}>
+        <Box sx={{ width: 40, height: 40, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center",
+          color: "#fff", fontWeight: 800, background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
+          {(row.name || row.email || "?").slice(0, 1).toUpperCase()}
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }} noWrap>{row.name}</Typography>
+          <Typography sx={{ color: "text.secondary", fontSize: "0.8rem" }} noWrap>{row.email}</Typography>
+        </Box>
+      </Stack>
+
+      {/* Assignments */}
+      <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ flex: 1.4 }}>
+        {row.courses.length === 0 && row.cohorts.length === 0 && row.live_sessions.length === 0 && (
+          <Typography sx={{ color: "text.secondary", fontSize: "0.8rem" }}>No assignments</Typography>
+        )}
+        {row.courses.map((c) => (
+          <Chip key={`c${c.id}`} size="small" icon={<Icon icon="mdi:book-education-outline" width={14} />}
+            label={c.title} sx={{ maxWidth: 180 }} />
+        ))}
+        {row.cohorts.map((c) => (
+          <Chip key={`h${c.id}`} size="small" icon={<Icon icon="mdi:account-group-outline" width={14} />}
+            label={c.name} color="primary" variant="outlined" sx={{ maxWidth: 180 }} />
+        ))}
+        {row.live_sessions.length > 0 && (
+          <Chip size="small" icon={<Icon icon="mdi:video-outline" width={14} />}
+            label={`${row.live_sessions.length} live`} variant="outlined" />
+        )}
+      </Stack>
+
+      {/* Code editor */}
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ flexShrink: 0 }}>
+        <TextField
+          size="small"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="e.g. INS-042"
+          onKeyDown={(e) => { if (e.key === "Enter") void save(); }}
+          sx={{ width: 150, "& .MuiOutlinedInput-root": { borderRadius: 2, bgcolor: "var(--surface)" } }}
+          InputProps={{ startAdornment: <Icon icon="mdi:shield-account-outline" width={16} style={{ marginRight: 6, opacity: 0.6 }} /> }}
+        />
+        <Button
+          onClick={() => void save()}
+          disabled={!dirty || saving}
+          variant="contained"
+          disableElevation
+          sx={{ borderRadius: 2, textTransform: "none", fontWeight: 700, minWidth: 72,
+            background: "linear-gradient(135deg,#6366f1,#a855f7)" }}
+        >
+          {saving ? <CircularProgress size={16} sx={{ color: "#fff" }} /> : "Save"}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -149,6 +149,8 @@ export interface AdaptiveCourseDetail extends AdaptiveCourseListItem {
   /** AI/admin header banner; null when absent or hidden by the admin. */
   header_image_url?: string | null;
   modules: AdaptiveCourseModule[];
+  /** Assigned instructor(s) as shown to the student — the public code when set, else the real name. */
+  instructors?: { name: string }[];
 }
 
 // --- Additional Practice (learner-generated, no points) ---

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -100,7 +100,32 @@ export interface AssignStaffBody {
   can_message?: boolean;
 }
 
+export interface InstructorDirectoryRow {
+  profile_id: number;
+  name: string;
+  email: string;
+  instructor_code: string;
+  courses: { id: number; title: string; role: string }[];
+  cohorts: { id: number; name: string; role: string }[];
+  live_sessions: { id: number; title: string }[];
+}
+
 export const instructorService = {
+  // --- Admin settings: instructor directory + public code ---
+  async getInstructorDirectory(): Promise<InstructorDirectoryRow[]> {
+    const { data } = await apiClient.get<InstructorDirectoryRow[]>(`${BASE}/admin/instructors/`);
+    return data;
+  },
+  async setInstructorCode(
+    profileId: number,
+    code: string,
+  ): Promise<{ profile_id: number; instructor_code: string }> {
+    const { data } = await apiClient.patch(`${BASE}/admin/instructors/${profileId}/`, {
+      instructor_code: code,
+    });
+    return data;
+  },
+
   // --- Dashboard (assignment-scoped) ---
   async getOverview(): Promise<InstructorOverview> {
     const { data } = await apiClient.get<InstructorOverview>(`${BASE}/overview/`);


### PR DESCRIPTION
Pairs with backend **#435** (public instructor code — merged + deployed).

## Admin — `/admin/instructors`
- New **Instructor codes & assignments** directory panel: each instructor's email, assigned courses/cohorts/live-sessions (chips), and an **inline editable public CODE** (save/clear; unique per tenant, enforced server-side).

## Student — adaptive course page
- Renders the assigned **instructor(s)** as a chip above the journey board — the **code** when the admin set one, else the real name. (Adaptive courses showed no instructor before.)
- Live-session instructor identity is already suppressed → code server-side (backend #435), so no student surface leaks the real name.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)