### PR TITLE
perf(auth): one navigation per login — kill the white flash + duplicate shimmer round

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -84,11 +84,15 @@ export default function LoginPage() {
 
       const role = Cookies.get("user_role") ?? "";
       const target = resolvePostLoginPath(role, searchParams.get("redirect"));
-      // Navigate immediately. This used to sit behind a hard-coded 500ms setTimeout, which added half
-      // a second of spinner to every single login for no functional reason — the navigation itself is
-      // the success feedback. (A full-document load is kept deliberately: the root layout is an async
-      // server component that resolves tenant/client info, so it must re-run with the new session.)
-      window.location.href = target;
+      // SPA navigation, immediately.
+      //
+      // This used to be `setTimeout(() => { window.location.href = target }, 500)`. That was a
+      // SECOND navigation to the same URL: the redirect effect above already fires router.replace the
+      // instant login() flips isAuthenticated. Nothing could cancel the timeout (this page had already
+      // unmounted), so 500ms later a full document reload tore down the dashboard React had just
+      // rendered — the white flash, and the second round of shimmers users reported. Using
+      // router.replace keeps navigation guaranteed here while staying idempotent with the effect.
+      router.replace(target);
     } catch (err: unknown) {
       showToast(getAxiosErrorDetail(err, t("auth.loginFailed")), "error");
       setLoading(false);

--- a/components/auth/GoogleSignIn.tsx
+++ b/components/auth/GoogleSignIn.tsx
@@ -108,9 +108,11 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
           role,
           searchParams.get("redirect")
         );
-        setTimeout(() => {
-          window.location.href = redirectUrl;
-        }, 500);
+        // SPA navigation, immediately — same fix as the password login path: this was a 500ms
+        // setTimeout doing a full document reload, which tore down the freshly-rendered destination
+        // (white flash + a second round of shimmers) on top of the router.replace the login page's
+        // redirect effect already fires.
+        router.replace(redirectUrl);
       } catch (error: unknown) {
         showToast(
           getAxiosErrorDetail(error, t("auth.googleSignInFailed")),


### PR DESCRIPTION
Follow-up to #1141, which fixed the shimmer *shapes* but not the real cause. A deeper trace found login performs **TWO navigations to the same URL**:

| when | what |
|---|---|
| **T+0ms** | the redirect effect (`login/page.tsx:52-64`) fires `router.replace` the instant `login()` flips `isAuthenticated` → the SPA renders the dashboard |
| **T+500ms** | an **orphaned `setTimeout`** assigned `window.location.href` to *that same URL*. Nothing could cancel it (LoginPage had already unmounted), so it **hard-reloaded the document and tore down the dashboard React had just rendered** |

That reload is the **white flash**: all chunks + MUI/emotion re-init, the root server layout re-awaited, the whole skeleton sequence runs a **second** time, and the in-flight `learner-dashboard` request is aborted then refetched cold. That is precisely the *'2 shimmers'* — one stack before the reload, one after, split by the flash.

**Fix:** both login paths now navigate **exactly once**, via SPA `router.replace` (idempotent with the effect, so navigation stays guaranteed):
- `app/(auth)/login/page.tsx` — password login
- `components/auth/GoogleSignIn.tsx` — the Google credential path had the **identical** bug

This also **corrects my note in #1141** that the full-document load was deliberate. It wasn't — the client navigation already happens, so the reload was pure duplication.

`tsc` clean; eslint baseline unchanged.