### PR TITLE
feat(instructor): live-session create + join-as-panelist

### DIFF
--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -1,29 +1,36 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Box,
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
   DialogTitle,
+  FormControlLabel,
+  IconButton,
+  MenuItem,
   Snackbar,
   Stack,
+  Switch,
+  TextField,
   Typography,
 } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
-import { instructorService, type InstructorLiveSession } from "@/lib/services/instructor.service";
+import {
+  instructorService,
+  type InstructorLiveSession,
+  type InstructorCohort,
+  type InstructorCourse,
+  type LiveSessionProvider,
+} from "@/lib/services/instructor.service";
 
 type SessionStatus = "live" | "scheduled" | "ended";
-
-interface Session extends InstructorLiveSession {
-  status: SessionStatus;
-}
 
 const STATUS_META: Record<SessionStatus, { label: string; color: string; bg: string }> = {
   live: { label: "Live now", color: "#dc2626", bg: "color-mix(in srgb,#ef4444 14%,transparent)" },
@@ -38,18 +45,18 @@ const TABS: { key: SessionStatus | "all"; label: string; icon: string }[] = [
   { key: "ended", label: "Ended", icon: "mdi:history" },
 ];
 
-function providerOf(link: string): { label: string; icon: string; color: string } {
-  const l = link.toLowerCase();
-  if (l.includes("zoom")) return { label: "Zoom", icon: "mdi:video", color: "#2563eb" };
-  if (l.includes("meet.google") || l.includes("hangouts")) return { label: "Google Meet", icon: "mdi:google", color: "#16a34a" };
-  if (l.includes("teams.microsoft")) return { label: "Teams", icon: "mdi:microsoft-teams", color: "#6366f1" };
-  return { label: "Online", icon: "mdi:web", color: "#6b7280" };
-}
+const PROVIDER_META: Record<LiveSessionProvider, { label: string; icon: string; color: string }> = {
+  webinar: { label: "Zoom Webinar", icon: "mdi:presentation", color: "#7c3aed" },
+  meeting: { label: "Zoom", icon: "mdi:video", color: "#2563eb" },
+  google_meet: { label: "Google Meet", icon: "mdi:google", color: "#16a34a" },
+  manual: { label: "Online", icon: "mdi:web", color: "#6b7280" },
+};
 
-function statusOf(s: InstructorLiveSession): SessionStatus {
+// Status is derived client-side from datetime+duration against a ticking `now`, so a scheduled
+// session flips to Live (and the counts/order update) without a manual reload.
+function statusOf(s: InstructorLiveSession, now: number): SessionStatus {
   const start = new Date(s.class_datetime).getTime();
   const end = start + (s.duration_minutes || 0) * 60_000;
-  const now = Date.now();
   if (now >= start && now <= end) return "live";
   if (now < start) return "scheduled";
   return "ended";
@@ -58,77 +65,115 @@ function statusOf(s: InstructorLiveSession): SessionStatus {
 function dayBadge(dt: string): { top: string; bottom: string } {
   try {
     const d = new Date(dt);
-    return {
-      top: d.toLocaleDateString(undefined, { month: "short" }).toUpperCase(),
-      bottom: String(d.getDate()),
-    };
+    return { top: d.toLocaleDateString(undefined, { month: "short" }).toUpperCase(), bottom: String(d.getDate()) };
   } catch {
     return { top: "", bottom: "" };
   }
 }
-
 function fmtTime(dt: string): string {
   try {
-    return new Date(dt).toLocaleString(undefined, {
-      weekday: "short",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return new Date(dt).toLocaleString(undefined, { weekday: "short", hour: "numeric", minute: "2-digit" });
   } catch {
     return dt;
   }
 }
 
 export default function InstructorLiveSessionsPage() {
-  const [sessions, setSessions] = useState<Session[]>([]);
+  const [sessions, setSessions] = useState<InstructorLiveSession[]>([]);
+  const [pastTotal, setPastTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [tab, setTab] = useState<SessionStatus | "all">("all");
-  const [scheduleOpen, setScheduleOpen] = useState(false);
-  const [toast, setToast] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  const [hostingId, setHostingId] = useState<number | null>(null);
+  const [toast, setToast] = useState<{ text: string; sev: "success" | "error" | "info" } | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await instructorService.getLiveSessions();
-        if (!cancelled) {
-          const all = [...data.upcoming, ...data.past].map((s) => ({ ...s, status: statusOf(s) }));
-          // live first, then scheduled (soonest), then ended (most recent).
-          const order: Record<SessionStatus, number> = { live: 0, scheduled: 1, ended: 2 };
-          all.sort((a, b) => {
-            if (order[a.status] !== order[b.status]) return order[a.status] - order[b.status];
-            const ta = new Date(a.class_datetime).getTime();
-            const tb = new Date(b.class_datetime).getTime();
-            return a.status === "ended" ? tb - ta : ta - tb;
-          });
-          setSessions(all);
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your live sessions.");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const reload = useCallback(async () => {
+    try {
+      const data = await instructorService.getLiveSessions();
+      setSessions([...data.upcoming, ...data.past]);
+      setPastTotal(data.past_total);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't load your live sessions.");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  const counts = useMemo(() => {
-    const c = { all: sessions.length, live: 0, scheduled: 0, ended: 0 } as Record<SessionStatus | "all", number>;
-    sessions.forEach((s) => (c[s.status] += 1));
-    return c;
-  }, [sessions]);
+  useEffect(() => {
+    void reload();
+  }, [reload]);
 
-  const visible = useMemo(() => (tab === "all" ? sessions : sessions.filter((s) => s.status === tab)), [sessions, tab]);
+  // Tick every 30s so live/scheduled/ended stays fresh while the page is open.
+  useEffect(() => {
+    const h = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(h);
+  }, []);
+
+  const withStatus = useMemo(
+    () => sessions.map((s) => ({ s, status: statusOf(s, now) })),
+    [sessions, now],
+  );
+  const ordered = useMemo(() => {
+    const order: Record<SessionStatus, number> = { live: 0, scheduled: 1, ended: 2 };
+    return [...withStatus].sort((a, b) => {
+      if (order[a.status] !== order[b.status]) return order[a.status] - order[b.status];
+      const ta = new Date(a.s.class_datetime).getTime();
+      const tb = new Date(b.s.class_datetime).getTime();
+      return a.status === "ended" ? tb - ta : ta - tb;
+    });
+  }, [withStatus]);
+
+  const counts = useMemo(() => {
+    const c = { all: ordered.length, live: 0, scheduled: 0, ended: 0 } as Record<SessionStatus | "all", number>;
+    ordered.forEach((x) => (c[x.status] += 1));
+    return c;
+  }, [ordered]);
+
+  const visible = useMemo(() => (tab === "all" ? ordered : ordered.filter((x) => x.status === tab)), [ordered, tab]);
+  const endedShown = useMemo(() => withStatus.filter((x) => x.status === "ended").length, [withStatus]);
+  const showTruncation = (tab === "all" || tab === "ended") && pastTotal > endedShown;
 
   const copyLink = async (link: string) => {
     try {
       await navigator.clipboard.writeText(link);
-      setToast("Join link copied to clipboard.");
+      setToast({ text: "Join link copied to clipboard.", sev: "success" });
     } catch {
-      setToast("Couldn't copy the link.");
+      setToast({ text: "Couldn't copy the link.", sev: "error" });
+    }
+  };
+
+  const startHosting = async (s: InstructorLiveSession) => {
+    setHostingId(s.id);
+    try {
+      const link = await instructorService.getHostLink(s.id);
+      if (!link.url) {
+        setToast({ text: "No host link is available for this session yet.", sev: "error" });
+        return;
+      }
+      window.open(link.url, "_blank", "noopener");
+      setToast({
+        text: link.kind === "panelist" ? "Opening your panelist link — you'll join as a presenter." : "Opening your host link.",
+        sev: "info",
+      });
+    } catch {
+      setToast({ text: "Couldn't get your host link right now.", sev: "error" });
+    } finally {
+      setHostingId(null);
+    }
+  };
+
+  const removeSession = async (s: InstructorLiveSession) => {
+    if (!window.confirm(`Delete "${s.topic_name}"? This also removes the Zoom session.`)) return;
+    try {
+      await instructorService.deleteLiveSession(s.id);
+      setSessions((cur) => cur.filter((x) => x.id !== s.id));
+      setToast({ text: "Session deleted.", sev: "success" });
+    } catch {
+      setToast({ text: "Couldn't delete this session.", sev: "error" });
     }
   };
 
@@ -137,11 +182,11 @@ export default function InstructorLiveSessionsPage() {
       <ModulePageHeader
         eyebrow="Teach"
         title="Live Sessions"
-        description="Sessions scheduled for the courses and cohorts you're assigned to — host, share links and follow up."
+        description="Host sessions for the courses and cohorts you're assigned to — create one, share links, and join as a presenter."
         accent="pink"
         icon="mdi:video-outline"
         action={
-          <HeaderActionButton icon="mdi:calendar-plus" variant="ghost" onClick={() => setScheduleOpen(true)}>
+          <HeaderActionButton icon="mdi:calendar-plus" variant="solid" onClick={() => setCreateOpen(true)}>
             Schedule session
           </HeaderActionButton>
         }
@@ -152,38 +197,15 @@ export default function InstructorLiveSessionsPage() {
         {TABS.map((t) => {
           const active = tab === t.key;
           return (
-            <Box
-              key={t.key}
-              onClick={() => setTab(t.key)}
-              sx={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 0.6,
-                px: 1.75,
-                py: 0.75,
-                borderRadius: 999,
-                cursor: "pointer",
-                fontSize: "0.82rem",
-                fontWeight: 700,
-                color: active ? "#fff" : "text.secondary",
+            <Box key={t.key} onClick={() => setTab(t.key)}
+              sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 1.75, py: 0.75, borderRadius: 999,
+                cursor: "pointer", fontSize: "0.82rem", fontWeight: 700, color: active ? "#fff" : "text.secondary",
                 background: active ? "linear-gradient(135deg,#ec4899,#a855f7)" : "var(--card-bg)",
-                border: active ? "none" : "1px solid var(--border-default)",
-              }}
-            >
+                border: active ? "none" : "1px solid var(--border-default)" }}>
               <Icon icon={t.icon} width={15} />
               {t.label}
-              <Box
-                component="span"
-                sx={{
-                  ml: 0.3,
-                  px: 0.7,
-                  py: 0.05,
-                  borderRadius: 999,
-                  fontSize: "0.68rem",
-                  fontWeight: 800,
-                  bgcolor: active ? "rgba(255,255,255,0.25)" : "color-mix(in srgb,var(--border-default) 60%,transparent)",
-                }}
-              >
+              <Box component="span" sx={{ ml: 0.3, px: 0.7, py: 0.05, borderRadius: 999, fontSize: "0.68rem", fontWeight: 800,
+                bgcolor: active ? "rgba(255,255,255,0.25)" : "color-mix(in srgb,var(--border-default) 60%,transparent)" }}>
                 {counts[t.key]}
               </Box>
             </Box>
@@ -192,129 +214,102 @@ export default function InstructorLiveSessionsPage() {
       </Stack>
 
       {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
+      {!error && loading && (
+        <Box sx={{ p: 5, display: "grid", placeItems: "center" }}><CircularProgress size={26} /></Box>
+      )}
       {!error && !loading && visible.length === 0 && (
         <Box sx={{ p: 5, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
           <Icon icon="mdi:video-off-outline" width={34} style={{ opacity: 0.4 }} />
           <Typography sx={{ color: "text.secondary", mt: 1 }}>
-            {sessions.length === 0
-              ? "No live sessions scheduled for your courses or cohorts yet."
-              : "No sessions in this view."}
+            {sessions.length === 0 ? "No live sessions yet — schedule one for a cohort you teach." : "No sessions in this view."}
           </Typography>
+          {sessions.length === 0 && (
+            <Button onClick={() => setCreateOpen(true)} startIcon={<Icon icon="mdi:calendar-plus" width={16} />}
+              sx={{ mt: 2, textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, py: 1, borderRadius: 999,
+                background: "linear-gradient(135deg,#ec4899,#a855f7)" }}>
+              Schedule your first session
+            </Button>
+          )}
         </Box>
       )}
 
       {/* Session cards */}
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "repeat(2,1fr)" }, gap: 2 }}>
-        {visible.map((s) => {
-          const m = STATUS_META[s.status];
-          const p = providerOf(s.join_link);
+        {visible.map(({ s, status }) => {
+          const m = STATUS_META[status];
+          const p = PROVIDER_META[s.provider] ?? PROVIDER_META.manual;
           const badge = dayBadge(s.class_datetime);
-          const isLive = s.status === "live";
+          const isLive = status === "live";
           return (
-            <Box
-              key={s.id}
-              sx={{
-                borderRadius: 4,
-                overflow: "hidden",
-                bgcolor: "var(--card-bg)",
+            <Box key={s.id}
+              sx={{ borderRadius: 4, overflow: "hidden", bgcolor: "var(--card-bg)",
                 border: isLive ? "1px solid color-mix(in srgb,#ef4444 45%,transparent)" : "1px solid var(--border-default)",
                 boxShadow: isLive ? "0 0 0 3px color-mix(in srgb,#ef4444 12%,transparent)" : "0 10px 30px -26px rgba(16,24,40,.3)",
-                display: "flex",
-                flexDirection: "column",
-              }}
-            >
+                display: "flex", flexDirection: "column" }}>
               <Box sx={{ p: 2.25, display: "flex", gap: 1.75, flex: 1 }}>
                 {/* Date badge */}
-                <Box
-                  sx={{
-                    width: 56,
-                    flexShrink: 0,
-                    borderRadius: 3,
-                    overflow: "hidden",
-                    border: "1px solid var(--border-default)",
-                    textAlign: "center",
-                  }}
-                >
-                  <Box sx={{ py: 0.4, background: "linear-gradient(135deg,#ec4899,#a855f7)", color: "#fff", fontSize: "0.62rem", fontWeight: 900, letterSpacing: 0.5 }}>
-                    {badge.top}
-                  </Box>
-                  <Box sx={{ py: 0.6 }}>
-                    <Typography sx={{ fontWeight: 900, fontSize: "1.35rem", lineHeight: 1 }}>{badge.bottom}</Typography>
-                  </Box>
+                <Box sx={{ width: 56, flexShrink: 0, borderRadius: 3, overflow: "hidden", border: "1px solid var(--border-default)", textAlign: "center" }}>
+                  <Box sx={{ py: 0.4, background: "linear-gradient(135deg,#ec4899,#a855f7)", color: "#fff", fontSize: "0.62rem", fontWeight: 900, letterSpacing: 0.5 }}>{badge.top}</Box>
+                  <Box sx={{ py: 0.6 }}><Typography sx={{ fontWeight: 900, fontSize: "1.35rem", lineHeight: 1 }}>{badge.bottom}</Typography></Box>
                 </Box>
-
                 {/* Body */}
                 <Box sx={{ minWidth: 0, flex: 1 }}>
                   <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 0.75, flexWrap: "wrap", gap: 0.5 }}>
-                    <Box
-                      sx={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: 0.4,
-                        px: 0.9,
-                        py: 0.25,
-                        borderRadius: 999,
-                        bgcolor: m.bg,
-                        color: m.color,
-                        fontSize: "0.68rem",
-                        fontWeight: 800,
-                      }}
-                    >
+                    <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.4, px: 0.9, py: 0.25, borderRadius: 999, bgcolor: m.bg, color: m.color, fontSize: "0.68rem", fontWeight: 800 }}>
                       {isLive && <Box sx={{ width: 6, height: 6, borderRadius: "50%", bgcolor: m.color, animation: "pulse 1.4s infinite" }} />}
                       {m.label}
                     </Box>
                     <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.35, px: 0.9, py: 0.25, borderRadius: 999, border: "1px solid var(--border-default)", fontSize: "0.68rem", fontWeight: 700, color: p.color }}>
-                      <Icon icon={p.icon} width={12} />
-                      {p.label}
+                      <Icon icon={p.icon} width={12} />{p.label}
                     </Box>
+                    {s.created_by_me && (
+                      <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.3, px: 0.8, py: 0.25, borderRadius: 999, bgcolor: "color-mix(in srgb,#10b981 12%,transparent)", color: "#059669", fontSize: "0.66rem", fontWeight: 800 }}>
+                        <Icon icon="mdi:account-check" width={11} />Yours
+                      </Box>
+                    )}
                   </Stack>
-
                   <Typography sx={{ fontWeight: 800, fontSize: "1.02rem", lineHeight: 1.25 }}>{s.topic_name}</Typography>
-                  <Stack direction="row" spacing={1.5} sx={{ mt: 0.6, color: "text.secondary" }}>
-                    <Stack direction="row" spacing={0.4} alignItems="center">
-                      <Icon icon="mdi:clock-outline" width={14} />
-                      <Typography sx={{ fontSize: "0.8rem" }}>{fmtTime(s.class_datetime)}</Typography>
-                    </Stack>
-                    <Stack direction="row" spacing={0.4} alignItems="center">
-                      <Icon icon="mdi:timer-sand" width={14} />
-                      <Typography sx={{ fontSize: "0.8rem" }}>{s.duration_minutes} min</Typography>
-                    </Stack>
+                  <Stack direction="row" spacing={1.5} sx={{ mt: 0.6, color: "text.secondary", flexWrap: "wrap", gap: 0.5 }}>
+                    <Stack direction="row" spacing={0.4} alignItems="center"><Icon icon="mdi:clock-outline" width={14} /><Typography sx={{ fontSize: "0.8rem" }}>{fmtTime(s.class_datetime)}</Typography></Stack>
+                    <Stack direction="row" spacing={0.4} alignItems="center"><Icon icon="mdi:timer-sand" width={14} /><Typography sx={{ fontSize: "0.8rem" }}>{s.duration_minutes} min</Typography></Stack>
+                    {s.cohort_name && <Stack direction="row" spacing={0.4} alignItems="center"><Icon icon="mdi:account-group" width={14} /><Typography sx={{ fontSize: "0.8rem" }} noWrap>{s.cohort_name}</Typography></Stack>}
                   </Stack>
                 </Box>
+                {s.created_by_me && (
+                  <IconButton size="small" onClick={() => removeSession(s)} sx={{ alignSelf: "flex-start", color: "text.secondary", "&:hover": { color: "#ef4444" } }} aria-label="Delete session">
+                    <Icon icon="mdi:trash-can-outline" width={18} />
+                  </IconButton>
+                )}
               </Box>
 
               {/* Actions */}
-              <Stack direction="row" spacing={1} sx={{ px: 2.25, pb: 2.25, flexWrap: "wrap", gap: 1 }}>
-                {(isLive || s.status === "scheduled") && s.join_link && (
-                  <Button
-                    href={s.join_link}
-                    target="_blank"
-                    rel="noopener"
-                    startIcon={<Icon icon={isLive ? "mdi:broadcast" : "mdi:login-variant"} width={16} />}
-                    sx={{
-                      textTransform: "none",
-                      fontWeight: 800,
-                      color: "#fff",
-                      px: 2,
-                      py: 0.9,
-                      borderRadius: 2,
+              <Stack direction="row" spacing={1} sx={{ px: 2.25, pb: 2.25, flexWrap: "wrap", gap: 1, alignItems: "center" }}>
+                {status !== "ended" && s.hostable ? (
+                  <Button onClick={() => startHosting(s)} disabled={hostingId === s.id}
+                    startIcon={hostingId === s.id ? <CircularProgress size={15} color="inherit" /> : <Icon icon={isLive ? "mdi:broadcast" : "mdi:login-variant"} width={16} />}
+                    sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2, py: 0.9, borderRadius: 2,
                       background: isLive ? "linear-gradient(135deg,#ef4444,#ec4899)" : "linear-gradient(135deg,#ec4899,#a855f7)",
-                      "&:hover": { filter: "brightness(1.06)" },
-                    }}
-                  >
-                    {isLive ? "Start hosting" : "Join"}
+                      "&:hover": { filter: "brightness(1.06)" }, "&.Mui-disabled": { color: "rgba(255,255,255,0.8)", filter: "grayscale(.3)" } }}>
+                    {isLive ? "Start hosting" : s.is_webinar ? "Get panelist link" : "Get host link"}
                   </Button>
-                )}
+                ) : status !== "ended" && s.join_link ? (
+                  <Button href={s.join_link} target="_blank" rel="noopener" startIcon={<Icon icon="mdi:login-variant" width={16} />}
+                    sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2, py: 0.9, borderRadius: 2, background: "linear-gradient(135deg,#ec4899,#a855f7)" }}>
+                    Join
+                  </Button>
+                ) : null}
                 {s.join_link && (
-                  <Button
-                    onClick={() => copyLink(s.join_link)}
-                    startIcon={<Icon icon="mdi:link-variant" width={16} />}
-                    sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1", px: 1.75, py: 0.9, borderRadius: 2, border: "1px solid var(--border-default)" }}
-                  >
-                    Copy link
+                  <Button onClick={() => copyLink(s.join_link)} startIcon={<Icon icon="mdi:link-variant" width={16} />}
+                    sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1", px: 1.75, py: 0.9, borderRadius: 2, border: "1px solid var(--border-default)" }}>
+                    Copy attendee link
                   </Button>
                 )}
-                {s.status === "ended" && (
+                {s.password && (
+                  <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.4, px: 1, py: 0.5, borderRadius: 2, bgcolor: "color-mix(in srgb,#6366f1 8%,transparent)", fontSize: "0.72rem", fontWeight: 700, color: "#4f46e5" }}>
+                    <Icon icon="mdi:key-variant" width={13} /> {s.password}
+                  </Box>
+                )}
+                {status === "ended" && (
                   <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", alignSelf: "center", fontStyle: "italic" }}>
                     Session ended · recordings & attendance coming soon
                   </Typography>
@@ -325,44 +320,150 @@ export default function InstructorLiveSessionsPage() {
         })}
       </Box>
 
-      {/* Schedule dialog — instructor sessions are provisioned by admin today */}
-      <Dialog open={scheduleOpen} onClose={() => setScheduleOpen(false)} fullWidth maxWidth="xs">
-        <DialogTitle sx={{ fontWeight: 800 }}>Schedule a live session</DialogTitle>
-        <DialogContent>
-          <DialogContentText sx={{ fontSize: "0.9rem" }}>
-            Live sessions are provisioned from the class calendar by your admin and mapped to your
-            cohorts automatically. Need a new session on the schedule? Send a quick request and
-            your admin will set it up with the right Zoom/Meet link.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={() => setScheduleOpen(false)} sx={{ textTransform: "none", fontWeight: 700 }}>
-            Close
-          </Button>
-          <Button
-            href="/tickets"
-            startIcon={<Icon icon="mdi:headset" width={16} />}
-            sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, borderRadius: 2, background: "linear-gradient(135deg,#ec4899,#a855f7)" }}
-          >
-            Request a session
-          </Button>
-        </DialogActions>
-      </Dialog>
+      {showTruncation && (
+        <Typography sx={{ textAlign: "center", color: "text.secondary", fontSize: "0.82rem", mt: 2.5 }}>
+          Showing the latest {endedShown} of {pastTotal} past sessions.
+        </Typography>
+      )}
 
-      <Snackbar open={!!toast} autoHideDuration={3000} onClose={() => setToast(null)} anchorOrigin={{ vertical: "bottom", horizontal: "center" }}>
-        {toast ? (
-          <Alert severity="success" variant="filled" onClose={() => setToast(null)} sx={{ fontWeight: 600 }}>
-            {toast}
-          </Alert>
-        ) : undefined}
+      <CreateSessionDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={(msg) => { setToast({ text: msg, sev: "success" }); void reload(); }}
+      />
+
+      <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: "bottom", horizontal: "center" }}>
+        {toast ? <Alert severity={toast.sev} variant="filled" onClose={() => setToast(null)} sx={{ fontWeight: 600 }}>{toast.text}</Alert> : undefined}
       </Snackbar>
 
-      <style jsx global>{`
-        @keyframes pulse {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0.3; }
-        }
-      `}</style>
+      <style jsx global>{`@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }`}</style>
     </PageShell>
+  );
+}
+
+/* --------------------------- create session dialog -------------------------- */
+
+function CreateSessionDialog({ open, onClose, onCreated }: {
+  open: boolean; onClose: () => void; onCreated: (msg: string) => void;
+}) {
+  const [cohorts, setCohorts] = useState<InstructorCohort[]>([]);
+  const [courses, setCourses] = useState<InstructorCourse[]>([]);
+  const [sessionType, setSessionType] = useState<"meeting" | "webinar">("meeting");
+  const [topic, setTopic] = useState("");
+  const [description, setDescription] = useState("");
+  const [when, setWhen] = useState("");
+  const [duration, setDuration] = useState(60);
+  const [audience, setAudience] = useState("");     // "c:<id>" | "a:<id>"
+  const [passcode, setPasscode] = useState("");
+  const [registration, setRegistration] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    instructorService.getCohorts().then(setCohorts).catch(() => undefined);
+    instructorService.getCourses().then(setCourses).catch(() => undefined);
+  }, [open]);
+
+  const reset = () => {
+    setTopic(""); setDescription(""); setWhen(""); setDuration(60); setAudience("");
+    setPasscode(""); setRegistration(false); setSessionType("meeting"); setErr(null);
+  };
+
+  const valid = topic.trim().length >= 2 && !!when && duration >= 1 && duration <= 600 && !!audience;
+
+  const submit = async () => {
+    if (!valid) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      const [kind, idStr] = audience.split(":");
+      const id = Number(idStr);
+      const created = await instructorService.createLiveSession({
+        topic_name: topic.trim(),
+        description: description.trim() || undefined,
+        class_datetime: new Date(when).toISOString(),
+        duration_minutes: duration,
+        session_type: sessionType,
+        ...(kind === "c" ? { cohort_id: id } : { adaptive_course_id: id }),
+        ...(sessionType === "webinar" ? { passcode: passcode.trim() || undefined, registration_required: registration } : {}),
+      });
+      onCreated(`Session created${sessionType === "webinar" ? " — you're added as a panelist." : "."}`);
+      if (created.host_link?.url) window.open(created.host_link.url, "_blank", "noopener");
+      reset();
+      onClose();
+    } catch (e) {
+      const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setErr(detail || (e instanceof Error ? e.message : "Couldn't create the session."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ fontWeight: 800 }}>Schedule a live session</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          {/* Type toggle */}
+          <Stack direction="row" spacing={1}>
+            {(["meeting", "webinar"] as const).map((t) => {
+              const active = sessionType === t;
+              return (
+                <Box key={t} onClick={() => setSessionType(t)}
+                  sx={{ flex: 1, p: 1.5, borderRadius: 2.5, cursor: "pointer", textAlign: "center",
+                    border: active ? "2px solid #7c3aed" : "1px solid var(--border-default)",
+                    bgcolor: active ? "color-mix(in srgb,#7c3aed 8%,transparent)" : "transparent" }}>
+                  <Icon icon={t === "webinar" ? "mdi:presentation" : "mdi:video"} width={22} style={{ color: active ? "#7c3aed" : "#6b7280" }} />
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.86rem", mt: 0.25 }}>{t === "webinar" ? "Webinar" : "Meeting"}</Typography>
+                  <Typography sx={{ fontSize: "0.68rem", color: "text.secondary" }}>
+                    {t === "webinar" ? "You join as a panelist" : "You host with the start link"}
+                  </Typography>
+                </Box>
+              );
+            })}
+          </Stack>
+
+          <TextField label="Topic" value={topic} onChange={(e) => setTopic(e.target.value)} fullWidth size="small" required />
+          <TextField label="Description (optional)" value={description} onChange={(e) => setDescription(e.target.value)} fullWidth size="small" multiline minRows={2} />
+          <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+            <TextField label="Starts" type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
+              fullWidth size="small" InputLabelProps={{ shrink: true }} />
+            <TextField label="Duration (min)" type="number" value={duration}
+              onChange={(e) => setDuration(Math.max(1, Math.min(600, Number(e.target.value) || 0)))}
+              size="small" sx={{ width: { xs: "100%", sm: 160 } }} inputProps={{ min: 1, max: 600 }} />
+          </Stack>
+
+          <TextField select label="Cohort or course" value={audience} onChange={(e) => setAudience(e.target.value)} fullWidth size="small">
+            {cohorts.length > 0 && <MenuItem disabled sx={{ fontWeight: 800, opacity: 1 }}>Cohorts</MenuItem>}
+            {cohorts.map((c) => <MenuItem key={`c${c.id}`} value={`c:${c.id}`}>&nbsp;&nbsp;{c.name}</MenuItem>)}
+            {courses.length > 0 && <MenuItem disabled sx={{ fontWeight: 800, opacity: 1 }}>Courses</MenuItem>}
+            {courses.map((c) => <MenuItem key={`a${c.id}`} value={`a:${c.id}`}>&nbsp;&nbsp;{c.title}</MenuItem>)}
+            {cohorts.length === 0 && courses.length === 0 && <MenuItem disabled>No assigned cohorts or courses</MenuItem>}
+          </TextField>
+
+          {sessionType === "webinar" && (
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems={{ sm: "center" }}>
+              <TextField label="Passcode (optional)" value={passcode} onChange={(e) => setPasscode(e.target.value)} size="small" sx={{ flex: 1 }} />
+              <FormControlLabel control={<Switch checked={registration} onChange={(e) => setRegistration(e.target.checked)} />} label="Require registration" />
+            </Stack>
+          )}
+
+          {err && <Alert severity="error" sx={{ fontWeight: 600 }}>{err}</Alert>}
+          <Typography sx={{ fontSize: "0.75rem", color: "text.secondary" }}>
+            Provisions a Zoom {sessionType} on your institution's account. {sessionType === "webinar" ? "You'll be added as a panelist and get a unique presenter link." : "You'll get the host start link to run it."}
+          </Typography>
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={saving} sx={{ textTransform: "none", fontWeight: 700 }}>Cancel</Button>
+        <Button onClick={submit} disabled={!valid || saving}
+          startIcon={saving ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:calendar-check" width={16} />}
+          sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, borderRadius: 2,
+            background: "linear-gradient(135deg,#7c3aed,#ec4899)", "&.Mui-disabled": { color: "rgba(255,255,255,0.7)", opacity: 0.7 } }}>
+          {saving ? "Creating…" : "Create session"}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -223,6 +223,8 @@ export interface InstructorAssessment {
   pending_grading: number;
 }
 
+export type LiveSessionProvider = "webinar" | "meeting" | "google_meet" | "manual";
+
 export interface InstructorLiveSession {
   id: number;
   topic_name: string;
@@ -230,11 +232,42 @@ export interface InstructorLiveSession {
   duration_minutes: number;
   join_link: string;
   is_upcoming: boolean;
+  provider: LiveSessionProvider;
+  status: "live" | "scheduled" | "ended";
+  is_zoom: boolean;
+  is_webinar: boolean;
+  is_google_meet: boolean;
+  cohort_name: string;
+  password: string;
+  hostable: boolean;
+  created_by_me: boolean;
 }
 
 export interface InstructorLiveSessions {
   upcoming: InstructorLiveSession[];
   past: InstructorLiveSession[];
+  past_total: number;
+}
+
+export interface HostLink {
+  kind: "panelist" | "host" | "join";
+  url: string;
+}
+
+export interface CreateLiveSessionPayload {
+  topic_name: string;
+  description?: string;
+  class_datetime: string;
+  duration_minutes: number;
+  session_type: "meeting" | "webinar";
+  cohort_id?: number;
+  adaptive_course_id?: number;
+  passcode?: string;
+  registration_required?: boolean;
+}
+
+export interface CreatedLiveSession extends InstructorLiveSession {
+  host_link: HostLink;
 }
 
 export const instructorService = {
@@ -272,6 +305,17 @@ export const instructorService = {
   async getLiveSessions(): Promise<InstructorLiveSessions> {
     const { data } = await apiClient.get<InstructorLiveSessions>(`${BASE}/live-sessions/`);
     return data;
+  },
+  async createLiveSession(payload: CreateLiveSessionPayload): Promise<CreatedLiveSession> {
+    const { data } = await apiClient.post<CreatedLiveSession>(`${BASE}/live-sessions/`, payload);
+    return data;
+  },
+  async getHostLink(sessionId: number): Promise<HostLink> {
+    const { data } = await apiClient.get<HostLink>(`${BASE}/live-sessions/${sessionId}/host-link/`);
+    return data;
+  },
+  async deleteLiveSession(sessionId: number): Promise<void> {
+    await apiClient.delete(`${BASE}/live-sessions/${sessionId}/`);
   },
 
   // --- Admin settings: instructor directory + public code ---


### PR DESCRIPTION
Instructor-side create + presenter join, pairs with BE #441.

- **Schedule session** opens a real create dialog — meeting/webinar toggle, topic, description, datetime, duration, an **assigned-cohort/course picker**, and webinar passcode + registration → `POST /instructor/api/live-sessions/`. On success it opens your host/panelist link and refreshes.
- Cards wire **Start hosting** → `GET …/host-link/` → the unique webinar **panelist** link or the meeting **host** start link; attendee 'Copy link' stays separate. Passcode chip, 'Yours' badge, and delete (created-by-me) added.
- Provider/cohort come from the enriched payload; **status is recomputed against a ticking `now`** so scheduled→live flips without a reload, and a 'showing latest 50 of N' note surfaces the past-sessions cap (both review nits folded in).

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)