### PR TITLE
perf(nav): mount app chrome once instead of remounting it on every navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { ThemeModeProvider } from "@/lib/contexts/ThemeContext";
 import { ReduxProvider } from "@/components/providers/ReduxProvider";
 import { QueryProvider } from "@/components/providers/QueryProvider";
+import { AppChrome } from "@/components/layout/AppChrome";
 import { AuthProvider } from "@/lib/auth/auth-context";
 import { ToastProvider } from "@/components/common/Toast";
 import { ErrorBoundary } from "@/components/common/ErrorBoundary";
@@ -129,7 +130,7 @@ export default async function RootLayout({
                                   <TourProvider>
                                     <ProfileActivationBlocker />
                                     <TenantSetupBlocker />
-                                    {children}
+                                    <AppChrome>{children}</AppChrome>
                                     <PointsPrimer />
                                     <XpCelebrationOverlay />
                                   </TourProvider>

--- a/components/layout/AppChrome.tsx
+++ b/components/layout/AppChrome.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box } from "@mui/material";
+import { usePathname } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import { isRtl } from "@/lib/i18n";
+import { AppBar } from "./AppBar";
+import { Sidebar, DRAWER_WIDTH } from "./Sidebar";
+import { BottomNavigation } from "./BottomNavigation";
+import { ChromeProvider } from "./ChromeContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { reportContentCompleted } from "@/lib/streak/streakCelebration";
+import { StreakCelebrationOverlay } from "@/components/common/StreakCelebrationOverlay";
+import { ReportIssueFAB } from "@/components/common/ReportIssueFAB";
+import { useHideLeaderboardView } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * Persistent app chrome, mounted ONCE in the root layout.
+ *
+ * Previously every one of the ~114 pages rendered its own <MainLayout>, and 43 of the loading.tsx
+ * files rendered a second one via PageShimmerLayout. Because those are different element positions in
+ * different route subtrees, React unmounted and remounted the ENTIRE shell on every navigation —
+ * AppBar, Sidebar, BottomNavigation, ReportIssueFAB and useTimeTracking all torn down and rebuilt,
+ * with the header refetching and the in-progress time segment dropped. It also meant the chrome
+ * visibly flashed between a route's loading.tsx and its page.
+ *
+ * Mounting it here instead means the shell survives navigation entirely; only the content column
+ * swaps. MainLayout stays in place as the per-page CONTENT wrapper (it collapses to just its content
+ * Box when it detects it is inside this chrome), so no page had to change.
+ */
+
+/**
+ * Routes that must NOT receive the shared chrome, and keep rendering exactly what they render today:
+ *  - the unauthenticated routes, which have no app shell at all;
+ *  - the first-login setup wizard, likewise;
+ *  - the legacy submodule player, the only page that passes RUNTIME-computed MainLayout props
+ *    (`hideSidebar={!isMobile} fullPage DrawerWidth={0}`), which cannot be expressed by a static
+ *    shared shell;
+ *  - the assessment runner, whose desktop-only gate mounts its own MainLayout and which must stay a
+ *    distraction-free full-page surface while proctored.
+ */
+const CHROMELESS_PREFIXES = [
+  // Unauthenticated / pre-app surfaces — no shell at all.
+  "/login",
+  "/signup",
+  "/forgot-password",
+  "/reset-password",
+  "/verify-email",
+  "/auth/handoff",
+  "/setup",
+  // Public, auth-free credential verification — must not show app navigation.
+  "/credentials",
+  // Off-screen render target captured into a PDF; any chrome would end up in the file.
+  "/user/scorecard/pdf",
+  // Standalone utilities / demos that deliberately render bare.
+  "/mock-interview/voice-sample",
+  "/proctoring-demo",
+];
+
+const CHROMELESS_PATTERNS: RegExp[] = [
+  /^\/courses\/[^/]+\/submodule\/[^/]+/, // legacy submodule player (runtime chrome props)
+  // Distraction-free, often proctored runners. These render their own full-page surface today and
+  // must not gain a sidebar/app bar.
+  /^\/assessments\/[^/]+\/take/,
+  /^\/assessments\/[^/]+\/calibration/,
+  /^\/mock-interview\/[^/]+\/take/,
+  /^\/adaptive-courses\/[^/]+\/interview\/[^/]+/,
+];
+
+function isChromeless(pathname: string | null): boolean {
+  if (!pathname) return true; // pre-hydration: render bare rather than flashing a shell
+  if (CHROMELESS_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) return true;
+  return CHROMELESS_PATTERNS.some((re) => re.test(pathname));
+}
+
+export function AppChrome({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  if (isChromeless(pathname)) {
+    // No chrome, and no ChromeProvider — so any MainLayout on these routes behaves exactly as before.
+    return <>{children}</>;
+  }
+  return <ChromeShell>{children}</ChromeShell>;
+}
+
+function ChromeShell({ children }: { children: React.ReactNode }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const handleDrawerToggle = () => setMobileOpen((o) => !o);
+
+  // Global app time tracking — now runs once for the session instead of restarting every navigation.
+  useTimeTracking();
+
+  const hideLeaderboardView = useHideLeaderboardView();
+
+  // Any content completion (legacy or adaptive) dispatches "submodule-complete";
+  // refetch the streak and celebrate if it went up.
+  useEffect(() => {
+    if (hideLeaderboardView || typeof window === "undefined") return;
+    const handleSubmoduleComplete = () => reportContentCompleted();
+    window.addEventListener("submodule-complete", handleSubmoduleComplete);
+    return () => window.removeEventListener("submodule-complete", handleSubmoduleComplete);
+  }, [hideLeaderboardView]);
+
+  const { i18n } = useTranslation();
+  const rtl = isRtl(i18n.language || "en");
+
+  // direction: ltr so flex order stays consistent (order 1 = left, order 2 = right); with dir="rtl"
+  // on the document, flex start would be on the right and main content would sit under the sidebar.
+  return (
+    <ChromeProvider value={true}>
+      <Box
+        sx={{
+          direction: "ltr",
+          display: "flex",
+          flexDirection: "row",
+          minHeight: "auto",
+          backgroundColor: "var(--background)",
+          width: "100%",
+        }}
+      >
+        <AppBar onMenuClick={handleDrawerToggle} DrawerWidth={DRAWER_WIDTH} />
+        <Box
+          sx={{
+            order: rtl ? 2 : 0,
+            flexShrink: 0,
+            width: { xs: 0, md: DRAWER_WIDTH },
+            minWidth: { md: DRAWER_WIDTH },
+            overflow: "hidden",
+          }}
+        >
+          <Sidebar mobileOpen={mobileOpen} onClose={handleDrawerToggle} />
+        </Box>
+        <Box
+          component="main"
+          sx={{
+            order: rtl ? 1 : 0,
+            direction: rtl ? "rtl" : "ltr",
+            flexGrow: 1,
+            flexShrink: 1,
+            minWidth: 0,
+            width: { xs: "100%", md: `calc(100% - ${DRAWER_WIDTH}px)` },
+            maxWidth: { md: `calc(100% - ${DRAWER_WIDTH}px)` },
+            minHeight: "auto",
+            overflow: "auto",
+            backgroundColor: "var(--background)",
+            display: "flex",
+            flexDirection: "column",
+            transition: "width 0.3s ease",
+          }}
+        >
+          {/* Toolbar spacer for the fixed AppBar */}
+          <Box sx={{ minHeight: { xs: "56px", sm: "64px" }, flexShrink: 0 }} />
+          {children}
+        </Box>
+        <BottomNavigation />
+        {!hideLeaderboardView && <StreakCelebrationOverlay />}
+        <ReportIssueFAB />
+      </Box>
+    </ChromeProvider>
+  );
+}

--- a/components/layout/ChromeContext.tsx
+++ b/components/layout/ChromeContext.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/**
+ * True when persistent app chrome (AppBar + Sidebar + BottomNavigation) is already mounted above the
+ * current tree by <AppChrome>, which lives in the ROOT layout.
+ *
+ * MainLayout reads this to decide whether it should render the chrome itself or just its content
+ * column. That is what lets the chrome be hoisted without editing the 114 pages that call MainLayout:
+ * inside AppChrome they collapse to the content wrapper, and the sidebar/app bar stop being torn down
+ * and rebuilt on every navigation.
+ */
+const ChromeContext = createContext(false);
+
+export const ChromeProvider = ChromeContext.Provider;
+
+export function useInsideChrome(): boolean {
+  return useContext(ChromeContext);
+}

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -13,6 +13,7 @@ import { reportContentCompleted } from "@/lib/streak/streakCelebration";
 import { StreakCelebrationOverlay } from "@/components/common/StreakCelebrationOverlay";
 import { ReportIssueFAB } from "@/components/common/ReportIssueFAB";
 import { useHideLeaderboardView } from "@/lib/contexts/ClientInfoContext";
+import { useInsideChrome } from "./ChromeContext";
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -22,7 +23,40 @@ interface MainLayoutProps {
   DrawerWidth?: number;
 }
 
-export const MainLayout: React.FC<MainLayoutProps> = memo(({
+export const MainLayout: React.FC<MainLayoutProps> = memo((props) => {
+  // When <AppChrome> (root layout) already provides the shell, collapse to just this page's CONTENT
+  // column. That is what lets the chrome be hoisted WITHOUT touching the ~114 pages that call
+  // MainLayout: they keep expressing their own width via fullWidthContent, while the AppBar/Sidebar
+  // stop being unmounted and rebuilt on every navigation.
+  const insideChrome = useInsideChrome();
+  return insideChrome ? <MainLayoutContent {...props} /> : <StandaloneMainLayout {...props} />;
+});
+
+/** The per-page content column — the only part that should change between routes. */
+function MainLayoutContent({ children, fullPage = false, fullWidthContent = false }: MainLayoutProps) {
+  return (
+    <Box
+      sx={{
+        flexGrow: 1,
+        p: fullPage ? 0 : { xs: 2, sm: 3, md: 4 },
+        width: "100%",
+        maxWidth: fullPage ? "100%" : fullWidthContent ? "none" : "1400px",
+        mx: fullPage ? 0 : "auto",
+        pb: fullPage ? 0 : { xs: "72px", md: 4 },
+        minHeight: fullPage ? 0 : "calc(100vh - 64px)",
+        position: "relative",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+/**
+ * The original self-contained layout, still used verbatim on the routes AppChrome deliberately skips
+ * (auth, setup, the legacy submodule player with its runtime chrome props, the proctored runner).
+ */
+const StandaloneMainLayout: React.FC<MainLayoutProps> = ({
   children,
   hideSidebar = false,
   fullPage = false,
@@ -144,6 +178,6 @@ export const MainLayout: React.FC<MainLayoutProps> = memo(({
       <ReportIssueFAB />
     </Box>
   );
-});
+};
 
 MainLayout.displayName = "MainLayout";


### PR DESCRIPTION
**Pivot 2 of 2 — the structural fix for instant navigation.**

Every one of the ~114 pages rendered its own `<MainLayout>`, and 43 `loading.tsx` files rendered a **second** one via `PageShimmerLayout`. Those are different element positions in different route subtrees, so React **unmounted and remounted the entire shell on every navigation** — AppBar, Sidebar, BottomNavigation, ReportIssueFAB and `useTimeTracking` torn down and rebuilt, the header refetching, the in-progress time segment dropped, and the chrome visibly flashing between a route's `loading.tsx` and its page.

**Approach: 3 new/changed files, not 114.** Editing every page would be large, risky, and hard to verify. Instead the chrome is hoisted and `MainLayout` is made **nesting-aware**, so every existing caller keeps working untouched:

- **`AppChrome`** renders the shell **once** from the root layout and provides `ChromeContext`. `useTimeTracking` now runs once per session instead of restarting each navigation.
- **`MainLayout`** detects it's inside `AppChrome` and collapses to just the page's **content column** — keeping its own `fullWidthContent` / 1400px semantics. Outside it, it renders the original self-contained layout **verbatim**.
- Net: the 41 width-capped pages, 30 full-width pages, and every `loading.tsx` shimmer keep their exact widths — **and the shimmer stops remounting the chrome**, which also removes the chrome flash between loading and page.

**Explicitly bypassed** (behave exactly as before, keeping their own MainLayout where they had one): unauthenticated routes, `/setup`, `/auth/handoff`, the **public `/credentials`** verification page, the **`/user/scorecard/pdf`** capture target, voice-sample + proctoring demos, the **legacy submodule player** (only page passing runtime-computed chrome props), and the distraction-free runners (assessment take + calibration, mock-interview take, adaptive interview). I enumerated every page rendering no chrome today specifically to make sure none of them would newly gain it.

`tsc` + eslint clean.

⚠️ **This is a layout change I could not fully verify without rendering** (Turbopack rejects the worktree's symlinked `node_modules`, so no local prod build). Please walk these on staging before it goes further:
- [ ] Dashboard / adaptive courses / admin pages: sidebar + app bar present, content width unchanged
- [ ] **Navigate between pages: sidebar should no longer flicker/rebuild**
- [ ] Login, `/credentials/<id>`, a proctored assessment, a mock interview: **no** sidebar (unchanged)
- [ ] Scorecard PDF export still renders without chrome
- [ ] Legacy course submodule player unchanged