### PR TITLE
feat(live-sessions): post-session feedback UI, and put the notice where students see it

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -46,6 +46,7 @@ import { GoogleMeetParticipantsSection } from "@/components/admin/live-sessions/
 import { LiveSessionTranscriptSection } from "@/components/admin/live-sessions/LiveSessionTranscriptSection";
 import { WebinarInvitationsSection } from "@/components/admin/live-sessions/WebinarInvitationsSection";
 import { WebinarEmailSection } from "@/components/admin/live-sessions/WebinarEmailSection";
+import { LiveSessionFeedbackSection } from "@/components/admin/live-sessions/LiveSessionFeedbackSection";
 import { LiveSessionNoticeDialog } from "@/components/admin/live-sessions/LiveSessionNoticeDialog";
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import { EditWebinarDialog } from "@/components/admin/live-sessions/EditWebinarDialog";
@@ -325,7 +326,14 @@ export default function LiveSessionDetailPage() {
       ? [...base, { key: "invitations", icon: "mdi:email-outline", label: t("adminLiveSessions.tabInvitations", "Invitations") }, { key: "emails", icon: "mdi:email-fast-outline", label: t("adminLiveSessions.tabEmail", "Email") }]
       : base;
   }, [isZoom, isGoogleMeet, isWebinar, isRecurring, t]);
-  const tabKey = tabs[tab]?.key ?? "overview";
+
+  // Feedback applies to every session kind, so it is appended after the provider-specific set
+  // rather than folded into any one branch.
+  const tabsWithFeedback = useMemo(
+    () => [...tabs, { key: "feedback", icon: "mdi:comment-quote-outline", label: t("adminLiveSessions.tabFeedback", "Feedback") }],
+    [tabs, t],
+  );
+  const tabKey = tabsWithFeedback[tab]?.key ?? "overview";
 
   const backButton = (
     <ButtonBase
@@ -442,7 +450,7 @@ export default function LiveSessionDetailPage() {
                     "& .MuiTabs-indicator": { backgroundColor: "var(--accent-indigo)" },
                   }}
                 >
-                  {tabs.map((tb, i) => (
+                  {tabsWithFeedback.map((tb, i) => (
                     <Tab key={i} iconPosition="start" icon={<IconWrapper icon={tb.icon} size={17} />} label={tb.label} />
                   ))}
                 </Tabs>
@@ -625,6 +633,12 @@ export default function LiveSessionDetailPage() {
                 {tabKey === "transcript" && (
                   <SectionCard>
                     <LiveSessionTranscriptSection liveClassId={activity.id} hasSummary={Boolean(activity.zoom_ai_summary?.trim() || (activity as { google_ai_summary?: string }).google_ai_summary?.trim())} />
+                  </SectionCard>
+                )}
+
+                {tabKey === "feedback" && (
+                  <SectionCard>
+                    <LiveSessionFeedbackSection liveClassId={activity.id} />
                   </SectionCard>
                 )}
 

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -11,6 +11,7 @@ import { LiveSessionsFeatureBlocked } from "@/components/live-sessions/LiveSessi
 import { useLiveSessions } from "@/components/live-sessions/useLiveSessions";
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import { StudentSessionSummaryDialog } from "@/components/live-sessions/StudentSessionSummaryDialog";
+import { LiveSessionFeedbackDialog } from "@/components/live-sessions/LiveSessionFeedbackDialog";
 import { studentLiveSessionsService } from "@/lib/services/live-sessions";
 import type { StudentLiveSession, StudentLiveOccurrence, MyLiveStats } from "@/lib/services/live-sessions";
 import { formatSessionClock, formatSessionTime } from "@/lib/utils/session-time";
@@ -150,6 +151,7 @@ export default function LiveSessionsPage() {
   const [reminders, setReminders] = useState<Record<number, boolean>>({});
   const [prep, setPrep] = useState<Record<number, number[]>>({});
   const [toast, setToast] = useState<string | null>(null);
+  const [feedbackFor, setFeedbackFor] = useState<StudentLiveSession | null>(null);
   // Extra calendar sources (best-effort — a failure just leaves those dots off the calendar).
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [interviews, setInterviews] = useState<MockInterview[]>([]);
@@ -173,7 +175,12 @@ export default function LiveSessionsPage() {
     });
   }, [sessions]);
 
-  const live = useMemo(() => sessions.find((s) => s.meeting_status === "live"), [sessions]);
+  const live = useMemo(
+    // A cancelled session must never drive the LIVE hero: the meeting still exists and is
+    // joinable, so without this the student is offered "Join now" for a class that is off.
+    () => sessions.find((s) => s.meeting_status === "live" && s.notice_type !== "cancelled"),
+    [sessions],
+  );
 
   // Unified calendar feed: live sessions + assessment windows (start=assessment, end=deadline) +
   // scheduled mock interviews.
@@ -436,7 +443,7 @@ export default function LiveSessionsPage() {
               {tab === "history" && (
                 history.length === 0 ? <Empty text="No past sessions yet." /> : (
                   <Stack spacing={1.25}>
-                    {history.map((s) => <HistoryRow key={s.id} s={s} />)}
+                    {history.map((s) => <HistoryRow key={s.id} s={s} onGiveFeedback={() => setFeedbackFor(s)} />)}
                   </Stack>
                 )
               )}
@@ -456,6 +463,14 @@ export default function LiveSessionsPage() {
       {summarySession && (
         <StudentSessionSummaryDialog activityId={summarySession.id} topicName={summarySession.topic_name || ""} open onClose={() => setSummarySession(null)} />
       )}
+
+      <LiveSessionFeedbackDialog
+        open={Boolean(feedbackFor)}
+        liveClassId={feedbackFor?.id ?? null}
+        sessionTitle={feedbackFor?.topic_name}
+        onClose={() => setFeedbackFor(null)}
+        onSubmitted={(msg) => setToast(msg)}
+      />
 
       {toast && <Snack text={toast} onClose={() => setToast(null)} />}
       <style jsx global>{`@keyframes pulse { 0%,100% { opacity:1 } 50% { opacity:.35 } }`}</style>
@@ -557,6 +572,41 @@ function useCountdown(target?: string | null): string | null {
   return `${hh}:${mm}:${ss}`;
 }
 
+/**
+ * Cancellation / reschedule notice from an admin or the assigned instructor.
+ *
+ * Rendered above everything else on the card: the student has to read WHY before they reach for a
+ * join link or plan around the old time.
+ */
+function SessionNotice({ s }: { s: StudentLiveSession }) {
+  const kind = s.notice_type;
+  if (kind !== "cancelled" && kind !== "rescheduled") return null;
+  const cancelled = kind === "cancelled";
+  const tone = cancelled ? "#ef4444" : "#f59e0b";
+  return (
+    <Box sx={{ display: "flex", gap: 1, px: 2.25, py: 1.25,
+      bgcolor: `color-mix(in srgb, ${tone} 10%, transparent)`,
+      borderBottom: `1px solid color-mix(in srgb, ${tone} 30%, transparent)` }}>
+      <Icon icon={cancelled ? "mdi:calendar-remove" : "mdi:calendar-clock"} width={18} style={{ color: tone, flexShrink: 0, marginTop: 2 }} />
+      <Box sx={{ minWidth: 0 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.78rem", color: tone }}>
+          {cancelled ? "Session cancelled" : "Session rescheduled"}
+        </Typography>
+        {s.notice_reason && (
+          <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", wordBreak: "break-word" }}>
+            {s.notice_reason}
+          </Typography>
+        )}
+        {!cancelled && s.previous_class_datetime && (
+          <Typography sx={{ fontSize: "0.75rem", color: "text.secondary", opacity: 0.8, textDecoration: "line-through" }}>
+            {formatSessionTime(s.previous_class_datetime, s.timezone)}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
 function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind, onTogglePrep }: {
   s: StudentLiveSession; isNext: boolean; reminderOn: boolean; prepDone: number[];
   onAddCalendar: () => void; onRemind: () => void; onTogglePrep: (index: number) => void;
@@ -570,6 +620,7 @@ function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind
 
   return (
     <Box sx={{ borderRadius: 3.5, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", overflow: "hidden" }}>
+      <SessionNotice s={s} />
       {isNext && countdown && (
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ px: 2.25, py: 0.75, background: "color-mix(in srgb,#7c3aed 8%,transparent)" }}>
           <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.6, color: "#7c3aed" }}>✦ STARTS NEXT</Typography>
@@ -685,7 +736,7 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
   );
 }
 
-function HistoryRow({ s }: { s: StudentLiveSession }) {
+function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedback?: () => void }) {
   const attended = Boolean(s.my_attendance?.attended);
   return (
     <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 1.75, display: "flex", gap: 1.5, alignItems: "center" }}>
@@ -702,6 +753,13 @@ function HistoryRow({ s }: { s: StudentLiveSession }) {
         {attended ? "Attended" : "Missed"}
       </Box>
       {s.has_recording && <Icon icon="mdi:play-circle-outline" width={18} style={{ color: "#7c3aed" }} />}
+      {/* Nothing to rate on a session that was called off. */}
+      {onGiveFeedback && s.notice_type !== "cancelled" && (
+        <Button onClick={onGiveFeedback} size="small" startIcon={<Icon icon="mdi:star-outline" width={16} />}
+          sx={{ textTransform: "none", fontWeight: 700, color: "#7c3aed", minWidth: 0, flexShrink: 0 }}>
+          Rate
+        </Button>
+      )}
     </Box>
   );
 }

--- a/components/admin/live-sessions/LiveSessionFeedbackSection.tsx
+++ b/components/admin/live-sessions/LiveSessionFeedbackSection.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  getLiveSessionFeedbackSummary,
+  type LiveSessionFeedbackSummary,
+} from "@/lib/services/admin/admin-live-activities.service";
+
+const RATING_TONE = ["#ef4444", "#f97316", "#f59e0b", "#84cc16", "#10b981"];
+
+function toneFor(value: number | null): string {
+  if (value == null) return "var(--font-tertiary)";
+  return RATING_TONE[Math.min(4, Math.max(0, Math.round(value) - 1))];
+}
+
+function Stars({ value }: { value: number | null }) {
+  if (value == null) return <Typography sx={{ color: "var(--font-tertiary)" }}>—</Typography>;
+  return (
+    <Stack direction="row" spacing={0.25} alignItems="center">
+      {[1, 2, 3, 4, 5].map((n) => (
+        <IconWrapper
+          key={n}
+          icon={value >= n - 0.25 ? "mdi:star" : value >= n - 0.75 ? "mdi:star-half-full" : "mdi:star-outline"}
+          size={15}
+          color={value >= n - 0.75 ? "#f59e0b" : "var(--border-default)"}
+        />
+      ))}
+    </Stack>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number | null }) {
+  return (
+    <Box sx={{ flex: "1 1 140px", p: 1.5, borderRadius: 2, border: "1px solid var(--border-default)" }}>
+      <Typography sx={{ fontSize: "0.7rem", fontWeight: 800, letterSpacing: ".04em",
+        textTransform: "uppercase", color: "var(--font-tertiary)" }}>
+        {label}
+      </Typography>
+      <Stack direction="row" alignItems="baseline" spacing={0.75} sx={{ mt: 0.5 }}>
+        <Typography sx={{ fontSize: "1.35rem", fontWeight: 800, color: toneFor(value),
+          fontVariantNumeric: "tabular-nums" }}>
+          {value == null ? "—" : value.toFixed(1)}
+        </Typography>
+        <Stars value={value} />
+      </Stack>
+    </Box>
+  );
+}
+
+/**
+ * Admin-only view of a session's post-session feedback.
+ *
+ * The backend refuses this to instructors — including the one who taught the session — so a 403 is
+ * an expected outcome here, not a failure: it is rendered as a plain explanation rather than an
+ * error, so an instructor who somehow reaches this screen is not shown a scary red state.
+ */
+export function LiveSessionFeedbackSection({ liveClassId }: { liveClassId: number }) {
+  const [data, setData] = useState<LiveSessionFeedbackSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setForbidden(false);
+    try {
+      setData(await getLiveSessionFeedbackSummary(liveClassId));
+    } catch (e) {
+      const status = (e as { response?: { status?: number } })?.response?.status;
+      if (status === 403) setForbidden(true);
+      else setError("Couldn't load feedback for this session.");
+    } finally {
+      setLoading(false);
+    }
+  }, [liveClassId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "grid", placeItems: "center", py: 6 }}>
+        <CircularProgress size={26} />
+      </Box>
+    );
+  }
+
+  if (forbidden) {
+    return (
+      <Box sx={{ p: 3, borderRadius: 3, border: "1px dashed var(--border-default)", textAlign: "center" }}>
+        <IconWrapper icon="mdi:lock-outline" size={26} color="var(--font-tertiary)" />
+        <Typography sx={{ mt: 1, fontWeight: 700 }}>Session feedback is visible to admins only</Typography>
+        <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.86rem", mt: 0.5 }}>
+          Ratings stay private from the instructor being rated, so learners can answer honestly.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return <Typography sx={{ color: "#ef4444", fontWeight: 700, py: 3 }}>{error}</Typography>;
+  }
+
+  const summary = data?.summary;
+  const responses = data?.responses ?? [];
+
+  if (!summary || summary.responses === 0) {
+    return (
+      <Box sx={{ p: 3, borderRadius: 3, border: "1px dashed var(--border-default)", textAlign: "center" }}>
+        <IconWrapper icon="mdi:comment-quote-outline" size={26} color="var(--font-tertiary)" />
+        <Typography sx={{ mt: 1, fontWeight: 700 }}>No feedback yet</Typography>
+        <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.86rem", mt: 0.5 }}>
+          Learners can rate this session once it has finished.
+        </Typography>
+      </Box>
+    );
+  }
+
+  const maxCount = Math.max(...Object.values(summary.distribution), 1);
+
+  return (
+    <Stack spacing={2.5}>
+      <Stack direction="row" spacing={1.5} sx={{ flexWrap: "wrap", gap: 1.5 }}>
+        <Metric label="Overall" value={summary.overall_rating} />
+        <Metric label="Content" value={summary.content_rating} />
+        <Metric label="Delivery" value={summary.instructor_rating} />
+        <Metric label="Pace" value={summary.pace_rating} />
+      </Stack>
+
+      <Box>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.82rem", mb: 1 }}>
+          {summary.responses} response{summary.responses === 1 ? "" : "s"}
+        </Typography>
+        <Stack spacing={0.6}>
+          {[5, 4, 3, 2, 1].map((star) => {
+            const count = summary.distribution[String(star)] ?? 0;
+            return (
+              <Stack key={star} direction="row" alignItems="center" spacing={1}>
+                <Typography sx={{ width: 34, fontSize: "0.78rem", color: "var(--font-secondary)",
+                  fontVariantNumeric: "tabular-nums" }}>
+                  {star}★
+                </Typography>
+                <Box sx={{ flex: 1, height: 8, borderRadius: 999, bgcolor: "var(--border-default)", overflow: "hidden" }}>
+                  <Box sx={{ width: `${(count / maxCount) * 100}%`, height: "100%",
+                    bgcolor: RATING_TONE[star - 1], transition: "width .3s" }} />
+                </Box>
+                <Typography sx={{ width: 26, textAlign: "right", fontSize: "0.78rem",
+                  fontVariantNumeric: "tabular-nums", color: "var(--font-secondary)" }}>
+                  {count}
+                </Typography>
+              </Stack>
+            );
+          })}
+        </Stack>
+      </Box>
+
+      <Stack spacing={1.25}>
+        {responses.map((r) => (
+          <Box key={r.id} sx={{ p: 1.75, borderRadius: 2.5, border: "1px solid var(--border-default)" }}>
+            <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing={1} sx={{ flexWrap: "wrap" }}>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }} noWrap>
+                  {r.student?.name || r.student?.email || "Learner"}
+                </Typography>
+                <Typography sx={{ color: "var(--font-tertiary)", fontSize: "0.76rem" }} noWrap>
+                  {r.student?.email}
+                  {r.cohort_name ? ` · ${r.cohort_name}` : ""}
+                </Typography>
+              </Box>
+              <Stars value={r.overall_rating} />
+            </Stack>
+            {r.comment && (
+              <Typography sx={{ mt: 1, fontSize: "0.86rem", color: "var(--font-secondary)", whiteSpace: "pre-wrap" }}>
+                {r.comment}
+              </Typography>
+            )}
+          </Box>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}

--- a/components/live-sessions/LiveSessionFeedbackDialog.tsx
+++ b/components/live-sessions/LiveSessionFeedbackDialog.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  getMyLiveSessionFeedback,
+  submitLiveSessionFeedback,
+} from "@/lib/services/live-sessions/student-live-sessions.service";
+
+interface Props {
+  open: boolean;
+  liveClassId: number | null;
+  sessionTitle?: string;
+  onClose: () => void;
+  onSubmitted?: (message: string) => void;
+}
+
+/** A 1-5 star row. Ratings are whole numbers; the backend rejects anything outside 1-5. */
+function StarRow({
+  label,
+  hint,
+  value,
+  onChange,
+  required,
+}: {
+  label: string;
+  hint?: string;
+  value: number | null;
+  onChange: (n: number) => void;
+  required?: boolean;
+}) {
+  return (
+    <Box>
+      <Typography sx={{ fontWeight: 700, fontSize: "0.86rem" }}>
+        {label}
+        {required && <Box component="span" sx={{ color: "#ef4444", ml: 0.5 }}>*</Box>}
+      </Typography>
+      {hint && (
+        <Typography sx={{ color: "var(--font-tertiary)", fontSize: "0.76rem", mb: 0.5 }}>{hint}</Typography>
+      )}
+      <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+        {[1, 2, 3, 4, 5].map((n) => (
+          <Box
+            key={n}
+            role="button"
+            aria-label={`${label}: ${n} of 5`}
+            tabIndex={0}
+            onClick={() => onChange(n)}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(n); } }}
+            sx={{ cursor: "pointer", p: 0.25, borderRadius: 1, lineHeight: 0,
+              "&:focus-visible": { outline: "2px solid var(--ai-violet)", outlineOffset: 2 } }}
+          >
+            <IconWrapper
+              icon={value != null && n <= value ? "mdi:star" : "mdi:star-outline"}
+              size={28}
+              color={value != null && n <= value ? "#f59e0b" : "var(--border-default)"}
+            />
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+/**
+ * Post-session feedback form.
+ *
+ * Answers go only to admins — never to the instructor being rated — and the copy says so, because a
+ * learner who thinks their trainer will read it answers differently.
+ */
+export function LiveSessionFeedbackDialog({
+  open,
+  liveClassId,
+  sessionTitle,
+  onClose,
+  onSubmitted,
+}: Props) {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [alreadySent, setAlreadySent] = useState(false);
+
+  const [overall, setOverall] = useState<number | null>(null);
+  const [content, setContent] = useState<number | null>(null);
+  const [delivery, setDelivery] = useState<number | null>(null);
+  const [pace, setPace] = useState<number | null>(null);
+  const [comment, setComment] = useState("");
+
+  const load = useCallback(async () => {
+    if (!liveClassId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const state = await getMyLiveSessionFeedback(liveClassId);
+      const mine = state.my_feedback;
+      setAlreadySent(Boolean(mine));
+      setOverall(mine?.overall_rating ?? null);
+      setContent(mine?.content_rating ?? null);
+      setDelivery(mine?.instructor_rating ?? null);
+      setPace(mine?.pace_rating ?? null);
+      setComment(mine?.comment ?? "");
+    } catch {
+      setError("Couldn't open the feedback form. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [liveClassId]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [open, load]);
+
+  const save = async () => {
+    if (!liveClassId || overall == null) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await submitLiveSessionFeedback(liveClassId, {
+        overall_rating: overall,
+        content_rating: content,
+        instructor_rating: delivery,
+        pace_rating: pace,
+        comment: comment.trim(),
+      });
+      onSubmitted?.(alreadySent ? "Your feedback was updated." : "Thanks — your feedback was sent.");
+      onClose();
+    } catch (e) {
+      const detail = (e as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setError(detail || "Couldn't send your feedback. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ fontWeight: 800, pb: 0.5 }}>
+        How was this session?
+        {sessionTitle && (
+          <Typography sx={{ fontWeight: 500, fontSize: "0.86rem", color: "var(--font-secondary)" }} noWrap>
+            {sessionTitle}
+          </Typography>
+        )}
+      </DialogTitle>
+      <DialogContent dividers>
+        {loading ? (
+          <Box sx={{ display: "grid", placeItems: "center", py: 4 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : (
+          <Stack spacing={2.25}>
+            <Box sx={{ display: "flex", gap: 1, p: 1.25, borderRadius: 2,
+              bgcolor: "color-mix(in srgb, var(--ai-violet) 8%, transparent)" }}>
+              <IconWrapper icon="mdi:shield-lock-outline" size={17} color="var(--ai-violet)" />
+              <Typography sx={{ fontSize: "0.78rem", color: "var(--font-secondary)" }}>
+                Only your admin team sees this — not your instructor. Please answer honestly.
+              </Typography>
+            </Box>
+
+            <StarRow label="Overall" value={overall} onChange={setOverall} required />
+            <StarRow label="Content" hint="Was the material useful?" value={content} onChange={setContent} />
+            <StarRow label="Delivery" hint="How well was it taught?" value={delivery} onChange={setDelivery} />
+            <StarRow label="Pace" hint="Too slow, too fast, or just right?" value={pace} onChange={setPace} />
+
+            <TextField
+              label="Anything else? (optional)"
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              fullWidth
+              multiline
+              minRows={3}
+            />
+
+            {error && (
+              <Typography sx={{ color: "#ef4444", fontWeight: 700, fontSize: "0.84rem" }}>{error}</Typography>
+            )}
+          </Stack>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={onClose} disabled={saving} sx={{ textTransform: "none", fontWeight: 700 }}>
+          Not now
+        </Button>
+        <Button
+          onClick={save}
+          disabled={saving || loading || overall == null}
+          variant="contained"
+          sx={{ textTransform: "none", fontWeight: 800 }}
+        >
+          {saving ? "Sending…" : alreadySent ? "Update feedback" : "Send feedback"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/live-sessions/ui/LiveSessionCard.tsx
+++ b/components/live-sessions/ui/LiveSessionCard.tsx
@@ -78,6 +78,8 @@ export interface LiveSessionCardProps<T extends LiveSessionCardData = LiveSessio
   onJoin?: (session: T) => void;
   onCopyPasscode?: (password: string) => void;
   onWatchRecording?: (session: T) => void;
+  /** Student: rate an ended session. Hidden on cancelled ones — there is nothing to rate. */
+  onGiveFeedback?: (session: T) => void;
   /** Ended sessions with an AI summary/transcript: open the session summary dialog. */
   onViewSummary?: (session: T) => void;
   formatDateTime?: (dateString: string) => string;
@@ -127,6 +129,7 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
   onJoin,
   onCopyPasscode,
   onWatchRecording,
+  onGiveFeedback,
   onViewSummary,
   formatDateTime,
 }: LiveSessionCardProps<T>) {
@@ -433,6 +436,14 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
           <Tooltip title={t("liveSessions.viewSummary", "View session summary")} placement="top">
             <IconButton onClick={() => onViewSummary(session)} aria-label={t("liveSessions.viewSummary", "View session summary")} sx={iconBtnSx}>
               <IconWrapper icon="mdi:text-box-outline" size={18} />
+            </IconButton>
+          </Tooltip>
+        )}
+
+        {isDone && !isCancelled && onGiveFeedback && (
+          <Tooltip title={t("liveSessions.giveFeedback", "Rate this session")} placement="top">
+            <IconButton onClick={() => onGiveFeedback(session)} aria-label={t("liveSessions.giveFeedback", "Rate this session")} sx={iconBtnSx}>
+              <IconWrapper icon="mdi:star-outline" size={18} />
             </IconButton>
           </Tooltip>
         )}

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -854,3 +854,47 @@ export const adminLiveActivitiesService = {
     }) as WebinarInvitation;
   },
 };
+
+// --- Post-session feedback ------------------------------------------------------------------- //
+
+export interface LiveSessionFeedbackResponse {
+  id: number;
+  overall_rating: number;
+  content_rating: number | null;
+  instructor_rating: number | null;
+  pace_rating: number | null;
+  comment: string;
+  created_at: string;
+  updated_at: string;
+  student?: { profile_id: number; name: string; email: string };
+  cohort_id?: number | null;
+  cohort_name?: string | null;
+}
+
+export interface LiveSessionFeedbackSummary {
+  session: { id: number; topic_name: string; class_datetime: string; cohort_id: number | null };
+  summary: {
+    responses: number;
+    overall_rating: number | null;
+    content_rating: number | null;
+    instructor_rating: number | null;
+    pace_rating: number | null;
+    distribution: Record<string, number>;
+  };
+  responses: LiveSessionFeedbackResponse[];
+}
+
+/**
+ * Admin-only. The backend returns 403 for instructors — including the one who taught the session —
+ * so callers must handle that as "not yours to see", not as an error to retry.
+ */
+export async function getLiveSessionFeedbackSummary(
+  liveClassId: number,
+  cohortId?: number
+): Promise<LiveSessionFeedbackSummary> {
+  const { data } = await apiClient.get<LiveSessionFeedbackSummary>(
+    `${BASE}/live-activities/${liveClassId}/feedback/summary/`,
+    { params: cohortId ? { cohort_id: cohortId } : undefined }
+  );
+  return data;
+}

--- a/lib/services/live-sessions/student-live-sessions.service.ts
+++ b/lib/services/live-sessions/student-live-sessions.service.ts
@@ -178,3 +178,52 @@ export const studentLiveSessionsService = {
     return response.data as Blob;
   },
 };
+
+// --- Post-session feedback (the student's own) ------------------------------------------------ //
+
+export interface MyLiveSessionFeedback {
+  id: number;
+  overall_rating: number;
+  content_rating: number | null;
+  instructor_rating: number | null;
+  pace_rating: number | null;
+  comment: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LiveSessionFeedbackState {
+  session_ended: boolean;
+  can_submit: boolean;
+  my_feedback: MyLiveSessionFeedback | null;
+}
+
+export interface SubmitFeedbackPayload {
+  overall_rating: number;
+  content_rating?: number | null;
+  instructor_rating?: number | null;
+  pace_rating?: number | null;
+  comment?: string;
+}
+
+/** Whether the form should be open, plus this student's existing answer if they already replied. */
+export async function getMyLiveSessionFeedback(
+  liveClassId: number
+): Promise<LiveSessionFeedbackState> {
+  const { data } = await apiClient.get<LiveSessionFeedbackState>(
+    `${BASE}/live-activities/${liveClassId}/feedback/`
+  );
+  return data;
+}
+
+/** Create or update — the backend upserts, so re-submitting edits rather than duplicating. */
+export async function submitLiveSessionFeedback(
+  liveClassId: number,
+  payload: SubmitFeedbackPayload
+): Promise<MyLiveSessionFeedback> {
+  const { data } = await apiClient.post<MyLiveSessionFeedback>(
+    `${BASE}/live-activities/${liveClassId}/feedback/`,
+    payload
+  );
+  return data;
+}


### PR DESCRIPTION
Frontend for **BE #462** (merged + live on prod), **plus a correction to FE #1157**.

## Feedback — student

A **Rate** action on sessions in their history opens a form: overall (required), content, delivery,
pace, and a comment. Re-opening loads their previous answer and updates it, matching the backend's
upsert.

The form says plainly: *"Only your admin team sees this — not your instructor."* That line is
load-bearing. A learner who believes their trainer will read it answers differently, so telling them
is what makes the data worth collecting at all.

Cancelled sessions get no Rate action — there is nothing to rate.

## Feedback — admin

A **Feedback** tab on the session detail page: averages per dimension, a 1–5 distribution bar, and
every response with the student and their cohort.

A **403 is an expected outcome here, not a failure** — the backend refuses instructors, including the
one who taught the session — so it renders as a plain explanation of why, rather than a red error
state.

## Correction to FE #1157

That PR put the cancellation banner in `LiveSessionCard`, and **its description claimed students
would see it. They would not.** The student page renders its own `UpcomingCard` / `RecordingCard` /
`HistoryRow`; `LiveSessionCard` is used only by the admin list. I found this while wiring the
feedback entry point.

Fixed here:

- The notice banner now renders in the **student** page (`SessionNotice`), above everything else on
  the card — reason, and for a reschedule the old time struck through.
- **A cancelled session no longer drives the LIVE hero.** This is the more serious half: the hero was
  still offering a big **"Join now"** for a class that had been called off. The Zoom meeting really is
  still joinable, which is exactly why the cancelled flag has to suppress it explicitly rather than
  relying on the link being dead.

The `LiveSessionCard` changes from #1157 are still correct and still apply — to the admin list, which
is the surface that actually uses that component.

## Verification

- `tsc --noEmit` → **clean**.
- `eslint` on all 7 changed/added files → 2 errors + 1 warning, **all confirmed pre-existing** by
  re-running on the stashed originals (`react-hooks/set-state-in-effect` in `app/live-sessions`,
  unused `formatDateTime` in `LiveSessionCard`) — none in new code.
- Not verified as a rendered page (`next build` can't run in a git worktree). On staging please check:
  a student's history shows **Rate** and the form submits; the admin session detail shows the
  **Feedback** tab with that response; and a cancelled session shows the banner with **no Join now**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)