### PR TITLE
fix(instructor): render classic assigned courses, and never treat them as adaptive

### DIFF
--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Box, Chip, Stack, Tooltip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
@@ -48,33 +48,47 @@ export default function InstructorCoursesPage() {
         </Box>
       )}
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }, gap: 2 }}>
-        {courses.map((c, i) => (
-          <Reveal key={c.id} delay={Math.min(i, 8) * 0.05}>
-            <Box
-              onClick={() => push(`/instructor/courses/${c.id}`)}
-              onMouseEnter={() => prefetch(`/instructor/courses/${c.id}`)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter") push(`/instructor/courses/${c.id}`); }}
-              sx={{ cursor: "pointer", p: 2.25, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
-                transition: "transform .14s, box-shadow .14s, border-color .14s",
-                "&:hover": { transform: "translateY(-3px)", borderColor: "color-mix(in srgb, #a855f7 40%, transparent)", boxShadow: "0 20px 40px -26px rgba(168,85,247,0.45)" } }}
-            >
-              <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 1 }}>
-                <Box sx={{ width: 40, height: 40, borderRadius: 2.5, display: "grid", placeItems: "center", color: "#fff", flexShrink: 0, background: "linear-gradient(135deg,#6366f1,#a855f7)" }}>
-                  <Icon icon="mdi:book-education" width={20} />
-                </Box>
-                <Chip size="small" label={c.is_published ? "published" : "draft"}
-                  sx={{ fontWeight: 700, color: c.is_published ? "#10b981" : "#f59e0b",
-                    bgcolor: `color-mix(in srgb, ${c.is_published ? "#10b981" : "#f59e0b"} 14%, transparent)` }} />
-              </Stack>
-              <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{c.title}</Typography>
-              <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", mt: 0.5 }}>
-                {c.student_count} student{c.student_count === 1 ? "" : "s"}
-              </Typography>
-            </Box>
-          </Reveal>
-        ))}
+        {courses.map((c, i) => {
+          // Only adaptive courses have an instructor detail view — it reads the adaptive roster API.
+          // Classic ids come from a different table, so sending one there would open an unrelated
+          // course that happens to share the number. Those cards stay non-navigable until a classic
+          // detail view exists.
+          const href = c.kind === "adaptive" ? `/instructor/courses/${c.id}` : null;
+          const open = () => { if (href) push(href); };
+          return (
+            <Reveal key={`${c.kind}-${c.id}`} delay={Math.min(i, 8) * 0.05}>
+              <Box
+                onClick={open}
+                onMouseEnter={() => { if (href) prefetch(href); }}
+                {...(href ? { role: "button", tabIndex: 0 } : {})}
+                onKeyDown={(e) => { if (href && e.key === "Enter") open(); }}
+                sx={{ cursor: href ? "pointer" : "default", p: 2.25, borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)",
+                  transition: "transform .14s, box-shadow .14s, border-color .14s",
+                  ...(href ? { "&:hover": { transform: "translateY(-3px)", borderColor: "color-mix(in srgb, #a855f7 40%, transparent)", boxShadow: "0 20px 40px -26px rgba(168,85,247,0.45)" } } : {}) }}
+              >
+                <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 1 }}>
+                  <Box sx={{ width: 40, height: 40, borderRadius: 2.5, display: "grid", placeItems: "center", color: "#fff", flexShrink: 0,
+                    background: c.kind === "adaptive" ? "linear-gradient(135deg,#6366f1,#a855f7)" : "linear-gradient(135deg,#0ea5e9,#14b8a6)" }}>
+                    <Icon icon={c.kind === "adaptive" ? "mdi:book-education" : "mdi:book-open-variant"} width={20} />
+                  </Box>
+                  <Chip size="small" label={c.is_published ? "published" : "draft"}
+                    sx={{ fontWeight: 700, color: c.is_published ? "#10b981" : "#f59e0b",
+                      bgcolor: `color-mix(in srgb, ${c.is_published ? "#10b981" : "#f59e0b"} 14%, transparent)` }} />
+                  {c.kind === "classic" && (
+                    <Tooltip title="A classic course. Its content is managed in the admin course area — the instructor course view is adaptive-only for now.">
+                      <Chip size="small" label="classic"
+                        sx={{ fontWeight: 700, color: "#0ea5e9", bgcolor: "color-mix(in srgb, #0ea5e9 14%, transparent)" }} />
+                    </Tooltip>
+                  )}
+                </Stack>
+                <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{c.title}</Typography>
+                <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", mt: 0.5 }}>
+                  {c.student_count} student{c.student_count === 1 ? "" : "s"}
+                </Typography>
+              </Box>
+            </Reveal>
+          );
+        })}
       </Box>
     </PageShell>
   );

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -436,7 +436,12 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
   useEffect(() => {
     if (!open) return;
     instructorService.getCohorts().then(setCohorts).catch(() => undefined);
-    instructorService.getCourses().then(setCourses).catch(() => undefined);
+    // Adaptive only: this picker submits the id as `adaptive_course_id`, and classic course ids come
+    // from a different table — sending one would address an unrelated adaptive course or be rejected.
+    instructorService
+      .getCourses()
+      .then((list) => setCourses(list.filter((c) => c.kind === "adaptive")))
+      .catch(() => undefined);
     // Default the session zone to the instructor's own zone (client-only).
     setSessionTz((prev) => prev || viewerTimeZone() || "Asia/Kolkata");
   }, [open]);

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -9,6 +9,9 @@ const BASE = "/instructor/api";
 
 export interface InstructorOverview {
   courses: number;
+  /** Breakdown of `courses`. Optional so an older backend still type-checks. */
+  adaptive_courses?: number;
+  classic_courses?: number;
   cohorts: number;
   students: number;
   is_admin_view: boolean;
@@ -76,10 +79,19 @@ export interface InstructorDashboard {
   progress_truncated: boolean;
 }
 
+/**
+ * Which assignment system a course came from. The two live in different tables with INDEPENDENT id
+ * spaces, so `id` alone is ambiguous — always branch on `kind` before routing or passing an id to an
+ * adaptive-only endpoint, or you can address a completely unrelated course that shares the number.
+ */
+export type InstructorCourseKind = "adaptive" | "classic";
+
 export interface InstructorCourse {
   id: number;
+  kind: InstructorCourseKind;
   title: string;
-  slug: string;
+  /** null for classic courses. */
+  slug: string | null;
   is_published: boolean;
   student_count: number;
   updated_at: string;


### PR DESCRIPTION
Frontend follow-up to **BE #460** (merged + prod-verified today).

## Context

`GET /instructor/api/courses/` now returns **both** adaptive and classic (legacy `lms_core`) courses,
each carrying a new `kind` discriminator (`"adaptive"` | `"classic"`). That fixed instructors seeing
an empty list — but the frontend had not caught up, which left two real problems.

## 1. Classic cards linked into an adaptive-only route

`/instructor/courses/<id>` reads `/adaptive-quiz/api/admin/courses/<id>/students/`. The two tables
have **independent id spaces**, so clicking a classic card could open a completely unrelated adaptive
course that happens to share the number — e.g. classic `475` → adaptive `475`.

Classic cards are now clearly labelled (`classic` chip + tooltip + distinct teal icon treatment) and
**non-navigable**, until a classic detail view exists. They still show title, published state and
student count, which is what makes the assignment visible in the first place.

## 2. The live-session dialog could create a session against the wrong course

`app/instructor/live-sessions/page.tsx` fed the same `getCourses()` list into its audience picker and
submitted the selection as **`adaptive_course_id`**. With classic courses now in that list, picking
one would either be rejected by the backend or address the wrong adaptive course. It now filters to
`kind === "adaptive"`.

This one is a regression the backend change introduced, so it ships together with it.

## Also

- **React key collision** — `key={c.id}` is no longer unique across the two id spaces; now
  `` `${c.kind}-${c.id}` ``.
- `InstructorCourse` gains `kind` and `slug: string | null` (classic rows have no slug).
- `InstructorOverview` gains optional `adaptive_courses` / `classic_courses`, matching the backend.

## Verification

- `tsc --noEmit` → **clean**.
- `eslint` on the three changed files → 2 errors, both in `live-sessions/page.tsx` at line 655
  (`react-hooks/set-state-in-effect`) in code this PR does not touch; confirmed **pre-existing** by
  re-running eslint on the stashed, pristine file.
- Not verified as a rendered page: `next build` cannot run in a git worktree (Turbopack rejects
  symlinked `node_modules`), so please eyeball `/instructor/courses` on staging — an instructor with
  classic assignments should see labelled, non-clickable cards, and adaptive ones should still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)