### PR TITLE
feat(auth+branding): premium auth card + clearer favicon/logo settings UX

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -81,6 +81,57 @@ function SettingCard({
  * (favicon + app name) and the login screen (logo + tagline) on the fixed
  * midnight-hyper palette. Updates as the admin types.
  */
+/**
+ * A realistic browser-tab chip showing the favicon in situ — and, crucially, a clear error state
+ * when the URL can't load, so a broken favicon is *visible* instead of an invisible broken image.
+ */
+function FaviconTabPreview({ url, appName }: { url: string; appName: string }) {
+  const [errored, setErrored] = useState(false);
+  useEffect(() => setErrored(false), [url]);
+  return (
+    <Box
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 1,
+        pl: 1,
+        pr: 1.5,
+        py: 0.75,
+        borderRadius: "10px 10px 4px 4px",
+        border: "1px solid var(--border-default)",
+        borderBottom: "none",
+        bgcolor: "var(--surface)",
+        maxWidth: 220,
+      }}
+    >
+      {errored ? (
+        <IconWrapper icon="mdi:image-broken-variant" size={18} color="var(--accent-red, #ef4444)" />
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={url}
+          alt=""
+          width={18}
+          height={18}
+          style={{ objectFit: "contain", flexShrink: 0 }}
+          onError={() => setErrored(true)}
+        />
+      )}
+      <Typography
+        sx={{
+          fontSize: "0.8rem",
+          color: errored ? "var(--accent-red, #ef4444)" : "var(--font-secondary)",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {errored ? "Couldn’t load this URL" : appName}
+      </Typography>
+    </Box>
+  );
+}
+
 function LivePreview({
   logoUrl,
   faviconUrl,
@@ -345,6 +396,7 @@ export default function AdminSettingsPage() {
               value={logoUrl}
               onChange={(e) => setLogoUrl(e.target.value)}
               placeholder="https://…/logo.png"
+              helperText="Paste the whole URL — including any “?…” at the end. SVG works."
               sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
             />
             {logoUrl.trim() && (
@@ -375,7 +427,7 @@ export default function AdminSettingsPage() {
             tourId="settings-favicon"
             icon="mdi:star-circle-outline"
             title="Favicon"
-            description="The small icon shown in the browser tab. Upload a square PNG, ICO, or SVG (32×32 or larger)."
+            description="The small icon shown in the browser tab. Paste a hosted image URL or upload a square PNG, ICO, or SVG (32×32 or larger)."
           >
             <input
               ref={faviconInputRef}
@@ -384,33 +436,26 @@ export default function AdminSettingsPage() {
               hidden
               onChange={(e) => handleFaviconFile(e.target.files?.[0])}
             />
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+            <TextField
+              label="Favicon URL"
+              placeholder="https://…/favicon.png"
+              fullWidth
+              size="small"
+              value={faviconUrl}
+              onChange={(e) => setFaviconUrl(e.target.value)}
+              helperText="Keep the whole URL — including any “?…” at the end. Then Save to apply."
+            />
+            <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", mt: 1.5 }}>
               <HeaderActionButton
                 icon={uploadingFavicon ? "mdi:loading" : "mdi:upload"}
                 variant="ghost"
                 onClick={() => faviconInputRef.current?.click()}
                 disabled={uploadingFavicon}
               >
-                {uploadingFavicon ? "Uploading…" : "Upload favicon"}
+                {uploadingFavicon ? "Uploading…" : "Upload instead"}
               </HeaderActionButton>
               {faviconUrl.trim() && (
-                <Box
-                  sx={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 1,
-                    px: 1.25,
-                    py: 0.75,
-                    borderRadius: 2,
-                    border: "1px solid var(--border-default)",
-                  }}
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={faviconUrl} alt="Favicon preview" width={24} height={24} style={{ objectFit: "contain" }} />
-                  <Typography sx={{ fontSize: "0.8rem", color: "var(--font-secondary)" }}>
-                    Current favicon
-                  </Typography>
-                </Box>
+                <FaviconTabPreview url={faviconUrl.trim()} appName={clientInfo?.name || "Your app"} />
               )}
             </Box>
           </SettingCard>

--- a/components/auth/layout/AuthLeftPanel.tsx
+++ b/components/auth/layout/AuthLeftPanel.tsx
@@ -11,6 +11,30 @@ interface AuthLeftPanelProps {
 }
 
 export function AuthLeftPanel({ variant, children }: AuthLeftPanelProps) {
+  // A brand-accented card the form sits in. The thin top gradient gives the auth pages a consistent
+  // identity; the layered shadow reads as depth without heaviness. Theme-aware via CSS vars.
+  const cardSx = {
+    position: "relative" as const,
+    width: "100%",
+    maxWidth: 440,
+    borderRadius: "20px",
+    px: { xs: 2.75, sm: 4 },
+    py: { xs: 3.25, sm: 4 },
+    overflow: "hidden",
+    border: "1px solid var(--border-default)",
+    boxShadow:
+      "0 1px 2px color-mix(in srgb, var(--font-primary) 6%, transparent), 0 24px 48px -28px color-mix(in srgb, var(--font-primary) 30%, transparent)",
+    "&::before": {
+      content: '""',
+      position: "absolute",
+      top: 0,
+      left: 0,
+      right: 0,
+      height: 4,
+      background: "linear-gradient(90deg, var(--primary-500) 0%, var(--accent-pink) 100%)",
+    },
+  } as const;
+
   if (variant === "glass") {
     return (
       <Box
@@ -28,17 +52,9 @@ export function AuthLeftPanel({ variant, children }: AuthLeftPanelProps) {
       >
         <Box
           sx={{
-            width: "100%",
-            maxWidth: 440,
-            borderRadius: 2,
-            px: { xs: 2.5, sm: 3.5 },
-            py: { xs: 3, sm: 3.5 },
-            backgroundColor:
-              "color-mix(in srgb, var(--surface) 78%, var(--background))",
+            ...cardSx,
+            backgroundColor: "color-mix(in srgb, var(--surface) 82%, var(--background))",
             backdropFilter: "blur(12px)",
-            border: "1px solid var(--border-default)",
-            boxShadow:
-              "0 4px 24px color-mix(in srgb, var(--font-primary) 10%, transparent)",
           }}
         >
           {children}
@@ -54,13 +70,15 @@ export function AuthLeftPanel({ variant, children }: AuthLeftPanelProps) {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        px: { xs: 3, sm: 4, md: 6 },
+        px: { xs: 2.5, sm: 4, md: 6 },
         py: { xs: 4, md: 0 },
-        backgroundColor: "var(--background)",
         overflow: "auto",
+        // A soft, brand-tinted ground so the white card reads as elevated rather than floating on flat white.
+        background:
+          "radial-gradient(120% 120% at 0% 0%, color-mix(in srgb, var(--primary-500) 7%, var(--background)) 0%, var(--background) 55%)",
       }}
     >
-      {children}
+      <Box sx={{ ...cardSx, backgroundColor: "var(--card-bg)" }}>{children}</Box>
     </Box>
   );
 }


### PR DESCRIPTION
Enhancement scoped to **login/auth pages + branding settings** (per request), on top of the branding-display fix (#1135).

- **Auth pages:** the *plain* left-panel variant (clients with no login hero image) rendered the form **bare on flat white**. It now sits in the same premium card as the glass variant — soft layered shadow, subtle brand-tinted ground, and a thin violet→pink accent strip. One change lifts **login / signup / forgot / reset / verify**.
- **Settings → Favicon:** added a **paste-a-URL** field (logo had one; favicon was upload-only although users paste), plus a **realistic browser-tab preview** that shows a clear *'Couldn't load this URL'* state on error — so a broken favicon is visible instead of an invisible broken image.
- **'Keep the whole URL (incl. ?…)'** hints on both fields, pairing with the normalize-URL fix.

Theme-aware; `tsc` clean.