### PR TITLE
feat(live-sessions): schedule in the institution's timezone, not the admin's browser

### DIFF
--- a/app/admin/live-sessions/create/page.tsx
+++ b/app/admin/live-sessions/create/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { useTenantTimezone } from "@/lib/hooks/useTenantTimezone";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import {
@@ -138,10 +139,12 @@ export default function CreateLiveSessionPage() {
     if (!authLoading && !canAccessAdmin) router.replace("/dashboard");
   }, [authLoading, canAccessAdmin, router]);
 
-  // Default the session's timezone to the admin's own zone once mounted (client-only so it can't
-  // cause a hydration mismatch). Falls back to IST if the browser can't resolve a zone.
+  // Default the session's timezone to the INSTITUTION's zone, not the admin's browser. Seeding from
+  // the browser is what produced the reported bug: an India-based admin scheduling for a KSA academy
+  // silently got IST preselected. Falls back to the viewer's zone only when the tenant has none.
+  const tenantTz = useTenantTimezone();
   useEffect(() => {
-    if (!sessionTz) setSessionTz(viewerTimeZone() || "Asia/Kolkata");
+    if (!sessionTz) setSessionTz(tenantTz);
   }, [sessionTz]);
 
   // Clamp step index if the step list shrinks (e.g. switching to Google Meet).

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTenantTimezone } from "@/lib/hooks/useTenantTimezone";
 import {
   Alert,
   Box,
@@ -433,6 +434,7 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  const tenantTz = useTenantTimezone();
   useEffect(() => {
     if (!open) return;
     instructorService.getCohorts().then(setCohorts).catch(() => undefined);
@@ -443,7 +445,7 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
       .then((list) => setCourses(list.filter((c) => c.kind === "adaptive")))
       .catch(() => undefined);
     // Default the session zone to the instructor's own zone (client-only).
-    setSessionTz((prev) => prev || viewerTimeZone() || "Asia/Kolkata");
+    setSessionTz((prev) => prev || tenantTz);
   }, [open]);
 
   const reset = () => {

--- a/components/admin/live-sessions/EditWebinarDialog.tsx
+++ b/components/admin/live-sessions/EditWebinarDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useTenantTimezone } from "@/lib/hooks/useTenantTimezone";
 import { useTranslation } from "react-i18next";
 import {
   Box,
@@ -43,9 +44,10 @@ export function EditWebinarDialog({ activity, open, onClose, onSaved }: Props) {
   const [passcode, setPasscode] = useState("");
   const [saving, setSaving] = useState(false);
 
+  const tenantTz = useTenantTimezone();
   useEffect(() => {
     if (!open) return;
-    const tz = activity.timezone || viewerTimeZone() || "Asia/Kolkata";
+    const tz = activity.timezone || tenantTz;
     setTopic(activity.topic_name ?? "");
     setSessionTz(tz);
     // Show the wall-clock in the session's OWN zone so editing from another zone doesn't shift it.

--- a/components/admin/live-sessions/LiveSessionNoticeDialog.tsx
+++ b/components/admin/live-sessions/LiveSessionNoticeDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTenantTimezone } from "@/lib/hooks/useTenantTimezone";
 import {
   Box,
   Button,
@@ -60,11 +61,12 @@ export function LiveSessionNoticeDialog({ open, session, onClose, onSaved }: Pro
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const tenantTz = useTenantTimezone();
   useEffect(() => {
     if (!open || !session) return;
     setMode(session.notice_type === "rescheduled" ? "rescheduled" : "cancelled");
     setReason(session.notice_reason || "");
-    const zone = session.timezone || viewerTimeZone() || "Asia/Kolkata";
+    const zone = session.timezone || tenantTz;
     setWhen(toLocalInputInZone(session.class_datetime, zone));
     // The session's own zone is authoritative; only fall back to the viewer's when it has none.
     setTz(zone);

--- a/lib/hooks/useTenantTimezone.ts
+++ b/lib/hooks/useTenantTimezone.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import { viewerTimeZone } from "@/lib/utils/session-time";
+
+/**
+ * The zone a NEW session should default to.
+ *
+ * Order is deliberate: the institution's own zone first, the viewer's browser only as a fallback.
+ * Seeding from the browser is what caused the reported bug — an India-based admin scheduling for a
+ * KSA academy silently got IST preselected and had to remember to change it every time.
+ */
+export function useTenantTimezone(): string {
+  const { clientInfo } = useClientInfo();
+  return (clientInfo?.timezone || "").trim() || viewerTimeZone() || "Asia/Kolkata";
+}
+
+/**
+ * The zone an EXISTING session should be read and displayed in: whatever it was scheduled in, then
+ * the institution's, then the viewer's. Never silently reinterprets a stored session in a new zone.
+ */
+export function useSessionTimezone(sessionTz?: string | null): string {
+  const tenant = useTenantTimezone();
+  return (sessionTz || "").trim() || tenant;
+}

--- a/lib/services/client.service.ts
+++ b/lib/services/client.service.ts
@@ -14,6 +14,12 @@ export interface ClientInfo {
   app_icon_url?: string | null;
   is_active?: boolean;
   features?: ClientFeature[];
+  /**
+   * The institution's IANA operating timezone (e.g. "Asia/Riyadh"). Live sessions default to and
+   * display in this zone, so a KSA academy administered from India still shows KSA times to
+   * everyone. Blank on tenants that haven't been seeded yet.
+   */
+  timezone?: string | null;
   theme_settings?: {
     colors?: {
       // Primary Colors


### PR DESCRIPTION
Frontend for **BE #469**. Merge the backend first (this reads `clientInfo.timezone`).

## The mechanism behind the InUn report

All four scheduling surfaces seeded the timezone picker from **`viewerTimeZone()` — the creator's
browser**:

| file | was |
|---|---|
| `app/admin/live-sessions/create/page.tsx` | `viewerTimeZone() \|\| "Asia/Kolkata"` |
| `app/instructor/live-sessions/page.tsx` | `viewerTimeZone() \|\| "Asia/Kolkata"` |
| `components/.../EditWebinarDialog.tsx` | `activity.timezone \|\| viewerTimeZone()` |
| `components/.../LiveSessionNoticeDialog.tsx` | `session.timezone \|\| viewerTimeZone()` |

An India-based admin scheduling for a KSA academy silently got **IST** preselected, every time.
That's *"scheduled 4:30 KSA, students see 7:00 IST"*.

## Fix

- **`useTenantTimezone()`** → institution → viewer → `Asia/Kolkata`
- **`useSessionTimezone(sessionTz)`** → puts *"whatever it was already scheduled in"* first, so
  editing an existing session never silently reinterprets it in a new zone

## Why there's no formatter change

`formatSessionTime` **already** renders in the session's zone with the viewer's time alongside — but
only when a zone is stored. It falls back to bare unlabelled local time when the field is **empty**,
and **#469's backfill stamps every one of those rows**.

Fixing the data is the durable fix. Adding a second fallback inside the formatter would paper over
whether the backfill actually ran, and I'd rather that stayed visible.

## Verification

- `tsc --noEmit` **clean**.
- Hook placement checked by hand on all four files — top-level in the component, after existing
  hooks, before the effect that consumes them. No conditionals or early returns above. This
  type-checks either way, so it needed eyes, not just the compiler.
- `eslint`: 8 errors, **all pre-existing** (`no-explicit-any` in untouched code) — confirmed by
  re-running on the stashed originals; identical count. My changes add warnings only.
- Not seen rendered (`next build` can't run in a worktree). On staging: open the create wizard as an
  India-based admin on the InUn tenant — the picker should preselect **Asia/Riyadh**, not IST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)