### PR TITLE
feat(instructor): show what each batch is studying; name the two concepts clearly

### DIFF
--- a/app/instructor/cohorts/page.tsx
+++ b/app/instructor/cohorts/page.tsx
@@ -117,7 +117,7 @@ export default function InstructorCohortsPage() {
       <ModulePageHeader
         eyebrow="Teaching"
         title="My Cohorts"
-        description="Courses and cohorts assigned to you by admin. Membership is managed centrally. You own delivery, sessions and reporting."
+        description="A batch is a group of students studying together. Open one to see its students, the courses it is doing, and its progress. Rosters and course mapping are set by your admin."
         accent="purple"
         icon="mdi:school-outline"
         action={
@@ -173,6 +173,32 @@ export default function InstructorCohortsPage() {
                   <Icon icon="mdi:bookmark-outline" width={14} />
                   <Typography sx={{ fontSize: "0.82rem" }}>{c.client_name || "AI Linc"}</Typography>
                 </Stack>
+
+                {/* What this batch is actually studying. Without it, "My Cohorts" and "My Courses"
+                    read as two unrelated lists and nobody can tell which batch does which course. */}
+                <Box sx={{ mt: 1.25, display: "flex", flexWrap: "wrap", gap: 0.6, alignItems: "center" }}>
+                  <Icon icon="mdi:book-open-variant" width={14} style={{ color: "var(--font-tertiary)" }} />
+                  {(c.courses ?? []).length === 0 ? (
+                    <Typography sx={{ fontSize: "0.78rem", color: "var(--font-tertiary)", fontStyle: "italic" }}>
+                      No course assigned yet — ask your admin to map one to this batch.
+                    </Typography>
+                  ) : (
+                    (c.courses ?? []).slice(0, 3).map((co) => (
+                      <Chip
+                        key={co.id}
+                        size="small"
+                        label={co.title}
+                        sx={{ fontWeight: 700, fontSize: "0.7rem", height: 22,
+                              bgcolor: "color-mix(in srgb,#6366f1 12%,transparent)", color: "#4f46e5" }}
+                      />
+                    ))
+                  )}
+                  {(c.courses ?? []).length > 3 && (
+                    <Typography sx={{ fontSize: "0.74rem", color: "var(--font-tertiary)", fontWeight: 700 }}>
+                      +{(c.courses ?? []).length - 3} more
+                    </Typography>
+                  )}
+                </Box>
 
                 <Stack direction="row" justifyContent="space-between" sx={{ mt: 2, mb: 0.5 }}>
                   <Typography sx={{ fontSize: "0.82rem", color: "text.secondary" }}>Cohort progress</Typography>

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -36,8 +36,8 @@ export default function InstructorCoursesPage() {
     <PageShell>
       <ModulePageHeader
         eyebrow="Teach"
-        title="My courses"
-        description="The adaptive courses you're assigned to. Open one for its students and progress."
+        title="Course Content"
+        description="The course material you teach. A course is the content; a batch is the group of students studying it — open My Batches to work with a specific class."
         accent="purple"
         icon="mdi:book-education"
       />

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -313,7 +313,7 @@ interface NavigationItem {
 const INSTRUCTOR_NAVIGATION_ITEMS: NavigationItem[] = [
   { label: "Dashboard", labelKey: "instructorNav.dashboard", path: "/instructor/dashboard", icon: "mdi:view-dashboard", featureName: "instructor" },
   { label: "My Batches", labelKey: "instructorNav.cohorts", path: "/instructor/cohorts", icon: "mdi:account-group", featureName: "instructor" },
-  { label: "My Courses", labelKey: "instructorNav.courses", path: "/instructor/courses", icon: "mdi:book-education", featureName: "instructor" },
+  { label: "Course Content", labelKey: "instructorNav.courses", path: "/instructor/courses", icon: "mdi:book-education", featureName: "instructor" },
   { label: "Students", labelKey: "instructorNav.students", path: "/instructor/students", icon: "mdi:account-school", featureName: "instructor" },
   { label: "Gradebook", labelKey: "instructorNav.gradebook", path: "/instructor/assessments", icon: "mdi:clipboard-check-outline", featureName: "instructor" },
   { label: "Live Sessions", labelKey: "instructorNav.live", path: "/instructor/live-sessions", icon: "mdi:video-outline", featureName: "instructor" },

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -24,6 +24,8 @@ export interface InstructorStatStudent {
 export interface InstructorCohortDetail {
   id: number;
   name: string;
+  /** The courses this batch is studying — the link between "My Cohorts" and "My Courses". */
+  courses?: { id: number; title: string }[];
   client_name: string;
   status: string;
   end_date: string | null;


### PR DESCRIPTION
Frontend half of the instructor IA work, paired with **BE #457**. Implements the *"cohort is the home"* model you picked.

**The problem:** an instructor saw **My Cohorts** and **My Courses** as two parallel lists with **nothing connecting them** — no way to answer *"which batch is doing which course?"*.

**What changed**
- **Each batch card now lists the courses that batch is studying** (chips, `+N more`), or says plainly *"No course assigned yet — ask your admin to map one to this batch."* That's the missing join, from the `courses[]` field added in BE #457.
- **Named the two concepts** so the model is obvious rather than implied:
  - **My Batches** = the *group of students* you teach — the home you work from
  - **Course Content** (was *My Courses*) = the *material* itself
  
  Both page descriptions now state the relationship outright.

**Degrades safely:** `courses` is optional on the type, so this is correct against a backend that hasn't deployed #457 yet — it just shows the empty-state line.

`tsc` + eslint clean. Pairs with #1150 (admin Courses ↔ Cohorts matrix).