### PR TITLE
feat(cohorts): Courses ↔ Cohorts mapping screen + plain-language cohort admin

### DIFF
--- a/app/admin/cohorts/mapping/page.tsx
+++ b/app/admin/cohorts/mapping/page.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Box, CircularProgress, Tooltip, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { useToast } from "@/components/common/Toast";
+import { useAuth } from "@/lib/auth/auth-context";
+import { canAccessAdminArea } from "@/lib/auth/role-utils";
+import { useRouter } from "next/navigation";
+import {
+  adminCohortsService,
+  type CohortListItem,
+  type CohortArtifact,
+} from "@/lib/services/admin/admin-cohorts.service";
+import {
+  adminAdaptiveCourseService,
+  type AdminAdaptiveCourseListItem,
+} from "@/lib/services/admin/admin-adaptive-course.service";
+
+/**
+ * Courses ↔ Cohorts — the single place an admin answers "who is doing what".
+ *
+ * Assigning a course to a cohort already existed, but only as a generic "add artifact" dialog buried
+ * in a cohort's tab and as an action on the course builder — so nobody could find it, and neither
+ * view showed the overall picture. This is the matrix: cohorts down the side, courses across the top,
+ * one click per cell. Assigning enrols the cohort's active students and auto-enrols anyone who joins
+ * later (backend), so a tick here genuinely means "these students have this course".
+ */
+
+/** cohortId -> (courseId -> the active artifact row linking them) */
+type LinkMap = Map<number, Map<number, CohortArtifact>>;
+
+export default function CohortCourseMappingPage() {
+  const router = useRouter();
+  const { showToast } = useToast();
+  const { user, loading: authLoading } = useAuth();
+  const canAccessAdmin = canAccessAdminArea(user?.role);
+
+  const [cohorts, setCohorts] = useState<CohortListItem[]>([]);
+  const [courses, setCourses] = useState<AdminAdaptiveCourseListItem[]>([]);
+  const [links, setLinks] = useState<LinkMap>(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  /** `${cohortId}:${courseId}` while that one cell is being written. */
+  const [busyCell, setBusyCell] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!authLoading && !canAccessAdmin) router.replace("/dashboard");
+  }, [authLoading, canAccessAdmin, router]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [cohortList, courseList] = await Promise.all([
+        adminCohortsService.listCohorts(),
+        adminAdaptiveCourseService.listCourses(),
+      ]);
+      const live = cohortList.filter((c) => c.status !== "archived");
+      setCohorts(live);
+      setCourses(courseList);
+
+      // One artifact fetch per cohort, in parallel — the API is per-cohort.
+      const rows = await Promise.all(
+        live.map(async (c) => {
+          try {
+            return [c.id, await adminCohortsService.listArtifacts(c.id)] as const;
+          } catch {
+            return [c.id, [] as CohortArtifact[]] as const;
+          }
+        })
+      );
+      const next: LinkMap = new Map();
+      for (const [cohortId, artifacts] of rows) {
+        const byCourse = new Map<number, CohortArtifact>();
+        for (const a of artifacts) {
+          if (a.artifact_type === "adaptive_course" && a.status === "active" && a.target) {
+            byCourse.set(a.target.id, a);
+          }
+        }
+        next.set(cohortId, byCourse);
+      }
+      setLinks(next);
+    } catch (e: unknown) {
+      const status = (e as { response?: { status?: number } })?.response?.status;
+      setError(
+        status === 403
+          ? "The Cohort Builder isn't enabled for this account. Ask your platform admin to enable it."
+          : "Couldn't load cohorts and courses. Please try again."
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (canAccessAdmin) void load();
+  }, [canAccessAdmin, load]);
+
+  const toggle = async (cohort: CohortListItem, course: AdminAdaptiveCourseListItem) => {
+    const key = `${cohort.id}:${course.id}`;
+    if (busyCell) return;
+    const existing = links.get(cohort.id)?.get(course.id);
+    setBusyCell(key);
+    try {
+      if (existing) {
+        await adminCohortsService.removeArtifact(cohort.id, existing.id);
+        setLinks((prev) => {
+          const next = new Map(prev);
+          const inner = new Map(next.get(cohort.id) ?? []);
+          inner.delete(course.id);
+          next.set(cohort.id, inner);
+          return next;
+        });
+        // Deliberately explicit: unassigning never revokes access from students who already have it.
+        showToast(
+          `Removed ${course.title} from ${cohort.name}. Students already enrolled keep their access.`,
+          "info"
+        );
+      } else {
+        const art = await adminCohortsService.assignArtifact(cohort.id, {
+          artifact_type: "adaptive_course",
+          target_id: course.id,
+        });
+        setLinks((prev) => {
+          const next = new Map(prev);
+          const inner = new Map(next.get(cohort.id) ?? []);
+          inner.set(course.id, art);
+          next.set(cohort.id, inner);
+          return next;
+        });
+        const enrolled = art.enrolled ?? 0;
+        showToast(
+          enrolled > 0
+            ? `${course.title} → ${cohort.name}: ${enrolled} student${enrolled === 1 ? "" : "s"} enrolled.`
+            : `${course.title} → ${cohort.name} assigned.`,
+          "success"
+        );
+      }
+    } catch (e: unknown) {
+      const status = (e as { response?: { status?: number } })?.response?.status;
+      showToast(
+        status === 409
+          ? "Already assigned — an adaptive course can only be the primary batch of one cohort."
+          : "Couldn't update that assignment.",
+        "error"
+      );
+    } finally {
+      setBusyCell(null);
+    }
+  };
+
+  const assignedCount = useMemo(
+    () => [...links.values()].reduce((n, m) => n + m.size, 0),
+    [links]
+  );
+
+  if (!authLoading && !canAccessAdmin) return null;
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Admin · Cohorts"
+        title="Courses ↔ Cohorts"
+        description="Give a whole batch a course in one click. Assigning enrols every active student in that cohort and auto-enrols anyone who joins it later."
+        icon="mdi:table-large"
+        accent="indigo"
+      />
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : error ? (
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Icon icon="mdi:alert-circle-outline" width={40} style={{ color: "var(--font-tertiary)" }} />
+          <Typography sx={{ mt: 1.5, color: "var(--font-secondary)", fontWeight: 600 }}>{error}</Typography>
+        </Box>
+      ) : cohorts.length === 0 || courses.length === 0 ? (
+        <Box sx={{ textAlign: "center", py: 8 }}>
+          <Typography sx={{ color: "var(--font-secondary)", fontWeight: 600 }}>
+            {cohorts.length === 0
+              ? "No cohorts yet — create one in Admin → Cohorts first."
+              : "No adaptive courses yet — create one in the course builder first."}
+          </Typography>
+        </Box>
+      ) : (
+        <>
+          <Typography sx={{ fontSize: "0.85rem", color: "var(--font-tertiary)", mb: 1.5 }}>
+            {cohorts.length} cohort{cohorts.length === 1 ? "" : "s"} · {courses.length} course
+            {courses.length === 1 ? "" : "s"} · {assignedCount} assignment
+            {assignedCount === 1 ? "" : "s"}
+          </Typography>
+
+          {/* The matrix. Scrolls horizontally on its own so the page body never does. */}
+          <Box
+            sx={{
+              overflowX: "auto",
+              border: "1px solid var(--border-default)",
+              borderRadius: "16px",
+              bgcolor: "var(--card-bg)",
+            }}
+          >
+            <Box component="table" sx={{ borderCollapse: "separate", borderSpacing: 0, minWidth: "100%" }}>
+              <Box component="thead">
+                <Box component="tr">
+                  <Box
+                    component="th"
+                    sx={{
+                      position: "sticky",
+                      left: 0,
+                      zIndex: 2,
+                      bgcolor: "var(--card-bg)",
+                      textAlign: "left",
+                      p: 2,
+                      minWidth: 220,
+                      borderBottom: "1px solid var(--border-default)",
+                      fontSize: "0.72rem",
+                      fontWeight: 800,
+                      letterSpacing: "0.08em",
+                      textTransform: "uppercase",
+                      color: "var(--font-tertiary)",
+                    }}
+                  >
+                    Cohort
+                  </Box>
+                  {courses.map((course) => (
+                    <Box
+                      component="th"
+                      key={course.id}
+                      sx={{
+                        p: 1.5,
+                        minWidth: 132,
+                        maxWidth: 160,
+                        borderBottom: "1px solid var(--border-default)",
+                        borderLeft: "1px solid var(--border-default)",
+                        verticalAlign: "bottom",
+                      }}
+                    >
+                      <Tooltip title={course.title}>
+                        <Typography
+                          sx={{
+                            fontSize: "0.8rem",
+                            fontWeight: 700,
+                            color: "var(--font-primary)",
+                            display: "-webkit-box",
+                            WebkitLineClamp: 3,
+                            WebkitBoxOrient: "vertical",
+                            overflow: "hidden",
+                            textAlign: "center",
+                          }}
+                        >
+                          {course.title}
+                        </Typography>
+                      </Tooltip>
+                    </Box>
+                  ))}
+                </Box>
+              </Box>
+              <Box component="tbody">
+                {cohorts.map((cohort) => (
+                  <Box component="tr" key={cohort.id}>
+                    <Box
+                      component="th"
+                      sx={{
+                        position: "sticky",
+                        left: 0,
+                        zIndex: 1,
+                        bgcolor: "var(--card-bg)",
+                        textAlign: "left",
+                        p: 2,
+                        borderBottom: "1px solid var(--border-default)",
+                        borderRight: "1px solid var(--border-default)",
+                      }}
+                    >
+                      <Typography sx={{ fontWeight: 700, fontSize: "0.92rem", color: "var(--font-primary)" }} noWrap>
+                        {cohort.name}
+                      </Typography>
+                      <Typography sx={{ fontSize: "0.75rem", color: "var(--font-tertiary)" }}>
+                        {cohort.member_count} member{cohort.member_count === 1 ? "" : "s"} · {cohort.status}
+                      </Typography>
+                    </Box>
+                    {courses.map((course) => {
+                      const key = `${cohort.id}:${course.id}`;
+                      const linked = Boolean(links.get(cohort.id)?.get(course.id));
+                      const busy = busyCell === key;
+                      return (
+                        <Box
+                          component="td"
+                          key={course.id}
+                          sx={{
+                            p: 0,
+                            borderBottom: "1px solid var(--border-default)",
+                            borderLeft: "1px solid var(--border-default)",
+                            textAlign: "center",
+                          }}
+                        >
+                          <Tooltip
+                            title={
+                              linked
+                                ? `Remove ${course.title} from ${cohort.name}`
+                                : `Give ${cohort.name} (${cohort.member_count} students) access to ${course.title}`
+                            }
+                          >
+                            <Box
+                              role="button"
+                              tabIndex={0}
+                              aria-pressed={linked}
+                              onClick={() => void toggle(cohort, course)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") void toggle(cohort, course);
+                              }}
+                              sx={{
+                                display: "grid",
+                                placeItems: "center",
+                                width: "100%",
+                                minHeight: 62,
+                                cursor: busyCell ? "default" : "pointer",
+                                bgcolor: linked
+                                  ? "color-mix(in srgb, #10b981 12%, transparent)"
+                                  : "transparent",
+                                transition: "background-color .15s",
+                                "&:hover": {
+                                  bgcolor: linked
+                                    ? "color-mix(in srgb, #ef4444 12%, transparent)"
+                                    : "color-mix(in srgb, #6366f1 10%, transparent)",
+                                },
+                              }}
+                            >
+                              {busy ? (
+                                <CircularProgress size={16} />
+                              ) : linked ? (
+                                <Icon icon="mdi:check-circle" width={22} style={{ color: "#10b981" }} />
+                              ) : (
+                                <Icon
+                                  icon="mdi:plus-circle-outline"
+                                  width={20}
+                                  style={{ color: "var(--font-tertiary)", opacity: 0.5 }}
+                                />
+                              )}
+                            </Box>
+                          </Tooltip>
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          </Box>
+
+          <Typography sx={{ mt: 1.5, fontSize: "0.78rem", color: "var(--font-tertiary)" }}>
+            Removing an assignment stops future auto-enrolment. Students who already started the course
+            keep their access and progress.
+          </Typography>
+        </>
+      )}
+    </PageShell>
+  );
+}

--- a/components/admin/cohorts/CohortAssignmentsTab.tsx
+++ b/components/admin/cohorts/CohortAssignmentsTab.tsx
@@ -24,13 +24,34 @@ import {
 import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
 import { getAssessments } from "@/lib/services/admin/admin-assessment.service";
 
-const TYPE_META: Record<CohortArtifactType, { label: string; icon: string; color: string }> = {
-  adaptive_course: { label: "Adaptive course", icon: "mdi:robot-outline", color: "#6366f1" },
-  live_series: { label: "Live series", icon: "mdi:video-outline", color: "#ec4899" },
-  classic_course: { label: "Course", icon: "mdi:book-open-variant", color: "#0ea5e9" },
-  assessment: { label: "Assessment", icon: "mdi:clipboard-text-outline", color: "#a855f7" },
-  mock_interview: { label: "Mock interview", icon: "mdi:account-voice", color: "#f59e0b" },
-  job_posting: { label: "Job", icon: "mdi:briefcase-outline", color: "#10b981" },
+const TYPE_META: Record<
+  CohortArtifactType,
+  { label: string; icon: string; color: string; blurb: string }
+> = {
+  adaptive_course: {
+    label: "Adaptive course", icon: "mdi:robot-outline", color: "#6366f1",
+    blurb: "Enrols every active student in this batch, and anyone who joins later.",
+  },
+  live_series: {
+    label: "Live session series", icon: "mdi:video-outline", color: "#ec4899",
+    blurb: "Links a recurring live class to this batch so its students see it.",
+  },
+  classic_course: {
+    label: "Classic course (legacy)", icon: "mdi:book-open-variant", color: "#0ea5e9",
+    blurb: "The older course format. Use an adaptive course for anything new.",
+  },
+  assessment: {
+    label: "Assessment", icon: "mdi:clipboard-text-outline", color: "#a855f7",
+    blurb: "Makes this test available to the batch, and only the batch.",
+  },
+  mock_interview: {
+    label: "Mock interview", icon: "mdi:account-voice", color: "#f59e0b",
+    blurb: "Gives the batch access to this AI interview template.",
+  },
+  job_posting: {
+    label: "Job posting", icon: "mdi:briefcase-outline", color: "#10b981",
+    blurb: "Shows this job opening to the batch's students.",
+  },
 };
 
 const ASSIGNABLE: CohortArtifactType[] = [
@@ -255,17 +276,27 @@ function AssignArtifactDialog({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle sx={{ fontWeight: 800 }}>Add assignment</DialogTitle>
+      <DialogTitle sx={{ fontWeight: 800, pb: 0.5 }}>
+        Give this batch something
+        <Typography sx={{ fontSize: "0.85rem", fontWeight: 500, color: "var(--font-secondary)", mt: 0.5 }}>
+          Pick what the students in this cohort should get. They receive it immediately, and anyone
+          who joins the cohort later gets it automatically.
+        </Typography>
+      </DialogTitle>
       <DialogContent sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
         <TextField
           select
-          label="Type"
+          label="What do you want to give them?"
           value={type}
           onChange={(e) => setType(e.target.value as CohortArtifactType)}
+          helperText={TYPE_META[type].blurb}
         >
           {ASSIGNABLE.map((t) => (
             <MenuItem key={t} value={t}>
-              {TYPE_META[t].label}
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Icon icon={TYPE_META[t].icon} width={18} style={{ color: TYPE_META[t].color }} />
+                {TYPE_META[t].label}
+              </Box>
             </MenuItem>
           ))}
         </TextField>
@@ -273,7 +304,7 @@ function AssignArtifactDialog({
         {usePicker ? (
           <TextField
             select
-            label={loadingOpts ? "Loading…" : "Target"}
+            label={loadingOpts ? "Loading…" : "Which one?"}
             value={targetId}
             onChange={(e) => setTargetId(e.target.value)}
             disabled={loadingOpts}
@@ -291,23 +322,27 @@ function AssignArtifactDialog({
           </TextField>
         ) : (
           <TextField
-            label="Target id"
+            label="Which one? (paste its ID)"
             type="number"
             value={targetId}
             onChange={(e) => setTargetId(e.target.value)}
-            helperText={`Enter the ${TYPE_META[type].label} id (from its own admin page).`}
+            helperText={"You will find the ID in the URL of its own admin page."}
           />
         )}
 
         <TextField
           select
-          label="Role"
+          label="Is this the batch's main course?"
           value={role}
           onChange={(e) => setRole(e.target.value as "primary" | "supplemental")}
-          helperText="Primary = the batch this cohort runs. Supplemental = an additional mapped artifact."
+          helperText={
+            role === "primary"
+              ? "Main: this is the course the batch is built around. Only one batch can claim a given course as its main one."
+              : "Additional: extra material alongside the batch's main course. Choose this if you are unsure."
+          }
         >
-          <MenuItem value="supplemental">Supplemental</MenuItem>
-          <MenuItem value="primary">Primary</MenuItem>
+          <MenuItem value="supplemental">No — additional material</MenuItem>
+          <MenuItem value="primary">Yes — this is the main course</MenuItem>
         </TextField>
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>

--- a/components/admin/cohorts/CohortScheduleTab.tsx
+++ b/components/admin/cohorts/CohortScheduleTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Button, MenuItem, TextField, Typography } from "@mui/material";
+import { Box, Button, ButtonBase, MenuItem, TextField, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { useToast } from "@/components/common/Toast";
 import {
@@ -20,6 +20,7 @@ export function CohortScheduleTab({ cohort, onSaved }: { cohort: CohortDetail; o
   const [timezone, setTimezone] = useState(cohort.timezone ?? "Asia/Kolkata");
   const [stagger, setStagger] = useState(cohort.week_stagger_days ?? 7);
   const [window, setWindow] = useState(cohort.week_window_days ?? 10);
+  const [showAdvanced, setShowAdvanced] = useState(false);
   const [capacity, setCapacity] = useState<string>(cohort.capacity != null ? String(cohort.capacity) : "");
   const [saving, setSaving] = useState(false);
 
@@ -56,7 +57,12 @@ export function CohortScheduleTab({ cohort, onSaved }: { cohort: CohortDetail; o
     >
       <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 2 }}>
         <Icon icon="mdi:calendar-clock" width={20} style={{ color: "#a855f7" }} />
-        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Schedule &amp; lifecycle</Typography>
+        <Box>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem" }}>Schedule</Typography>
+          <Typography sx={{ fontSize: "0.82rem", color: "var(--font-tertiary)" }}>
+            When this batch runs, and how many students it can hold.
+          </Typography>
+        </Box>
       </Box>
 
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 2 }}>
@@ -77,7 +83,7 @@ export function CohortScheduleTab({ cohort, onSaved }: { cohort: CohortDetail; o
           type="number"
           value={capacity}
           onChange={(e) => setCapacity(e.target.value)}
-          helperText="Blank = unlimited"
+          helperText="Leave blank for no limit on how many students can join"
         />
         <TextField
           label="Start date"
@@ -93,23 +99,48 @@ export function CohortScheduleTab({ cohort, onSaved }: { cohort: CohortDetail; o
           onChange={(e) => setEndDate(e.target.value)}
           InputLabelProps={{ shrink: true }}
         />
-        <TextField label="Timezone" value={timezone} onChange={(e) => setTimezone(e.target.value)} />
-        <Box sx={{ display: "flex", gap: 2 }}>
-          <TextField
-            label="Week stagger (days)"
-            type="number"
-            value={stagger}
-            onChange={(e) => setStagger(Number(e.target.value))}
-            fullWidth
-          />
-          <TextField
-            label="Week window (days)"
-            type="number"
-            value={window}
-            onChange={(e) => setWindow(Number(e.target.value))}
-            fullWidth
-          />
-        </Box>
+        <TextField
+          label="Timezone"
+          value={timezone}
+          onChange={(e) => setTimezone(e.target.value)}
+          helperText="Deadlines and weekly unlocks are calculated in this timezone"
+        />
+      </Box>
+
+      {/* Weekly-drip settings. These only do anything on a course with the weekly content lock
+          switched ON, so they are tucked away instead of sitting in the main form looking like
+          required fields nobody understands. */}
+      <Box sx={{ mt: 2.5 }}>
+        <ButtonBase
+          onClick={() => setShowAdvanced((v) => !v)}
+          sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, fontWeight: 700,
+                fontSize: "0.85rem", color: "#6366f1", borderRadius: 1 }}
+        >
+          <Icon icon={showAdvanced ? "mdi:chevron-down" : "mdi:chevron-right"} width={18} />
+          Weekly unlock settings
+        </ButtonBase>
+        <Typography sx={{ fontSize: "0.78rem", color: "var(--font-tertiary)", mt: 0.5 }}>
+          Only used when a course in this batch has the weekly content lock turned on. Otherwise these
+          are ignored — leave them as they are.
+        </Typography>
+        {showAdvanced && (
+          <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" }, gap: 2, mt: 2 }}>
+            <TextField
+              label="Days between weeks opening"
+              type="number"
+              value={stagger}
+              onChange={(e) => setStagger(Number(e.target.value))}
+              helperText="7 = a new week unlocks every calendar week"
+            />
+            <TextField
+              label="Days a week stays open"
+              type="number"
+              value={window}
+              onChange={(e) => setWindow(Number(e.target.value))}
+              helperText="How long students get full points for that week's work"
+            />
+          </Box>
+        )}
       </Box>
 
       <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>

--- a/components/instructor/InstructorAssignPanel.tsx
+++ b/components/instructor/InstructorAssignPanel.tsx
@@ -141,8 +141,17 @@ export function InstructorAssignPanel({ scope, id }: { scope: "course" | "cohort
               variant="contained"
               disableElevation
               startIcon={<Icon icon="mdi:plus" width={18} />}
-              sx={{ borderRadius: 2, textTransform: "none", fontWeight: 700,
-                background: "linear-gradient(135deg,#6366f1,#a855f7)" }}
+              sx={{
+                borderRadius: 2,
+                textTransform: "none",
+                fontWeight: 700,
+                background: "linear-gradient(135deg,#6366f1,#a855f7)",
+                // Explicit: the custom `background` overrides MUI's contained variant, so without
+                // this the label inherited a dark colour and read as dark-on-dark on the gradient.
+                color: "#fff",
+                "&:hover": { background: "linear-gradient(135deg,#5457e5,#9333ea)" },
+                "&.Mui-disabled": { background: "var(--border-default)", color: "var(--font-tertiary)" },
+              }}
             >
               Assign
             </Button>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -493,6 +493,15 @@ export const Sidebar: React.FC<SidebarProps> = ({
       featureName: "admin_cohorts",
       descKey: "navDesc.admin_cohorts",
     },
+    {
+      // The one place to answer "which batch is doing which course". Assigning here enrols the
+      // whole cohort, so it needs to be findable rather than buried in a per-cohort tab.
+      label: "Courses ↔ Cohorts",
+      labelKey: "nav.adminCohortCourseMapping",
+      path: "/admin/cohorts/mapping",
+      icon: "mdi:table-large",
+      featureName: "admin_cohorts",
+    },
     // {
     //   label: "Workshop Registration",
     //   path: "/admin/workshop-registration",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -14,6 +14,7 @@
     "pendingInstructors": "Instructors",
     "instructors": "Instructors",
     "courseBuilder": "Course Builder",
+    "adminCohortCourseMapping": "Courses \u2194 Cohorts",
     "adminCohorts": "Cohorts",
     "emails": "Emails",
     "notifications": "Notifications",


### PR DESCRIPTION
**The headline finding: the feature you asked for already exists — you just can't reach it.**

Admin course→cohort assignment shipped earlier (BE #451 / FE #1131), but the whole Cohort Builder is behind **two feature flags** (`cohort_builder` for the API, `admin_cohorts` for the sidebar). If your tenant lacks them, the surface is invisible. There's a command for it:

```
python manage.py enable_cohort_builder --dry-run   # see targets
python manage.py enable_cohort_builder             # enable
```

**This PR makes the feature findable and readable:**

- **NEW `/admin/cohorts/mapping`** — a **matrix**: cohorts down the side, courses across the top, one click per cell. Sticky first column, its own horizontal scroll, per-cell busy state, and toasts reporting how many students were actually enrolled. Added to the sidebar.
- **'Add assignment' → 'Give this batch something'.** The type field now asks *"What do you want to give them?"* and every option explains what assigning it **does**. `Course` renamed **"Classic course (legacy)"** — next to "Adaptive course" it read as two names for one thing.
- **Role field**: *Primary/Supplemental* → **"Is this the batch's main course?"** with Yes/No answers, explaining the one-batch-per-course constraint.
- **Schedule tab**: *Week stagger* / *Week window* only matter when a course has the weekly content lock on — so they moved behind a **"Weekly unlock settings"** disclosure that says exactly that, relabelled **"Days between weeks opening"** / **"Days a week stays open"**.
- **Instructors 'Assign' button** — custom gradient with no `color` set, so the label inherited dark text on a dark gradient. Fixed with explicit white + hover/disabled states.

`tsc` + eslint clean. Instructor IA (making the cohort the home) is the next PR.