### PR TITLE
fix(adaptive-builder): responsive course-builder header (title no longer crushed by the action row)

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -383,8 +383,21 @@ export default function AdminAdaptiveCourseDetailPage() {
                 subtitle={course.description}
                 icon="mdi:book-cog-outline"
                 accent="indigo"
-                rightSlot={
-                  <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center" }}>
+              />
+
+              {/* Action toolbar — full-width so it wraps onto its own rows instead of crushing the
+                  hero title (the old rightSlot crammed 7 pills beside a 2.5rem title, which collapsed
+                  the title column when zoomed / on narrow screens). */}
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  flexWrap: "wrap",
+                  alignItems: "center",
+                  mt: { xs: -1.5, md: -2 },
+                  mb: 2.5,
+                }}
+              >
                     {showHealthBanner && health && (
                       <ContentHealthPill
                         health={health}
@@ -443,9 +456,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                       <Icon icon={course.is_published ? "mdi:eye-off-outline" : "mdi:earth"} width={16} />
                       {course.is_published ? "Unpublish" : "Publish"}
                     </ButtonBase>
-                  </Box>
-                }
-              />
+              </Box>
 
               <Box sx={{ display: "flex", gap: 1, mb: 2.5, flexWrap: "wrap" }}>
                 {([
@@ -1238,14 +1249,15 @@ function ContentHealthPill({
 
 function pillBtnSx(variant: "solid" | "outline") {
   return {
-    px: 2,
-    py: 1,
+    px: { xs: 1.5, sm: 2 },
+    py: { xs: 0.75, sm: 1 },
     borderRadius: 999,
     fontWeight: 800,
-    fontSize: "0.82rem",
+    fontSize: { xs: "0.75rem", sm: "0.82rem" },
     gap: 0.5,
     display: "inline-flex",
     alignItems: "center",
+    whiteSpace: "nowrap",
     color: variant === "solid" ? "white" : "#6366f1",
     background:
       variant === "solid"

--- a/components/scorecard/shared/SectionHero.tsx
+++ b/components/scorecard/shared/SectionHero.tsx
@@ -51,11 +51,14 @@ export function SectionHero({
         display: "flex",
         alignItems: { xs: "flex-start", sm: "center" },
         flexDirection: { xs: "column", sm: "row" },
+        // Wrap so a heavy rightSlot drops below the title instead of starving its column.
+        flexWrap: "wrap",
         gap: 2.5,
         mb: { xs: 3.5, md: 4.5 },
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 2, flex: 1, minWidth: 0 }}>
+      {/* flex-basis keeps the title column from collapsing under a wide rightSlot at zoom/narrow widths. */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 2, flex: "1 1 320px", minWidth: 0 }}>
         {iconBadge ? (
           <Box
             sx={{


### PR DESCRIPTION
The adaptive course-builder header broke at browser zoom and on narrow screens (see report): the title wrapped word-by-word down the left edge while the 7 action pills held the width.

**Cause:** the 7 pills were passed as `SectionHero`'s `rightSlot`, which renders `flexShrink:0`; on the row layout that non-shrinking cluster starved the title's `flex:1` column.

**Fix:**
- Actions move into a dedicated **full-width toolbar** below the hero that wraps onto its own rows — title always gets full width.
- **Shared `SectionHero` hardened**: outer `flexWrap` + title column `flex: 1 1 320px` so any heavy `rightSlot` drops below instead of crushing the title (protects all callers).
- Responsive pill sizing on `xs` + `nowrap` labels.

Verified: `tsc --noEmit` clean.