### PR TITLE
feat(live-sessions): per-session timezone end-to-end (pick on create/edit + dual-zone display)

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -48,12 +48,10 @@ import { WebinarInvitationsSection } from "@/components/admin/live-sessions/Webi
 import { WebinarEmailSection } from "@/components/admin/live-sessions/WebinarEmailSection";
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import { EditWebinarDialog } from "@/components/admin/live-sessions/EditWebinarDialog";
+import { formatSessionTime } from "@/lib/utils/session-time";
 
-function formatDateTime(s?: string | null) {
-  if (!s) return "-";
-  return new Date(s).toLocaleString("en-US", {
-    year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
-  });
+function formatDateTime(s?: string | null, timezone?: string | null) {
+  return formatSessionTime(s, timezone);
 }
 
 function platformIcon(a: LiveActivity): string {
@@ -388,7 +386,7 @@ export default function LiveSessionDetailPage() {
               <AdaptiveSectionHero
                 chapter={t("adminLiveSessions.chapter", "Manage · Live Sessions")}
                 title={activity.topic_name || t("adminLiveSessions.untitledSession", "Untitled session")}
-                subtitle={`${formatDateTime(activity.class_datetime)} · ${activity.duration_minutes} ${t("liveSessions.minShort", "min")}${activity.course_detail?.title ? ` · ${activity.course_detail.title}` : ""}${activity.cohort_detail?.name ? ` · 👥 ${activity.cohort_detail.name}` : ""}`}
+                subtitle={`${formatDateTime(activity.class_datetime, activity.timezone)} · ${activity.duration_minutes} ${t("liveSessions.minShort", "min")}${activity.course_detail?.title ? ` · ${activity.course_detail.title}` : ""}${activity.cohort_detail?.name ? ` · 👥 ${activity.cohort_detail.name}` : ""}`}
                 accent="indigo"
                 icon={platformIcon(activity)}
                 rightSlot={headerActions}

--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -42,6 +42,7 @@ import {
   copyToClipboard,
 } from "@/lib/utils/live-session-errors";
 import { InfoCallout, SectionCard } from "@/components/live-sessions/ui/LiveSessionUI";
+import { viewerTimeZone, timezoneOptions, formatNaiveWallClock } from "@/lib/utils/session-time";
 
 type SessionType = "zoom" | "webinar" | "meet";
 
@@ -68,6 +69,10 @@ export default function CreateLiveSessionPage() {
   const [topicName, setTopicName] = useState("");
   const [description, setDescription] = useState("");
   const [classDatetime, setClassDatetime] = useState("");
+  // The zone the wall-clock above is entered in. Defaults to the admin's own browser zone (set in an
+  // effect to avoid an SSR/client mismatch) so "6 PM" means 6 PM where they're sitting — the fix for
+  // a KSA admin's session landing in IST.
+  const [sessionTz, setSessionTz] = useState("");
   const [durationMinutes, setDurationMinutes] = useState(60);
   const [recurrence, setRecurrence] = useState<LiveSessionRecurrence | null>(null);
   const [closesAt, setClosesAt] = useState("");
@@ -132,6 +137,12 @@ export default function CreateLiveSessionPage() {
   useEffect(() => {
     if (!authLoading && !canAccessAdmin) router.replace("/dashboard");
   }, [authLoading, canAccessAdmin, router]);
+
+  // Default the session's timezone to the admin's own zone once mounted (client-only so it can't
+  // cause a hydration mismatch). Falls back to IST if the browser can't resolve a zone.
+  useEffect(() => {
+    if (!sessionTz) setSessionTz(viewerTimeZone() || "Asia/Kolkata");
+  }, [sessionTz]);
 
   // Clamp step index if the step list shrinks (e.g. switching to Google Meet).
   useEffect(() => {
@@ -285,7 +296,8 @@ export default function CreateLiveSessionPage() {
             showToast(t("adminLiveSessions.invalidCloseDateTime"), "error");
             return;
           }
-          closesIso = cd.toISOString();
+          // Send the naive wall-clock; the backend interprets it in `timezone`, same as class_datetime.
+          closesIso = closesAt;
         }
 
         // Manual mode: legacy paste-your-own-link - save the session with the link directly.
@@ -294,6 +306,7 @@ export default function CreateLiveSessionPage() {
             topic_name: trimmedTopic,
             description: description.trim() || undefined,
             class_datetime: classDatetime,
+            timezone: sessionTz || undefined,
             duration_minutes: duration,
             instructor_id: getValidInstructorId(),
             course: courseId ?? undefined,
@@ -321,6 +334,7 @@ export default function CreateLiveSessionPage() {
             topic_name: trimmedTopic,
             description: description.trim() || undefined,
             class_datetime: classDatetime,
+            timezone: sessionTz || undefined,
             duration_minutes: duration,
             instructor_id: getValidInstructorId(),
             course: courseId ?? undefined,
@@ -373,11 +387,12 @@ export default function CreateLiveSessionPage() {
           topic_name: trimmedTopic,
           description: description.trim() || undefined,
           class_datetime: classDatetime,
+          timezone: sessionTz || undefined,
           duration_minutes: duration,
           instructor_id: getValidInstructorId(),
           course: courseId ?? undefined,
-            cohort: cohortId ?? undefined,
-            adaptive_course: adaptiveCourseId ?? undefined,
+          cohort: cohortId ?? undefined,
+          adaptive_course: adaptiveCourseId ?? undefined,
           zoom_meeting_type: isWebinar ? "webinar" : "meeting",
         });
         setCreatedSession(session);
@@ -553,10 +568,23 @@ export default function CreateLiveSessionPage() {
                       value={classDatetime}
                       onChange={(e) => setClassDatetime(e.target.value)}
                       required size="small"
-                      sx={{ flex: "1 1 240px" }}
+                      sx={{ flex: "1 1 220px" }}
                       InputLabelProps={{ shrink: true }}
-                      helperText={t("adminLiveSessions.timesLocalTimezone")}
+                      helperText={t("adminLiveSessions.timeInSelectedZone", "The wall-clock time, in the timezone selected →")}
                     />
+                    <TextField
+                      label={t("adminLiveSessions.timezone", "Timezone")}
+                      select
+                      value={sessionTz}
+                      onChange={(e) => setSessionTz(e.target.value)}
+                      size="small"
+                      sx={{ flex: "1 1 200px" }}
+                      helperText={t("adminLiveSessions.timezoneHelper", "The session is scheduled in this zone")}
+                    >
+                      {timezoneOptions(sessionTz).map((z) => (
+                        <MenuItem key={z.value} value={z.value}>{z.label}</MenuItem>
+                      ))}
+                    </TextField>
                     <TextField
                       label={t("adminLiveSessions.durationMinutes")}
                       type="number"
@@ -760,7 +788,7 @@ export default function CreateLiveSessionPage() {
                     <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
                       <ReviewRow label={t("adminLiveSessions.sessionType")} value={isMeet ? t("adminLiveSessions.sessionTypeMeet") : isWebinar ? t("adminLiveSessions.sessionTypeWebinar", "Zoom Webinar") : t("adminLiveSessions.sessionTypeZoom")} />
                       <ReviewRow label={t("adminLiveSessions.topicName")} value={topicName.trim() || "-"} />
-                      <ReviewRow label={t("adminLiveSessions.classDateAndTime")} value={classDatetime ? new Date(classDatetime).toLocaleString() : "-"} />
+                      <ReviewRow label={t("adminLiveSessions.classDateAndTime")} value={formatNaiveWallClock(classDatetime, sessionTz)} />
                       <ReviewRow label={t("adminLiveSessions.durationMinutes")} value={`${durationMinutes} min`} />
                       {courseId != null && <ReviewRow label={t("adminLiveSessions.course")} value={courses.find((c) => c.id === courseId)?.title ?? String(courseId)} />}
                       {cohortId != null && <ReviewRow label="Cohort" value={cohorts.find((c) => c.id === cohortId)?.name ?? String(cohortId)} />}

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -28,6 +28,7 @@ import {
   ImportedMeetingsInboxHandle,
 } from "@/components/admin/live-sessions/ImportedMeetingsInbox";
 import { MeetingPresetsDialog } from "@/components/admin/live-sessions/MeetingPresetsDialog";
+import { sessionTimeParts } from "@/lib/utils/session-time";
 import { VirtualBackgroundsDialog } from "@/components/admin/live-sessions/VirtualBackgroundsDialog";
 import { LiveSessionCard } from "@/components/live-sessions/ui/LiveSessionCard";
 import { LiveSessionsCalendar } from "@/components/live-sessions/ui/LiveSessionsCalendar";
@@ -524,10 +525,10 @@ function SessionListRow({ session, onOpen }: { session: LiveActivity; onOpen: (s
   const status = isCancelled ? "cancelled" : session.meeting_status ?? "scheduled";
   const statusLabel = ROW_STATUS_LABEL[status] ?? ROW_STATUS_LABEL.scheduled;
 
-  const dt = session.class_datetime ? new Date(session.class_datetime) : null;
-  const validDt = dt && !isNaN(dt.getTime()) ? dt : null;
-  const dateStr = validDt ? validDt.toLocaleDateString(undefined, { month: "short", day: "numeric" }) : "-";
-  const timeStr = validDt ? validDt.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }) : "-";
+  // Rendered in the session's own timezone (consistent for every admin), with a zone label.
+  const timeParts = sessionTimeParts(session.class_datetime, session.timezone);
+  const dateStr = timeParts.date;
+  const timeStr = timeParts.zoneAbbr ? `${timeParts.time} ${timeParts.zoneAbbr}` : timeParts.time;
   const durStr = session.duration_minutes ? `${session.duration_minutes}m` : "-";
   const attendees = session.attendance_count ?? 0;
 

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -30,6 +30,7 @@ import {
   type LiveSessionProvider,
   type AttendeeRow,
 } from "@/lib/services/instructor.service";
+import { viewerTimeZone, timezoneOptions, sessionTimeParts } from "@/lib/utils/session-time";
 
 type SessionStatus = "live" | "scheduled" | "ended";
 
@@ -70,21 +71,23 @@ function isToday(dt: string, now: number): boolean {
   const n = new Date(now);
   return d.getFullYear() === n.getFullYear() && d.getMonth() === n.getMonth() && d.getDate() === n.getDate();
 }
-function timeLabel(dt: string): string {
+function timeLabel(dt: string, tz?: string | null): string {
   try {
-    return new Date(dt).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false });
+    const p = sessionTimeParts(dt, tz);
+    return p.zoneAbbr ? `${p.time} ${p.zoneAbbr}` : p.time;
   } catch {
     return "";
   }
 }
-function dateLabel(dt: string, now: number, status: SessionStatus): string {
+function dateLabel(dt: string, now: number, status: SessionStatus, tz?: string | null): string {
   if (isToday(dt, now)) return "TODAY";
   try {
     const d = new Date(dt);
-    const day = d.toLocaleDateString(undefined, { day: "numeric" });
-    const mon = d.toLocaleDateString(undefined, { month: "short" }).toUpperCase();
+    const z = tz || undefined;
+    const day = d.toLocaleDateString(undefined, { day: "numeric", timeZone: z });
+    const mon = d.toLocaleDateString(undefined, { month: "short", timeZone: z }).toUpperCase();
     if (status === "scheduled") {
-      const wd = d.toLocaleDateString(undefined, { weekday: "short" }).toUpperCase();
+      const wd = d.toLocaleDateString(undefined, { weekday: "short", timeZone: z }).toUpperCase();
       return `${wd} ${day} ${mon}`;
     }
     return `${day} ${mon}`;
@@ -300,6 +303,7 @@ function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttenda
   const p = PROVIDER_META[s.provider] ?? PROVIDER_META.manual;
   const isLive = status === "live";
   const today = isToday(s.class_datetime, now);
+  const viewerTime = sessionTimeParts(s.class_datetime, s.timezone).viewerTime;
   const hasStats = s.registered > 0 && s.turnout != null && (status === "ended" || s.attendance > 0);
 
   const outlineBtn = { textTransform: "none", fontWeight: 700, color: "#6366f1", px: 1.75, py: 0.9, borderRadius: 2, border: "1px solid var(--border-default)" } as const;
@@ -312,11 +316,11 @@ function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttenda
       {/* Date/time badge */}
       <Box sx={{ width: 78, flexShrink: 0, borderRadius: 2.5, textAlign: "center", py: 1,
         bgcolor: today ? "color-mix(in srgb,#10b981 14%,transparent)" : "color-mix(in srgb,var(--border-default) 40%,transparent)" }}>
-        <Typography sx={{ fontWeight: 900, fontSize: "1.05rem", lineHeight: 1, color: today ? "#059669" : "var(--font-primary)" }}>
-          {timeLabel(s.class_datetime)}
+        <Typography sx={{ fontWeight: 900, fontSize: "0.98rem", lineHeight: 1.15, color: today ? "#059669" : "var(--font-primary)" }}>
+          {timeLabel(s.class_datetime, s.timezone)}
         </Typography>
         <Typography sx={{ fontSize: "0.6rem", fontWeight: 800, letterSpacing: 0.4, color: "text.secondary", mt: 0.4 }}>
-          {dateLabel(s.class_datetime, now, status)}
+          {dateLabel(s.class_datetime, now, status, s.timezone)}
         </Typography>
       </Box>
 
@@ -332,6 +336,9 @@ function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttenda
             <Typography sx={{ fontSize: "0.72rem", fontWeight: 700 }}>{p.label}</Typography>
           </Stack>
           <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>{s.duration_minutes}m</Typography>
+          {viewerTime && (
+            <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>· {viewerTime} your time</Typography>
+          )}
         </Stack>
         <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.2 }} noWrap>{s.topic_name}</Typography>
         <Stack direction="row" spacing={0.4} alignItems="center" sx={{ color: "text.secondary", mt: 0.3 }}>
@@ -418,6 +425,7 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
   const [topic, setTopic] = useState("");
   const [description, setDescription] = useState("");
   const [when, setWhen] = useState("");
+  const [sessionTz, setSessionTz] = useState("");
   const [duration, setDuration] = useState(60);
   const [audience, setAudience] = useState("");
   const [passcode, setPasscode] = useState("");
@@ -429,6 +437,8 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
     if (!open) return;
     instructorService.getCohorts().then(setCohorts).catch(() => undefined);
     instructorService.getCourses().then(setCourses).catch(() => undefined);
+    // Default the session zone to the instructor's own zone (client-only).
+    setSessionTz((prev) => prev || viewerTimeZone() || "Asia/Kolkata");
   }, [open]);
 
   const reset = () => {
@@ -446,7 +456,8 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
       const created = await instructorService.createLiveSession({
         topic_name: topic.trim(),
         description: description.trim() || undefined,
-        class_datetime: new Date(when).toISOString(),
+        class_datetime: when,
+        timezone: sessionTz || undefined,
         duration_minutes: duration,
         session_type: sessionType,
         ...(kind === "c" ? { cohort_id: id } : { adaptive_course_id: id }),
@@ -489,11 +500,17 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
           <TextField label="Description (optional)" value={description} onChange={(e) => setDescription(e.target.value)} fullWidth size="small" multiline minRows={2} />
           <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
             <TextField label="Starts" type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
-              fullWidth size="small" InputLabelProps={{ shrink: true }} />
+              fullWidth size="small" InputLabelProps={{ shrink: true }} helperText="Wall-clock time, in the timezone →" />
             <TextField label="Duration (min)" type="number" value={duration}
               onChange={(e) => setDuration(Math.max(1, Math.min(600, Number(e.target.value) || 0)))}
-              size="small" sx={{ width: { xs: "100%", sm: 160 } }} inputProps={{ min: 1, max: 600 }} />
+              size="small" sx={{ width: { xs: "100%", sm: 130 } }} inputProps={{ min: 1, max: 600 }} />
           </Stack>
+          <TextField select label="Timezone" value={sessionTz} onChange={(e) => setSessionTz(e.target.value)}
+            fullWidth size="small" helperText="The session is scheduled in this zone">
+            {timezoneOptions(sessionTz).map((z) => (
+              <MenuItem key={z.value} value={z.value}>{z.label}</MenuItem>
+            ))}
+          </TextField>
           <TextField select label="Cohort or course" value={audience} onChange={(e) => setAudience(e.target.value)} fullWidth size="small">
             {cohorts.length > 0 && <MenuItem disabled sx={{ fontWeight: 800, opacity: 1 }}>Cohorts</MenuItem>}
             {cohorts.map((c) => <MenuItem key={`c${c.id}`} value={`c:${c.id}`}>&nbsp;&nbsp;{c.name}</MenuItem>)}
@@ -528,11 +545,19 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
 
 /* ----------------------------- edit dialog -------------------------------- */
 
-function toLocalInput(iso: string): string {
+/** Render an absolute instant as a datetime-local wall-clock IN THE GIVEN ZONE (not the browser's). */
+function toLocalInput(iso: string, tz?: string | null): string {
   try {
     const d = new Date(iso);
-    const pad = (n: number) => String(n).padStart(2, "0");
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    if (isNaN(d.getTime())) return "";
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", hour12: false,
+      timeZone: tz || undefined,
+    }).formatToParts(d);
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+    const hour = get("hour") === "24" ? "00" : get("hour");
+    return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}`;
   } catch {
     return "";
   }
@@ -543,14 +568,18 @@ function EditSessionDialog({ session, onClose, onSaved }: {
 }) {
   const [topic, setTopic] = useState("");
   const [when, setWhen] = useState("");
+  const [sessionTz, setSessionTz] = useState("");
   const [duration, setDuration] = useState(60);
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
     if (session) {
+      const tz = session.timezone || viewerTimeZone() || "Asia/Kolkata";
       setTopic(session.topic_name);
-      setWhen(toLocalInput(session.class_datetime));
+      setSessionTz(tz);
+      // Show the wall-clock in the SESSION's own zone so editing from another zone doesn't shift it.
+      setWhen(toLocalInput(session.class_datetime, tz));
       setDuration(session.duration_minutes);
       setErr(null);
     }
@@ -564,7 +593,8 @@ function EditSessionDialog({ session, onClose, onSaved }: {
     try {
       await instructorService.editLiveSession(session.id, {
         topic_name: topic.trim(),
-        class_datetime: new Date(when).toISOString(),
+        class_datetime: when,
+        timezone: sessionTz || undefined,
         duration_minutes: duration,
       });
       onSaved(); onClose();
@@ -583,7 +613,13 @@ function EditSessionDialog({ session, onClose, onSaved }: {
         <Stack spacing={2} sx={{ mt: 0.5 }}>
           <TextField label="Topic" value={topic} onChange={(e) => setTopic(e.target.value)} fullWidth size="small" />
           <TextField label="Starts" type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
-            fullWidth size="small" InputLabelProps={{ shrink: true }} />
+            fullWidth size="small" InputLabelProps={{ shrink: true }} helperText="Wall-clock time, in the timezone below" />
+          <TextField select label="Timezone" value={sessionTz} onChange={(e) => setSessionTz(e.target.value)}
+            fullWidth size="small">
+            {timezoneOptions(sessionTz).map((z) => (
+              <MenuItem key={z.value} value={z.value}>{z.label}</MenuItem>
+            ))}
+          </TextField>
           <TextField label="Duration (min)" type="number" value={duration}
             onChange={(e) => setDuration(Math.max(1, Math.min(600, Number(e.target.value) || 0)))}
             size="small" inputProps={{ min: 1, max: 600 }} />

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -13,6 +13,7 @@ import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlaye
 import { StudentSessionSummaryDialog } from "@/components/live-sessions/StudentSessionSummaryDialog";
 import { studentLiveSessionsService } from "@/lib/services/live-sessions";
 import type { StudentLiveSession, StudentLiveOccurrence, MyLiveStats } from "@/lib/services/live-sessions";
+import { formatSessionClock, formatSessionTime } from "@/lib/utils/session-time";
 
 /* --------------------------------- helpers -------------------------------- */
 
@@ -35,18 +36,15 @@ function joinUrlOf(s: StudentLiveSession): string {
 function initials(name: string): string {
   return (name || "?").trim().slice(0, 2).toUpperCase();
 }
-function fmtDay(dt?: string | null) {
+function fmtDay(dt?: string | null, tz?: string | null) {
   if (!dt) return { d: "", mon: "", wd: "" };
   const x = new Date(dt);
+  const z = tz || undefined;
   return {
-    d: x.toLocaleDateString(undefined, { day: "2-digit" }),
-    mon: x.toLocaleDateString(undefined, { month: "short" }).toUpperCase(),
-    wd: x.toLocaleDateString(undefined, { weekday: "short" }).toUpperCase(),
+    d: x.toLocaleDateString(undefined, { day: "2-digit", timeZone: z }),
+    mon: x.toLocaleDateString(undefined, { month: "short", timeZone: z }).toUpperCase(),
+    wd: x.toLocaleDateString(undefined, { weekday: "short", timeZone: z }).toUpperCase(),
   };
-}
-function fmtTime(dt?: string | null) {
-  if (!dt) return "";
-  return new Date(dt).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 function startedAgo(dt?: string | null): string {
   if (!dt) return "";
@@ -423,8 +421,8 @@ function StatCard({ icon, tint, value, label, sub }: { icon: string; tint: strin
   );
 }
 
-function DateBadge({ dt }: { dt?: string | null }) {
-  const b = fmtDay(dt);
+function DateBadge({ dt, tz }: { dt?: string | null; tz?: string | null }) {
+  const b = fmtDay(dt, tz);
   return (
     <Box sx={{ width: 58, flexShrink: 0, borderRadius: 2.5, border: "1px solid var(--border-default)", textAlign: "center", overflow: "hidden" }}>
       <Box sx={{ py: 0.3, bgcolor: "color-mix(in srgb,var(--border-default) 35%,transparent)", fontSize: "0.58rem", fontWeight: 800, color: "text.secondary" }}>{b.wd}</Box>
@@ -511,12 +509,12 @@ function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind
         </Stack>
       )}
       <Box sx={{ p: 2.25, display: "flex", gap: 2, alignItems: "flex-start", flexWrap: "wrap" }}>
-        <DateBadge dt={s.class_datetime} />
+        <DateBadge dt={s.class_datetime} tz={s.timezone} />
         <Box sx={{ flex: 1, minWidth: 200 }}>
           <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 0.5, flexWrap: "wrap", gap: 0.5 }}>
             <Box sx={{ px: 0.9, py: 0.2, borderRadius: 999, bgcolor: "color-mix(in srgb,#8b5cf6 14%,transparent)", color: "#6d28d9", fontSize: "0.66rem", fontWeight: 800 }}>Scheduled</Box>
             <Stack direction="row" spacing={0.35} alignItems="center" sx={{ color: p.color }}><Icon icon={p.icon} width={14} /><Typography sx={{ fontSize: "0.72rem", fontWeight: 700 }}>{p.label}</Typography></Stack>
-            <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>{fmtTime(s.class_datetime)} · {s.duration_minutes || 0}m</Typography>
+            <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>{formatSessionClock(s.class_datetime, s.timezone)} · {s.duration_minutes || 0}m</Typography>
             {recurring && <Box sx={{ px: 0.8, py: 0.2, borderRadius: 999, bgcolor: "color-mix(in srgb,#6366f1 12%,transparent)", color: "#4f46e5", fontSize: "0.64rem", fontWeight: 800 }}>Recurring</Box>}
           </Stack>
           <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.2 }}>{s.topic_name}</Typography>
@@ -537,7 +535,7 @@ function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind
                       <Icon icon={o.meeting_status === "ended" ? "mdi:check-circle" : o.meeting_status === "live" ? "mdi:access-point" : "mdi:calendar-blank-outline"} width={14}
                         style={{ color: o.meeting_status === "ended" ? "#10b981" : o.meeting_status === "live" ? "#ef4444" : "#94a3b8" }} />
                       <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
-                        {o.occurrence_datetime ? new Date(o.occurrence_datetime).toLocaleString(undefined, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }) : ""}
+                        {o.occurrence_datetime ? formatSessionTime(o.occurrence_datetime, s.timezone, { format: { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }, dual: false }) : ""}
                       </Typography>
                       {o.has_recording && <Icon icon="mdi:play-circle-outline" width={13} style={{ color: "#7c3aed" }} />}
                     </Stack>
@@ -597,7 +595,7 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
   const hasSummary = Boolean(s.zoom_ai_summary || s.google_ai_summary);
   return (
     <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 2, display: "flex", gap: 1.75, alignItems: "center", flexWrap: "wrap" }}>
-      <DateBadge dt={s.class_datetime} />
+      <DateBadge dt={s.class_datetime} tz={s.timezone} />
       <Box sx={{ flex: 1, minWidth: 180 }}>
         <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{s.topic_name}</Typography>
         <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>{courseOf(s) || "Recording available"}</Typography>
@@ -627,7 +625,7 @@ function HistoryRow({ s }: { s: StudentLiveSession }) {
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }} noWrap>{s.topic_name}</Typography>
         <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
-          {s.class_datetime ? new Date(s.class_datetime).toLocaleDateString(undefined, { month: "short", day: "numeric" }) : ""}
+          {s.class_datetime ? formatSessionTime(s.class_datetime, s.timezone, { format: { month: "short", day: "numeric" }, dual: false, showZone: false }) : ""}
           {courseOf(s) ? ` · ${courseOf(s)}` : ""}
         </Typography>
       </Box>

--- a/components/admin/live-sessions/EditWebinarDialog.tsx
+++ b/components/admin/live-sessions/EditWebinarDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogContent,
   DialogActions,
   TextField,
+  MenuItem,
   IconButton,
   CircularProgress,
 } from "@mui/material";
@@ -22,6 +23,7 @@ import {
 } from "@/lib/services/admin/admin-live-activities.service";
 import { getZoomApiErrorMessage } from "@/lib/utils/live-session-errors";
 import { InfoCallout } from "@/components/live-sessions/ui/LiveSessionUI";
+import { viewerTimeZone, timezoneOptions, wallClockToUtcIso, toLocalInputInZone } from "@/lib/utils/session-time";
 
 interface Props {
   activity: LiveActivity;
@@ -36,21 +38,18 @@ export function EditWebinarDialog({ activity, open, onClose, onSaved }: Props) {
   const { showToast } = useToast();
   const [topic, setTopic] = useState("");
   const [datetime, setDatetime] = useState("");
+  const [sessionTz, setSessionTz] = useState("");
   const [duration, setDuration] = useState(60);
   const [passcode, setPasscode] = useState("");
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!open) return;
+    const tz = activity.timezone || viewerTimeZone() || "Asia/Kolkata";
     setTopic(activity.topic_name ?? "");
-    // datetime-local wants 'YYYY-MM-DDTHH:mm' in local time.
-    if (activity.class_datetime) {
-      const d = new Date(activity.class_datetime);
-      const pad = (n: number) => String(n).padStart(2, "0");
-      setDatetime(`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`);
-    } else {
-      setDatetime("");
-    }
+    setSessionTz(tz);
+    // Show the wall-clock in the session's OWN zone so editing from another zone doesn't shift it.
+    setDatetime(toLocalInputInZone(activity.class_datetime, tz));
     setDuration(activity.duration_minutes ?? 60);
     setPasscode(activity.zoom_password ?? "");
   }, [open, activity]);
@@ -59,11 +58,16 @@ export function EditWebinarDialog({ activity, open, onClose, onSaved }: Props) {
     const input: {
       topic?: string;
       start_time?: string;
+      timezone?: string;
       duration?: number;
       passcode?: string;
     } = {};
     if (topic.trim() && topic.trim() !== activity.topic_name) input.topic = topic.trim();
-    if (datetime) input.start_time = new Date(datetime).toISOString().replace(/\.\d{3}Z$/, "Z");
+    if (datetime) {
+      // Interpret the wall-clock in the picked zone → an unambiguous UTC instant for Zoom.
+      input.start_time = wallClockToUtcIso(datetime, sessionTz).replace(/\.\d{3}Z$/, "Z");
+      if (sessionTz) input.timezone = sessionTz;
+    }
     if (duration && duration !== activity.duration_minutes) input.duration = duration;
     if (passcode !== (activity.zoom_password ?? "")) input.passcode = passcode;
 
@@ -133,7 +137,20 @@ export function EditWebinarDialog({ activity, open, onClose, onSaved }: Props) {
             fullWidth
             size="small"
             InputLabelProps={{ shrink: true }}
+            helperText={t("adminLiveSessions.timeInSelectedZone", "The wall-clock time, in the timezone below")}
           />
+          <TextField
+            select
+            label={t("adminLiveSessions.timezone", "Timezone")}
+            value={sessionTz}
+            onChange={(e) => setSessionTz(e.target.value)}
+            fullWidth
+            size="small"
+          >
+            {timezoneOptions(sessionTz).map((z) => (
+              <MenuItem key={z.value} value={z.value}>{z.label}</MenuItem>
+            ))}
+          </TextField>
           <TextField
             label={t("adminLiveSessions.durationMinutes")}
             type="number"

--- a/components/live-sessions/ui/LiveSessionCard.tsx
+++ b/components/live-sessions/ui/LiveSessionCard.tsx
@@ -4,6 +4,7 @@ import { Box, ButtonBase, CircularProgress, IconButton, Tooltip, Typography } fr
 import { useTranslation } from "react-i18next";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { StatusChip, type ChipTone } from "@/components/admin/assessment/shared";
+import { sessionTimeParts } from "@/lib/utils/session-time";
 
 /**
  * Minimal session shape the card renders. Both the admin `LiveActivity` and the
@@ -13,6 +14,7 @@ export interface LiveSessionCardData {
   id: number;
   topic_name?: string;
   class_datetime?: string | null;
+  timezone?: string | null;
   duration_minutes?: number;
   is_zoom?: boolean;
   is_google_meet?: boolean;
@@ -195,11 +197,12 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
   const platform = platformChip(session);
   const attendees = attendanceCount ?? session.attendance_count ?? 0;
 
-  // Compact strip values.
-  const dt = session.class_datetime ? new Date(session.class_datetime) : null;
-  const validDt = dt && !isNaN(dt.getTime()) ? dt : null;
-  const dateStr = validDt ? validDt.toLocaleDateString(undefined, { month: "short", day: "numeric" }) : "-";
-  const timeStr = validDt ? validDt.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }) : "-";
+  // Compact strip values — rendered in the SESSION's own timezone so everyone sees the same wall-clock,
+  // with the viewer's local time added below when it differs.
+  const timeParts = sessionTimeParts(session.class_datetime, session.timezone);
+  const dateStr = timeParts.date;
+  const timeStr = timeParts.time;
+  const timeCellLabel = timeParts.zoneAbbr || t("liveSessions.time", "Time");
   const durStr = session.duration_minutes ? `${session.duration_minutes}m` : "-";
 
   // Meta line (like the assessment "deadline" line): recurrence > course > one-time.
@@ -281,7 +284,7 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
       >
         {[
           { value: dateStr, label: t("liveSessions.date", "Date") },
-          { value: timeStr, label: t("liveSessions.time", "Time") },
+          { value: timeStr, label: timeCellLabel },
           { value: durStr, label: t("liveSessions.duration", "Duration") },
         ].map((cell, i) => (
           <Box
@@ -297,6 +300,12 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
           </Box>
         ))}
       </Box>
+
+      {timeParts.viewerTime && (
+        <Typography sx={{ mt: -0.75, textAlign: "center", fontSize: "0.72rem", color: "var(--font-tertiary)" }}>
+          {t("liveSessions.yourTimeIs", "{{time}} your time", { time: timeParts.viewerTime })}
+        </Typography>
+      )}
 
       {/* Meta line: recurrence / course / one-time, plus attendance for admins */}
       <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, flexWrap: "wrap", minWidth: 0 }}>

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -53,6 +53,8 @@ export interface LiveActivity {
   join_link?: string | null;
   recording_link?: string | null;
   class_datetime: string;
+  /** IANA zone the session was scheduled in (authoritative for display; "" on legacy rows). */
+  timezone?: string | null;
   duration_minutes: number;
   instructor?: unknown;
   is_zoom: boolean;

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -229,6 +229,8 @@ export interface InstructorLiveSession {
   id: number;
   topic_name: string;
   class_datetime: string;
+  /** IANA zone the session was scheduled in (authoritative for display; "" on legacy rows). */
+  timezone?: string | null;
   duration_minutes: number;
   join_link: string;
   is_upcoming: boolean;
@@ -252,7 +254,9 @@ export interface InstructorLiveSession {
 export interface EditLiveSessionPayload {
   topic_name?: string;
   description?: string;
+  /** Naive wall-clock; interpreted in `timezone` when both are sent. */
   class_datetime?: string;
+  timezone?: string;
   duration_minutes?: number;
 }
 
@@ -283,7 +287,10 @@ export interface HostLink {
 export interface CreateLiveSessionPayload {
   topic_name: string;
   description?: string;
+  /** Naive wall-clock ("YYYY-MM-DDTHH:mm"); the backend interprets it in `timezone`. */
   class_datetime: string;
+  /** IANA zone the wall-clock is in (defaults to the instructor's browser zone). */
+  timezone?: string;
   duration_minutes: number;
   session_type: "meeting" | "webinar";
   cohort_id?: number;

--- a/lib/services/live-class.service.ts
+++ b/lib/services/live-class.service.ts
@@ -9,6 +9,7 @@ export interface LiveClassSession {
   title?: string;
   description?: string;
   class_datetime?: string;
+  timezone?: string | null;
   scheduled_time?: string;
   duration_minutes: number;
   instructor?: { id: number; name?: string } | number;
@@ -28,7 +29,10 @@ export interface LiveClassSession {
 export interface CreateLiveClassSessionPayload {
   topic_name: string;
   description?: string;
+  /** Naive wall-clock ("YYYY-MM-DDTHH:mm"); the backend interprets it in `timezone`. */
   class_datetime: string;
+  /** IANA zone the wall-clock is in (defaults to the picker's browser/tenant zone). */
+  timezone?: string;
   duration_minutes: number;
   instructor_id?: number;
   instructor?: number;
@@ -45,7 +49,9 @@ export interface CreateLiveClassSessionPayload {
 export interface UpdateLiveClassSessionPayload {
   topic_name?: string;
   description?: string;
+  /** Naive wall-clock; interpreted in `timezone` when both are sent together. */
   class_datetime?: string;
+  timezone?: string;
   duration_minutes?: number;
   meeting_link?: string;
   status?: string;

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -3,6 +3,8 @@ export interface StudentLiveSession {
   id: number;
   topic_name?: string;
   class_datetime?: string;
+  /** IANA zone the session was scheduled in (authoritative for display; may be "" on legacy rows). */
+  timezone?: string | null;
   duration_minutes?: number;
   time_remaining_minutes: number;
   is_zoom?: boolean;

--- a/lib/utils/session-time.ts
+++ b/lib/utils/session-time.ts
@@ -1,0 +1,243 @@
+/**
+ * Single source of truth for rendering a live session's time.
+ *
+ * A session now carries the IANA `timezone` it was scheduled in (the zone the admin/instructor
+ * picked). We always show the time in THAT zone first, then — only when the viewer sits in a
+ * different zone — append their own local wall-clock, e.g.:
+ *
+ *     "Jul 27, 2026, 6:00 PM GMT+4 (8:30 PM your time)"
+ *
+ * Every live-session surface (student, admin, instructor) routes through here so the dual-zone
+ * rule stays consistent; the per-surface date/time granularity is passed via `format`.
+ */
+
+/** The viewer's own IANA zone (best-effort; empty string if the platform can't resolve it). */
+export function viewerTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+  } catch {
+    return "";
+  }
+}
+
+/** Validate/normalize a session tz; returns undefined for blank or unknown zones. */
+function safeZone(tz?: string | null): string | undefined {
+  const z = (tz || "").trim();
+  if (!z) return undefined;
+  try {
+    // Throws RangeError on an unknown IANA id.
+    new Intl.DateTimeFormat("en-US", { timeZone: z });
+    return z;
+  } catch {
+    return undefined;
+  }
+}
+
+const DEFAULT_FORMAT: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+};
+
+export interface SessionTimeOptions {
+  /** Intl parts to render (date/time granularity). Defaults to "Mon D, YYYY, H:MM AM". */
+  format?: Intl.DateTimeFormatOptions;
+  /** Append "(H:MM AM your time)" when the viewer's zone differs. Default true. */
+  dual?: boolean;
+  /** Append the session zone's short label (e.g. GMT+4 / IST) to the primary. Default true. */
+  showZone?: boolean;
+}
+
+/**
+ * Format `iso` in the session's own timezone, appending the viewer's local time when it differs.
+ * Falls back to the viewer's local zone (no dual, no misleading label) when the session has no tz.
+ */
+export function formatSessionTime(
+  iso: string | null | undefined,
+  sessionTz?: string | null,
+  opts?: SessionTimeOptions
+): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "-";
+
+  const fmt = opts?.format ?? DEFAULT_FORMAT;
+  const dual = opts?.dual ?? true;
+  const showZone = opts?.showZone ?? true;
+
+  const sTz = safeZone(sessionTz);
+  const vTz = viewerTimeZone();
+
+  // Primary: rendered in the session's own zone (or the viewer's when none is stored).
+  const primaryOpts: Intl.DateTimeFormatOptions = { ...fmt };
+  if (sTz) primaryOpts.timeZone = sTz;
+  if (showZone) primaryOpts.timeZoneName = "short";
+  const primary = new Intl.DateTimeFormat("en-US", primaryOpts).format(d);
+
+  if (!dual || !sTz) return primary;
+
+  // Only add "your time" when the session zone actually displays differently to the viewer's.
+  const inSession = new Intl.DateTimeFormat("en-US", { ...fmt, timeZone: sTz }).format(d);
+  const inViewer = new Intl.DateTimeFormat("en-US", { ...fmt, timeZone: vTz || undefined }).format(d);
+  if (inSession === inViewer) return primary;
+
+  const localTimeOnly = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: vTz || undefined,
+  }).format(d);
+  return `${primary} (${localTimeOnly} your time)`;
+}
+
+export interface SessionTimeParts {
+  /** "Jul 27" in the session zone. */
+  date: string;
+  /** "6:00 PM" in the session zone. */
+  time: string;
+  /** Session zone short label ("GMT+4", "IST") — "" when the session has no stored zone. */
+  zoneAbbr: string;
+  /** Viewer's local "8:30 PM", only when it differs from the session time; else null. */
+  viewerTime: string | null;
+}
+
+/** Split a session's time into pieces for compact strips (date / time / zone / viewer conversion). */
+export function sessionTimeParts(iso: string | null | undefined, sessionTz?: string | null): SessionTimeParts {
+  const empty: SessionTimeParts = { date: "-", time: "-", zoneAbbr: "", viewerTime: null };
+  if (!iso) return empty;
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return empty;
+
+  const sTz = safeZone(sessionTz);
+  const vTz = viewerTimeZone();
+  const date = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: sTz }).format(d);
+  const time = new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit", timeZone: sTz }).format(d);
+
+  let zoneAbbr = "";
+  if (sTz) {
+    const parts = new Intl.DateTimeFormat("en-US", { hour: "numeric", timeZoneName: "short", timeZone: sTz }).formatToParts(d);
+    zoneAbbr = parts.find((p) => p.type === "timeZoneName")?.value || "";
+  }
+
+  let viewerTime: string | null = null;
+  if (sTz) {
+    const inViewer = new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit", timeZone: vTz || undefined }).format(d);
+    if (inViewer !== time) viewerTime = inViewer;
+  }
+  return { date, time, zoneAbbr, viewerTime };
+}
+
+/** Compact "H:MM AM" in the session zone + viewer suffix — for card chips where the date is elsewhere. */
+export function formatSessionClock(iso: string | null | undefined, sessionTz?: string | null): string {
+  return formatSessionTime(iso, sessionTz, {
+    format: { hour: "numeric", minute: "2-digit" },
+  });
+}
+
+/** A zone's offset from UTC (minutes) at a given instant — DST-correct for the instant supplied. */
+function tzOffsetMinutes(date: Date, tz: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(date);
+  const map: Record<string, number> = {};
+  for (const p of parts) if (p.type !== "literal") map[p.type] = Number(p.value);
+  const asUTC = Date.UTC(map.year, map.month - 1, map.day, map.hour % 24, map.minute, map.second);
+  return (asUTC - date.getTime()) / 60000;
+}
+
+/** Render an absolute instant as a `datetime-local` wall-clock IN the given zone (not the browser's). */
+export function toLocalInputInZone(iso: string | null | undefined, tz?: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return "";
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: safeZone(tz),
+  }).formatToParts(d);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+  const hour = get("hour") === "24" ? "00" : get("hour");
+  return `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}`;
+}
+
+/**
+ * Convert a naive `datetime-local` wall-clock ("YYYY-MM-DDTHH:mm") interpreted in `tz` to the correct
+ * absolute UTC ISO string. Self-contained (no server round-trip) — for edit paths that must send Zoom
+ * an unambiguous instant. Falls back to browser-local interpretation when `tz` is blank/unknown.
+ */
+export function wallClockToUtcIso(local: string, tz?: string | null): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(local);
+  const z = safeZone(tz);
+  if (!m || !z) return new Date(local).toISOString();
+  const [, y, mo, da, h, mi] = m.map(Number);
+  const guess = Date.UTC(y, mo - 1, da, h, mi);
+  const offset = tzOffsetMinutes(new Date(guess), z);
+  return new Date(guess - offset * 60000).toISOString();
+}
+
+/**
+ * Format a naive `datetime-local` value ("YYYY-MM-DDTHH:mm") as its literal wall-clock, with no zone
+ * shift, optionally tagged with the chosen zone. For create/edit previews where the value hasn't yet
+ * become an absolute instant.
+ */
+export function formatNaiveWallClock(local: string, tzLabel?: string | null): string {
+  if (!local) return "-";
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})/.exec(local);
+  if (!m) return local;
+  const [, y, mo, da, h, mi] = m;
+  const d = new Date(Date.UTC(+y, +mo - 1, +da, +h, +mi));
+  const base = new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC",
+  }).format(d);
+  return tzLabel ? `${base} (${tzLabel})` : base;
+}
+
+/** Curated IANA zones for the create/edit pickers — the platform's actual tenant regions first. */
+export const COMMON_TIMEZONES: { value: string; label: string }[] = [
+  { value: "Asia/Kolkata", label: "India (IST)" },
+  { value: "Asia/Riyadh", label: "Saudi Arabia (AST)" },
+  { value: "Asia/Dubai", label: "UAE / Gulf (GST)" },
+  { value: "Asia/Qatar", label: "Qatar" },
+  { value: "Asia/Kuwait", label: "Kuwait" },
+  { value: "Asia/Bahrain", label: "Bahrain" },
+  { value: "Asia/Karachi", label: "Pakistan (PKT)" },
+  { value: "Asia/Dhaka", label: "Bangladesh (BST)" },
+  { value: "Asia/Singapore", label: "Singapore (SGT)" },
+  { value: "Asia/Manila", label: "Philippines (PHT)" },
+  { value: "Europe/London", label: "UK (GMT/BST)" },
+  { value: "Europe/Berlin", label: "Central Europe (CET)" },
+  { value: "America/New_York", label: "US Eastern (ET)" },
+  { value: "America/Chicago", label: "US Central (CT)" },
+  { value: "America/Los_Angeles", label: "US Pacific (PT)" },
+  { value: "Australia/Sydney", label: "Sydney (AEST)" },
+  { value: "UTC", label: "UTC" },
+];
+
+/**
+ * A picker-ready zone list guaranteed to include `current` (the resolved viewer/tenant zone) so the
+ * default selection is always representable even for a zone not in the curated list.
+ */
+export function timezoneOptions(current?: string | null): { value: string; label: string }[] {
+  const cur = safeZone(current);
+  if (cur && !COMMON_TIMEZONES.some((z) => z.value === cur)) {
+    return [{ value: cur, label: cur.replace(/_/g, " ") }, ...COMMON_TIMEZONES];
+  }
+  return COMMON_TIMEZONES;
+}


### PR DESCRIPTION
Pairs with **BE #450**. A session now carries the IANA zone it was scheduled in; the FE picks it on create/edit and shows every time in that zone with the viewer's local time alongside — the fix for a KSA session reading as IST.

**Write path (the actual bug)**
- Admin create wizard + instructor create dialog get a **Timezone picker** (defaults to the creator's own browser zone) and send the naive `class_datetime` + `timezone` — no more `new Date(x).toISOString()` browser round-trip. `closes_at` too.
- Instructor edit + admin **webinar edit** now load the wall-clock in the **session's own zone** (not the editor's) and save it back correctly (`wallClockToUtcIso`) — fixes the edit-time shift.

**Display**
- One formatter (`lib/utils/session-time.ts`) → `formatSessionTime` renders `6:00 PM GST (8:30 PM your time)`; `sessionTimeParts` powers compact strips.
- Wired into: student page (date badge / time / recurring occurrences / history), shared `LiveSessionCard`, admin list row + detail header, instructor list rows.

**Types**: `timezone` added across the live-session service types. Misleading "times are local" helper copy fixed.

Verified: `tsc --noEmit` clean.