### PR TITLE
perf: delete the dead adaptive getCourse fetch + stop the tab-return request storm

### DIFF
--- a/app/adaptive-courses/[courseId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/page.tsx
@@ -1,38 +1,23 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { Box, ButtonBase, Chip, Stack } from "@mui/material";
+import { Box, ButtonBase } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { AdaptiveSectionShell } from "@/components/adaptive-quiz/shared/AdaptiveSectionShell";
 import { JourneyBoard } from "@/components/adaptive-journey/JourneyBoard";
-import { adaptiveCourseService } from "@/lib/services/adaptive-course.service";
 
 export default function AdaptiveCourseDetailPage() {
   const { push } = useInstantNavigation();
   const params = useParams();
   const courseId = Number(params.courseId);
-  // Assigned instructor(s), shown as the public code (or real name). Fetched with a small course-only
-  // call because JourneyBoard drives the main render off the journey payload, not getCourse.
-  const [instructors, setInstructors] = useState<{ name: string }[]>([]);
-
-  useEffect(() => {
-    if (!Number.isFinite(courseId)) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const course = await adaptiveCourseService.getCourse(courseId);
-        if (!cancelled) setInstructors(course.instructors ?? []);
-      } catch {
-        /* non-fatal — the instructor line is optional decoration */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [courseId]);
+  // NOTE: there used to be a getCourse() fetch here to populate an instructor chip. It was dead:
+  // this endpoint is served by LearnerCourseDetailSerializer, whose field list does NOT include
+  // `instructors`, so the value was always undefined and the chip never rendered — while the request
+  // itself dragged the entire course tree (modules -> submodules -> per-item counts, an N+1 on the
+  // backend) on every visit to this page. Removed; JourneyBoard already drives the whole render off
+  // the journey payload.
 
   // JourneyBoard fetches the journey (which already returns the course) and renders
   // its own loading skeleton, 403 "not enrolled" state, and errors - so there is no
@@ -47,23 +32,6 @@ export default function AdaptiveCourseDetailPage() {
           <Icon icon="mdi:arrow-left" width={18} />
           Back to Adaptive Courses
         </ButtonBase>
-
-        {instructors.length > 0 && (
-          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap" useFlexGap sx={{ mb: 2 }}>
-            <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, color: "text.secondary", fontSize: "0.85rem", fontWeight: 600 }}>
-              <Icon icon="mdi:account-tie-outline" width={16} />
-              Instructor{instructors.length > 1 ? "s" : ""}:
-            </Box>
-            {instructors.map((i, idx) => (
-              <Chip
-                key={idx}
-                size="small"
-                label={i.name}
-                sx={{ fontWeight: 700, bgcolor: "color-mix(in srgb, #6366f1 12%, transparent)", color: "#4f46e5" }}
-              />
-            ))}
-          </Stack>
-        )}
 
         <AdaptiveSectionShell meshOpacity={0.18}>
           {Number.isFinite(courseId) && <JourneyBoard courseId={courseId} />}

--- a/components/adaptive-quiz/results/RemediationPathCard.tsx
+++ b/components/adaptive-quiz/results/RemediationPathCard.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { gridStagger, fadeRise } from "@/components/scorecard/shared/motion";
 import { AIPill } from "../shared/AIPill";
 import { adaptiveQuizService } from "@/lib/services/adaptive-quiz.service";
+import { useVisibilityRefresh } from "@/lib/hooks/useVisibilityRefresh";
 import type { AdaptiveAINarration, RemediationProgress } from "@/lib/types/adaptive-quiz";
 
 type RemediationStep = AdaptiveAINarration["remediation_path"][number];
@@ -75,14 +76,12 @@ export function RemediationPathCard({ steps, sessionId, onStartPath }: Remediati
 
   useEffect(() => {
     refresh();
-    const onVis = () => { if (document.visibilityState === "visible") refresh(); };
-    document.addEventListener("visibilitychange", onVis);
-    window.addEventListener("focus", refresh);
-    return () => {
-      document.removeEventListener("visibilitychange", onVis);
-      window.removeEventListener("focus", refresh);
-    };
   }, [refresh]);
+
+  // Previously this ALSO registered a window 'focus' listener alongside visibilitychange; alt-tabbing
+  // back fires both, so the same request went out twice. useVisibilityRefresh listens to
+  // visibilitychange only and throttles repeat runs.
+  useVisibilityRefresh(refresh, { minIntervalMs: 10_000, enabled: Boolean(sessionId) });
 
   if (!steps.length) return null;
 

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -44,6 +44,7 @@ import { useTranslation } from "react-i18next";
 import { isRtl } from "@/lib/i18n";
 import { useToast } from "@/components/common/Toast";
 import { config } from "@/lib/config";
+import { useVisibilityRefresh } from "@/lib/hooks/useVisibilityRefresh";
 import {
   notificationService,
   type Notification,
@@ -204,11 +205,22 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
     if (isAuthenticated && clientId) {
       // Mount: served from the module cache on a remount (i.e. on every navigation).
       fetchUnreadCount();
-      // Poll: force a real request so the badge still updates live.
-      const interval = setInterval(() => fetchUnreadCount(true), 60000);
+      // Poll: force a real request so the badge still updates live — but SKIP while the tab is
+      // hidden. Browsers throttle background timers and then fire the backlog on return, so an
+      // unguarded poll contributed a catch-up request burst exactly when the user was trying to
+      // navigate. The visibility refresh below covers the "came back" case once, cheaply.
+      const interval = setInterval(() => {
+        if (document.visibilityState === "visible") fetchUnreadCount(true);
+      }, 60000);
       return () => clearInterval(interval);
     }
   }, [isAuthenticated, clientId, fetchUnreadCount]);
+
+  // One throttled refresh when the tab comes back, instead of the throttled-timer backlog.
+  useVisibilityRefresh(() => fetchUnreadCount(true), {
+    minIntervalMs: 60_000,
+    enabled: Boolean(isAuthenticated && clientId),
+  });
 
   const handleNotificationClick = (event: React.MouseEvent<HTMLElement>) => {
     setNotificationAnchorEl(event.currentTarget);

--- a/lib/hooks/useVisibilityRefresh.ts
+++ b/lib/hooks/useVisibilityRefresh.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Run `fn` when the tab becomes visible again, at most once per `minIntervalMs`.
+ *
+ * Why this exists: several screens refetch on tab return by registering BOTH
+ * `document.visibilitychange` AND `window.focus`. Those two fire together when you alt-tab back, so
+ * the same request went out twice. Combined with background-throttled `setInterval` polls all firing
+ * their catch-up tick at the same moment, returning to a tab produced a request burst that competed
+ * with whatever the user actually clicked — a big part of "coming back after a while is slow".
+ *
+ * `visibilitychange` alone already covers tab return (and, unlike `focus`, does not fire when the
+ * user merely clicks back into the window from another app pane). The throttle additionally protects
+ * against rapid tab flipping.
+ */
+export function useVisibilityRefresh(
+  fn: () => void,
+  { minIntervalMs = 30_000, enabled = true }: { minIntervalMs?: number; enabled?: boolean } = {}
+) {
+  // Keep the latest callback without re-registering the listener (which would reset the throttle).
+  const fnRef = useRef(fn);
+  useEffect(() => {
+    fnRef.current = fn;
+  }, [fn]);
+
+  const lastRunRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled || typeof document === "undefined") return;
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      const now = Date.now();
+      if (now - lastRunRef.current < minIntervalMs) return;
+      lastRunRef.current = now;
+      fnRef.current();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [minIntervalMs, enabled]);
+}


### PR DESCRIPTION
**1. A dead — but expensive — fetch on the adaptive course page.**
`app/adaptive-courses/[courseId]/page.tsx` called `getCourse()` purely to populate an instructor chip from `course.instructors`. That endpoint is served by `LearnerCourseDetailSerializer`, whose field tuple is **explicit and contains no `instructors`** (verified in `adaptive_quiz/serializers.py`) — so the value was **always** `undefined` and the chip **could never render**. Meanwhile the request dragged the **entire course tree** (modules → submodules → per-item counts — an N+1 on the backend) on every visit. Removed the effect, the chip, and the now-unused imports.

**2. The tab-return request storm.** New `lib/hooks/useVisibilityRefresh(fn, {minIntervalMs})` — listens to `visibilitychange` **only**, throttles repeats:
- `RemediationPathCard` registered **both** `visibilitychange` **and** `window focus` with no dedup, so alt-tabbing back fired the same request **twice**.
- `AppBar`'s 60s unread poll now **skips ticks while the tab is hidden**. Browsers throttle background timers then fire the backlog on return, so it added a catch-up burst exactly when you were trying to navigate. One throttled visibility refresh covers "came back" instead.

Both feed the *"inactive then it takes forever"* path, on top of the proactive token refresh in #1140.

`tsc` clean; eslint baseline identical (6 problems before and after).