### PR TITLE
fix(cohorts): Archive no longer deletes the cohort; add a separate Delete

### DIFF
--- a/app/admin/cohorts/page.tsx
+++ b/app/admin/cohorts/page.tsx
@@ -59,7 +59,9 @@ export default function AdminCohortsPage() {
   const [statusTab, setStatusTab] = useState<StatusTab>("all");
   const [search, setSearch] = useState("");
   const [viewMode, setViewMode] = useState<ListView>("cards");
+  const [pendingArchive, setPendingArchive] = useState<CohortListItem | null>(null);
   const [pendingDelete, setPendingDelete] = useState<CohortListItem | null>(null);
+  const [archiving, setArchiving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   // "Course mapping" is a way of LOOKING at cohorts, not a separate destination, so it lives here
@@ -115,13 +117,33 @@ export default function AdminCohortsPage() {
     });
   }, [cohorts, statusTab, search]);
 
+  /** Archive = keep the cohort, move it to the Archived tab. This used to call deleteCohort(), which
+   *  soft-DELETED it instead — so the cohort vanished entirely and the Archived tab stayed empty. */
+  async function handleConfirmArchive() {
+    if (!pendingArchive) return;
+    setArchiving(true);
+    try {
+      await adminCohortsService.updateCohort(pendingArchive.id, { status: "archived" });
+      setCohorts((prev) =>
+        prev.map((c) => (c.id === pendingArchive.id ? { ...c, status: "archived" as CohortStatus } : c)),
+      );
+      showToast(`"${pendingArchive.name}" archived. Find it under the Archived tab.`, "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "Couldn't archive.", "error");
+    } finally {
+      setArchiving(false);
+      setPendingArchive(null);
+    }
+  }
+
+  /** Delete = soft-delete on the backend: removed from the working set, learner history retained. */
   async function handleConfirmDelete() {
     if (!pendingDelete) return;
     setDeleting(true);
     try {
       await adminCohortsService.deleteCohort(pendingDelete.id);
       setCohorts((prev) => prev.filter((c) => c.id !== pendingDelete.id));
-      showToast(`"${pendingDelete.name}" archived.`, "success");
+      showToast(`"${pendingDelete.name}" deleted.`, "success");
     } catch (e) {
       showToast(e instanceof Error ? e.message : "Couldn't delete.", "error");
     } finally {
@@ -244,7 +266,8 @@ export default function AdminCohortsPage() {
                 key={cohort.id}
                 cohort={cohort}
                 onOpen={() => push(`/admin/cohorts/${cohort.id}`)}
-                onArchive={() => setPendingDelete(cohort)}
+                onArchive={() => setPendingArchive(cohort)}
+                onDelete={() => setPendingDelete(cohort)}
               />
             ))}
           </Box>
@@ -279,17 +302,31 @@ export default function AdminCohortsPage() {
 
       <ConfirmDialog
         open={pendingDelete !== null}
-        title="Archive cohort"
+        title="Delete cohort?"
         message={
           pendingDelete
-            ? `"${pendingDelete.name}" will be removed from the working set. Member and assignment history is kept.`
+            ? `"${pendingDelete.name}" will be removed from your cohorts. Member and assignment history is kept, and students keep any course access they already have. To keep the cohort but take it out of the way, use Archive instead.`
             : ""
         }
-        confirmText={deleting ? "Archiving…" : "Archive"}
+        confirmText={deleting ? "Deleting…" : "Delete"}
         cancelText="Cancel"
         confirmColor="error"
         onConfirm={() => void handleConfirmDelete()}
         onCancel={() => setPendingDelete(null)}
+      />
+
+      <ConfirmDialog
+        open={pendingArchive !== null}
+        title="Archive cohort?"
+        message={
+          pendingArchive
+            ? `"${pendingArchive.name}" moves to the Archived tab. Nothing is lost — its members, assignments and history stay, and you can set it back to active any time from its Schedule tab.`
+            : ""
+        }
+        confirmText={archiving ? "Archiving…" : "Archive"}
+        cancelText="Cancel"
+        onConfirm={() => void handleConfirmArchive()}
+        onCancel={() => setPendingArchive(null)}
       />
     </PageShell>
   );

--- a/components/admin/cohorts/CohortCard.tsx
+++ b/components/admin/cohorts/CohortCard.tsx
@@ -32,10 +32,12 @@ export function CohortCard({
   cohort,
   onOpen,
   onArchive,
+  onDelete,
 }: {
   cohort: CohortListItem;
   onOpen: () => void;
   onArchive: () => void;
+  onDelete: () => void;
 }) {
   const s = STATUS[cohort.status];
   return (
@@ -73,8 +75,14 @@ export function CohortCard({
             </Typography>
           )}
           <Box onClick={(e) => e.stopPropagation()}>
-            <IconButton size="small" onClick={onArchive} aria-label="Archive cohort" sx={{ color: "var(--font-tertiary)", "&:hover": { color: "var(--error-500, #ea4335)" } }}>
+            {/* Archive and delete are DIFFERENT things and must not share one button: archive keeps
+                the cohort (it moves to the Archived tab and can be brought back), delete removes it
+                from the working set entirely. */}
+            <IconButton size="small" onClick={onArchive} aria-label="Archive cohort" title="Archive — keeps it, moves it to the Archived tab" sx={{ color: "var(--font-tertiary)", "&:hover": { color: "#6366f1" } }}>
               <Icon icon="mdi:archive-outline" width={17} />
+            </IconButton>
+            <IconButton size="small" onClick={onDelete} aria-label="Delete cohort" title="Delete — removes it from the working set" sx={{ color: "var(--font-tertiary)", "&:hover": { color: "var(--error-500, #ea4335)" } }}>
+              <Icon icon="mdi:trash-can-outline" width={17} />
             </IconButton>
           </Box>
         </Box>


### PR DESCRIPTION
**Your report:** archiving a cohort deletes it. Confirmed — and the screenshot showed the tell: you archived one and **"Archived 0"**.

**Cause:** the card's archive button called `adminCohortsService.deleteCohort()`, which hits `DELETE` and **soft-deletes the row** (`is_deleted=True`). `listCohorts` filters `is_deleted=False`, so the cohort vanished — and since its `status` was never set to `archived`, it could never appear under the Archived tab either. One button was doing the **destructive** thing while wearing the label of the **reversible** one.

**Fix — they're now two distinct actions:**
- **Archive** → `PATCH status='archived'`. The cohort **stays**, moves to the Archived tab (which filters on `status`), and can be set back to active from its Schedule tab. No backend change needed — `CohortDetailView.patch` already accepts a partial patch.
- **Delete** → its own trash-icon action with its own confirm, still the backend soft-delete: removed from the working set, learner history retained.

Both confirm dialogs now state what will actually happen, and each points at the other so they can't be confused.

`tsc` clean.