### PR TITLE
fix(branding): client logo + favicon reliably display (login/sidebar/settings)

### DIFF
--- a/components/auth/layout/AuthRightPanelDefault.tsx
+++ b/components/auth/layout/AuthRightPanelDefault.tsx
@@ -6,7 +6,6 @@ import type { LoginHeroBrandingUi } from "@/lib/theme/authHeroBranding";
 import {
   brandNameTypographySx,
   logoContainerSx,
-  logoImageSizes,
   sloganTypographySx,
 } from "@/lib/theme/authHeroBranding";
 import { brandWordHighlightSx } from "./authBrandStyles";
@@ -139,13 +138,14 @@ export function AuthRightPanelDefault({
               >
                 {logoUrl ? (
                   <Box sx={logoContainerSx(true, heroBranding)}>
-                    <Image
+                    {/* Plain <img>, NOT next/image: branding logos are arbitrary admin URLs — often
+                        SVG, or on hosts/protocols the next/image optimizer 400s on — which it silently
+                        dropped for many clients. A plain tag renders any valid image URL. */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
                       src={logoUrl}
                       alt={brandName || "Logo"}
-                      fill
-                      sizes={logoImageSizes(true, heroBranding)}
-                      style={{ objectFit: "contain" }}
-                      priority
+                      style={{ width: "100%", height: "100%", objectFit: "contain" }}
                     />
                   </Box>
                 ) : null}
@@ -314,13 +314,12 @@ export function AuthRightPanelDefault({
             >
               {logoUrl ? (
                 <Box sx={logoContainerSx(false, heroBranding)}>
-                  <Image
+                  {/* Plain <img>, NOT next/image — see the note above. */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
                     src={logoUrl}
                     alt={brandName || "Logo"}
-                    fill
-                    sizes={logoImageSizes(false, heroBranding)}
-                    style={{ objectFit: "contain" }}
-                    priority
+                    style={{ width: "100%", height: "100%", objectFit: "contain" }}
                   />
                 </Box>
               ) : null}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -3,7 +3,6 @@
 import { useState, useTransition, useMemo, useEffect, useRef } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
 import {
   Drawer,
   List,
@@ -943,13 +942,13 @@ export const Sidebar: React.FC<SidebarProps> = ({
           >
           {sidebarLogoUrl ? (
             <Box sx={sidebarLogoBoxSx}>
-              <Image
+              {/* Plain <img>, NOT next/image: client-provided branding logos are often SVG or on
+                  hosts the optimizer 400s on, which next/image silently dropped. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
                 src={sidebarLogoUrl}
                 alt={clientInfo?.app_name || "Logo"}
-                fill
-                style={{ objectFit: "contain" }}
-                sizes={`${sidebarLogoSizing.logoMaxWidthPx}px`}
-                priority
+                style={{ width: "100%", height: "100%", objectFit: "contain" }}
               />
             </Box>
           ) : (

--- a/lib/services/admin/branding.service.ts
+++ b/lib/services/admin/branding.service.ts
@@ -125,15 +125,10 @@ function normalizeBrandingUrl(
   if (value == null) return value;
   const trimmed = value.trim();
   if (!trimmed) return null;
-  try {
-    const url = new URL(trimmed);
-    url.search = "";
-    url.hash = "";
-    return url.toString();
-  } catch {
-    // Preserve original value so backend can return a clear URL validation error.
-    return trimmed;
-  }
+  // Keep the URL intact — trim only. Previously this stripped `?query` and `#hash`, which broke
+  // every pasted favicon/logo whose query is load-bearing (presigned S3 `?X-Amz-…`, CDN tokens,
+  // image-resize `?w=64`) — the stored URL then 403/404s and the icon silently disappears.
+  return trimmed;
 }
 
 function extractApiErrorMessage(error: unknown): string {


### PR DESCRIPTION
RCA of *'logo added but not on the login page'* + *'favicon I pasted doesn't show'* — both systemic (many clients):

**1. `next/image` silently dropped branding logos.** Login (`AuthRightPanelDefault`) + sidebar rendered client logos through `next/image`, whose optimizer **blocks SVG** (no `dangerouslyAllowSVG`) and 400s on many client-hosted URLs — so an SVG/awkward-host logo showed **nothing** while the brand name still rendered (exactly the screenshot). Switched both to a plain `<img>` (what the settings previews already use) → any valid image URL renders.

**2. Saving stripped the URL's query string.** `normalizeBrandingUrl` did `url.search = ''`, so a pasted favicon/logo whose query is load-bearing (presigned S3 `?X-Amz-…`, CDN tokens, `?w=64`) was **stored broken** and 403/404'd. Now the URL is kept intact (trim only).

The tab favicon (`ClientFaviconSync` `<link>`) + settings previews already use plain tags, so once the stored URL is intact they work. **Note:** an already-broken favicon needs a one-time re-paste + Save to overwrite the query-stripped value.

`tsc` clean.