### PR TITLE
docs(zoom): complete the in-app scope list so the setup guide matches what we actually call

### DIFF
--- a/components/admin/live-sessions/ZoomSetupGuide.tsx
+++ b/components/admin/live-sessions/ZoomSetupGuide.tsx
@@ -105,21 +105,45 @@ export function ZoomSetupGuide({ webhookUrl }: { webhookUrl: string }) {
           <strong>Information</strong> tab - fill the required basics (name, descriptions, company, developer name + email).
         </Box>
         <Box component="li" sx={liSx}>
-          <strong>Scopes</strong> tab → <strong>+ Add Scopes</strong>:
+          <strong>Scopes</strong> tab → <strong>+ Add Scopes</strong>. Each line says what stops working
+          without it, so you can skip the ones you don’t need:
           <Box component="ul" sx={{ mt: 0.5, mb: 0, pl: 2 }}>
             <Box component="li" sx={liSx}>
-              Meeting - <Code>meeting:write:admin</Code>, <Code>meeting:read:admin</Code>
+              Meeting - <Code>meeting:write:admin</Code>, <Code>meeting:read:admin</Code>{" "}
+              <em>(create, edit, end and delete sessions)</em>
             </Box>
             <Box component="li" sx={liSx}>
-              Cloud Recording - <Code>cloud_recording:read:list_recording_files:admin</Code>
+              User - <Code>user:read:admin</Code>{" "}
+              <em>(required — sessions are created as your chosen host user; without it every create fails)</em>
             </Box>
             <Box component="li" sx={liSx}>
-              Report (attendance) - <Code>report:read:admin</Code>
+              Cloud Recording - <Code>cloud_recording:read:list_recording_files:admin</Code>,{" "}
+              <Code>recording:read:admin</Code> <em>(recording + transcript sync)</em>
+            </Box>
+            <Box component="li" sx={liSx}>
+              Report (attendance) - <Code>report:read:admin</Code>{" "}
+              <em>(who attended, after the session ends)</em>
+            </Box>
+            <Box component="li" sx={liSx}>
+              Dashboard - <Code>dashboard:read:admin</Code>{" "}
+              <em>(the live “N joined” count while a session is running — also needs a Zoom
+              Business plan or higher; on Pro this endpoint is unavailable whatever the scope)</em>
+            </Box>
+            <Box component="li" sx={liSx}>
+              Account - <Code>account:read:admin</Code>, <Code>account:write:admin</Code>{" "}
+              <em>(virtual backgrounds / branding applied to your sessions)</em>
             </Box>
             <Box component="li" sx={liSx}>
               <strong>Webinars (optional)</strong> - <Code>webinar:write:admin</Code>, <Code>webinar:read:admin</Code>{" "}
-              <em>(needs the Zoom Webinar add-on)</em>
+              <em>(webinars, panelists and registration — needs the Zoom Webinar add-on)</em>
             </Box>
+          </Box>
+          <Box sx={{ ...liSx, mt: 0.75, opacity: 0.85 }}>
+            Newer Zoom apps use “granular” scope names such as{" "}
+            <Code>meeting:read:list_meetings:admin</Code> instead of the classic ones above. If the
+            picker doesn’t show these exact strings, search it for the resource word — <em>meeting</em>,{" "}
+            <em>user</em>, <em>report</em>, <em>dashboard</em>, <em>account</em>, <em>recording</em>,{" "}
+            <em>webinar</em> — and add the read/write <Code>:admin</Code> variants.
           </Box>
         </Box>
         <Box component="li" sx={liSx}>
@@ -135,6 +159,11 @@ export function ZoomSetupGuide({ webhookUrl }: { webhookUrl: string }) {
             <Box component="li" sx={liSx}>
               <strong>+ Add Events</strong> → Meeting → <em>Started</em> & <em>Ended</em>, Recording →{" "}
               <em>All recordings completed</em>. For webinars also add Webinar → <em>Started</em> & <em>Ended</em>.
+            </Box>
+            <Box component="li" sx={liSx}>
+              <em>Started</em> is what tells the platform the trainer has actually opened the meeting.
+              Without it we only know the scheduled time, so students are offered <strong>Join</strong>{" "}
+              from the clock time even if nobody has started the session yet.
             </Box>
             <Box component="li" sx={liSx}>
               <strong>Don’t click Validate yet</strong> - do Part 2 first.


### PR DESCRIPTION
The in-app **Zoom credentials → setup guide** listed **4** scopes. The platform calls endpoints
needing **8**. Anyone who followed it got an app that creates meetings but silently fails elsewhere —
approximately the state AgileOlogy is in today.

## Derived from the code, not guessed

Walked every Zoom URL in `live_class/services/zoom_service.py`:

| Endpoint | Scope | Was it documented? |
|---|---|---|
| `/users/{host}/meetings\|webinars\|*_templates` | `user:read:admin` | ❌ **missing** |
| `/metrics/{meetings\|webinars}/{id}` | `dashboard:read:admin` | ❌ **missing** |
| `/accounts/me/settings[/virtual_backgrounds]` | `account:read/write:admin` | ❌ **missing** |
| `/meetings/{id}/recordings` | `recording:read:admin` | ❌ partial only |
| `/meetings/*`, `/webinars/*` | `meeting:*`, `webinar:*` | ✅ |
| `/report/webinars/{id}/participants` | `report:read:admin` | ✅ |

**`user:read:admin` is the important one.** Sessions are created as the configured host user
(`/users/support@agileologyedu.com/meetings`), so without it *every create fails* — and it wasn't
mentioned at all.

**`dashboard:read:admin`** is the live "N joined" count. The guide now also warns it needs a Zoom
**Business** plan — on Pro it fails no matter what scope you grant, which is worth knowing before
someone spends an hour debugging it.

## Two other fixes

**Granular scopes.** Zoom moved to names like `meeting:read:list_meetings:admin` in 2024. The guide
showed only classic names, so to anyone on a newer app the whole list looked wrong. It now says to
search the picker by resource word and take the read/write `:admin` variants.

**Why `Started` matters.** The events list already included Meeting → *Started*, but never said what
it does. It's the signal that the trainer actually opened the meeting — without it we only know the
scheduled time, so students are offered **Join** from the clock even when nobody has started. That's
exactly AgileOlogy's item 2, so the guide now spells it out.

## Verification

- `tsc --noEmit` clean, `eslint` clean.
- Copy-only change: no logic, no API calls, no new dependencies.
- Not seen rendered (`next build` can't run in a worktree) — it's a text block inside an existing
  dialog, so the risk is low, but worth a glance on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)