### PR TITLE
feat(live-sessions): show "waiting for your trainer" instead of Join until the class starts

### DIFF
--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -387,11 +387,23 @@ export default function LiveSessionsPage() {
                   <Stack direction="row" spacing={0.4} alignItems="center"><Icon icon={providerOf(live).icon} width={15} /><Typography sx={{ fontSize: "0.85rem" }}>{providerOf(live).label}</Typography></Stack>
                 </Stack>
                 <Stack direction="row" spacing={1.5} sx={{ mt: 2.5 }} flexWrap="wrap" useFlexGap>
-                  <Button component="a" href={joinUrlOf(live)} target="_blank" rel="noopener"
-                    startIcon={<Icon icon="mdi:video" width={18} />}
-                    sx={{ px: 3, py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#047857", bgcolor: "#fff", "&:hover": { bgcolor: "rgba(255,255,255,0.9)" } }}>
-                    Join now
-                  </Button>
+                  {/* Where the tenant requires it, Join only opens once the trainer has actually
+                      started — the scheduled time passing is not the same as the class beginning.
+                      `join_gated` is false whenever the backend can't observe that (fail-open), so a
+                      false here must read as "not gated", never as "not started". */}
+                  {live.join_gated && !live.host_started ? (
+                    <Button disabled startIcon={<Icon icon="mdi:clock-outline" width={18} />}
+                      sx={{ px: 3, py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none",
+                        color: "rgba(255,255,255,0.75) !important", bgcolor: "rgba(255,255,255,0.14)" }}>
+                      Waiting for your trainer to start
+                    </Button>
+                  ) : (
+                    <Button component="a" href={joinUrlOf(live)} target="_blank" rel="noopener"
+                      startIcon={<Icon icon="mdi:video" width={18} />}
+                      sx={{ px: 3, py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#047857", bgcolor: "#fff", "&:hover": { bgcolor: "rgba(255,255,255,0.9)" } }}>
+                      Join now
+                    </Button>
+                  )}
                   {communityEnabled && (
                     <Button onClick={() => router.push("/community")} startIcon={<Icon icon="mdi:comment-question-outline" width={18} />}
                       sx={{ px: 2.5, py: 1.1, borderRadius: 2.5, fontWeight: 800, textTransform: "none", color: "#fff", bgcolor: "rgba(255,255,255,0.12)", border: "1px solid rgba(255,255,255,0.2)", "&:hover": { bgcolor: "rgba(255,255,255,0.2)" } }}>

--- a/lib/services/live-sessions/student-live-sessions.service.ts
+++ b/lib/services/live-sessions/student-live-sessions.service.ts
@@ -57,6 +57,8 @@ function toStudentSession(item: LiveActivityListItem): StudentLiveSession {
     my_attendance: item.my_attendance ?? null,
     zoom_ai_summary: item.zoom_ai_summary ?? null,
     zoom_transcript_synced_at: item.zoom_transcript_synced_at ?? null,
+    join_gated: Boolean(item.join_gated),
+    host_started: Boolean(item.host_started),
     notice_type: (item.notice_type as StudentLiveSession["notice_type"]) ?? null,
     notice_reason: (item.notice_reason as string) ?? null,
     notice_at: (item.notice_at as string) ?? null,

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -28,6 +28,15 @@ export interface StudentLiveSession {
    * instructor. Distinct from `google_status` / zoom status, which mirror what the PROVIDER did to
    * the meeting and carry no reason. `""`/null means the session is running normally.
    */
+  /**
+   * True when this tenant requires the trainer to actually open the meeting before students may
+   * join. False means the old schedule-based behaviour — the backend deliberately fails open when
+   * it cannot observe Zoom's started webhook, so `false` must be treated as "not gated", never as
+   * "not started".
+   */
+  join_gated?: boolean;
+  /** Whether the host has actually opened the meeting (from Zoom's started webhook). */
+  host_started?: boolean;
   notice_type?: "" | "cancelled" | "rescheduled" | null;
   /** Why it was cancelled or moved — shown verbatim to the student. */
   notice_reason?: string | null;


### PR DESCRIPTION
Frontend for **BE #465** (merged). AgileOlogy item 2.

> "if he starts at 8:10pm — in students view it should reflect as not yet started (disabled button)
> instead of join now"

The LIVE hero now renders a disabled **"Waiting for your trainer to start"** while
`join_gated && !host_started`, and the normal **Join now** otherwise.

## The one subtlety

`join_gated` is **false whenever the backend cannot observe Zoom's started webhook** — it fails open
by design. So the UI must read `false` as *"not gated"*, never as *"not started"*. Getting that
backwards would hide Join from every tenant that has no webhook configured, which today is all of
them.

## Still inert until Zoom is configured

BE #465 ships the gate off until `ZOOM_WEBHOOK_SECRET` is set, the started events are subscribed, and
the tenant gets the `require_host_start` flag. Until then students see exactly what they see now.

## Verification

- `tsc --noEmit` → clean.
- Not seen rendering (`next build` can't run in a worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)