### PR TITLE
refactor(cohorts): fold course mapping into /admin/cohorts instead of a separate nav item

### DIFF
--- a/app/admin/cohorts/page.tsx
+++ b/app/admin/cohorts/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
+import { CohortCourseMatrix } from "@/components/admin/cohorts/CohortCourseMatrix";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useToast } from "@/components/common/Toast";
@@ -61,6 +62,9 @@ export default function AdminCohortsPage() {
   const [pendingDelete, setPendingDelete] = useState<CohortListItem | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  // "Course mapping" is a way of LOOKING at cohorts, not a separate destination, so it lives here
+  // as a view rather than its own sidebar entry.
+  const [view, setView] = useState<"list" | "mapping">("list");
 
   const load = useCallback(async () => {
     try {
@@ -140,6 +144,28 @@ export default function AdminCohortsPage() {
           </HeaderActionButton>
         }
       />
+
+      <Box sx={{ mt: 3 }}>
+        <SegmentedTabs<"list" | "mapping">
+          tabs={[
+            { value: "list", label: "All cohorts", icon: "mdi:account-group" },
+            { value: "mapping", label: "Course mapping", icon: "mdi:table-large" },
+          ]}
+          value={view}
+          onChange={setView}
+        />
+      </Box>
+
+      {view === "mapping" ? (
+        <Box sx={{ mt: 2.5 }}>
+          <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", mb: 2 }}>
+            Give a whole batch a course in one click. Assigning enrols every active student in that
+            cohort and auto-enrols anyone who joins it later.
+          </Typography>
+          <CohortCourseMatrix />
+        </Box>
+      ) : (
+      <>
 
         {!loading && cohorts.length > 0 && (
           <Box data-tour-id="cohorts-stats" sx={{ mt: 3 }}>
@@ -239,6 +265,8 @@ export default function AdminCohortsPage() {
         {!loading && cohorts.length > 0 && filtered.length === 0 && (
           <AssessmentEmptyState icon="mdi:filter-off-outline" title="No cohorts match" description="Try a different status filter or search." />
         )}
+      </>
+      )}
 
       <CreateCohortDialog
         open={createOpen}

--- a/components/admin/cohorts/CohortCourseMatrix.tsx
+++ b/components/admin/cohorts/CohortCourseMatrix.tsx
@@ -3,12 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, CircularProgress, Tooltip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
-import { PageShell } from "@/components/common/PageShell";
-import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { useToast } from "@/components/common/Toast";
-import { useAuth } from "@/lib/auth/auth-context";
-import { canAccessAdminArea } from "@/lib/auth/role-utils";
-import { useRouter } from "next/navigation";
 import {
   adminCohortsService,
   type CohortListItem,
@@ -20,7 +15,8 @@ import {
 } from "@/lib/services/admin/admin-adaptive-course.service";
 
 /**
- * Courses ↔ Cohorts — the single place an admin answers "who is doing what".
+ * Courses ↔ Cohorts matrix — rendered as a VIEW inside /admin/cohorts (not its own nav item,
+ * because it is a way of looking at cohorts rather than a separate destination).
  *
  * Assigning a course to a cohort already existed, but only as a generic "add artifact" dialog buried
  * in a cohort's tab and as an action on the course builder — so nobody could find it, and neither
@@ -32,11 +28,8 @@ import {
 /** cohortId -> (courseId -> the active artifact row linking them) */
 type LinkMap = Map<number, Map<number, CohortArtifact>>;
 
-export default function CohortCourseMappingPage() {
-  const router = useRouter();
+export function CohortCourseMatrix() {
   const { showToast } = useToast();
-  const { user, loading: authLoading } = useAuth();
-  const canAccessAdmin = canAccessAdminArea(user?.role);
 
   const [cohorts, setCohorts] = useState<CohortListItem[]>([]);
   const [courses, setCourses] = useState<AdminAdaptiveCourseListItem[]>([]);
@@ -45,10 +38,6 @@ export default function CohortCourseMappingPage() {
   const [error, setError] = useState<string | null>(null);
   /** `${cohortId}:${courseId}` while that one cell is being written. */
   const [busyCell, setBusyCell] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!authLoading && !canAccessAdmin) router.replace("/dashboard");
-  }, [authLoading, canAccessAdmin, router]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -96,8 +85,8 @@ export default function CohortCourseMappingPage() {
   }, []);
 
   useEffect(() => {
-    if (canAccessAdmin) void load();
-  }, [canAccessAdmin, load]);
+    void load();
+  }, [load]);
 
   const toggle = async (cohort: CohortListItem, course: AdminAdaptiveCourseListItem) => {
     const key = `${cohort.id}:${course.id}`;
@@ -157,18 +146,8 @@ export default function CohortCourseMappingPage() {
     [links]
   );
 
-  if (!authLoading && !canAccessAdmin) return null;
-
   return (
-    <PageShell>
-      <ModulePageHeader
-        eyebrow="Admin · Cohorts"
-        title="Courses ↔ Cohorts"
-        description="Give a whole batch a course in one click. Assigning enrols every active student in that cohort and auto-enrols anyone who joins it later."
-        icon="mdi:table-large"
-        accent="indigo"
-      />
-
+    <>
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
           <CircularProgress />
@@ -357,6 +336,6 @@ export default function CohortCourseMappingPage() {
           </Typography>
         </>
       )}
-    </PageShell>
+    </>
   );
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -493,15 +493,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
       featureName: "admin_cohorts",
       descKey: "navDesc.admin_cohorts",
     },
-    {
-      // The one place to answer "which batch is doing which course". Assigning here enrols the
-      // whole cohort, so it needs to be findable rather than buried in a per-cohort tab.
-      label: "Courses ↔ Cohorts",
-      labelKey: "nav.adminCohortCourseMapping",
-      path: "/admin/cohorts/mapping",
-      icon: "mdi:table-large",
-      featureName: "admin_cohorts",
-    },
     // {
     //   label: "Workshop Registration",
     //   path: "/admin/workshop-registration",


### PR DESCRIPTION
Follow-up to #1150. Course mapping is a **way of looking at cohorts**, not a separate destination — giving it its own sidebar entry lengthened the nav without making anything clearer.

- Extracted the matrix into **`components/admin/cohorts/CohortCourseMatrix.tsx`** (page shell, header and auth guard stripped — the parent page owns those).
- **`/admin/cohorts` gains a view switch**: **All cohorts** | **Course mapping**, reusing the same `SegmentedTabs` control the page already uses for status filtering, so it looks native rather than bolted on.
- **Deleted** the standalone `/admin/cohorts/mapping` route and its sidebar entry.

`tsc` clean; eslint 0 errors on touched files.