### PR TITLE
feat(live-sessions): AgileOlogy feedback — community opt-out, recurring counts, hidden headcount

### DIFF
--- a/app/community/layout.tsx
+++ b/app/community/layout.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Box, CircularProgress, Container, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { COMMUNITY_FEATURE, useClientFeature } from "@/lib/hooks/useClientFeature";
+
+/**
+ * Gate for every `/community/*` route.
+ *
+ * The sidebar and bottom nav already hide Community when the tenant doesn't have the feature, but
+ * hiding a link is not a gate — the URL still worked. A tenant that has deliberately switched
+ * student discussion off needs the route itself closed, including deep links into a thread.
+ *
+ * A layout is the right place because it covers every nested route at once; adding the check to each
+ * page would leave the next new page unguarded by default.
+ */
+export default function CommunityLayout({ children }: { children: React.ReactNode }) {
+  const { enabled, loading } = useClientFeature(COMMUNITY_FEATURE);
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <Box sx={{ display: "grid", placeItems: "center", py: 10 }}>
+          <CircularProgress size={28} />
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  if (!enabled) {
+    return (
+      <MainLayout>
+        <Container maxWidth="sm" sx={{ py: 8 }}>
+          <Box sx={{ p: 4, borderRadius: 3, textAlign: "center",
+            border: "1px dashed var(--border-default)", bgcolor: "var(--card-bg)" }}>
+            <Icon icon="mdi:forum-outline" width={34} style={{ color: "var(--font-tertiary)" }} />
+            <Typography sx={{ mt: 1.5, fontWeight: 800, fontSize: "1.05rem" }}>
+              Community isn&apos;t available
+            </Typography>
+            <Typography sx={{ mt: 0.5, color: "var(--font-secondary)", fontSize: "0.9rem" }}>
+              Your organization has discussions switched off. Reach out to your instructor or admin if
+              you need help with a session.
+            </Typography>
+          </Box>
+        </Container>
+      </MainLayout>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -12,6 +12,7 @@ import { useLiveSessions } from "@/components/live-sessions/useLiveSessions";
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import { StudentSessionSummaryDialog } from "@/components/live-sessions/StudentSessionSummaryDialog";
 import { LiveSessionFeedbackDialog } from "@/components/live-sessions/LiveSessionFeedbackDialog";
+import { COMMUNITY_FEATURE, HIDE_PARTICIPANT_COUNTS, useClientFeature, useClientOptIn } from "@/lib/hooks/useClientFeature";
 import { studentLiveSessionsService } from "@/lib/services/live-sessions";
 import type { StudentLiveSession, StudentLiveOccurrence, MyLiveStats } from "@/lib/services/live-sessions";
 import { formatSessionClock, formatSessionTime } from "@/lib/utils/session-time";
@@ -152,6 +153,8 @@ export default function LiveSessionsPage() {
   const [prep, setPrep] = useState<Record<number, number[]>>({});
   const [toast, setToast] = useState<string | null>(null);
   const [feedbackFor, setFeedbackFor] = useState<StudentLiveSession | null>(null);
+  const { enabled: communityEnabled } = useClientFeature(COMMUNITY_FEATURE);
+  const hideCounts = useClientOptIn(HIDE_PARTICIPANT_COUNTS);
   // Extra calendar sources (best-effort — a failure just leaves those dots off the calendar).
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [interviews, setInterviews] = useState<MockInterview[]>([]);
@@ -175,11 +178,45 @@ export default function LiveSessionsPage() {
     });
   }, [sessions]);
 
+  /**
+   * A recurring series is ONE session row carrying N dated occurrences, and its `meeting_status`
+   * describes the series as a whole. Bucketing the raw rows therefore collapsed 50 scheduled
+   * sessions into a single entry — and once today's occurrence was running the series read "live",
+   * so "Upcoming" showed 0 while 49 dates were still to come.
+   *
+   * Expand each series into one entry per occurrence so every date is counted and listed on its own.
+   * Non-recurring sessions pass through untouched.
+   */
+  const instances = useMemo<StudentLiveSession[]>(() => {
+    const out: StudentLiveSession[] = [];
+    for (const s of sessions) {
+      const occs = s.occurrences ?? [];
+      if (!s.zoom_is_recurring || occs.length === 0) {
+        out.push(s);
+        continue;
+      }
+      for (const o of occs) {
+        if (o.status === "cancelled" || o.meeting_status === "cancelled") continue;
+        out.push({
+          ...s,
+          // Keep the parent id for API calls (feedback, reminders) but make the key unique per date.
+          occurrence_id: o.id,
+          class_datetime: o.occurrence_datetime ?? s.class_datetime,
+          duration_minutes: o.duration_minutes ?? s.duration_minutes,
+          meeting_status: o.meeting_status ?? s.meeting_status,
+          has_recording: Boolean(o.has_recording ?? s.has_recording),
+          zoom_recording_url: o.zoom_recording_url ?? s.zoom_recording_url,
+        });
+      }
+    }
+    return out;
+  }, [sessions]);
+
   const live = useMemo(
     // A cancelled session must never drive the LIVE hero: the meeting still exists and is
     // joinable, so without this the student is offered "Join now" for a class that is off.
-    () => sessions.find((s) => s.meeting_status === "live" && s.notice_type !== "cancelled"),
-    [sessions],
+    () => instances.find((s) => s.meeting_status === "live" && s.notice_type !== "cancelled"),
+    [instances],
   );
 
   // Unified calendar feed: live sessions + assessment windows (start=assessment, end=deadline) +
@@ -233,14 +270,15 @@ export default function LiveSessionsPage() {
     };
   }, [liveId]);
 
+
   const upcoming = useMemo(
-    () => sessions.filter((s) => s.meeting_status === "scheduled").sort((a, b) => (a.class_datetime || "").localeCompare(b.class_datetime || "")),
-    [sessions],
+    () => instances.filter((s) => s.meeting_status === "scheduled").sort((a, b) => (a.class_datetime || "").localeCompare(b.class_datetime || "")),
+    [instances],
   );
-  const recordings = useMemo(() => sessions.filter((s) => s.has_recording), [sessions]);
+  const recordings = useMemo(() => instances.filter((s) => s.has_recording), [instances]);
   const history = useMemo(
-    () => sessions.filter((s) => PAST.has(s.meeting_status ?? "")).sort((a, b) => (b.class_datetime || "").localeCompare(a.class_datetime || "")),
-    [sessions],
+    () => instances.filter((s) => PAST.has(s.meeting_status ?? "")).sort((a, b) => (b.class_datetime || "").localeCompare(a.class_datetime || "")),
+    [instances],
   );
 
   const syncAll = useCallback(() => {
@@ -354,10 +392,12 @@ export default function LiveSessionsPage() {
                     sx={{ px: 3, py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#047857", bgcolor: "#fff", "&:hover": { bgcolor: "rgba(255,255,255,0.9)" } }}>
                     Join now
                   </Button>
-                  <Button onClick={() => router.push("/community")} startIcon={<Icon icon="mdi:comment-question-outline" width={18} />}
-                    sx={{ px: 2.5, py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#fff", bgcolor: "rgba(255,255,255,0.12)", border: "1px solid rgba(255,255,255,0.2)", "&:hover": { bgcolor: "rgba(255,255,255,0.2)" } }}>
-                    Ask a question
-                  </Button>
+                  {communityEnabled && (
+                    <Button onClick={() => router.push("/community")} startIcon={<Icon icon="mdi:comment-question-outline" width={18} />}
+                      sx={{ px: 2.5, py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#fff", bgcolor: "rgba(255,255,255,0.12)", border: "1px solid rgba(255,255,255,0.2)", "&:hover": { bgcolor: "rgba(255,255,255,0.2)" } }}>
+                      Ask a question
+                    </Button>
+                  )}
                 </Stack>
               </Box>
               <Box sx={{ p: 2.5, borderLeft: { md: "1px solid rgba(255,255,255,0.1)" }, display: "flex", flexDirection: "column", justifyContent: "center", gap: 1.5 }}>
@@ -374,15 +414,19 @@ export default function LiveSessionsPage() {
                     </Stack>
                   </Box>
                 )}
-                <Box>
-                  <Stack direction="row" spacing={-0.8} sx={{ mb: 0.75 }}>
-                    {[0, 1, 2, 3].map((i) => (
-                      <Box key={i} sx={{ width: 26, height: 26, borderRadius: "50%", border: "2px solid #052e16", ml: i ? "-8px" : 0,
-                        background: ["#a855f7", "#6366f1", "#ec4899", "#f59e0b"][i] }} />
-                    ))}
-                  </Stack>
-                  <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }}>{(liveJoined ?? live.attendance_count) || 0} joined</Typography>
-                </Box>
+                {/* Headcount is hidden where the tenant opted out — the avatar stack goes too, since
+                    four faces still implies "several people are here". */}
+                {!hideCounts && (
+                  <Box>
+                    <Stack direction="row" spacing={-0.8} sx={{ mb: 0.75 }}>
+                      {[0, 1, 2, 3].map((i) => (
+                        <Box key={i} sx={{ width: 26, height: 26, borderRadius: "50%", border: "2px solid #052e16", ml: i ? "-8px" : 0,
+                          background: ["#a855f7", "#6366f1", "#ec4899", "#f59e0b"][i] }} />
+                      ))}
+                    </Stack>
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }}>{(liveJoined ?? live.attendance_count) || 0} joined</Typography>
+                  </Box>
+                )}
               </Box>
             </Box>
           )}
@@ -420,7 +464,7 @@ export default function LiveSessionsPage() {
                 upcoming.length === 0 ? <Empty text="No upcoming sessions. New classes will show up here." /> : (
                   <Stack spacing={1.75}>
                     {upcoming.map((s, i) => (
-                      <UpcomingCard key={s.id} s={s} isNext={i === 0}
+                      <UpcomingCard key={s.occurrence_id ?? s.id} s={s} isNext={i === 0}
                         reminderOn={reminders[s.id] ?? Boolean(s.reminder_enabled)}
                         prepDone={prep[s.id] ?? s.my_prep ?? []}
                         onAddCalendar={() => addToCalendar(s)} onRemind={() => toggleReminder(s)}
@@ -433,7 +477,7 @@ export default function LiveSessionsPage() {
                 recordings.length === 0 ? <Empty text="No recordings yet. They appear here automatically after a session ends." /> : (
                   <Stack spacing={1.5}>
                     {recordings.map((s) => (
-                      <RecordingCard key={s.id} s={s} watching={watchingRecordingId === s.id}
+                      <RecordingCard key={s.occurrence_id ?? s.id} s={s} watching={watchingRecordingId === s.id}
                         onWatch={() => handleWatchRecording(s)}
                         onSummary={() => setSummarySession(s)} />
                     ))}
@@ -443,7 +487,7 @@ export default function LiveSessionsPage() {
               {tab === "history" && (
                 history.length === 0 ? <Empty text="No past sessions yet." /> : (
                   <Stack spacing={1.25}>
-                    {history.map((s) => <HistoryRow key={s.id} s={s} onGiveFeedback={() => setFeedbackFor(s)} />)}
+                    {history.map((s) => <HistoryRow key={s.occurrence_id ?? s.id} s={s} onGiveFeedback={() => setFeedbackFor(s)} />)}
                   </Stack>
                 )
               )}

--- a/lib/hooks/useClientFeature.ts
+++ b/lib/hooks/useClientFeature.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * Whether a tenant feature is switched on for the current client.
+ *
+ * The "empty means everything" rule is deliberate and must be preserved: a tenant that has never had
+ * its feature list configured returns `[]`, and treating that as "nothing is enabled" would black out
+ * the whole portal for them. Only an explicitly-populated list can turn something off.
+ *
+ * Returns `enabled` alongside `loading` so a caller can avoid flashing a blocked state while the
+ * client info is still in flight.
+ */
+export function useClientFeature(featureName: string): { enabled: boolean; loading: boolean } {
+  const { clientInfo, loading } = useClientInfo();
+  const names = clientInfo?.features?.map((f) => f.name) ?? [];
+  return {
+    enabled: names.length === 0 || names.includes(featureName),
+    loading,
+  };
+}
+
+export const COMMUNITY_FEATURE = "community_forum";
+
+/**
+ * Whether a flag is EXPLICITLY switched on for this tenant.
+ *
+ * Deliberately does NOT apply `useClientFeature`'s "empty list means everything is on" rule. That
+ * rule is right for capability flags (a tenant with no configured list should still get the whole
+ * product) but catastrophic for a flag that HIDES something: a new hide-flag would read as "off"
+ * for unconfigured tenants and "on" for every configured one, silently suppressing UI everywhere.
+ *
+ * Use this for opt-in restrictions; use `useClientFeature` for capabilities.
+ */
+export function useClientOptIn(flagName: string): boolean {
+  const { clientInfo } = useClientInfo();
+  return (clientInfo?.features?.map((f) => f.name) ?? []).includes(flagName);
+}
+
+/** Opt-in: hide "N joined" and any batch headcount from students. */
+export const HIDE_PARTICIPANT_COUNTS = "hide_participant_counts";

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -56,6 +56,12 @@ export interface StudentLiveSession {
   recurrence_summary?: string | null;
   zoom_is_recurring?: boolean;
   occurrences?: StudentLiveOccurrence[];
+  /**
+   * Set ONLY on client-side expansions of a recurring series into one entry per date. `id` stays
+   * the parent series id so API calls keep working; this disambiguates the React key and tells
+   * the UI which dated instance it is looking at.
+   */
+  occurrence_id?: number;
   /** AI-generated (Phase 2A): planned agenda + 'come prepared' checklist + the student's ticks. */
   agenda?: string[];
   prep_items?: string[];


### PR DESCRIPTION
Items **1, 3 and 6 (our half)** of AgileOlogy's seven. **Stacked on #1158** (same file, heavy overlap);
merge #1158 first and this retargets to `stagging` cleanly.

## 1 — No student discussion

- **"Ask a question"** beside *Join now* is gated on the tenant's existing `community_forum` feature.
- **`/community/*` gets a layout guard.** The sidebar already hid the link, but hiding a link is not
  a gate — the URL still worked, including deep links into a thread. A layout covers every nested
  route at once, so the next page added under `/community` is guarded by default.

Done **per tenant, not deleted**: other clients keep the module, and it's reversible from admin.

## 3 — Recurring sessions counted wrong

> "showing 0 upcoming sessions but I have scheduled 50 recurring sessions — it should be like
> live (1), upcoming (49), history (0)"

Confirmed on prod: AgileOlogy has **one** `LiveClass` (id 183) carrying **50 occurrences**. A
recurring series is one row whose `meeting_status` describes the *whole series*, so the student page
bucketed 50 dates as a single entry — and once today's occurrence was running, the series read
`"live"` and **Upcoming showed 0**. Exactly as reported.

Sessions are now expanded into **one entry per occurrence** before bucketing, so 50 recurring dates
read **Live(1) / Upcoming(49)**. The LIVE hero reads the same expansion, and React keys are
per-occurrence (`occurrence_id ?? id`) since a series now yields many rows.

## 6 (our half) — Headcount hidden

`N joined` and its avatar stack are suppressed under a new opt-in tenant flag. The stack goes with
the number deliberately — four faces still tells a student a crowd is present.

### One deliberate design call

The flag uses a **new `useClientOptIn`**, *not* `useClientFeature`. The existing "empty list means
everything is on" rule is right for **capabilities** (an unconfigured tenant should still get the
whole product) but exactly inverted for a flag that **hides** something: read that way, a new
hide-flag would be off for unconfigured tenants and **on for every configured one**, silently
suppressing the count platform-wide.

## Not in this PR

- **2** (Join disabled until the trainer starts) — blocked: `ZOOM_WEBHOOK_SECRET` is not set on prod
  (**0 of 50** occurrences have `zoom_started_at`), so the platform currently cannot know.
- **4, 5, 7** and **6's Zoom half** — Zoom account settings / plan features, not application code.
- The **`hide_participant_counts`** AppFeature row and AgileOlogy's flag changes are a data step, not
  code — I'll apply them on prod once this merges.

## Verification

- `tsc --noEmit` → **clean**.
- `eslint` → 2 errors, both `react-hooks/set-state-in-effect` in `app/live-sessions/page.tsx` code
  this PR doesn't touch; confirmed **pre-existing** on the stashed original.
- Not seen rendering (`next build` can't run in a worktree). On staging please confirm: Upcoming
  shows 49 for the recurring series, and Community is gone for AgileOlogy including a direct
  `/community` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)