### PR TITLE
feat(instructor): Students / Gradebook / Live Sessions / Analytics (Phase 2B-2E)

### DIFF
--- a/app/instructor/analytics/page.tsx
+++ b/app/instructor/analytics/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { KpiRail } from "@/components/scorecard/shared";
+import {
+  instructorService,
+  type InstructorDashboard,
+  type InstructorStudentRow,
+} from "@/lib/services/instructor.service";
+
+const BUCKETS = [
+  { label: "0–25%", min: 0, max: 25, color: "#ef4444" },
+  { label: "25–50%", min: 25, max: 50, color: "#f59e0b" },
+  { label: "50–75%", min: 50, max: 75, color: "#6366f1" },
+  { label: "75–100%", min: 75, max: 100.01, color: "#10b981" },
+];
+
+export default function InstructorAnalyticsPage() {
+  const [dash, setDash] = useState<InstructorDashboard | null>(null);
+  const [students, setStudents] = useState<InstructorStudentRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [d, s] = await Promise.all([
+          instructorService.getDashboard(),
+          instructorService.getStudents(undefined, 1, 100),
+        ]);
+        if (cancelled) return;
+        setDash(d);
+        setStudents(s.results);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load analytics.");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const distribution = useMemo(() => {
+    const counts = BUCKETS.map(() => 0);
+    students.forEach((s) => {
+      const idx = BUCKETS.findIndex((b) => s.progress >= b.min && s.progress < b.max);
+      if (idx >= 0) counts[idx] += 1;
+    });
+    const max = Math.max(1, ...counts);
+    return BUCKETS.map((b, i) => ({ ...b, count: counts[i], pct: (counts[i] / max) * 100 }));
+  }, [students]);
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Teach"
+        title="Analytics"
+        description="How your students are progressing across the courses and batches you teach."
+        accent="cyan"
+        icon="mdi:chart-box-outline"
+      />
+
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+
+      {!error && (
+        <>
+          <KpiRail
+            items={[
+              { value: `${dash?.avg_progress ?? 0}%`, label: "Avg progress", accent: "#6366f1" },
+              { value: `${dash?.completion_rate ?? 0}%`, label: "Completed", accent: "#10b981" },
+              { value: dash?.active_students ?? 0, label: "Active (7d)", accent: "#06b6d4" },
+              { value: dash?.at_risk_count ?? 0, label: "At risk", accent: "#ef4444" },
+            ]}
+          />
+
+          <Box sx={{ mt: 3.5, p: { xs: 2, md: 3 }, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+            <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 2 }}>
+              <Icon icon="mdi:chart-bar" width={20} style={{ color: "#06b6d4" }} />
+              <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Progress distribution</Typography>
+              <Typography sx={{ color: "text.secondary", fontSize: "0.82rem" }}>
+                — {students.length} student{students.length === 1 ? "" : "s"}
+              </Typography>
+            </Stack>
+            <Stack spacing={1.5}>
+              {distribution.map((b) => (
+                <Stack key={b.label} direction="row" alignItems="center" spacing={1.5}>
+                  <Typography sx={{ width: 72, fontSize: "0.8rem", color: "text.secondary", flexShrink: 0 }}>{b.label}</Typography>
+                  <Box sx={{ flex: 1, height: 22, borderRadius: 1.5, bgcolor: "color-mix(in srgb, var(--border-default) 40%, transparent)", overflow: "hidden" }}>
+                    <Box sx={{ width: `${b.pct}%`, height: "100%", borderRadius: 1.5, background: b.color, transition: "width .5s ease" }} />
+                  </Box>
+                  <Typography sx={{ width: 32, textAlign: "right", fontWeight: 800, fontSize: "0.85rem" }}>{b.count}</Typography>
+                </Stack>
+              ))}
+            </Stack>
+          </Box>
+        </>
+      )}
+    </PageShell>
+  );
+}

--- a/app/instructor/assessments/page.tsx
+++ b/app/instructor/assessments/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { Reveal } from "@/components/scorecard/shared";
+import { instructorService, type InstructorAssessment } from "@/lib/services/instructor.service";
+
+export default function InstructorGradebookPage() {
+  const [items, setItems] = useState<InstructorAssessment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await instructorService.getAssessments();
+        if (!cancelled) setItems(list);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your assessments.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const totalPending = items.reduce((n, a) => n + a.pending_grading, 0);
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Teach"
+        title="Gradebook"
+        description="Assessments mapped to your batches. Track submissions and what's pending your review."
+        accent="amber"
+        icon="mdi:clipboard-check-outline"
+      />
+
+      {totalPending > 0 && (
+        <Box sx={{ mb: 2, p: 1.5, borderRadius: 2, display: "inline-flex", alignItems: "center", gap: 1,
+          bgcolor: "color-mix(in srgb, #f59e0b 12%, transparent)", color: "#b45309", fontWeight: 700 }}>
+          <Icon icon="mdi:alert-circle-outline" width={18} />
+          {totalPending} submission{totalPending === 1 ? "" : "s"} pending your grading
+        </Box>
+      )}
+
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+      {!error && !loading && items.length === 0 && (
+        <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+          <Typography sx={{ color: "text.secondary" }}>No assessments mapped to your batches yet.</Typography>
+        </Box>
+      )}
+
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)" }, gap: 2 }}>
+        {items.map((a, i) => (
+          <Reveal key={a.id} delay={Math.min(i, 8) * 0.05}>
+            <Box sx={{ p: 2.25, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+              <Stack direction="row" alignItems="flex-start" spacing={1.25}>
+                <Box sx={{ width: 40, height: 40, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center",
+                  color: "#fff", background: "linear-gradient(135deg,#f59e0b,#ec4899)" }}>
+                  <Icon icon="mdi:clipboard-text-outline" width={20} />
+                </Box>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{a.title}</Typography>
+                  <Typography sx={{ color: "text.secondary", fontSize: "0.82rem" }}>{a.duration_minutes} min</Typography>
+                </Box>
+                {a.is_draft && <Chip size="small" label="draft" sx={{ fontWeight: 700 }} />}
+              </Stack>
+              <Stack direction="row" spacing={1} sx={{ mt: 1.5 }}>
+                <Chip size="small" icon={<Icon icon="mdi:file-document-outline" width={14} />}
+                  label={`${a.submissions} submission${a.submissions === 1 ? "" : "s"}`} />
+                <Chip size="small"
+                  icon={<Icon icon={a.pending_grading ? "mdi:clock-alert-outline" : "mdi:check-circle-outline"} width={14} />}
+                  label={a.pending_grading ? `${a.pending_grading} to grade` : "up to date"}
+                  sx={{ fontWeight: 700, color: a.pending_grading ? "#b45309" : "#059669",
+                    bgcolor: `color-mix(in srgb, ${a.pending_grading ? "#f59e0b" : "#10b981"} 14%, transparent)` }} />
+              </Stack>
+            </Box>
+          </Reveal>
+        ))}
+      </Box>
+    </PageShell>
+  );
+}

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { instructorService, type InstructorLiveSession } from "@/lib/services/instructor.service";
+
+function fmt(dt: string): string {
+  try {
+    return new Date(dt).toLocaleString(undefined, {
+      weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+    });
+  } catch {
+    return dt;
+  }
+}
+
+export default function InstructorLiveSessionsPage() {
+  const [upcoming, setUpcoming] = useState<InstructorLiveSession[]>([]);
+  const [past, setPast] = useState<InstructorLiveSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await instructorService.getLiveSessions();
+        if (!cancelled) {
+          setUpcoming(data.upcoming);
+          setPast(data.past);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your live sessions.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Teach"
+        title="Live sessions"
+        description="Sessions scheduled for the courses and batches you're assigned to."
+        accent="pink"
+        icon="mdi:video-outline"
+      />
+
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+      {!error && !loading && upcoming.length === 0 && past.length === 0 && (
+        <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+          <Typography sx={{ color: "text.secondary" }}>No live sessions scheduled for your courses or batches.</Typography>
+        </Box>
+      )}
+
+      <SessionGroup title="Upcoming" icon="mdi:calendar-clock" sessions={upcoming} highlight />
+      <SessionGroup title="Past" icon="mdi:history" sessions={past} />
+    </PageShell>
+  );
+}
+
+function SessionGroup({
+  title,
+  icon,
+  sessions,
+  highlight,
+}: {
+  title: string;
+  icon: string;
+  sessions: InstructorLiveSession[];
+  highlight?: boolean;
+}) {
+  if (sessions.length === 0) return null;
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
+        <Icon icon={icon} width={20} style={{ color: highlight ? "#ec4899" : "#6b7280" }} />
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>{title}</Typography>
+      </Stack>
+      <Stack spacing={1}>
+        {sessions.map((s) => (
+          <Box key={s.id} sx={{ display: "flex", alignItems: "center", gap: 1.5, p: 1.75, borderRadius: 2,
+            bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
+            opacity: highlight ? 1 : 0.85 }}>
+            <Box sx={{ width: 40, height: 40, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center",
+              color: "#fff", background: highlight ? "linear-gradient(135deg,#ec4899,#a855f7)" : "linear-gradient(135deg,#94a3b8,#64748b)" }}>
+              <Icon icon="mdi:video" width={20} />
+            </Box>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography sx={{ fontWeight: 700, fontSize: "0.94rem" }} noWrap>{s.topic_name}</Typography>
+              <Typography sx={{ color: "text.secondary", fontSize: "0.82rem" }}>
+                {fmt(s.class_datetime)} · {s.duration_minutes} min
+              </Typography>
+            </Box>
+            {highlight && s.join_link && (
+              <Button variant="contained" size="small" disableElevation href={s.join_link} target="_blank" rel="noopener"
+                startIcon={<Icon icon="mdi:login-variant" width={16} />}
+                sx={{ borderRadius: 2, textTransform: "none", fontWeight: 700,
+                  background: "linear-gradient(135deg,#ec4899,#a855f7)" }}>
+                Join
+              </Button>
+            )}
+            {!highlight && <Chip size="small" label="ended" sx={{ fontWeight: 700 }} />}
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Box, Button, Chip, LinearProgress, Stack, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { RosterRow } from "@/components/instructor/RosterRow";
+import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
+import { instructorService, type InstructorStudentRow } from "@/lib/services/instructor.service";
+
+export default function InstructorStudentsPage() {
+  const [rows, setRows] = useState<InstructorStudentRow[]>([]);
+  const [count, setCount] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const load = useCallback(async (search: string, p: number) => {
+    setLoading(true);
+    try {
+      const data = await instructorService.getStudents(search || undefined, p);
+      setRows(data.results);
+      setCount(data.count);
+      setPage(data.page);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't load your students.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load("", 1);
+  }, [load]);
+
+  // Debounced search.
+  useEffect(() => {
+    const h = setTimeout(() => void load(query, 1), 350);
+    return () => clearTimeout(h);
+  }, [query, load]);
+
+  const pageSize = 25;
+  const pages = Math.max(1, Math.ceil(count / pageSize));
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Teach"
+        title="Students"
+        description="Everyone in the courses and batches you're assigned to, with their progress."
+        accent="emerald"
+        icon="mdi:account-school"
+      />
+
+      <TextField
+        size="small"
+        fullWidth
+        placeholder="Search students by name or email…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        sx={{ maxWidth: 420, mb: 2, "& .MuiOutlinedInput-root": { borderRadius: 2, bgcolor: "var(--surface)" } }}
+        InputProps={{ startAdornment: <Icon icon="mdi:magnify" width={18} style={{ marginRight: 6, opacity: 0.6 }} /> }}
+      />
+
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+      {!error && !loading && rows.length === 0 && (
+        <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+          <Typography sx={{ color: "text.secondary" }}>
+            {count === 0 ? "No students in your courses or batches yet." : "No students match your search."}
+          </Typography>
+        </Box>
+      )}
+
+      <Stack spacing={1}>
+        {rows.map((s) => (
+          <RosterRow
+            key={s.student_id}
+            name={s.name}
+            email={s.email}
+            onClick={() => setSelected(s.student_id)}
+            right={
+              <Stack direction="row" spacing={1.5} alignItems="center">
+                <Box sx={{ width: 96, display: { xs: "none", sm: "block" } }}>
+                  <LinearProgress variant="determinate" value={Math.max(0, Math.min(100, s.progress))}
+                    sx={{ height: 6, borderRadius: 3 }} />
+                  <Typography sx={{ fontSize: "0.68rem", color: "text.secondary", mt: 0.25 }}>
+                    {Math.round(s.progress)}% avg
+                  </Typography>
+                </Box>
+                <Chip size="small" icon={<Icon icon="mdi:book-outline" width={13} />}
+                  label={s.courses_count} sx={{ fontWeight: 700 }} />
+              </Stack>
+            }
+          />
+        ))}
+      </Stack>
+
+      {pages > 1 && (
+        <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ mt: 3 }}>
+          <Button disabled={page <= 1 || loading} onClick={() => void load(query, page - 1)}
+            startIcon={<Icon icon="mdi:chevron-left" />}>Prev</Button>
+          <Typography sx={{ fontSize: "0.85rem", color: "text.secondary" }}>Page {page} of {pages} · {count} students</Typography>
+          <Button disabled={page >= pages || loading} onClick={() => void load(query, page + 1)}
+            endIcon={<Icon icon="mdi:chevron-right" />}>Next</Button>
+        </Stack>
+      )}
+
+      <StudentDetailDrawer studentId={selected} open={selected != null} onClose={() => setSelected(null)} />
+    </PageShell>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -310,11 +310,15 @@ interface NavigationItem {
 }
 
 // Instructors get a DEDICATED nav — never the student or admin nav. Static (no i18n/feature gating);
-// scoped to what they teach. More items (Students, Gradebook, Live Sessions) land in later phases.
+// scoped to what they teach.
 const INSTRUCTOR_NAVIGATION_ITEMS: NavigationItem[] = [
   { label: "Dashboard", labelKey: "instructorNav.dashboard", path: "/instructor/dashboard", icon: "mdi:view-dashboard", featureName: "instructor" },
   { label: "My Batches", labelKey: "instructorNav.cohorts", path: "/instructor/cohorts", icon: "mdi:account-group", featureName: "instructor" },
   { label: "My Courses", labelKey: "instructorNav.courses", path: "/instructor/courses", icon: "mdi:book-education", featureName: "instructor" },
+  { label: "Students", labelKey: "instructorNav.students", path: "/instructor/students", icon: "mdi:account-school", featureName: "instructor" },
+  { label: "Gradebook", labelKey: "instructorNav.gradebook", path: "/instructor/assessments", icon: "mdi:clipboard-check-outline", featureName: "instructor" },
+  { label: "Live Sessions", labelKey: "instructorNav.live", path: "/instructor/live-sessions", icon: "mdi:video-outline", featureName: "instructor" },
+  { label: "Analytics", labelKey: "instructorNav.analytics", path: "/instructor/analytics", icon: "mdi:chart-box-outline", featureName: "instructor" },
 ];
 
 interface SidebarProps {

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -133,7 +133,63 @@ export interface InstructorDirectoryRow {
   live_sessions: { id: number; title: string }[];
 }
 
+export interface InstructorStudentRow {
+  student_id: number;
+  name: string;
+  email: string;
+  phone: string;
+  progress: number;
+  courses_count: number;
+  cohorts_count: number;
+}
+
+export interface InstructorStudentsPage {
+  count: number;
+  page: number;
+  page_size: number;
+  results: InstructorStudentRow[];
+}
+
+export interface InstructorAssessment {
+  id: number;
+  title: string;
+  slug: string;
+  is_draft: boolean;
+  duration_minutes: number;
+  submissions: number;
+  pending_grading: number;
+}
+
+export interface InstructorLiveSession {
+  id: number;
+  topic_name: string;
+  class_datetime: string;
+  duration_minutes: number;
+  join_link: string;
+  is_upcoming: boolean;
+}
+
+export interface InstructorLiveSessions {
+  upcoming: InstructorLiveSession[];
+  past: InstructorLiveSession[];
+}
+
 export const instructorService = {
+  async getStudents(search?: string, page = 1, pageSize?: number): Promise<InstructorStudentsPage> {
+    const { data } = await apiClient.get<InstructorStudentsPage>(`${BASE}/students/`, {
+      params: { page, ...(pageSize ? { page_size: pageSize } : {}), ...(search ? { search } : {}) },
+    });
+    return data;
+  },
+  async getAssessments(): Promise<InstructorAssessment[]> {
+    const { data } = await apiClient.get<InstructorAssessment[]>(`${BASE}/assessments/`);
+    return data;
+  },
+  async getLiveSessions(): Promise<InstructorLiveSessions> {
+    const { data } = await apiClient.get<InstructorLiveSessions>(`${BASE}/live-sessions/`);
+    return data;
+  },
+
   // --- Admin settings: instructor directory + public code ---
   async getInstructorDirectory(): Promise<InstructorDirectoryRow[]> {
     const { data } = await apiClient.get<InstructorDirectoryRow[]>(`${BASE}/admin/instructors/`);


### PR DESCRIPTION
Completes the instructor module build-out (INSTRUCTOR-EXPERIENCE-PROGRAM.md). Pairs with backend **#437**. Four new pages + nav items, all assignment-scoped:

- **Students** (`/instructor/students`) — every student in scope + avg progress + course/cohort counts; search + pagination; row → shared-scope detail drawer.
- **Gradebook** (`/instructor/assessments`) — assessments mapped to your batches + submission / pending-grading counts + a "N pending your grading" banner.
- **Live Sessions** (`/instructor/live-sessions`) — upcoming (with Join) + past sessions on your courses/cohorts.
- **Analytics** (`/instructor/analytics`) — avg progress / completion / active / at-risk KPIs + a progress-distribution chart.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)