### PR TITLE
feat(instructor): Student Reports table + Live Sessions workspace (mockups 3 & 4)

### DIFF
--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -1,16 +1,78 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Box, Button, Chip, Stack, Typography } from "@mui/material";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Snackbar,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
-import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { instructorService, type InstructorLiveSession } from "@/lib/services/instructor.service";
 
-function fmt(dt: string): string {
+type SessionStatus = "live" | "scheduled" | "ended";
+
+interface Session extends InstructorLiveSession {
+  status: SessionStatus;
+}
+
+const STATUS_META: Record<SessionStatus, { label: string; color: string; bg: string }> = {
+  live: { label: "Live now", color: "#dc2626", bg: "color-mix(in srgb,#ef4444 14%,transparent)" },
+  scheduled: { label: "Scheduled", color: "#4338ca", bg: "color-mix(in srgb,#6366f1 14%,transparent)" },
+  ended: { label: "Ended", color: "#475569", bg: "color-mix(in srgb,#64748b 14%,transparent)" },
+};
+
+const TABS: { key: SessionStatus | "all"; label: string; icon: string }[] = [
+  { key: "all", label: "All", icon: "mdi:view-grid-outline" },
+  { key: "live", label: "Live", icon: "mdi:access-point" },
+  { key: "scheduled", label: "Scheduled", icon: "mdi:calendar-clock" },
+  { key: "ended", label: "Ended", icon: "mdi:history" },
+];
+
+function providerOf(link: string): { label: string; icon: string; color: string } {
+  const l = link.toLowerCase();
+  if (l.includes("zoom")) return { label: "Zoom", icon: "mdi:video", color: "#2563eb" };
+  if (l.includes("meet.google") || l.includes("hangouts")) return { label: "Google Meet", icon: "mdi:google", color: "#16a34a" };
+  if (l.includes("teams.microsoft")) return { label: "Teams", icon: "mdi:microsoft-teams", color: "#6366f1" };
+  return { label: "Online", icon: "mdi:web", color: "#6b7280" };
+}
+
+function statusOf(s: InstructorLiveSession): SessionStatus {
+  const start = new Date(s.class_datetime).getTime();
+  const end = start + (s.duration_minutes || 0) * 60_000;
+  const now = Date.now();
+  if (now >= start && now <= end) return "live";
+  if (now < start) return "scheduled";
+  return "ended";
+}
+
+function dayBadge(dt: string): { top: string; bottom: string } {
+  try {
+    const d = new Date(dt);
+    return {
+      top: d.toLocaleDateString(undefined, { month: "short" }).toUpperCase(),
+      bottom: String(d.getDate()),
+    };
+  } catch {
+    return { top: "", bottom: "" };
+  }
+}
+
+function fmtTime(dt: string): string {
   try {
     return new Date(dt).toLocaleString(undefined, {
-      weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+      weekday: "short",
+      hour: "numeric",
+      minute: "2-digit",
     });
   } catch {
     return dt;
@@ -18,10 +80,12 @@ function fmt(dt: string): string {
 }
 
 export default function InstructorLiveSessionsPage() {
-  const [upcoming, setUpcoming] = useState<InstructorLiveSession[]>([]);
-  const [past, setPast] = useState<InstructorLiveSession[]>([]);
+  const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<SessionStatus | "all">("all");
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -29,8 +93,16 @@ export default function InstructorLiveSessionsPage() {
       try {
         const data = await instructorService.getLiveSessions();
         if (!cancelled) {
-          setUpcoming(data.upcoming);
-          setPast(data.past);
+          const all = [...data.upcoming, ...data.past].map((s) => ({ ...s, status: statusOf(s) }));
+          // live first, then scheduled (soonest), then ended (most recent).
+          const order: Record<SessionStatus, number> = { live: 0, scheduled: 1, ended: 2 };
+          all.sort((a, b) => {
+            if (order[a.status] !== order[b.status]) return order[a.status] - order[b.status];
+            const ta = new Date(a.class_datetime).getTime();
+            const tb = new Date(b.class_datetime).getTime();
+            return a.status === "ended" ? tb - ta : ta - tb;
+          });
+          setSessions(all);
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your live sessions.");
@@ -43,74 +115,254 @@ export default function InstructorLiveSessionsPage() {
     };
   }, []);
 
+  const counts = useMemo(() => {
+    const c = { all: sessions.length, live: 0, scheduled: 0, ended: 0 } as Record<SessionStatus | "all", number>;
+    sessions.forEach((s) => (c[s.status] += 1));
+    return c;
+  }, [sessions]);
+
+  const visible = useMemo(() => (tab === "all" ? sessions : sessions.filter((s) => s.status === tab)), [sessions, tab]);
+
+  const copyLink = async (link: string) => {
+    try {
+      await navigator.clipboard.writeText(link);
+      setToast("Join link copied to clipboard.");
+    } catch {
+      setToast("Couldn't copy the link.");
+    }
+  };
+
   return (
     <PageShell>
       <ModulePageHeader
         eyebrow="Teach"
-        title="Live sessions"
-        description="Sessions scheduled for the courses and batches you're assigned to."
+        title="Live Sessions"
+        description="Sessions scheduled for the courses and cohorts you're assigned to — host, share links and follow up."
         accent="pink"
         icon="mdi:video-outline"
+        action={
+          <HeaderActionButton icon="mdi:calendar-plus" variant="ghost" onClick={() => setScheduleOpen(true)}>
+            Schedule session
+          </HeaderActionButton>
+        }
       />
 
+      {/* Filter tabs */}
+      <Stack direction="row" spacing={0.75} sx={{ mb: 2.5, flexWrap: "wrap", gap: 0.75 }}>
+        {TABS.map((t) => {
+          const active = tab === t.key;
+          return (
+            <Box
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.6,
+                px: 1.75,
+                py: 0.75,
+                borderRadius: 999,
+                cursor: "pointer",
+                fontSize: "0.82rem",
+                fontWeight: 700,
+                color: active ? "#fff" : "text.secondary",
+                background: active ? "linear-gradient(135deg,#ec4899,#a855f7)" : "var(--card-bg)",
+                border: active ? "none" : "1px solid var(--border-default)",
+              }}
+            >
+              <Icon icon={t.icon} width={15} />
+              {t.label}
+              <Box
+                component="span"
+                sx={{
+                  ml: 0.3,
+                  px: 0.7,
+                  py: 0.05,
+                  borderRadius: 999,
+                  fontSize: "0.68rem",
+                  fontWeight: 800,
+                  bgcolor: active ? "rgba(255,255,255,0.25)" : "color-mix(in srgb,var(--border-default) 60%,transparent)",
+                }}
+              >
+                {counts[t.key]}
+              </Box>
+            </Box>
+          );
+        })}
+      </Stack>
+
       {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
-      {!error && !loading && upcoming.length === 0 && past.length === 0 && (
-        <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
-          <Typography sx={{ color: "text.secondary" }}>No live sessions scheduled for your courses or batches.</Typography>
+      {!error && !loading && visible.length === 0 && (
+        <Box sx={{ p: 5, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
+          <Icon icon="mdi:video-off-outline" width={34} style={{ opacity: 0.4 }} />
+          <Typography sx={{ color: "text.secondary", mt: 1 }}>
+            {sessions.length === 0
+              ? "No live sessions scheduled for your courses or cohorts yet."
+              : "No sessions in this view."}
+          </Typography>
         </Box>
       )}
 
-      <SessionGroup title="Upcoming" icon="mdi:calendar-clock" sessions={upcoming} highlight />
-      <SessionGroup title="Past" icon="mdi:history" sessions={past} />
-    </PageShell>
-  );
-}
+      {/* Session cards */}
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "repeat(2,1fr)" }, gap: 2 }}>
+        {visible.map((s) => {
+          const m = STATUS_META[s.status];
+          const p = providerOf(s.join_link);
+          const badge = dayBadge(s.class_datetime);
+          const isLive = s.status === "live";
+          return (
+            <Box
+              key={s.id}
+              sx={{
+                borderRadius: 4,
+                overflow: "hidden",
+                bgcolor: "var(--card-bg)",
+                border: isLive ? "1px solid color-mix(in srgb,#ef4444 45%,transparent)" : "1px solid var(--border-default)",
+                boxShadow: isLive ? "0 0 0 3px color-mix(in srgb,#ef4444 12%,transparent)" : "0 10px 30px -26px rgba(16,24,40,.3)",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <Box sx={{ p: 2.25, display: "flex", gap: 1.75, flex: 1 }}>
+                {/* Date badge */}
+                <Box
+                  sx={{
+                    width: 56,
+                    flexShrink: 0,
+                    borderRadius: 3,
+                    overflow: "hidden",
+                    border: "1px solid var(--border-default)",
+                    textAlign: "center",
+                  }}
+                >
+                  <Box sx={{ py: 0.4, background: "linear-gradient(135deg,#ec4899,#a855f7)", color: "#fff", fontSize: "0.62rem", fontWeight: 900, letterSpacing: 0.5 }}>
+                    {badge.top}
+                  </Box>
+                  <Box sx={{ py: 0.6 }}>
+                    <Typography sx={{ fontWeight: 900, fontSize: "1.35rem", lineHeight: 1 }}>{badge.bottom}</Typography>
+                  </Box>
+                </Box>
 
-function SessionGroup({
-  title,
-  icon,
-  sessions,
-  highlight,
-}: {
-  title: string;
-  icon: string;
-  sessions: InstructorLiveSession[];
-  highlight?: boolean;
-}) {
-  if (sessions.length === 0) return null;
-  return (
-    <Box sx={{ mt: 3 }}>
-      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.5 }}>
-        <Icon icon={icon} width={20} style={{ color: highlight ? "#ec4899" : "#6b7280" }} />
-        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>{title}</Typography>
-      </Stack>
-      <Stack spacing={1}>
-        {sessions.map((s) => (
-          <Box key={s.id} sx={{ display: "flex", alignItems: "center", gap: 1.5, p: 1.75, borderRadius: 2,
-            bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
-            opacity: highlight ? 1 : 0.85 }}>
-            <Box sx={{ width: 40, height: 40, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center",
-              color: "#fff", background: highlight ? "linear-gradient(135deg,#ec4899,#a855f7)" : "linear-gradient(135deg,#94a3b8,#64748b)" }}>
-              <Icon icon="mdi:video" width={20} />
+                {/* Body */}
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 0.75, flexWrap: "wrap", gap: 0.5 }}>
+                    <Box
+                      sx={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 0.4,
+                        px: 0.9,
+                        py: 0.25,
+                        borderRadius: 999,
+                        bgcolor: m.bg,
+                        color: m.color,
+                        fontSize: "0.68rem",
+                        fontWeight: 800,
+                      }}
+                    >
+                      {isLive && <Box sx={{ width: 6, height: 6, borderRadius: "50%", bgcolor: m.color, animation: "pulse 1.4s infinite" }} />}
+                      {m.label}
+                    </Box>
+                    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.35, px: 0.9, py: 0.25, borderRadius: 999, border: "1px solid var(--border-default)", fontSize: "0.68rem", fontWeight: 700, color: p.color }}>
+                      <Icon icon={p.icon} width={12} />
+                      {p.label}
+                    </Box>
+                  </Stack>
+
+                  <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.25 }}>{s.topic_name}</Typography>
+                  <Stack direction="row" spacing={1.5} sx={{ mt: 0.6, color: "text.secondary" }}>
+                    <Stack direction="row" spacing={0.4} alignItems="center">
+                      <Icon icon="mdi:clock-outline" width={14} />
+                      <Typography sx={{ fontSize: "0.8rem" }}>{fmtTime(s.class_datetime)}</Typography>
+                    </Stack>
+                    <Stack direction="row" spacing={0.4} alignItems="center">
+                      <Icon icon="mdi:timer-sand" width={14} />
+                      <Typography sx={{ fontSize: "0.8rem" }}>{s.duration_minutes} min</Typography>
+                    </Stack>
+                  </Stack>
+                </Box>
+              </Box>
+
+              {/* Actions */}
+              <Stack direction="row" spacing={1} sx={{ px: 2.25, pb: 2.25, flexWrap: "wrap", gap: 1 }}>
+                {(isLive || s.status === "scheduled") && s.join_link && (
+                  <Button
+                    href={s.join_link}
+                    target="_blank"
+                    rel="noopener"
+                    startIcon={<Icon icon={isLive ? "mdi:broadcast" : "mdi:login-variant"} width={16} />}
+                    sx={{
+                      textTransform: "none",
+                      fontWeight: 800,
+                      color: "#fff",
+                      px: 2,
+                      py: 0.9,
+                      borderRadius: 2,
+                      background: isLive ? "linear-gradient(135deg,#ef4444,#ec4899)" : "linear-gradient(135deg,#ec4899,#a855f7)",
+                      "&:hover": { filter: "brightness(1.06)" },
+                    }}
+                  >
+                    {isLive ? "Start hosting" : "Join"}
+                  </Button>
+                )}
+                {s.join_link && (
+                  <Button
+                    onClick={() => copyLink(s.join_link)}
+                    startIcon={<Icon icon="mdi:link-variant" width={16} />}
+                    sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1", px: 1.75, py: 0.9, borderRadius: 2, border: "1px solid var(--border-default)" }}
+                  >
+                    Copy link
+                  </Button>
+                )}
+                {s.status === "ended" && (
+                  <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", alignSelf: "center", fontStyle: "italic" }}>
+                    Session ended · recordings & attendance coming soon
+                  </Typography>
+                )}
+              </Stack>
             </Box>
-            <Box sx={{ minWidth: 0, flex: 1 }}>
-              <Typography sx={{ fontWeight: 700, fontSize: "0.94rem" }} noWrap>{s.topic_name}</Typography>
-              <Typography sx={{ color: "text.secondary", fontSize: "0.82rem" }}>
-                {fmt(s.class_datetime)} · {s.duration_minutes} min
-              </Typography>
-            </Box>
-            {highlight && s.join_link && (
-              <Button variant="contained" size="small" disableElevation href={s.join_link} target="_blank" rel="noopener"
-                startIcon={<Icon icon="mdi:login-variant" width={16} />}
-                sx={{ borderRadius: 2, textTransform: "none", fontWeight: 700,
-                  background: "linear-gradient(135deg,#ec4899,#a855f7)" }}>
-                Join
-              </Button>
-            )}
-            {!highlight && <Chip size="small" label="ended" sx={{ fontWeight: 700 }} />}
-          </Box>
-        ))}
-      </Stack>
-    </Box>
+          );
+        })}
+      </Box>
+
+      {/* Schedule dialog — instructor sessions are provisioned by admin today */}
+      <Dialog open={scheduleOpen} onClose={() => setScheduleOpen(false)} fullWidth maxWidth="xs">
+        <DialogTitle sx={{ fontWeight: 800 }}>Schedule a live session</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{ fontSize: "0.9rem" }}>
+            Live sessions are provisioned from the class calendar by your admin and mapped to your
+            cohorts automatically. Need a new session on the schedule? Send a quick request and
+            your admin will set it up with the right Zoom/Meet link.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setScheduleOpen(false)} sx={{ textTransform: "none", fontWeight: 700 }}>
+            Close
+          </Button>
+          <Button
+            href="/tickets"
+            startIcon={<Icon icon="mdi:headset" width={16} />}
+            sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, borderRadius: 2, background: "linear-gradient(135deg,#ec4899,#a855f7)" }}
+          >
+            Request a session
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar open={!!toast} autoHideDuration={3000} onClose={() => setToast(null)} anchorOrigin={{ vertical: "bottom", horizontal: "center" }}>
+        {toast ? (
+          <Alert severity="success" variant="filled" onClose={() => setToast(null)} sx={{ fontWeight: 600 }}>
+            {toast}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+
+      <style jsx global>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.3; }
+        }
+      `}</style>
+    </PageShell>
   );
 }

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -1,28 +1,315 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { Box, Button, Chip, LinearProgress, Stack, TextField, Typography } from "@mui/material";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Snackbar,
+  Alert,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
-import { ModulePageHeader } from "@/components/common/ModulePageHeader";
-import { RosterRow } from "@/components/instructor/RosterRow";
-import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
-import { instructorService, type InstructorStudentRow } from "@/lib/services/instructor.service";
+import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
+import {
+  instructorService,
+  type InstructorStudentRow,
+  type InstructorStudentStatus,
+  type InstructorStudentDetail,
+  type InstructorCohortDetail,
+} from "@/lib/services/instructor.service";
+
+/* --------------------------------- status --------------------------------- */
+
+const STATUS_META: Record<InstructorStudentStatus, { label: string; color: string; bg: string; dot: string }> = {
+  on_track: { label: "On track", color: "#047857", bg: "color-mix(in srgb,#10b981 14%,transparent)", dot: "#10b981" },
+  watch: { label: "Watch", color: "#b45309", bg: "color-mix(in srgb,#f59e0b 16%,transparent)", dot: "#f59e0b" },
+  at_risk: { label: "At risk", color: "#b91c1c", bg: "color-mix(in srgb,#ef4444 14%,transparent)", dot: "#ef4444" },
+};
+
+const STATUS_TABS: { key: InstructorStudentStatus | ""; label: string }[] = [
+  { key: "", label: "All" },
+  { key: "on_track", label: "On track" },
+  { key: "watch", label: "Watch" },
+  { key: "at_risk", label: "At risk" },
+];
+
+function StatusChip({ status }: { status: InstructorStudentStatus }) {
+  const m = STATUS_META[status];
+  return (
+    <Box
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.6,
+        px: 1,
+        py: 0.35,
+        borderRadius: 999,
+        bgcolor: m.bg,
+        color: m.color,
+        fontSize: "0.72rem",
+        fontWeight: 800,
+        whiteSpace: "nowrap",
+      }}
+    >
+      <Box sx={{ width: 7, height: 7, borderRadius: "50%", bgcolor: m.dot }} />
+      {m.label}
+    </Box>
+  );
+}
+
+function relTime(iso: string | null): string {
+  if (!iso) return "No activity yet";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "—";
+  const s = Math.max(0, (Date.now() - then) / 1000);
+  if (s < 90) return "Active now";
+  const m = s / 60;
+  if (m < 60) return `${Math.round(m)}m ago`;
+  const h = m / 60;
+  if (h < 24) return `${Math.round(h)}h ago`;
+  const d = h / 24;
+  if (d < 30) return `${Math.round(d)}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function initials(name: string): string {
+  return (
+    name
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((p) => p[0]?.toUpperCase() ?? "")
+      .join("") || "?"
+  );
+}
+
+/* -------------------------------- expand row ------------------------------- */
+
+function ExpandedDetail({
+  studentId,
+  onNudge,
+}: {
+  studentId: number;
+  onNudge: (id: number) => void;
+}) {
+  const [detail, setDetail] = useState<InstructorStudentDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    instructorService
+      .getStudent(studentId)
+      .then((d) => !cancelled && setDetail(d))
+      .catch(() => !cancelled && setDetail(null))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [studentId]);
+
+  return (
+    <Box
+      sx={{
+        p: 2.5,
+        display: "grid",
+        gap: 2.5,
+        gridTemplateColumns: { xs: "1fr", md: "1fr 1fr auto" },
+        bgcolor: "color-mix(in srgb,#6366f1 4%,transparent)",
+        borderTop: "1px solid var(--border-default)",
+      }}
+    >
+      {/* Enrolled courses */}
+      <Box>
+        <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, letterSpacing: 0.5, textTransform: "uppercase", color: "text.secondary", mb: 1 }}>
+          Enrolled courses
+        </Typography>
+        {loading ? (
+          <CircularProgress size={16} />
+        ) : detail && detail.courses.length ? (
+          <Stack spacing={0.75}>
+            {detail.courses.map((c) => (
+              <Stack key={c.id} direction="row" spacing={0.75} alignItems="center">
+                <Icon icon="mdi:book-open-variant" width={15} style={{ color: "#7c3aed" }} />
+                <Typography sx={{ fontSize: "0.82rem", fontWeight: 600 }}>{c.title}</Typography>
+              </Stack>
+            ))}
+          </Stack>
+        ) : (
+          <Typography sx={{ fontSize: "0.82rem", color: "text.secondary" }}>No shared courses.</Typography>
+        )}
+      </Box>
+
+      {/* Cohorts */}
+      <Box>
+        <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, letterSpacing: 0.5, textTransform: "uppercase", color: "text.secondary", mb: 1 }}>
+          Cohorts
+        </Typography>
+        {loading ? (
+          <CircularProgress size={16} />
+        ) : detail && detail.cohorts.length ? (
+          <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap>
+            {detail.cohorts.map((c) => (
+              <Chip key={c.id} size="small" label={c.name} icon={<Icon icon="mdi:account-group" width={13} />} sx={{ fontWeight: 700 }} />
+            ))}
+          </Stack>
+        ) : (
+          <Typography sx={{ fontSize: "0.82rem", color: "text.secondary" }}>No shared cohorts.</Typography>
+        )}
+      </Box>
+
+      {/* Actions */}
+      <Box>
+        <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, letterSpacing: 0.5, textTransform: "uppercase", color: "text.secondary", mb: 1 }}>
+          Instructor actions
+        </Typography>
+        <Stack spacing={1}>
+          <Button
+            onClick={() => onNudge(studentId)}
+            startIcon={<Icon icon="mdi:bell-ring-outline" width={16} />}
+            sx={{ justifyContent: "flex-start", textTransform: "none", fontWeight: 700, color: "#fff", px: 1.75, py: 0.9, borderRadius: 2, background: "linear-gradient(135deg,#7c3aed,#ec4899)", "&:hover": { filter: "brightness(1.06)" } }}
+          >
+            Send a nudge
+          </Button>
+          <Button
+            href={detail ? `mailto:${detail.email}` : undefined}
+            startIcon={<Icon icon="mdi:calendar-account" width={16} />}
+            sx={{ justifyContent: "flex-start", textTransform: "none", fontWeight: 700, color: "#6366f1", px: 1.75, py: 0.9, borderRadius: 2, border: "1px solid var(--border-default)" }}
+          >
+            Book 1:1
+          </Button>
+        </Stack>
+      </Box>
+    </Box>
+  );
+}
+
+/* ---------------------------------- cell ---------------------------------- */
+
+const COLS = "minmax(180px,2.2fr) minmax(90px,1fr) minmax(120px,1.3fr) 88px 78px 108px 36px";
+
+function ReportRow({
+  s,
+  expanded,
+  onToggle,
+  onNudge,
+}: {
+  s: InstructorStudentRow;
+  expanded: boolean;
+  onToggle: () => void;
+  onNudge: (id: number) => void;
+}) {
+  const pct = Math.max(0, Math.min(100, s.progress));
+  return (
+    <Box sx={{ borderBottom: "1px solid var(--border-default)", "&:last-of-type": { borderBottom: "none" } }}>
+      <Box
+        onClick={onToggle}
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr auto", md: COLS },
+          alignItems: "center",
+          gap: 1.5,
+          px: 2,
+          py: 1.5,
+          cursor: "pointer",
+          transition: "background .12s",
+          "&:hover": { bgcolor: "color-mix(in srgb,#6366f1 5%,transparent)" },
+        }}
+      >
+        {/* Student */}
+        <Stack direction="row" spacing={1.25} alignItems="center" sx={{ minWidth: 0 }}>
+          <Box sx={{ width: 38, height: 38, flexShrink: 0, borderRadius: "50%", display: "grid", placeItems: "center", color: "#fff", fontWeight: 800, fontSize: "0.82rem", background: "linear-gradient(135deg,#7c3aed,#ec4899)" }}>
+            {initials(s.name)}
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography noWrap sx={{ fontWeight: 700, fontSize: "0.9rem" }}>{s.name}</Typography>
+            <Typography noWrap sx={{ fontSize: "0.72rem", color: "text.secondary" }}>{relTime(s.last_active)}</Typography>
+          </Box>
+        </Stack>
+
+        {/* Cohort */}
+        <Typography noWrap sx={{ fontSize: "0.82rem", color: "text.secondary", display: { xs: "none", md: "block" } }}>
+          {s.cohort || "—"}
+        </Typography>
+
+        {/* Progress */}
+        <Box sx={{ display: { xs: "none", md: "block" } }}>
+          <Stack direction="row" justifyContent="space-between" sx={{ mb: 0.4 }}>
+            <Typography sx={{ fontSize: "0.72rem", fontWeight: 800 }}>{Math.round(pct)}%</Typography>
+          </Stack>
+          <Box sx={{ height: 6, borderRadius: 3, bgcolor: "color-mix(in srgb,var(--border-default) 55%,transparent)", overflow: "hidden" }}>
+            <Box sx={{ width: `${pct}%`, height: "100%", background: pct >= 60 ? "#10b981" : pct >= 40 ? "#f59e0b" : "#ef4444" }} />
+          </Box>
+        </Box>
+
+        {/* Avg score */}
+        <Typography sx={{ fontSize: "0.86rem", fontWeight: 800, display: { xs: "none", md: "block" } }}>
+          {s.avg_score ? `${Math.round(s.avg_score)}%` : "—"}
+        </Typography>
+
+        {/* Points */}
+        <Stack direction="row" spacing={0.4} alignItems="center" sx={{ display: { xs: "none", md: "flex" } }}>
+          <Icon icon="mdi:lightning-bolt" width={14} style={{ color: "#f59e0b" }} />
+          <Typography sx={{ fontSize: "0.84rem", fontWeight: 800 }}>{s.points}</Typography>
+        </Stack>
+
+        {/* Status */}
+        <Box sx={{ display: { xs: "none", md: "block" } }}>
+          <StatusChip status={s.status} />
+        </Box>
+
+        {/* Chevron */}
+        <Box sx={{ display: "grid", placeItems: "center", color: "text.secondary" }}>
+          <Icon icon={expanded ? "mdi:chevron-up" : "mdi:chevron-down"} width={20} />
+        </Box>
+      </Box>
+      <Collapse in={expanded} unmountOnExit>
+        <ExpandedDetail studentId={s.student_id} onNudge={onNudge} />
+      </Collapse>
+    </Box>
+  );
+}
+
+/* ---------------------------------- page ---------------------------------- */
 
 export default function InstructorStudentsPage() {
   const [rows, setRows] = useState<InstructorStudentRow[]>([]);
+  const [summary, setSummary] = useState({ count: 0, avg_progress: 0, avg_score: 0 });
+  const [cohorts, setCohorts] = useState<InstructorCohortDetail[]>([]);
   const [count, setCount] = useState(0);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
-  const [selected, setSelected] = useState<number | null>(null);
+  const [status, setStatus] = useState<InstructorStudentStatus | "">("");
+  const [cohortFilter, setCohortFilter] = useState<string>("");
+  const [expanded, setExpanded] = useState<number | null>(null);
 
-  const load = useCallback(async (search: string, p: number) => {
+  const [msgOpen, setMsgOpen] = useState(false);
+  const [msgCohort, setMsgCohort] = useState<number | "">("");
+  const [msgBody, setMsgBody] = useState("");
+  const [msgSending, setMsgSending] = useState(false);
+  const [toast, setToast] = useState<{ text: string; sev: "success" | "error" } | null>(null);
+
+  const pageSize = 25;
+
+  const load = useCallback(async (search: string, p: number, st: InstructorStudentStatus | "") => {
     setLoading(true);
     try {
-      const data = await instructorService.getStudents(search || undefined, p);
+      const data = await instructorService.getStudents(search || undefined, p, pageSize, st);
       setRows(data.results);
+      setSummary(data.summary);
       setCount(data.count);
       setPage(data.page);
       setError(null);
@@ -33,83 +320,292 @@ export default function InstructorStudentsPage() {
     }
   }, []);
 
+  // Cohort list (for filter tabs + message dialog).
   useEffect(() => {
-    void load("", 1);
+    instructorService
+      .getDashboard()
+      .then((d) => setCohorts(d.cohorts_detailed))
+      .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    void load("", 1, "");
   }, [load]);
 
-  // Debounced search.
+  // Debounced search / status refetch.
   useEffect(() => {
-    const h = setTimeout(() => void load(query, 1), 350);
+    const h = setTimeout(() => void load(query, 1, status), 350);
     return () => clearTimeout(h);
-  }, [query, load]);
+  }, [query, status, load]);
 
-  const pageSize = 25;
   const pages = Math.max(1, Math.ceil(count / pageSize));
+
+  const visible = useMemo(
+    () => (cohortFilter ? rows.filter((r) => r.cohort === cohortFilter) : rows),
+    [rows, cohortFilter],
+  );
+
+  const atRiskOnPage = useMemo(() => rows.filter((r) => r.status === "at_risk").length, [rows]);
+
+  const doNudge = useCallback(async (id: number) => {
+    try {
+      await instructorService.nudgeStudent(id);
+      setToast({ text: "Nudge sent — the student will see it in their notifications.", sev: "success" });
+    } catch {
+      setToast({ text: "Couldn't send the nudge right now.", sev: "error" });
+    }
+  }, []);
+
+  const sendMessage = useCallback(async () => {
+    if (msgCohort === "" || !msgBody.trim()) return;
+    setMsgSending(true);
+    try {
+      const r = await instructorService.messageCohort(msgCohort, msgBody.trim());
+      setToast({ text: `Message delivered to ${r.sent} student${r.sent === 1 ? "" : "s"}.`, sev: "success" });
+      setMsgOpen(false);
+      setMsgBody("");
+      setMsgCohort("");
+    } catch {
+      setToast({ text: "Couldn't message this cohort.", sev: "error" });
+    } finally {
+      setMsgSending(false);
+    }
+  }, [msgCohort, msgBody]);
+
+  const exportCsv = useCallback(() => {
+    const header = ["Name", "Email", "Cohort", "Progress %", "Avg score %", "Points", "Status", "Last active"];
+    const esc = (v: string) => `"${v.replace(/"/g, '""')}"`;
+    const lines = visible.map((r) =>
+      [r.name, r.email, r.cohort || "", Math.round(r.progress), Math.round(r.avg_score), r.points, STATUS_META[r.status].label, r.last_active || ""]
+        .map((c) => esc(String(c)))
+        .join(","),
+    );
+    const csv = [header.map(esc).join(","), ...lines].join("\n");
+    const url = URL.createObjectURL(new Blob([csv], { type: "text/csv;charset=utf-8;" }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "student-report.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [visible]);
+
+  const kpis = [
+    { label: "Students", value: summary.count, icon: "mdi:account-multiple", color: "#6366f1" },
+    { label: "Avg progress", value: `${Math.round(summary.avg_progress)}%`, icon: "mdi:chart-line", color: "#0ea5e9" },
+    { label: "Avg score", value: summary.avg_score ? `${Math.round(summary.avg_score)}%` : "—", icon: "mdi:star-outline", color: "#10b981" },
+    { label: "At risk", value: atRiskOnPage, icon: "mdi:alert-outline", color: "#ef4444" },
+  ];
 
   return (
     <PageShell>
       <ModulePageHeader
         eyebrow="Teach"
-        title="Students"
-        description="Everyone in the courses and batches you're assigned to, with their progress."
-        accent="emerald"
-        icon="mdi:account-school"
+        title="Student Reports"
+        description="Progress, scores and engagement across the courses and cohorts you're assigned to."
+        accent="purple"
+        icon="mdi:chart-box-outline"
+        action={
+          <Stack direction="row" spacing={1}>
+            <HeaderActionButton icon="mdi:message-text-outline" variant="ghost" onClick={() => setMsgOpen(true)}>
+              Message cohort
+            </HeaderActionButton>
+            <HeaderActionButton icon="mdi:download-outline" variant="ghost" onClick={exportCsv}>
+              Export CSV
+            </HeaderActionButton>
+          </Stack>
+        }
       />
 
-      <TextField
-        size="small"
-        fullWidth
-        placeholder="Search students by name or email…"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        sx={{ maxWidth: 420, mb: 2, "& .MuiOutlinedInput-root": { borderRadius: 2, bgcolor: "var(--surface)" } }}
-        InputProps={{ startAdornment: <Icon icon="mdi:magnify" width={18} style={{ marginRight: 6, opacity: 0.6 }} /> }}
-      />
-
-      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
-      {!error && !loading && rows.length === 0 && (
-        <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
-          <Typography sx={{ color: "text.secondary" }}>
-            {count === 0 ? "No students in your courses or batches yet." : "No students match your search."}
-          </Typography>
-        </Box>
-      )}
-
-      <Stack spacing={1}>
-        {rows.map((s) => (
-          <RosterRow
-            key={s.student_id}
-            name={s.name}
-            email={s.email}
-            onClick={() => setSelected(s.student_id)}
-            right={
-              <Stack direction="row" spacing={1.5} alignItems="center">
-                <Box sx={{ width: 96, display: { xs: "none", sm: "block" } }}>
-                  <LinearProgress variant="determinate" value={Math.max(0, Math.min(100, s.progress))}
-                    sx={{ height: 6, borderRadius: 3 }} />
-                  <Typography sx={{ fontSize: "0.68rem", color: "text.secondary", mt: 0.25 }}>
-                    {Math.round(s.progress)}% avg
-                  </Typography>
-                </Box>
-                <Chip size="small" icon={<Icon icon="mdi:book-outline" width={13} />}
-                  label={s.courses_count} sx={{ fontWeight: 700 }} />
-              </Stack>
-            }
-          />
+      {/* KPIs */}
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2,1fr)", md: "repeat(4,1fr)" }, gap: 2, mb: 3 }}>
+        {kpis.map((k) => (
+          <Box key={k.label} sx={{ p: 2, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+            <Stack direction="row" spacing={1} alignItems="center" sx={{ color: "text.secondary", mb: 0.75 }}>
+              <Icon icon={k.icon} width={16} style={{ color: k.color }} />
+              <Typography sx={{ fontSize: "0.72rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: 0.4 }}>{k.label}</Typography>
+            </Stack>
+            <Typography sx={{ fontWeight: 900, fontSize: "1.7rem", lineHeight: 1 }}>{k.value}</Typography>
+          </Box>
         ))}
+      </Box>
+
+      {/* Filters */}
+      <Stack direction={{ xs: "column", md: "row" }} spacing={1.5} alignItems={{ md: "center" }} justifyContent="space-between" sx={{ mb: 2 }}>
+        <Stack direction="row" spacing={0.75} sx={{ flexWrap: "wrap", gap: 0.75 }}>
+          {STATUS_TABS.map((t) => {
+            const active = status === t.key;
+            return (
+              <Box
+                key={t.label}
+                onClick={() => setStatus(t.key)}
+                sx={{
+                  px: 1.75,
+                  py: 0.7,
+                  borderRadius: 999,
+                  cursor: "pointer",
+                  fontSize: "0.8rem",
+                  fontWeight: 700,
+                  color: active ? "#fff" : "text.secondary",
+                  background: active ? "linear-gradient(135deg,#7c3aed,#ec4899)" : "var(--card-bg)",
+                  border: active ? "none" : "1px solid var(--border-default)",
+                }}
+              >
+                {t.label}
+              </Box>
+            );
+          })}
+        </Stack>
+        <TextField
+          size="small"
+          placeholder="Search name or email…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          sx={{ minWidth: { xs: "100%", md: 280 }, "& .MuiOutlinedInput-root": { borderRadius: 2, bgcolor: "var(--card-bg)" } }}
+          InputProps={{ startAdornment: <Icon icon="mdi:magnify" width={18} style={{ marginRight: 6, opacity: 0.6 }} /> }}
+        />
       </Stack>
 
-      {pages > 1 && (
-        <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ mt: 3 }}>
-          <Button disabled={page <= 1 || loading} onClick={() => void load(query, page - 1)}
-            startIcon={<Icon icon="mdi:chevron-left" />}>Prev</Button>
-          <Typography sx={{ fontSize: "0.85rem", color: "text.secondary" }}>Page {page} of {pages} · {count} students</Typography>
-          <Button disabled={page >= pages || loading} onClick={() => void load(query, page + 1)}
-            endIcon={<Icon icon="mdi:chevron-right" />}>Next</Button>
+      {/* Cohort tabs */}
+      {cohorts.length > 0 && (
+        <Stack direction="row" spacing={0.75} sx={{ mb: 2, flexWrap: "wrap", gap: 0.75 }}>
+          <Chip
+            label="All cohorts"
+            onClick={() => setCohortFilter("")}
+            variant={cohortFilter === "" ? "filled" : "outlined"}
+            sx={{ fontWeight: 700, ...(cohortFilter === "" ? { bgcolor: "color-mix(in srgb,#6366f1 15%,transparent)", color: "#4f46e5" } : {}) }}
+          />
+          {cohorts.map((c) => (
+            <Chip
+              key={c.id}
+              label={c.name}
+              onClick={() => setCohortFilter(c.name)}
+              variant={cohortFilter === c.name ? "filled" : "outlined"}
+              sx={{ fontWeight: 700, ...(cohortFilter === c.name ? { bgcolor: "color-mix(in srgb,#6366f1 15%,transparent)", color: "#4f46e5" } : {}) }}
+            />
+          ))}
         </Stack>
       )}
 
-      <StudentDetailDrawer studentId={selected} open={selected != null} onClose={() => setSelected(null)} />
+      {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+
+      {/* Table */}
+      <Box sx={{ borderRadius: 3, overflow: "hidden", bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)" }}>
+        {/* Header row */}
+        <Box
+          sx={{
+            display: { xs: "none", md: "grid" },
+            gridTemplateColumns: COLS,
+            gap: 1.5,
+            px: 2,
+            py: 1.25,
+            bgcolor: "color-mix(in srgb,#6366f1 6%,transparent)",
+            borderBottom: "1px solid var(--border-default)",
+          }}
+        >
+          {["Student", "Cohort", "Progress", "Avg score", "Points", "Status", ""].map((h, i) => (
+            <Typography key={i} sx={{ fontSize: "0.68rem", fontWeight: 800, letterSpacing: 0.5, textTransform: "uppercase", color: "text.secondary" }}>
+              {h}
+            </Typography>
+          ))}
+        </Box>
+
+        {loading && rows.length === 0 ? (
+          <Box sx={{ p: 5, display: "grid", placeItems: "center" }}>
+            <CircularProgress size={26} />
+          </Box>
+        ) : visible.length === 0 ? (
+          <Box sx={{ p: 5, textAlign: "center" }}>
+            <Typography sx={{ color: "text.secondary" }}>
+              {count === 0 ? "No students in your courses or cohorts yet." : "No students match these filters."}
+            </Typography>
+          </Box>
+        ) : (
+          visible.map((s) => (
+            <ReportRow
+              key={s.student_id}
+              s={s}
+              expanded={expanded === s.student_id}
+              onToggle={() => setExpanded((cur) => (cur === s.student_id ? null : s.student_id))}
+              onNudge={doNudge}
+            />
+          ))
+        )}
+      </Box>
+
+      {pages > 1 && (
+        <Stack direction="row" spacing={1} justifyContent="center" alignItems="center" sx={{ mt: 3 }}>
+          <Button disabled={page <= 1 || loading} onClick={() => void load(query, page - 1, status)} startIcon={<Icon icon="mdi:chevron-left" />}>
+            Prev
+          </Button>
+          <Typography sx={{ fontSize: "0.85rem", color: "text.secondary" }}>
+            Page {page} of {pages} · {count} students
+          </Typography>
+          <Button disabled={page >= pages || loading} onClick={() => void load(query, page + 1, status)} endIcon={<Icon icon="mdi:chevron-right" />}>
+            Next
+          </Button>
+        </Stack>
+      )}
+
+      {/* Message cohort dialog */}
+      <Dialog open={msgOpen} onClose={() => setMsgOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle sx={{ fontWeight: 800 }}>Message a cohort</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 0.5 }}>
+            <TextField
+              select
+              label="Cohort"
+              value={msgCohort}
+              onChange={(e) => setMsgCohort(Number(e.target.value))}
+              fullWidth
+              size="small"
+            >
+              {cohorts.map((c) => (
+                <MenuItem key={c.id} value={c.id}>
+                  {c.name} · {c.student_count} student{c.student_count === 1 ? "" : "s"}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Message"
+              value={msgBody}
+              onChange={(e) => setMsgBody(e.target.value)}
+              fullWidth
+              multiline
+              minRows={4}
+              placeholder="Share an announcement, reminder or encouragement with the whole cohort…"
+            />
+            <Typography sx={{ fontSize: "0.75rem", color: "text.secondary" }}>
+              Delivered as an in-app notification to every student in the cohort.
+            </Typography>
+          </Stack>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setMsgOpen(false)} sx={{ textTransform: "none", fontWeight: 700 }}>
+            Cancel
+          </Button>
+          <Button
+            onClick={sendMessage}
+            disabled={msgCohort === "" || !msgBody.trim() || msgSending}
+            startIcon={msgSending ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:send" width={16} />}
+            sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, borderRadius: 2, background: "linear-gradient(135deg,#7c3aed,#ec4899)" }}
+          >
+            Send message
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={!!toast}
+        autoHideDuration={4000}
+        onClose={() => setToast(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        {toast ? (
+          <Alert severity={toast.sev} variant="filled" onClose={() => setToast(null)} sx={{ fontWeight: 600 }}>
+            {toast.text}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
     </PageShell>
   );
 }

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -170,14 +170,27 @@ export interface InstructorDirectoryRow {
   live_sessions: { id: number; title: string }[];
 }
 
+export type InstructorStudentStatus = "on_track" | "watch" | "at_risk";
+
 export interface InstructorStudentRow {
   student_id: number;
   name: string;
   email: string;
   phone: string;
   progress: number;
+  avg_score: number;
+  points: number;
+  last_active: string | null;
+  cohort: string;
+  status: InstructorStudentStatus;
   courses_count: number;
   cohorts_count: number;
+}
+
+export interface InstructorStudentsSummary {
+  count: number;
+  avg_progress: number;
+  avg_score: number;
 }
 
 export interface InstructorStudentsPage {
@@ -185,6 +198,7 @@ export interface InstructorStudentsPage {
   page: number;
   page_size: number;
   results: InstructorStudentRow[];
+  summary: InstructorStudentsSummary;
 }
 
 export interface InstructorAssessment {
@@ -212,9 +226,34 @@ export interface InstructorLiveSessions {
 }
 
 export const instructorService = {
-  async getStudents(search?: string, page = 1, pageSize?: number): Promise<InstructorStudentsPage> {
+  async getStudents(
+    search?: string,
+    page = 1,
+    pageSize?: number,
+    status?: InstructorStudentStatus | "",
+  ): Promise<InstructorStudentsPage> {
     const { data } = await apiClient.get<InstructorStudentsPage>(`${BASE}/students/`, {
-      params: { page, ...(pageSize ? { page_size: pageSize } : {}), ...(search ? { search } : {}) },
+      params: {
+        page,
+        ...(pageSize ? { page_size: pageSize } : {}),
+        ...(search ? { search } : {}),
+        ...(status ? { status } : {}),
+      },
+    });
+    return data;
+  },
+  async nudgeStudent(studentId: number, message?: string): Promise<{ student_id: number; sent: boolean }> {
+    const { data } = await apiClient.post(`${BASE}/students/${studentId}/nudge/`, message ? { message } : {});
+    return data;
+  },
+  async messageCohort(
+    cohortId: number,
+    message: string,
+    title?: string,
+  ): Promise<{ cohort_id: number; sent: number }> {
+    const { data } = await apiClient.post(`${BASE}/cohorts/${cohortId}/message/`, {
+      message,
+      ...(title ? { title } : {}),
     });
     return data;
   },


### PR DESCRIPTION
Instructor workspace redesign, continuing #1114.

**Student Reports** (`/instructor/students`) — 4 KPIs (Students · Avg progress · Avg score · At risk), status filter tabs (server-side `?status=`), cohort filter tabs, search, rich table (avatar + last-active, cohort, progress bar, avg score, points, status pill), expandable row (enrolled courses/cohorts + **Send a nudge** / Book 1:1), **Message cohort** dialog, **Export CSV**.

**Live Sessions** (`/instructor/live-sessions`) — filter tabs (All/Live/Scheduled/Ended w/ counts), live/scheduled/ended derived from datetime+duration, rich session cards (date badge, status pill w/ live pulse, provider chip, Start hosting/Join + Copy link), Schedule-session request dialog.

Backed by BE #439 (student-report columns + `nudge` / `message-cohort` endpoints), merged + deployed. `tsc --noEmit` clean.

Follow-up BE (noted, not blocking): per-session turnout/attendance, instructor-scoped session scheduling, per-student skill breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)