### PR TITLE
perf(nav): collapse the login double-shimmer + stop chrome flashing on route loads

### DIFF
--- a/app/(auth)/loading.tsx
+++ b/app/(auth)/loading.tsx
@@ -1,0 +1,25 @@
+import { Box, CircularProgress } from "@mui/material";
+
+/**
+ * Loading UI for the unauthenticated routes (login / signup / forgot / reset / verify).
+ *
+ * Without this file these routes fell back to the ROOT app/loading.tsx, which renders
+ * `PageShimmerLayout` — and that wraps MainLayout. So a LOGGED-OUT visitor briefly saw the full app
+ * chrome (sidebar + app bar) shimmering before the login form appeared, which is both wrong and an
+ * extra visual phase. A bare centered spinner on the auth background is the honest shape here.
+ */
+export default function AuthLoading() {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "var(--background)",
+      }}
+    >
+      <CircularProgress size={36} />
+    </Box>
+  );
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -84,9 +84,11 @@ export default function LoginPage() {
 
       const role = Cookies.get("user_role") ?? "";
       const target = resolvePostLoginPath(role, searchParams.get("redirect"));
-      setTimeout(() => {
-        window.location.href = target;
-      }, 500);
+      // Navigate immediately. This used to sit behind a hard-coded 500ms setTimeout, which added half
+      // a second of spinner to every single login for no functional reason — the navigation itself is
+      // the success feedback. (A full-document load is kept deliberately: the root layout is an async
+      // server component that resolves tenant/client info, so it must re-run with the new session.)
+      window.location.href = target;
     } catch (err: unknown) {
       showToast(getAxiosErrorDetail(err, t("auth.loginFailed")), "error");
       setLoading(false);

--- a/app/admin/cohorts/[cohortId]/loading.tsx
+++ b/app/admin/cohorts/[cohortId]/loading.tsx
@@ -1,11 +1,18 @@
 import { Box, Skeleton } from "@mui/material";
+import { MainLayout } from "@/components/layout/MainLayout";
 
+/**
+ * Must render the SAME chrome as the page (MainLayout fullWidthContent). Without it the sidebar and
+ * app bar visibly disappeared and snapped back during the transition into this route.
+ */
 export default function Loading() {
   return (
-    <Box sx={{ maxWidth: 1400, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
-      <Skeleton variant="rounded" height={120} sx={{ borderRadius: 4, mb: 2 }} />
-      <Skeleton variant="rounded" height={44} sx={{ borderRadius: 999, mb: 3, maxWidth: 420 }} />
-      <Skeleton variant="rounded" height={400} sx={{ borderRadius: 4 }} />
-    </Box>
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1400, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        <Skeleton variant="rounded" height={120} sx={{ borderRadius: 4, mb: 2 }} />
+        <Skeleton variant="rounded" height={44} sx={{ borderRadius: 999, mb: 3, maxWidth: 420 }} />
+        <Skeleton variant="rounded" height={400} sx={{ borderRadius: 4 }} />
+      </Box>
+    </MainLayout>
   );
 }

--- a/app/admin/cohorts/loading.tsx
+++ b/app/admin/cohorts/loading.tsx
@@ -1,14 +1,21 @@
 import { Box, Skeleton } from "@mui/material";
+import { PageShell } from "@/components/common/PageShell";
 
+/**
+ * Must render the SAME chrome as the page (PageShell -> MainLayout). Without it the sidebar and app
+ * bar visibly disappeared and snapped back during the transition into this route.
+ */
 export default function Loading() {
   return (
-    <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
-      <Skeleton variant="rounded" height={140} sx={{ borderRadius: 4, mb: 3 }} />
-      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" }, gap: 2 }}>
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} variant="rounded" height={180} sx={{ borderRadius: 4 }} />
-        ))}
+    <PageShell>
+      <Box sx={{ maxWidth: 1760, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 5 } }}>
+        <Skeleton variant="rounded" height={140} sx={{ borderRadius: 4, mb: 3 }} />
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "repeat(3, 1fr)" }, gap: 2 }}>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={180} sx={{ borderRadius: 4 }} />
+          ))}
+        </Box>
       </Box>
-    </Box>
+    </PageShell>
   );
 }

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,5 +1,26 @@
-import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+"use client";
 
-export default function Loading() {
-  return <PageShimmerLayout variant="grid" />;
+import { Box } from "@mui/material";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { DashboardSkeleton } from "@/components/dashboard/v2/DashboardSkeleton";
+import { useHideLeaderboardView } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * Route-level loading UI for /dashboard.
+ *
+ * Renders the page's REAL shell (MainLayout fullWidthContent + the same max-width Box) and the REAL
+ * skeleton DashboardV2 shows while it fetches (DashboardSkeleton). This previously rendered a generic
+ * `PageShimmerLayout variant="grid"`, so signing in showed a grid shimmer and then a completely
+ * different dashboard skeleton — two visibly different loading states back to back. Matching them
+ * makes the whole load read as ONE continuous state.
+ */
+export default function DashboardLoading() {
+  const hideLeaderboard = useHideLeaderboardView();
+  return (
+    <MainLayout fullWidthContent>
+      <Box sx={{ maxWidth: 1600, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 2, md: 3 } }}>
+        <DashboardSkeleton hideLeaderboard={hideLeaderboard} />
+      </Box>
+    </MainLayout>
+  );
 }

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -58,6 +58,38 @@ interface AppBarProps {
   DrawerWidth: number;
 }
 
+/**
+ * Module-level cache + in-flight dedup for the unread badge.
+ *
+ * MainLayout (and therefore AppBar) is rendered per-page, so it REMOUNTS on every navigation — which
+ * meant every single page transition fired another unread-count request. Within the TTL a remount now
+ * reuses the last value instead of hitting the network, and concurrent callers share one request.
+ * Mirrors the caching already used by useLeaderboardAndStreak. The 60s poll passes force=true so live
+ * updates are unaffected.
+ */
+const UNREAD_TTL_MS = 60_000;
+let unreadCache: { clientId: unknown; count: number; at: number } | null = null;
+let unreadInFlight: Promise<number> | null = null;
+
+function getUnreadCountCached(clientId: unknown, force = false): Promise<number> {
+  const fresh =
+    unreadCache !== null &&
+    unreadCache.clientId === clientId &&
+    Date.now() - unreadCache.at < UNREAD_TTL_MS;
+  if (!force && fresh) return Promise.resolve(unreadCache!.count);
+  if (!force && unreadInFlight) return unreadInFlight;
+  unreadInFlight = notificationService
+    .getUnreadCount(clientId as never)
+    .then((count) => {
+      unreadCache = { clientId, count, at: Date.now() };
+      return count;
+    })
+    .finally(() => {
+      unreadInFlight = null;
+    });
+  return unreadInFlight;
+}
+
 export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
   const router = useRouter();
   const { user, logout, isAuthenticated } = useAuth();
@@ -141,15 +173,17 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
     setStreakAnchorEl(event.currentTarget);
   };
 
-  const fetchUnreadCount = React.useCallback(async () => {
-    if (!isAuthenticated || !clientId) return;
-    try {
-      const count = await notificationService.getUnreadCount(clientId);
-      setUnreadCount(count);
-    } catch {
-      // Silently ignore - user may not have notifications
-    }
-  }, [isAuthenticated, clientId]);
+  const fetchUnreadCount = React.useCallback(
+    async (force = false) => {
+      if (!isAuthenticated || !clientId) return;
+      try {
+        setUnreadCount(await getUnreadCountCached(clientId, force));
+      } catch {
+        // Silently ignore - user may not have notifications
+      }
+    },
+    [isAuthenticated, clientId]
+  );
 
   const fetchNotifications = React.useCallback(async () => {
     if (!isAuthenticated || !clientId) return;
@@ -157,7 +191,8 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
     try {
       const data = await notificationService.getNotifications(clientId);
       setNotifications(data.results);
-      fetchUnreadCount();
+      // The user just opened the panel — bypass the cache so the badge is exact.
+      fetchUnreadCount(true);
     } catch {
       setNotifications([]);
     } finally {
@@ -167,8 +202,10 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
 
   useEffect(() => {
     if (isAuthenticated && clientId) {
+      // Mount: served from the module cache on a remount (i.e. on every navigation).
       fetchUnreadCount();
-      const interval = setInterval(fetchUnreadCount, 60000);
+      // Poll: force a real request so the badge still updates live.
+      const interval = setInterval(() => fetchUnreadCount(true), 60000);
       return () => clearInterval(interval);
     }
   }, [isAuthenticated, clientId, fetchUnreadCount]);


### PR DESCRIPTION
**Your report:** *'when students login they see 2 shimmers getting loaded'*. Traced the exact chain:

1. `SignInLoader` spinner — held open by a **hard-coded 500ms `setTimeout`** before redirecting.
2. `app/dashboard/loading.tsx` → generic `PageShimmerLayout variant="grid"`.
3. `DashboardV2.tsx:91` → the **real** `DashboardSkeleton` while it fetches.

Phases 2 and 3 are **different shapes back to back**, so it reads as two shimmers that visibly re-arrange.

**Fixes**
- **Dashboard `loading.tsx` now renders the page's real shell + real skeleton** (same `MainLayout fullWidthContent` + same max-width Box + `DashboardSkeleton`) → route-level and data-level loading are pixel-identical → **one** continuous load.
- **Dropped the artificial 500ms login delay** (half a second of spinner on every login for no functional reason). The full-document load is kept **deliberately** — the root layout is an async server component that resolves tenant/client info, so it must re-run with the new session.
- **Added `app/(auth)/loading.tsx`** — without it the auth routes fell back to the root `app/loading.tsx`, which wraps `MainLayout`, so a **logged-out** visitor saw the whole app chrome shimmering before the login form.
- **`admin/cohorts` `loading.tsx` (both)** rendered no chrome → sidebar/app-bar vanished and snapped back; now matched to their pages.
- **AppBar unread badge**: module-level cache + in-flight dedup. `MainLayout` remounts on every navigation, so this fired a request *per page transition*; remounts now reuse the value within 60s. The 60s poll and opening the panel force a real request, so live updates are unchanged.

`tsc` clean; eslint baseline identical (no new problems). Phase 2 of the perf program (#1140 was phase 1).