### PR TITLE
feat(live-sessions): real live 'joined' count while a session is live

### DIFF
--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -159,6 +159,33 @@ export default function LiveSessionsPage() {
   }, [sessions]);
 
   const live = useMemo(() => sessions.find((s) => s.meeting_status === "live"), [sessions]);
+
+  // While a session is live, poll Zoom for the CURRENT participant count (the stored
+  // attendance_count only lands after the meeting ends — that's why it read '0 joined').
+  const [liveJoined, setLiveJoined] = useState<number | null>(null);
+  const liveId = live?.id;
+  useEffect(() => {
+    if (!liveId) {
+      setLiveJoined(null);
+      return;
+    }
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const r = await studentLiveSessionsService.getLiveCount(liveId);
+        if (!cancelled) setLiveJoined(r.live && r.count != null ? r.count : null);
+      } catch {
+        /* keep the attendance-count fallback */
+      }
+    };
+    poll();
+    const timer = setInterval(poll, 25000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [liveId]);
+
   const upcoming = useMemo(
     () => sessions.filter((s) => s.meeting_status === "scheduled").sort((a, b) => (a.class_datetime || "").localeCompare(b.class_datetime || "")),
     [sessions],
@@ -307,7 +334,7 @@ export default function LiveSessionsPage() {
                         background: ["#a855f7", "#6366f1", "#ec4899", "#f59e0b"][i] }} />
                     ))}
                   </Stack>
-                  <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }}>{live.attendance_count || 0} joined</Typography>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }}>{(liveJoined ?? live.attendance_count) || 0} joined</Typography>
                 </Box>
               </Box>
             </Box>

--- a/lib/services/live-sessions/student-live-sessions.service.ts
+++ b/lib/services/live-sessions/student-live-sessions.service.ts
@@ -7,6 +7,7 @@
 import apiClient from "../api";
 import { config } from "../../config";
 import type {
+  LiveJoinedCount,
   StudentLiveSession,
   LiveSessionRecordingResponse,
   StudentLiveSessionTranscript,
@@ -121,6 +122,15 @@ export const studentLiveSessionsService = {
 
   getMyStats: async (): Promise<MyLiveStats> => {
     const response = await apiClient.get<MyLiveStats>(`${BASE}/my-live-stats/`);
+    return response.data;
+  },
+
+  /** Current live participant count from Zoom (while the session is live). `count` is null when
+   *  Zoom's dashboard metrics aren't available for this tenant — caller falls back to attendance. */
+  getLiveCount: async (activityId: number): Promise<LiveJoinedCount> => {
+    const response = await apiClient.get<LiveJoinedCount>(
+      `${BASE}/live-activities/${activityId}/live-count/`
+    );
     return response.data;
   },
 

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -63,6 +63,14 @@ export interface StudentLiveOccurrence {
   zoom_recording_url?: string | null;
 }
 
+/** GET .../live-activities/<id>/live-count/ — how many are in the Zoom session right now. */
+export interface LiveJoinedCount {
+  live: boolean;
+  /** Current participants from Zoom's dashboard; null when unavailable for this tenant. */
+  count: number | null;
+  source: "zoom" | "unavailable" | "not_live";
+}
+
 /** GET .../my-live-stats/ - the student's own live-attendance summary. */
 export interface MyLiveStats {
   sessions_attended: number;


### PR DESCRIPTION
Pairs with **BE #452**. Fixes the hero showing **'0 joined' during a live class** — `attendance_count` only fills in after the meeting ends. Now, while live, the page polls the Zoom-backed `live-count` endpoint (~25s) and shows the current participant count; falls back to `attendance_count` when Zoom's dashboard metrics aren't available for the tenant or on any error. Poll runs only while live and cleans up on unmount. `tsc` clean.