### PR TITLE
fix(instructor): center ring label + remove em dashes

### DIFF
--- a/app/instructor/analytics/page.tsx
+++ b/app/instructor/analytics/page.tsx
@@ -82,7 +82,7 @@ export default function InstructorAnalyticsPage() {
               <Icon icon="mdi:chart-bar" width={20} style={{ color: "#06b6d4" }} />
               <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Progress distribution</Typography>
               <Typography sx={{ color: "text.secondary", fontSize: "0.82rem" }}>
-                — {students.length} student{students.length === 1 ? "" : "s"}
+                · {students.length} student{students.length === 1 ? "" : "s"}
               </Typography>
             </Stack>
             <Stack spacing={1.5}>

--- a/app/instructor/cohorts/page.tsx
+++ b/app/instructor/cohorts/page.tsx
@@ -117,7 +117,7 @@ export default function InstructorCohortsPage() {
       <ModulePageHeader
         eyebrow="Teaching"
         title="My Cohorts"
-        description="Courses and cohorts assigned to you by admin. Membership is managed centrally — you own delivery, sessions and reporting."
+        description="Courses and cohorts assigned to you by admin. Membership is managed centrally. You own delivery, sessions and reporting."
         accent="purple"
         icon="mdi:school-outline"
         action={
@@ -135,7 +135,7 @@ export default function InstructorCohortsPage() {
           <Icon icon="mdi:information-outline" width={18} />
           <Typography sx={{ fontWeight: 600, fontSize: "0.9rem" }}>
             Cohort rosters are assigned by your admin. Students join using your instructor code
-            {code ? <> — <b>{code}</b>.</> : "."}
+            {code ? <>: <b>{code}</b>.</> : "."}
           </Typography>
         </Stack>
         <Button href="/tickets" startIcon={<Icon icon="mdi:headset" width={16} />}

--- a/app/instructor/dashboard/page.tsx
+++ b/app/instructor/dashboard/page.tsx
@@ -90,12 +90,12 @@ export default function InstructorDashboardPage() {
   }
 
   const headline = liveSession
-    ? `You're live now, ${firstName} — your session is running.`
+    ? `You're live now, ${firstName}. Your session is running.`
     : atRisk > 0
-      ? `${greeting()}, ${firstName} — ${atRisk} student${atRisk === 1 ? "" : "s"} need${atRisk === 1 ? "s" : ""} a nudge today.`
+      ? `${greeting()}, ${firstName}. ${atRisk} student${atRisk === 1 ? "" : "s"} need${atRisk === 1 ? "s" : ""} a nudge today.`
       : pending > 0
-        ? `${greeting()}, ${firstName} — ${pending} submission${pending === 1 ? "" : "s"} waiting on your review.`
-        : `${greeting()}, ${firstName} — your cohorts are on track.`;
+        ? `${greeting()}, ${firstName}. ${pending} submission${pending === 1 ? "" : "s"} waiting on your review.`
+        : `${greeting()}, ${firstName}. Your cohorts are on track.`;
 
   const primary =
     liveSession
@@ -148,7 +148,7 @@ export default function InstructorDashboardPage() {
 
               <Typography sx={{ mt: 1.25, color: "rgba(255,255,255,0.8)", fontSize: "0.96rem", maxWidth: 620, lineHeight: 1.5 }}>
                 {topRiskCohort && topRiskCohort.at_risk > 0 ? (
-                  <>Your biggest lever is <b style={{ color: "#fff" }}>{topRiskCohort.name}</b> — <b style={{ color: "#fca5a5" }}>{topRiskCohort.at_risk} student{topRiskCohort.at_risk === 1 ? "" : "s"}</b> slipping. A quick check-in moves them back on track.{" "}
+                  <>Your biggest lever is <b style={{ color: "#fff" }}>{topRiskCohort.name}</b>, with <b style={{ color: "#fca5a5" }}>{topRiskCohort.at_risk} student{topRiskCohort.at_risk === 1 ? "" : "s"}</b> slipping. A quick check-in moves them back on track.{" "}
                     <Box component="span" onClick={() => push("/instructor/students?status=at_risk")}
                       sx={{ color: "#fcd34d", fontWeight: 800, cursor: "pointer", whiteSpace: "nowrap" }}>Review →</Box></>
                 ) : pending > 0 ? (
@@ -296,7 +296,7 @@ export default function InstructorDashboardPage() {
                 </Box>
               ))}
               {dash && dash.at_risk.length === 0 && (
-                <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", py: 1 }}>No at-risk students — great job!</Typography>
+                <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", py: 1 }}>No at-risk students. Great job!</Typography>
               )}
             </Stack>
             {dash && dash.at_risk.length > 0 && (
@@ -342,7 +342,7 @@ function Ring({ pct, size = 120, stroke = 11, track = "rgba(255,255,255,0.12)", 
             strokeDasharray={c} strokeDashoffset={off} strokeLinecap="round" style={{ transition: "stroke-dashoffset .8s ease" }} />
         )}
       </svg>
-      <Box sx={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", textAlign: "center" }}>{children}</Box>
+      <Box sx={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", textAlign: "center", gap: 0.25, px: 1 }}>{children}</Box>
     </Box>
   );
 }
@@ -536,7 +536,7 @@ function CohortHealthCard({ cohorts, avg, onReport }: { cohorts: InstructorCohor
         <Box sx={{ mt: 2, p: 1.5, borderRadius: 2.5, bgcolor: "color-mix(in srgb,#7c3aed 8%,transparent)", display: "flex", gap: 1, alignItems: "flex-start" }}>
           <Icon icon="mdi:sparkles" width={16} style={{ color: "#7c3aed", flexShrink: 0, marginTop: 2 }} />
           <Typography sx={{ fontSize: "0.8rem", color: "var(--font-secondary)", lineHeight: 1.4 }}>
-            Focus on <b>{weakest.name}</b> next — it's your lowest-progress cohort at {fmtPct(weakest.progress)}.
+            Focus on <b>{weakest.name}</b> next. It's your lowest-progress cohort at {fmtPct(weakest.progress)}.
           </Typography>
         </Box>
       )}

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -156,7 +156,7 @@ export default function InstructorLiveSessionsPage() {
       }
       window.open(link.url, "_blank", "noopener");
       setToast({
-        text: link.kind === "panelist" ? "Opening your panelist link — you'll join as a presenter." : "Opening your host link.",
+        text: link.kind === "panelist" ? "Opening your panelist link. You'll join as a presenter." : "Opening your host link.",
         sev: "info",
       });
     } catch {
@@ -182,7 +182,7 @@ export default function InstructorLiveSessionsPage() {
       <ModulePageHeader
         eyebrow="Teach"
         title="Live Sessions"
-        description="Host sessions for the courses and cohorts you're assigned to — create one, share links, and join as a presenter."
+        description="Host sessions for the courses and cohorts you're assigned to. Create one, share links, and join as a presenter."
         accent="pink"
         icon="mdi:video-outline"
         action={
@@ -221,7 +221,7 @@ export default function InstructorLiveSessionsPage() {
         <Box sx={{ p: 5, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
           <Icon icon="mdi:video-off-outline" width={34} style={{ opacity: 0.4 }} />
           <Typography sx={{ color: "text.secondary", mt: 1 }}>
-            {sessions.length === 0 ? "No live sessions yet — schedule one for a cohort you teach." : "No sessions in this view."}
+            {sessions.length === 0 ? "No live sessions yet. Schedule one for a cohort you teach." : "No sessions in this view."}
           </Typography>
           {sessions.length === 0 && (
             <Button onClick={() => setCreateOpen(true)} startIcon={<Icon icon="mdi:calendar-plus" width={16} />}
@@ -388,7 +388,7 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
         ...(kind === "c" ? { cohort_id: id } : { adaptive_course_id: id }),
         ...(sessionType === "webinar" ? { passcode: passcode.trim() || undefined, registration_required: registration } : {}),
       });
-      onCreated(`Session created${sessionType === "webinar" ? " — you're added as a panelist." : "."}`);
+      onCreated(`Session created${sessionType === "webinar" ? ". You're added as a panelist." : "."}`);
       if (created.host_link?.url) window.open(created.host_link.url, "_blank", "noopener");
       reset();
       onClose();

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -72,7 +72,7 @@ function StatusChip({ status }: { status: InstructorStudentStatus }) {
 function relTime(iso: string | null): string {
   if (!iso) return "No activity yet";
   const then = new Date(iso).getTime();
-  if (Number.isNaN(then)) return "—";
+  if (Number.isNaN(then)) return "-";
   const s = Math.max(0, (Date.now() - then) / 1000);
   if (s < 90) return "Active now";
   const m = s / 60;
@@ -246,7 +246,7 @@ function ReportRow({
 
         {/* Cohort */}
         <Typography noWrap sx={{ fontSize: "0.82rem", color: "text.secondary", display: { xs: "none", md: "block" } }}>
-          {s.cohort || "—"}
+          {s.cohort || "-"}
         </Typography>
 
         {/* Progress */}
@@ -261,7 +261,7 @@ function ReportRow({
 
         {/* Avg score — null means no scored submission; a real 0 shows "0%". */}
         <Typography sx={{ fontSize: "0.86rem", fontWeight: 800, display: { xs: "none", md: "block" }, color: s.avg_score == null ? "text.disabled" : undefined }}>
-          {s.avg_score == null ? "—" : `${Math.round(s.avg_score)}%`}
+          {s.avg_score == null ? "-" : `${Math.round(s.avg_score)}%`}
         </Typography>
 
         {/* Points */}
@@ -362,7 +362,7 @@ export default function InstructorStudentsPage() {
     setNudgingId(id);
     try {
       await instructorService.nudgeStudent(id);
-      setToast({ text: "Nudge sent — the student will see it in their notifications.", sev: "success" });
+      setToast({ text: "Nudge sent. The student will see it in their notifications.", sev: "success" });
     } catch {
       setToast({ text: "Couldn't send the nudge right now.", sev: "error" });
     } finally {
@@ -435,7 +435,7 @@ export default function InstructorStudentsPage() {
   const kpis = [
     { label: "Students", value: summary.count, icon: "mdi:account-multiple", color: "#6366f1" },
     { label: "Avg progress", value: `${Math.round(summary.avg_progress)}%`, icon: "mdi:chart-line", color: "#0ea5e9" },
-    { label: "Avg score", value: summary.avg_score ? `${Math.round(summary.avg_score)}%` : "—", icon: "mdi:star-outline", color: "#10b981" },
+    { label: "Avg score", value: summary.avg_score ? `${Math.round(summary.avg_score)}%` : "-", icon: "mdi:star-outline", color: "#10b981" },
     { label: "At risk", value: summary.at_risk, icon: "mdi:alert-outline", color: "#ef4444" },
   ];
 

--- a/components/instructor/InstructorAssignPanel.tsx
+++ b/components/instructor/InstructorAssignPanel.tsx
@@ -81,7 +81,7 @@ export function InstructorAssignPanel({ scope, id }: { scope: "course" | "cohort
         <Icon icon="mdi:account-tie-outline" width={20} style={{ color: "#6366f1" }} />
         <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>Instructors</Typography>
         <Typography sx={{ color: "text.secondary", fontSize: "0.8rem" }}>
-          — assigned instructors own this {scope}&apos;s students.
+          · assigned instructors own this {scope}&apos;s students.
         </Typography>
       </Stack>
 

--- a/components/instructor/RosterRow.tsx
+++ b/components/instructor/RosterRow.tsx
@@ -46,7 +46,7 @@ export function RosterRow({
         {(name || email || "?").slice(0, 1).toUpperCase()}
       </Box>
       <Box sx={{ minWidth: 0, flex: 1 }}>
-        <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }} noWrap>{name || "—"}</Typography>
+        <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }} noWrap>{name || "-"}</Typography>
         <Typography sx={{ color: "text.secondary", fontSize: "0.8rem" }} noWrap>{email}</Typography>
       </Box>
       {right && <Box sx={{ flexShrink: 0 }}>{right}</Box>}


### PR DESCRIPTION
- **Ring**: number+label now centered as one group (was a 2-row grid pushing the % high / label low).
- **Em dashes** removed from all instructor UI strings (dashboard, cohorts, live-sessions, students, analytics, assign panel) — periods/commas/':' /'·' for prose, '-' for empty-value placeholders. Matches the platform's no-em-dash convention.

`tsc` clean.