### PR TITLE
feat(instructor): redesign Dashboard + My Cohorts to the workspace mockups

### DIFF
--- a/app/instructor/cohorts/page.tsx
+++ b/app/instructor/cohorts/page.tsx
@@ -1,17 +1,34 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
-import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { Reveal } from "@/components/scorecard/shared";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { instructorService, type InstructorCohort } from "@/lib/services/instructor.service";
+import { instructorService, type InstructorCohortDetail } from "@/lib/services/instructor.service";
+
+const GRADS = [
+  "linear-gradient(120deg,#6366f1,#f59e0b)",
+  "linear-gradient(120deg,#a855f7,#ec4899)",
+  "linear-gradient(120deg,#6366f1,#8b5cf6)",
+  "linear-gradient(120deg,#0ea5e9,#6366f1)",
+];
+
+function fmtEnd(d: string | null): string {
+  if (!d) return "";
+  try {
+    return `Ends ${new Date(d).toLocaleDateString(undefined, { month: "short", day: "numeric" }).toUpperCase()}`;
+  } catch {
+    return "";
+  }
+}
 
 export default function InstructorCohortsPage() {
   const { push, prefetch } = useInstantNavigation();
-  const [cohorts, setCohorts] = useState<InstructorCohort[]>([]);
+  const [cohorts, setCohorts] = useState<InstructorCohortDetail[]>([]);
+  const [code, setCode] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,10 +36,13 @@ export default function InstructorCohortsPage() {
     let cancelled = false;
     (async () => {
       try {
-        const list = await instructorService.getCohorts();
-        if (!cancelled) setCohorts(list);
+        const d = await instructorService.getDashboard();
+        if (!cancelled) {
+          setCohorts(d.cohorts_detailed);
+          setCode(d.instructor_code);
+        }
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your batches.");
+        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your cohorts.");
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -35,41 +55,107 @@ export default function InstructorCohortsPage() {
   return (
     <PageShell>
       <ModulePageHeader
-        eyebrow="Teach"
-        title="My batches"
-        description="The cohorts you're assigned to. Open one for its roster and student details."
-        accent="indigo"
-        icon="mdi:account-group"
+        eyebrow="Teaching"
+        title="My Cohorts"
+        description="Courses and cohorts assigned to you by admin. Membership is managed centrally — you own delivery, sessions and reporting."
+        accent="purple"
+        icon="mdi:school-outline"
+        action={
+          <HeaderActionButton icon="mdi:download-outline" variant="ghost" onClick={() => window.print()}>
+            Export report
+          </HeaderActionButton>
+        }
       />
+
+      {/* Assignment banner */}
+      <Box sx={{ mb: 3, p: 2, borderRadius: 3, display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "center",
+        justifyContent: "space-between", bgcolor: "color-mix(in srgb,#6366f1 8%,transparent)",
+        border: "1px solid color-mix(in srgb,#6366f1 22%,transparent)" }}>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ color: "#4f46e5" }}>
+          <Icon icon="mdi:information-outline" width={18} />
+          <Typography sx={{ fontWeight: 600, fontSize: "0.9rem" }}>
+            Cohort rosters are assigned by your admin. Students join using your instructor code
+            {code ? <> — <b>{code}</b>.</> : "."}
+          </Typography>
+        </Stack>
+        <Button href="/tickets" startIcon={<Icon icon="mdi:headset" width={16} />}
+          sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1" }}>Request a change</Button>
+      </Box>
+
       {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
       {!error && !loading && cohorts.length === 0 && (
         <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
-          <Typography sx={{ color: "text.secondary" }}>No batches assigned yet. An admin can assign you to a cohort.</Typography>
+          <Typography sx={{ color: "text.secondary" }}>No cohorts assigned yet. An admin can assign you to a cohort.</Typography>
         </Box>
       )}
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }, gap: 2 }}>
+
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(2, 1fr)", xl: "repeat(3, 1fr)" }, gap: 2.5 }}>
         {cohorts.map((c, i) => (
           <Reveal key={c.id} delay={Math.min(i, 8) * 0.05}>
-            <Box
-              onClick={() => push(`/instructor/cohorts/${c.id}`)}
-              onMouseEnter={() => prefetch(`/instructor/cohorts/${c.id}`)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter") push(`/instructor/cohorts/${c.id}`); }}
-              sx={{ cursor: "pointer", p: 2.25, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
-                transition: "transform .14s, box-shadow .14s, border-color .14s",
-                "&:hover": { transform: "translateY(-3px)", borderColor: "color-mix(in srgb, #6366f1 40%, transparent)", boxShadow: "0 20px 40px -26px rgba(99,102,241,0.45)" } }}
-            >
-              <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 1 }}>
-                <Box sx={{ width: 40, height: 40, borderRadius: 2.5, display: "grid", placeItems: "center", color: "#fff", flexShrink: 0, background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
-                  <Icon icon="mdi:account-group" width={20} />
+            <Box sx={{ borderRadius: 4, overflow: "hidden", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
+              boxShadow: "0 10px 30px -24px rgba(16,24,40,.3)" }}>
+              {/* Gradient header */}
+              <Box sx={{ p: 2, background: GRADS[i % GRADS.length], color: "#fff", minHeight: 96 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Chip size="small" label={c.client_name || "Cohort"} sx={{ fontWeight: 700, color: "#fff",
+                    bgcolor: "rgba(255,255,255,0.18)" }} />
+                  {c.end_date && <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.6,
+                    bgcolor: "rgba(0,0,0,0.2)", px: 1, py: 0.4, borderRadius: 999 }}>{fmtEnd(c.end_date)}</Typography>}
+                </Stack>
+                <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 1.5 }}>
+                  <Box sx={{ width: 36, height: 36, borderRadius: "50%", display: "grid", placeItems: "center",
+                    bgcolor: "rgba(255,255,255,0.25)", border: "2px solid rgba(255,255,255,0.5)" }}>
+                    <Icon icon="mdi:account" width={18} />
+                  </Box>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.85rem", ml: 0.5 }}>
+                    {c.student_count} student{c.student_count === 1 ? "" : "s"}
+                  </Typography>
+                </Stack>
+              </Box>
+              {/* Body */}
+              <Box sx={{ p: 2.25 }}>
+                <Typography sx={{ fontWeight: 800, fontSize: "1.1rem" }}>{c.name}</Typography>
+                <Stack direction="row" spacing={0.5} alignItems="center" sx={{ color: "text.secondary", mt: 0.5 }}>
+                  <Icon icon="mdi:bookmark-outline" width={14} />
+                  <Typography sx={{ fontSize: "0.82rem" }}>{c.client_name || "AI Linc"}</Typography>
+                </Stack>
+
+                <Stack direction="row" justifyContent="space-between" sx={{ mt: 2, mb: 0.5 }}>
+                  <Typography sx={{ fontSize: "0.82rem", color: "text.secondary" }}>Cohort progress</Typography>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.85rem" }}>{c.progress}%</Typography>
+                </Stack>
+                <Box sx={{ height: 8, borderRadius: 4, bgcolor: "color-mix(in srgb,var(--border-default) 50%,transparent)", overflow: "hidden" }}>
+                  <Box sx={{ width: `${Math.max(0, Math.min(100, c.progress))}%`, height: "100%", background: GRADS[i % GRADS.length] }} />
                 </Box>
-                <Chip size="small" label={c.status} sx={{ fontWeight: 700, textTransform: "capitalize" }} />
-              </Stack>
-              <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{c.name}</Typography>
-              <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", mt: 0.5 }}>
-                {c.member_count} student{c.member_count === 1 ? "" : "s"} · {c.artifact_count} item{c.artifact_count === 1 ? "" : "s"}
-              </Typography>
+
+                <Box sx={{ mt: 2, display: "grid", gridTemplateColumns: "repeat(3,1fr)", borderRadius: 2.5,
+                  border: "1px solid var(--border-default)", overflow: "hidden" }}>
+                  {[
+                    { n: c.student_count, l: "students", d: false },
+                    { n: `${c.avg_score}%`, l: "avg score", d: false },
+                    { n: c.at_risk, l: "at risk", d: c.at_risk > 0 },
+                  ].map((s, j) => (
+                    <Box key={s.l} sx={{ p: 1.5, textAlign: "center", borderLeft: j ? "1px solid var(--border-default)" : "none" }}>
+                      <Typography sx={{ fontWeight: 900, fontSize: "1.2rem", color: s.d ? "#ef4444" : "var(--font-primary)" }}>{s.n}</Typography>
+                      <Typography sx={{ fontSize: "0.62rem", color: "text.secondary", textTransform: "uppercase", letterSpacing: 0.4 }}>{s.l}</Typography>
+                    </Box>
+                  ))}
+                </Box>
+
+                <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+                  <Button fullWidth onClick={() => push(`/instructor/cohorts/${c.id}`)}
+                    onMouseEnter={() => prefetch(`/instructor/cohorts/${c.id}`)}
+                    endIcon={<Icon icon="mdi:arrow-right" width={18} />}
+                    sx={{ py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#fff",
+                      background: "linear-gradient(135deg,#7c3aed,#ec4899)", "&:hover": { filter: "brightness(1.06)" } }}>
+                    Student report
+                  </Button>
+                  <Button onClick={() => push("/instructor/live-sessions")}
+                    sx={{ minWidth: 48, borderRadius: 2.5, border: "1px solid var(--border-default)", color: "#6366f1" }}>
+                    <Icon icon="mdi:access-point" width={18} />
+                  </Button>
+                </Stack>
+              </Box>
             </Box>
           </Reveal>
         ))}

--- a/app/instructor/dashboard/page.tsx
+++ b/app/instructor/dashboard/page.tsx
@@ -1,47 +1,49 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Box, Chip, Stack, Typography } from "@mui/material";
+import { useEffect, useMemo, useState } from "react";
+import { Box, Button, Chip, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
-import { ModulePageHeader } from "@/components/common/ModulePageHeader";
-import { KpiRail, Reveal } from "@/components/scorecard/shared";
-import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { useToast } from "@/components/common/Toast";
+import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
 import {
   instructorService,
   type InstructorDashboard,
-  type InstructorStatStudent,
-  type InstructorCohort,
-  type InstructorCourse,
+  type InstructorCohortDetail,
+  type InstructorScheduleItem,
+  type InstructorRecentSubmission,
 } from "@/lib/services/instructor.service";
+
+function greeting(): string {
+  const h = new Date().getHours();
+  if (h < 12) return "Good morning";
+  if (h < 17) return "Good afternoon";
+  return "Good evening";
+}
+
+const COHORT_GRADIENTS = [
+  "linear-gradient(120deg,#6366f1,#f59e0b)",
+  "linear-gradient(120deg,#a855f7,#ec4899)",
+  "linear-gradient(120deg,#6366f1,#8b5cf6)",
+  "linear-gradient(120deg,#0ea5e9,#6366f1)",
+];
 
 export default function InstructorDashboardPage() {
   const { push, prefetch } = useInstantNavigation();
+  const { showToast } = useToast();
   const [dash, setDash] = useState<InstructorDashboard | null>(null);
-  const [cohorts, setCohorts] = useState<InstructorCohort[]>([]);
-  const [courses, setCourses] = useState<InstructorCourse[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedStudent, setSelectedStudent] = useState<number | null>(null);
+  const [selected, setSelected] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const [d, ch, co] = await Promise.all([
-          instructorService.getDashboard(),
-          instructorService.getCohorts(),
-          instructorService.getCourses(),
-        ]);
-        if (cancelled) return;
-        setDash(d);
-        setCohorts(ch);
-        setCourses(co);
+        const d = await instructorService.getDashboard();
+        if (!cancelled) setDash(d);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load your dashboard.");
-      } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load your workspace.");
       }
     })();
     return () => {
@@ -49,323 +51,312 @@ export default function InstructorDashboardPage() {
     };
   }, []);
 
-  const firstName = (dash?.instructor_name || "").trim().split(/\s+/)[0] || "Instructor";
+  const firstName = (dash?.instructor_name || "").trim().split(/\s+/)[0] || "there";
+  const liveSession = useMemo(() => dash?.schedule.find((s) => s.status === "live"), [dash]);
+
+  function copyCode() {
+    if (!dash?.instructor_code) return;
+    navigator.clipboard?.writeText(dash.instructor_code).then(
+      () => showToast("Instructor code copied.", "success"),
+      () => showToast("Couldn't copy the code.", "error"),
+    );
+  }
 
   return (
     <PageShell>
-      <ModulePageHeader
-        eyebrow="Teach"
-        title={`Welcome, ${firstName}`}
-        description={
-          dash?.is_admin_view
-            ? "Admin preview — every batch, course, and student in your organisation."
-            : "You see the courses & cohorts you're assigned to, and the students in them."
-        }
-        accent="indigo"
-        icon="mdi:teach"
-      />
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
 
-      {error && (
-        <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>
-      )}
-
-      {!error && (
-        <>
-          <KpiRail
-            items={[
-              { value: dash?.batches ?? 0, label: "My batches", accent: "#6366f1" },
-              { value: dash?.courses ?? 0, label: "My courses", accent: "#a855f7" },
-              { value: dash?.students ?? 0, label: "Students", accent: "#10b981" },
-              { value: dash?.active_students ?? 0, label: "Active (7d)", accent: "#06b6d4" },
-              { value: `${dash?.avg_progress ?? 0}%`, label: "Avg progress", accent: "#f59e0b" },
-              { value: dash?.upcoming_sessions ?? 0, label: "Upcoming sessions", accent: "#ec4899" },
-            ]}
-          />
-
-          {/* Student statistics — at-risk + top performers side by side */}
-          <Box
-            sx={{
-              mt: 3.5,
-              display: "grid",
-              gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
-              gap: 2,
-            }}
-          >
-            <StudentStatList
-              title="Needs attention"
-              icon="mdi:alert-outline"
-              accent="#ef4444"
-              emptyText={loading ? "Loading…" : "No at-risk students — great job!"}
-              students={dash?.at_risk ?? []}
-              onOpen={setSelectedStudent}
-            />
-            <StudentStatList
-              title="Top performers"
-              icon="mdi:trophy-outline"
-              accent="#10b981"
-              emptyText={loading ? "Loading…" : "No student progress yet."}
-              students={dash?.top_performers ?? []}
-              onOpen={setSelectedStudent}
-            />
+      {/* ---- Hero ---- */}
+      <Box
+        sx={{
+          borderRadius: 4,
+          p: { xs: 3, md: 4 },
+          color: "#fff",
+          position: "relative",
+          overflow: "hidden",
+          background: "radial-gradient(120% 140% at 85% 0%, #4c1d95 0%, #2e1065 45%, #1e1b4b 100%)",
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", md: "1fr auto" },
+          gap: { xs: 3, md: 4 },
+          alignItems: "start",
+        }}
+      >
+        <Box sx={{ minWidth: 0 }}>
+          <Box sx={{ mb: 2, px: 1.25, py: 0.5, borderRadius: 999, border: "1px solid rgba(255,255,255,0.2)",
+            display: "inline-flex", alignItems: "center", gap: 0.75, fontSize: "0.68rem", fontWeight: 800,
+            letterSpacing: 0.6, textTransform: "uppercase", color: "rgba(255,255,255,0.85)" }}>
+            <Icon icon="mdi:school-outline" width={14} /> Instructor workspace
           </Box>
+          <Typography sx={{ fontWeight: 900, fontSize: { xs: "1.8rem", md: "2.4rem" }, lineHeight: 1.1 }}>
+            {greeting()}, {firstName}.
+          </Typography>
+          <Typography sx={{ mt: 1.5, color: "rgba(255,255,255,0.8)", fontSize: "1rem", maxWidth: 560, lineHeight: 1.5 }}>
+            You have <b style={{ color: "#fff" }}>{dash?.live_now ?? 0} session{(dash?.live_now ?? 0) === 1 ? "" : "s"} live now</b>{" "}
+            and <b style={{ color: "#fca5a5" }}>{dash?.at_risk_count ?? 0} students</b> flagged as needing a nudge across your {dash?.batches ?? 0} cohort{(dash?.batches ?? 0) === 1 ? "" : "s"}.
+          </Typography>
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={1.5} sx={{ mt: 3 }}>
+            <Button
+              component="a"
+              disabled={!liveSession?.join_link}
+              href={liveSession?.join_link || undefined}
+              target="_blank"
+              rel="noopener"
+              startIcon={<Icon icon="mdi:video" width={18} />}
+              sx={{ px: 2.5, py: 1.25, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#fff",
+                background: "linear-gradient(135deg,#10b981,#059669)", "&:hover": { filter: "brightness(1.06)" },
+                "&.Mui-disabled": { background: "rgba(255,255,255,0.12)", color: "rgba(255,255,255,0.5)" } }}>
+              {liveSession ? "Join live session" : "No live session"}
+            </Button>
+            <Button
+              onClick={() => push("/instructor/students")}
+              startIcon={<Icon icon="mdi:flag-outline" width={18} />}
+              sx={{ px: 2.5, py: 1.25, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#fff",
+                bgcolor: "rgba(255,255,255,0.1)", border: "1px solid rgba(255,255,255,0.18)",
+                "&:hover": { bgcolor: "rgba(255,255,255,0.18)" } }}>
+              Review flagged students
+            </Button>
+          </Stack>
+        </Box>
 
-          <Section title="My batches" icon="mdi:account-group-outline" empty={!loading && cohorts.length === 0}
-            emptyText="No batches assigned yet. An admin can assign you to a cohort.">
-            <CardGrid>
-              {cohorts.map((c, i) => (
-                <Reveal key={c.id} delay={Math.min(i, 8) * 0.05}>
-                  <EntityCard
-                    icon="mdi:account-group"
-                    title={c.name}
-                    subtitle={`${c.member_count} student${c.member_count === 1 ? "" : "s"} · ${c.artifact_count} item${c.artifact_count === 1 ? "" : "s"}`}
-                    chip={c.status}
-                    onOpen={() => push(`/instructor/cohorts/${c.id}`)}
-                    onHover={() => prefetch(`/instructor/cohorts/${c.id}`)}
-                  />
-                </Reveal>
-              ))}
-            </CardGrid>
-          </Section>
+        {/* Instructor code card */}
+        <Box sx={{ width: { xs: "100%", md: 320 }, p: 2.5, borderRadius: 3, border: "1px solid rgba(255,255,255,0.14)",
+          bgcolor: "rgba(0,0,0,0.25)" }}>
+          <Stack direction="row" alignItems="center" spacing={0.75} sx={{ mb: 1.5, color: "rgba(255,255,255,0.75)" }}>
+            <Icon icon="mdi:shield-check-outline" width={16} />
+            <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, letterSpacing: 0.6, textTransform: "uppercase" }}>
+              Your instructor code
+            </Typography>
+          </Stack>
+          <Box sx={{ p: 2, borderRadius: 2, textAlign: "center", bgcolor: "rgba(255,255,255,0.06)",
+            border: "1px solid rgba(255,255,255,0.1)", mb: 1.5 }}>
+            <Typography sx={{ fontWeight: 900, fontSize: "1.7rem", letterSpacing: 4, fontFamily: "monospace" }}>
+              {dash?.instructor_code || "— — —"}
+            </Typography>
+          </Box>
+          <Typography sx={{ color: "rgba(255,255,255,0.65)", fontSize: "0.8rem", lineHeight: 1.5, mb: 1.5 }}>
+            {dash?.instructor_code
+              ? "Students see this code instead of your name. It's your public teacher identity — never share your login."
+              : "No code set yet. Ask an admin to set your instructor code on the Instructors page."}
+          </Typography>
+          {dash?.instructor_code && (
+            <Button fullWidth onClick={copyCode} startIcon={<Icon icon="mdi:content-copy" width={16} />}
+              sx={{ py: 1, borderRadius: 2, fontWeight: 800, textTransform: "none", bgcolor: "#fff", color: "#4c1d95",
+                "&:hover": { bgcolor: "rgba(255,255,255,0.9)" } }}>
+              Copy code
+            </Button>
+          )}
+        </Box>
+      </Box>
 
-          <Section title="My courses" icon="mdi:book-education-outline" empty={!loading && courses.length === 0}
-            emptyText="No courses assigned yet.">
-            <CardGrid>
-              {courses.map((c, i) => (
-                <Reveal key={c.id} delay={Math.min(i, 8) * 0.05}>
-                  <EntityCard
-                    icon="mdi:book-education"
-                    title={c.title}
-                    subtitle={`${c.student_count} student${c.student_count === 1 ? "" : "s"}`}
-                    chip={c.is_published ? "published" : "draft"}
-                    chipColor={c.is_published ? "#10b981" : "#f59e0b"}
-                    onOpen={() => push(`/instructor/courses/${c.id}`)}
-                    onHover={() => prefetch(`/instructor/courses/${c.id}`)}
-                  />
-                </Reveal>
-              ))}
-            </CardGrid>
-          </Section>
-        </>
-      )}
+      {/* ---- KPI cards ---- */}
+      <Box sx={{ mt: 2.5, display: "grid", gridTemplateColumns: { xs: "1fr 1fr", lg: "repeat(4, 1fr)" }, gap: 2 }}>
+        <Kpi label="Students" value={dash?.students ?? 0} icon="mdi:account-outline" sub={`${dash?.active_students ?? 0} active this week`} />
+        <Kpi label="Cohorts assigned" value={dash?.batches ?? 0} icon="mdi:school-outline" sub={`${dash?.courses ?? 0} courses`} />
+        <Kpi label="Cohort avg score" value={`${dash?.avg_progress ?? 0}%`} icon="mdi:target" tint="#10b981" sub={`${dash?.completion_rate ?? 0}% completed`} />
+        <Kpi label="Need attention" value={dash?.at_risk_count ?? 0} icon="mdi:flag-variant-outline" tint="#ef4444"
+          sub={<span style={{ color: "#ef4444", fontWeight: 700 }}>flagged by AI</span>} />
+      </Box>
 
-      <StudentDetailDrawer
-        studentId={selectedStudent}
-        open={selectedStudent != null}
-        onClose={() => setSelectedStudent(null)}
-      />
+      {/* ---- Cohorts + Schedule ---- */}
+      <Box sx={{ mt: 3.5, display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 340px" }, gap: 2.5, alignItems: "start" }}>
+        <Box>
+          <Stack direction="row" justifyContent="space-between" alignItems="baseline" sx={{ mb: 0.5 }}>
+            <Typography sx={{ fontWeight: 800, fontSize: "1.15rem" }}>Your cohorts</Typography>
+            <Button onClick={() => push("/instructor/cohorts")} endIcon={<Icon icon="mdi:chevron-right" width={18} />}
+              sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1" }}>All cohorts</Button>
+          </Stack>
+          <Typography sx={{ color: "text.secondary", fontSize: "0.82rem", mb: 1.5 }}>Assigned by admin · you own delivery & reporting</Typography>
+          <Stack spacing={1.5}>
+            {(dash?.cohorts_detailed ?? []).map((c, i) => (
+              <CohortRow key={c.id} c={c} grad={COHORT_GRADIENTS[i % COHORT_GRADIENTS.length]}
+                onOpen={() => push(`/instructor/cohorts/${c.id}`)} onHover={() => prefetch(`/instructor/cohorts/${c.id}`)} />
+            ))}
+            {dash && dash.cohorts_detailed.length === 0 && (
+              <Box sx={{ p: 3, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+                <Typography sx={{ color: "text.secondary" }}>No cohorts assigned yet.</Typography>
+              </Box>
+            )}
+          </Stack>
+        </Box>
+
+        <SchedulePanel items={dash?.schedule ?? []} onSchedule={() => push("/instructor/live-sessions")} />
+      </Box>
+
+      {/* ---- Recent submissions + Needs attention ---- */}
+      <Box sx={{ mt: 3.5, display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 340px" }, gap: 2.5, alignItems: "start" }}>
+        <Box>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.15rem", mb: 1.5 }}>Recent submissions</Typography>
+          <Box sx={{ borderRadius: 3, border: "1px solid var(--border-default)", bgcolor: "var(--card-bg)", overflow: "hidden" }}>
+            {(dash?.recent_submissions ?? []).length === 0 ? (
+              <Typography sx={{ color: "text.secondary", p: 3 }}>No submissions yet.</Typography>
+            ) : (
+              (dash?.recent_submissions ?? []).map((s, i) => <SubmissionRow key={s.submission_id} s={s} first={i === 0} />)
+            )}
+          </Box>
+        </Box>
+
+        <Box sx={{ borderRadius: 3, border: "1px solid var(--border-default)", bgcolor: "var(--card-bg)", p: 2 }}>
+          <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.25 }}>
+            <Icon icon="mdi:flag-variant-outline" width={18} style={{ color: "#ef4444" }} />
+            <Typography sx={{ fontWeight: 800 }}>Needs attention</Typography>
+          </Stack>
+          <Typography sx={{ color: "text.secondary", fontSize: "0.78rem", mb: 1.5 }}>
+            AI-flagged · {dash?.at_risk_count ?? 0} students
+          </Typography>
+          <Stack spacing={0.5}>
+            {(dash?.at_risk ?? []).map((s) => (
+              <Box key={s.student_id} onClick={() => setSelected(s.student_id)}
+                role="button" tabIndex={0}
+                onKeyDown={(e) => { if (e.key === "Enter") setSelected(s.student_id); }}
+                sx={{ display: "flex", alignItems: "center", gap: 1.25, p: 1, borderRadius: 2, cursor: "pointer",
+                  "&:hover": { bgcolor: "color-mix(in srgb, #ef4444 6%, transparent)" } }}>
+                <Box sx={{ width: 30, height: 30, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center",
+                  color: "#fff", fontWeight: 800, fontSize: "0.72rem", background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
+                  {(s.name || s.email || "?").slice(0, 1).toUpperCase()}
+                </Box>
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontWeight: 700, fontSize: "0.85rem" }} noWrap>{s.name || s.email}</Typography>
+                  <Typography sx={{ color: "#ef4444", fontSize: "0.74rem" }}>{Math.round(s.progress)}% progress · low</Typography>
+                </Box>
+                <Box sx={{ width: 8, height: 8, borderRadius: "50%", bgcolor: "#ef4444", flexShrink: 0 }} />
+              </Box>
+            ))}
+            {dash && dash.at_risk.length === 0 && (
+              <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", py: 1 }}>No at-risk students — great job!</Typography>
+            )}
+          </Stack>
+        </Box>
+      </Box>
+
+      <StudentDetailDrawer studentId={selected} open={selected != null} onClose={() => setSelected(null)} />
     </PageShell>
   );
 }
 
-function StudentStatList({
-  title,
-  icon,
-  accent,
-  students,
-  emptyText,
-  onOpen,
-}: {
-  title: string;
-  icon: string;
-  accent: string;
-  students: InstructorStatStudent[];
-  emptyText: string;
-  onOpen: (id: number) => void;
+function Kpi({ label, value, sub, icon, tint = "#6366f1" }: {
+  label: string; value: React.ReactNode; sub?: React.ReactNode; icon: string; tint?: string;
 }) {
   return (
-    <Box
-      sx={{
-        p: 2,
-        borderRadius: 3,
-        bgcolor: "var(--card-bg, #fff)",
-        border: "1px solid var(--border-default, #ececf1)",
-      }}
-    >
-      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
-        <Icon icon={icon} width={20} style={{ color: accent }} />
-        <Typography sx={{ fontWeight: 800, fontSize: "1rem" }}>{title}</Typography>
+    <Box sx={{ p: 2.25, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+        <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, letterSpacing: 0.6, textTransform: "uppercase", color: "text.secondary" }}>{label}</Typography>
+        <Box sx={{ width: 30, height: 30, borderRadius: 2, display: "grid", placeItems: "center",
+          color: tint, bgcolor: `color-mix(in srgb, ${tint} 12%, transparent)` }}>
+          <Icon icon={icon} width={17} />
+        </Box>
       </Stack>
-      {students.length === 0 ? (
-        <Typography sx={{ color: "text.secondary", fontSize: "0.85rem", py: 1 }}>{emptyText}</Typography>
-      ) : (
-        <Stack spacing={0.75}>
-          {students.map((s) => (
-            <Box
-              key={s.student_id}
-              onClick={() => onOpen(s.student_id)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  onOpen(s.student_id);
-                }
-              }}
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 1.25,
-                p: 1,
-                borderRadius: 2,
-                cursor: "pointer",
-                "&:hover": { bgcolor: "color-mix(in srgb, var(--card-bg) 40%, transparent)" },
-                "&:focus-visible": { outline: `2px solid ${accent}`, outlineOffset: 1 },
-              }}
-            >
-              <Box sx={{ width: 32, height: 32, borderRadius: "50%", flexShrink: 0, display: "grid",
-                placeItems: "center", color: "#fff", fontWeight: 800, fontSize: "0.8rem",
-                background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
-                {(s.name || s.email || "?").slice(0, 1).toUpperCase()}
-              </Box>
-              <Box sx={{ minWidth: 0, flex: 1 }}>
-                <Typography sx={{ fontWeight: 700, fontSize: "0.86rem" }} noWrap>{s.name || s.email}</Typography>
-                <Typography sx={{ color: "text.secondary", fontSize: "0.76rem" }} noWrap>{s.email}</Typography>
-              </Box>
-              <Chip
-                size="small"
-                label={`${Math.round(s.progress)}%`}
-                sx={{ fontWeight: 800, color: accent, bgcolor: `color-mix(in srgb, ${accent} 14%, transparent)` }}
-              />
+      <Typography sx={{ fontWeight: 900, fontSize: "1.9rem", mt: 0.5, fontFamily: "monospace" }}>{value}</Typography>
+      {sub && <Typography sx={{ color: "text.secondary", fontSize: "0.78rem", mt: 0.25 }}>{sub}</Typography>}
+    </Box>
+  );
+}
+
+function CohortRow({ c, grad, onOpen, onHover }: {
+  c: InstructorCohortDetail; grad: string; onOpen: () => void; onHover: () => void;
+}) {
+  return (
+    <Box onClick={onOpen} onMouseEnter={onHover} role="button" tabIndex={0}
+      onKeyDown={(e) => { if (e.key === "Enter") onOpen(); }}
+      sx={{ cursor: "pointer", p: 2, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
+        display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr auto" }, gap: 2, alignItems: "center",
+        transition: "border-color .15s, box-shadow .15s",
+        "&:hover": { borderColor: "color-mix(in srgb, #6366f1 40%, transparent)", boxShadow: "0 12px 30px -20px rgba(99,102,241,.4)" } }}>
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ minWidth: 0 }}>
+        <Box sx={{ width: 44, height: 44, borderRadius: 2.5, flexShrink: 0, display: "grid", placeItems: "center",
+          color: "#fff", background: grad }}>
+          <Icon icon="mdi:account-group" width={22} />
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 800, fontSize: "0.98rem" }} noWrap>{c.name}</Typography>
+          <Box sx={{ mt: 0.5, height: 6, borderRadius: 3, bgcolor: "color-mix(in srgb, var(--border-default) 50%, transparent)", overflow: "hidden", maxWidth: 220 }}>
+            <Box sx={{ width: `${Math.max(0, Math.min(100, c.progress))}%`, height: "100%", background: grad }} />
+          </Box>
+        </Box>
+      </Stack>
+      <Stack direction="row" spacing={2.5} alignItems="center" sx={{ flexShrink: 0 }}>
+        <Stat n={c.student_count} label="students" />
+        <Stat n={`${c.avg_score}%`} label="avg score" />
+        <Stat n={c.at_risk} label="at risk" danger={c.at_risk > 0} />
+        <Icon icon="mdi:chevron-right" width={22} style={{ color: "var(--font-tertiary)" }} />
+      </Stack>
+    </Box>
+  );
+}
+
+function Stat({ n, label, danger }: { n: React.ReactNode; label: string; danger?: boolean }) {
+  return (
+    <Box sx={{ textAlign: "center" }}>
+      <Typography sx={{ fontWeight: 900, fontSize: "1.05rem", color: danger ? "#f59e0b" : "var(--font-primary)" }}>{n}</Typography>
+      <Typography sx={{ fontSize: "0.62rem", color: "text.secondary", textTransform: "uppercase", letterSpacing: 0.4 }}>{label}</Typography>
+    </Box>
+  );
+}
+
+function SchedulePanel({ items, onSchedule }: { items: InstructorScheduleItem[]; onSchedule: () => void }) {
+  return (
+    <Box sx={{ borderRadius: 3, border: "1px solid var(--border-default)", bgcolor: "var(--card-bg)", p: 2 }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="baseline" sx={{ mb: 1.5 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Schedule</Typography>
+        <Button onClick={onSchedule} endIcon={<Icon icon="mdi:arrow-right" width={16} />}
+          sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1", minWidth: 0 }}>All</Button>
+      </Stack>
+      <Stack spacing={1}>
+        {items.length === 0 && <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", py: 1 }}>No upcoming sessions.</Typography>}
+        {items.map((s) => {
+          const live = s.status === "live";
+          return (
+            <Box key={s.id} sx={{ p: 1.5, borderRadius: 2, border: "1px solid var(--border-default)",
+              bgcolor: live ? "color-mix(in srgb,#10b981 8%,transparent)" : "transparent" }}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 0.5 }}>
+                <Chip size="small" label={live ? "● Live" : "Scheduled"}
+                  sx={{ fontWeight: 800, height: 20, color: live ? "#059669" : "#6366f1",
+                    bgcolor: live ? "color-mix(in srgb,#10b981 16%,transparent)" : "color-mix(in srgb,#6366f1 12%,transparent)" }} />
+                <Typography sx={{ fontSize: "0.72rem", color: "text.secondary", fontWeight: 600 }}>
+                  {new Date(s.datetime).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" })}
+                </Typography>
+              </Stack>
+              <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }} noWrap>{s.topic}</Typography>
+              <Typography sx={{ color: "text.secondary", fontSize: "0.76rem" }} noWrap>
+                {s.cohort_name}{s.registered ? ` · ${s.registered} registered` : ""}
+              </Typography>
             </Box>
-          ))}
-        </Stack>
-      )}
+          );
+        })}
+      </Stack>
+      <Button fullWidth onClick={onSchedule} startIcon={<Icon icon="mdi:plus" width={18} />}
+        sx={{ mt: 1.5, py: 1, borderRadius: 2, fontWeight: 800, textTransform: "none", color: "#6366f1",
+          bgcolor: "color-mix(in srgb,#6366f1 8%,transparent)" }}>
+        Schedule session
+      </Button>
     </Box>
   );
 }
 
-function Section({
-  title,
-  icon,
-  children,
-  empty,
-  emptyText,
-}: {
-  title: string;
-  icon: string;
-  children: React.ReactNode;
-  empty: boolean;
-  emptyText: string;
-}) {
+function SubmissionRow({ s, first }: { s: InstructorRecentSubmission; first: boolean }) {
+  const graded = s.review_status === "evaluated" || s.review_status === "published" || s.score != null;
   return (
-    <Box sx={{ mt: 3.5 }}>
-      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
-        <Icon icon={icon} width={20} style={{ color: "#6366f1" }} />
-        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>{title}</Typography>
-      </Stack>
-      {empty ? (
-        <Box
-          sx={{
-            p: { xs: 3, md: 4 },
-            borderRadius: 3,
-            textAlign: "center",
-            bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)",
-            border: "1px dashed color-mix(in srgb, var(--border-default) 90%, transparent)",
-          }}
-        >
-          <Typography sx={{ color: "text.secondary" }}>{emptyText}</Typography>
-        </Box>
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, p: 1.75,
+      borderTop: first ? "none" : "1px solid var(--border-default)" }}>
+      <Box sx={{ width: 34, height: 34, borderRadius: "50%", flexShrink: 0, display: "grid", placeItems: "center",
+        color: "#fff", fontWeight: 800, fontSize: "0.78rem", background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
+        {(s.student_name || "?").slice(0, 1).toUpperCase()}
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }} noWrap>{s.student_name}</Typography>
+        <Typography sx={{ color: "text.secondary", fontSize: "0.8rem" }} noWrap>{s.assessment_title}</Typography>
+      </Box>
+      {s.completed_at && (
+        <Typography sx={{ fontSize: "0.74rem", color: "text.secondary", display: { xs: "none", sm: "block" } }}>
+          {new Date(s.completed_at).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+        </Typography>
+      )}
+      {graded && s.score != null ? (
+        <Chip size="small" label={`${Math.round(s.score)}`} sx={{ fontWeight: 800, color: "#059669",
+          bgcolor: "color-mix(in srgb,#10b981 14%,transparent)" }} />
       ) : (
-        children
+        <Chip size="small" label="Grade" sx={{ fontWeight: 800, color: "#6366f1", cursor: "pointer",
+          bgcolor: "color-mix(in srgb,#6366f1 12%,transparent)" }} />
       )}
-    </Box>
-  );
-}
-
-function CardGrid({ children }: { children: React.ReactNode }) {
-  return (
-    <Box
-      sx={{
-        display: "grid",
-        gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" },
-        gap: 2,
-      }}
-    >
-      {children}
-    </Box>
-  );
-}
-
-function EntityCard({
-  icon,
-  title,
-  subtitle,
-  chip,
-  chipColor = "#6366f1",
-  onOpen,
-  onHover,
-}: {
-  icon: string;
-  title: string;
-  subtitle: string;
-  chip: string;
-  chipColor?: string;
-  onOpen: () => void;
-  onHover?: () => void;
-}) {
-  return (
-    <Box
-      onClick={onOpen}
-      onMouseEnter={onHover}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      sx={{
-        cursor: "pointer",
-        p: 2.25,
-        borderRadius: 3,
-        bgcolor: "var(--card-bg, #fff)",
-        border: "1px solid var(--border-default, #ececf1)",
-        transition: "transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease",
-        "&:hover": {
-          transform: "translateY(-3px)",
-          borderColor: "color-mix(in srgb, #6366f1 40%, transparent)",
-          boxShadow: "0 20px 40px -26px rgba(99,102,241,0.45)",
-        },
-        "&:focus-visible": { outline: "2px solid #6366f1", outlineOffset: 2 },
-      }}
-    >
-      <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 1 }}>
-        <Box
-          sx={{
-            width: 40,
-            height: 40,
-            borderRadius: 2.5,
-            display: "grid",
-            placeItems: "center",
-            color: "#fff",
-            flexShrink: 0,
-            background: "linear-gradient(135deg,#6366f1,#a855f7)",
-          }}
-        >
-          <Icon icon={icon} width={20} />
-        </Box>
-        <Box
-          component="span"
-          sx={{
-            px: 1,
-            py: 0.3,
-            borderRadius: 999,
-            fontSize: "0.62rem",
-            fontWeight: 800,
-            letterSpacing: 0.4,
-            textTransform: "uppercase",
-            color: chipColor,
-            bgcolor: `color-mix(in srgb, ${chipColor} 14%, transparent)`,
-          }}
-        >
-          {chip}
-        </Box>
-      </Stack>
-      <Typography sx={{ fontWeight: 800, fontSize: "1rem", lineHeight: 1.3 }} noWrap>
-        {title}
-      </Typography>
-      <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", mt: 0.5 }}>{subtitle}</Typography>
     </Box>
   );
 }

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -21,8 +21,41 @@ export interface InstructorStatStudent {
   progress: number;
 }
 
+export interface InstructorCohortDetail {
+  id: number;
+  name: string;
+  client_name: string;
+  status: string;
+  end_date: string | null;
+  student_count: number;
+  progress: number;
+  avg_score: number;
+  at_risk: number;
+}
+
+export interface InstructorScheduleItem {
+  id: number;
+  topic: string;
+  datetime: string;
+  duration_minutes: number;
+  status: "live" | "scheduled";
+  registered: number;
+  cohort_name: string;
+  join_link: string;
+}
+
+export interface InstructorRecentSubmission {
+  submission_id: number;
+  student_name: string;
+  assessment_title: string;
+  score: number | null;
+  review_status: string;
+  completed_at: string | null;
+}
+
 export interface InstructorDashboard {
   instructor_name: string;
+  instructor_code: string;
   is_admin_view: boolean;
   batches: number;
   courses: number;
@@ -32,8 +65,12 @@ export interface InstructorDashboard {
   completion_rate: number;
   at_risk_count: number;
   upcoming_sessions: number;
+  live_now: number;
   at_risk: InstructorStatStudent[];
   top_performers: InstructorStatStudent[];
+  cohorts_detailed: InstructorCohortDetail[];
+  schedule: InstructorScheduleItem[];
+  recent_submissions: InstructorRecentSubmission[];
   progress_truncated: boolean;
 }
 


### PR DESCRIPTION
Instructor workspace redesign — **Dashboard** (dark hero + instructor-code card + 4 KPIs + cohorts list + schedule + recent submissions + needs-attention) and **My Cohorts** (gradient cohort cards + assignment banner + export). Fed by the enriched dashboard endpoint (backend #438). `tsc` clean. Student Reports + Live Sessions follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)