### PR TITLE
feat(admin): delete student + instructor page de-dupe/remove

### DIFF
--- a/app/admin/instructors/page.tsx
+++ b/app/admin/instructors/page.tsx
@@ -39,7 +39,8 @@ import {
 } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { PageShell } from "@/components/common/PageShell";
-import { InstructorCodeDirectory } from "@/components/admin/instructors/InstructorCodeDirectory";
+import { instructorService } from "@/lib/services/instructor.service";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import {
   ModulePageHeader,
 } from "@/components/common/ModulePageHeader";
@@ -149,6 +150,25 @@ export default function InstructorsPage() {
   const [menuRow, setMenuRow] = useState<InstructorRow | null>(null);
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
 
+  // Public instructor codes, folded into the table (was a separate duplicate directory panel).
+  const [codeById, setCodeById] = useState<Record<number, string>>({});
+  const [codeRow, setCodeRow] = useState<InstructorRow | null>(null);
+  const [codeValue, setCodeValue] = useState("");
+  const [savingCode, setSavingCode] = useState(false);
+  const [removeRow, setRemoveRow] = useState<InstructorRow | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  const loadCodes = useCallback(async () => {
+    try {
+      const rows = await instructorService.getInstructorDirectory();
+      const m: Record<number, string> = {};
+      for (const r of rows) if (r.instructor_code) m[r.profile_id] = r.instructor_code;
+      setCodeById(m);
+    } catch {
+      /* codes are supplementary; ignore load failure */
+    }
+  }, []);
+
   const loadStatus = useCallback(
     async (status: InstructorListStatus) => {
       setLoadingByStatus((s) => ({ ...s, [status]: true }));
@@ -171,7 +191,8 @@ export default function InstructorsPage() {
 
   useEffect(() => {
     void refreshAll();
-  }, [refreshAll]);
+    void loadCodes();
+  }, [refreshAll, loadCodes]);
 
   const refreshCourses = useCallback(async () => {
     try {
@@ -383,7 +404,17 @@ export default function InstructorsPage() {
     }
     if (activeTab === "approved") {
       return (
-        <Stack direction="row" spacing={1} justifyContent="flex-end">
+        <Stack direction="row" spacing={1} justifyContent="flex-end" alignItems="center">
+          {codeById[row.id] && (
+            <Chip
+              size="small"
+              icon={<IconWrapper icon="mdi:shield-account-outline" size={13} />}
+              label={codeById[row.id]}
+              onClick={() => { setCodeValue(codeById[row.id] || ""); setCodeRow(row); }}
+              sx={{ fontWeight: 800, fontFamily: "monospace", cursor: "pointer" }}
+              title="Instructor code (students see this instead of the name)"
+            />
+          )}
           <Button
             size="small"
             variant="outlined"
@@ -393,7 +424,7 @@ export default function InstructorsPage() {
           >
             {t("adminInstructors.actions.assignCourses")}
           </Button>
-          <Tooltip title={t("adminInstructors.actions.promote")}>
+          <Tooltip title="More">
             <IconButton size="small" onClick={(e) => openMenu(row, e.currentTarget)}>
               <IconWrapper icon="mdi:dots-vertical" size={20} />
             </IconButton>
@@ -402,16 +433,28 @@ export default function InstructorsPage() {
       );
     }
     return (
-      <Button
-        size="small"
-        variant="outlined"
-        disabled={busyId === row.id}
-        startIcon={<IconWrapper icon="mdi:refresh" size={16} />}
-        onClick={() => setConfirmReopenRow(row)}
-        sx={{ textTransform: "none" }}
-      >
-        {t("adminInstructors.actions.reopen")}
-      </Button>
+      <Stack direction="row" spacing={1} justifyContent="flex-end">
+        <Button
+          size="small"
+          variant="outlined"
+          disabled={busyId === row.id}
+          startIcon={<IconWrapper icon="mdi:refresh" size={16} />}
+          onClick={() => setConfirmReopenRow(row)}
+          sx={{ textTransform: "none" }}
+        >
+          {t("adminInstructors.actions.reopen")}
+        </Button>
+        <Button
+          size="small"
+          variant="text"
+          color="error"
+          startIcon={<IconWrapper icon="mdi:account-remove-outline" size={16} />}
+          onClick={() => setRemoveRow(row)}
+          sx={{ textTransform: "none" }}
+        >
+          Remove
+        </Button>
+      </Stack>
     );
   };
 
@@ -442,22 +485,6 @@ export default function InstructorsPage() {
         accent="indigo"
         icon="mdi:account-tie"
       />
-
-      {/* Directory: email, assignments, and the public code students see instead of the real name. */}
-      <Box
-        sx={{
-          mb: 3,
-          p: { xs: 2, md: 2.5 },
-          borderRadius: 3,
-          border: "1px solid var(--border-default)",
-          bgcolor: "var(--card-bg)",
-        }}
-      >
-        <Typography sx={{ fontWeight: 800, fontSize: "1rem", mb: 1.5 }}>
-          Instructor codes &amp; assignments
-        </Typography>
-        <InstructorCodeDirectory />
-      </Box>
 
       {/* Status quick-stats (click to switch tab) */}
       <Box
@@ -912,7 +939,90 @@ export default function InstructorsPage() {
             <IconWrapper icon="mdi:book-open-variant" size={18} />
             <Box sx={{ ml: 1 }}>{t("adminInstructors.actions.viewCourses")}</Box>
           </MenuItem>
+          <MenuItem
+            onClick={() => {
+              if (menuRow) { setCodeValue(codeById[menuRow.id] || ""); setCodeRow(menuRow); }
+              closeMenu();
+            }}
+          >
+            <IconWrapper icon="mdi:shield-key-outline" size={18} />
+            <Box sx={{ ml: 1 }}>Set instructor code</Box>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              if (menuRow) setRemoveRow(menuRow);
+              closeMenu();
+            }}
+            sx={{ color: "#ef4444" }}
+          >
+            <IconWrapper icon="mdi:account-remove-outline" size={18} />
+            <Box sx={{ ml: 1 }}>Remove as instructor</Box>
+          </MenuItem>
         </Menu>
+
+        {/* Set instructor code */}
+        <Dialog open={!!codeRow} onClose={() => (savingCode ? undefined : setCodeRow(null))} fullWidth maxWidth="xs">
+          <DialogTitle sx={{ fontWeight: 800 }}>Set instructor code</DialogTitle>
+          <DialogContent>
+            <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", mb: 2 }}>
+              Students see this code instead of the instructor&apos;s real name across courses and live sessions. Leave blank to clear it.
+            </Typography>
+            <TextField
+              autoFocus fullWidth size="small" label="Instructor code"
+              value={codeValue} onChange={(e) => setCodeValue(e.target.value)}
+              placeholder="e.g. RM-07" inputProps={{ maxLength: 32 }}
+            />
+          </DialogContent>
+          <DialogActions sx={{ px: 3, pb: 2 }}>
+            <Button onClick={() => setCodeRow(null)} disabled={savingCode} sx={{ textTransform: "none", fontWeight: 700 }}>Cancel</Button>
+            <Button
+              variant="contained" disabled={savingCode}
+              onClick={async () => {
+                if (!codeRow) return;
+                setSavingCode(true);
+                try {
+                  const res = await instructorService.setInstructorCode(codeRow.id, codeValue.trim());
+                  setCodeById((m) => ({ ...m, [codeRow.id]: res.instructor_code }));
+                  showToast("Instructor code updated.", "success");
+                  setCodeRow(null);
+                } catch (err: unknown) {
+                  showToast(readApiError(err, "Couldn't update the code."), "error");
+                } finally {
+                  setSavingCode(false);
+                }
+              }}
+              sx={{ textTransform: "none", fontWeight: 800 }}
+            >
+              {savingCode ? "Saving…" : "Save code"}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Remove instructor (demote) */}
+        <ConfirmDialog
+          open={!!removeRow}
+          title="Remove as instructor?"
+          message={`This removes ${removeRow?.full_name || "this person"} as an instructor — their role goes back to student, their instructor code is cleared, and all their course/cohort/live-session assignments are removed. Their account and learning data are kept.`}
+          confirmText={removing ? "Removing…" : "Remove instructor"}
+          cancelText="Cancel"
+          confirmColor="error"
+          onCancel={() => (removing ? undefined : setRemoveRow(null))}
+          onConfirm={async () => {
+            if (!removeRow) return;
+            setRemoving(true);
+            try {
+              await adminInstructorsService.removeInstructor(removeRow.id);
+              showToast(`${removeRow.full_name || "Instructor"} is no longer an instructor.`, "success");
+              setRemoveRow(null);
+              await refreshAll();
+              await loadCodes();
+            } catch (err: unknown) {
+              showToast(readApiError(err, "Couldn't remove this instructor."), "error");
+            } finally {
+              setRemoving(false);
+            }
+          }}
+        />
 
         {/* Approve dialog */}
         <Dialog

--- a/app/admin/manage-students/page.tsx
+++ b/app/admin/manage-students/page.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { useToast } from "@/components/common/Toast";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import {
   adminStudentService,
@@ -190,6 +191,11 @@ export default function ManageStudentsPage() {
   // the user's scope, so this only exposes the UI.
   const showOrgAdminEnrollmentTools =
     isClientOrgAdminRole(user?.role) || courseManagerUser;
+  const canDeleteStudents = isClientOrgAdminRole(user?.role);
+
+  // Permanent-delete confirm state.
+  const [deleteTarget, setDeleteTarget] = useState<Student | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   // State - Original data from API
   const [allStudents, setAllStudents] = useState<Student[]>([]);
@@ -1038,6 +1044,7 @@ export default function ManageStudentsPage() {
             onToggleSelectAll={handleToggleSelectAll}
             allSelected={allFilteredSelected}
             someSelected={someFilteredSelected}
+            onDelete={canDeleteStudents ? (s) => setDeleteTarget(s) : undefined}
           />
           <StudentsPagination
             totalPages={totalPages}
@@ -1132,6 +1139,32 @@ export default function ManageStudentsPage() {
           open={quickEnrollDialogOpen}
           onClose={() => setQuickEnrollDialogOpen(false)}
           onSuccess={handleQuickEnrollSuccess}
+        />
+
+        <ConfirmDialog
+          open={!!deleteTarget}
+          title="Delete student permanently?"
+          message={
+            `This permanently removes ${deleteTarget?.name || "this student"} from your organization — their enrollments, submissions, community posts, progress and payment records here are erased. This can't be undone. (If they belong to another organization, their login there is unaffected.)`
+          }
+          confirmText={deleting ? "Deleting…" : "Delete permanently"}
+          cancelText="Cancel"
+          confirmColor="error"
+          onCancel={() => (deleting ? undefined : setDeleteTarget(null))}
+          onConfirm={async () => {
+            if (!deleteTarget) return;
+            setDeleting(true);
+            try {
+              await adminStudentService.deleteStudent(deleteTarget.id);
+              showToast(`${deleteTarget.name || "Student"} removed from your organization.`, "success");
+              setDeleteTarget(null);
+              await loadStudents();
+            } catch {
+              showToast("Couldn't delete this student.", "error");
+            } finally {
+              setDeleting(false);
+            }
+          }}
         />
     </PageShell>
   );

--- a/components/admin/manage-students/StudentsTable.tsx
+++ b/components/admin/manage-students/StudentsTable.tsx
@@ -58,6 +58,8 @@ interface StudentsTableProps {
   /** Header checkbox state across the full (filtered) set. */
   allSelected?: boolean;
   someSelected?: boolean;
+  /** Per-row delete (permanent). When provided, a red delete action renders in the row. */
+  onDelete?: (student: Student) => void;
 }
 
 const getSortIcon = (
@@ -102,6 +104,7 @@ export function StudentsTable({
   onToggleSelectAll,
   allSelected = false,
   someSelected = false,
+  onDelete,
 }: StudentsTableProps) {
   const router = useRouter();
   const { t } = useTranslation("common");
@@ -798,6 +801,21 @@ export function StudentsTable({
                         >
                           <IconWrapper icon="mdi:school-outline" size={18} />
                         </IconButton>
+                        {onDelete && (
+                          <IconButton
+                            size="small"
+                            onClick={() => onDelete(student)}
+                            title="Delete student"
+                            aria-label="Delete student"
+                            sx={{
+                              color: "#ef4444",
+                              "&:hover": { backgroundColor: "#fef2f2", transform: "scale(1.1)" },
+                              transition: "all 0.2s",
+                            }}
+                          >
+                            <IconWrapper icon="mdi:trash-can-outline" size={18} />
+                          </IconButton>
+                        )}
                       </Box>
                     </TableCell>
                   </TableRow>

--- a/lib/services/admin/admin-instructors.service.ts
+++ b/lib/services/admin/admin-instructors.service.ts
@@ -115,6 +115,15 @@ export const adminInstructorsService = {
     return response.data;
   },
 
+  // Remove someone as an instructor: demote to student + strip code/assignments/staff rows.
+  removeInstructor: async (profileId: number): Promise<MutationResponse> => {
+    const response = await apiClient.post<MutationResponse>(
+      `${baseUrl()}/${profileId}/remove/`,
+      {}
+    );
+    return response.data;
+  },
+
   getInstructorCourses: async (
     profileId: number
   ): Promise<InstructorCoursesPayload> => {

--- a/lib/services/admin/admin-student.service.ts
+++ b/lib/services/admin/admin-student.service.ts
@@ -417,6 +417,15 @@ export const adminStudentService = {
     return response.data;
   },
 
+  // Permanently delete a student from THIS org (?hard=true). Removes their per-tenant profile +
+  // this org's data; the shared login survives if they belong to another org. Admin only.
+  deleteStudent: async (studentId: number) => {
+    const response = await apiClient.delete(
+      `/admin-dashboard/api/clients/${config.clientId}/manage-student/${studentId}/?hard=true`
+    );
+    return response.data;
+  },
+
   // Bulk enroll / unenroll EXISTING students across courses (synchronous M2M op).
   // Accepts legacy course ids and/or adaptive course ids.
   bulkCourseAction: async (


### PR DESCRIPTION
Backed by BE #449.

**Manage Students** — red per-row **delete** (admin/superadmin), with a ConfirmDialog spelling out the permanent per-org consequence → `deleteStudent` (`?hard=true`) → reload.

**Instructors page** (fixes 'data twice / pending buried / unorganised'):
- **Removed** the duplicated `InstructorCodeDirectory` panel that sat above the stats+tabs — that was the double-listing + why pending/rejected were pushed down. Stats + status tabs are now the top.
- **Folded the instructor code into the table**: a code chip on approved rows (click to edit) + a 'Set instructor code' menu item. One list, no duplication.
- Added **'Remove as instructor'** (approved menu + rejected row) → `removeInstructor` with a clear confirm.

`tsc` clean.