### PR TITLE
feat(admin): timezone picker in settings + Check connection on the Zoom card

### DIFF
--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -69,6 +69,7 @@ export default function AdminLiveSessionsPage() {
     searchParams.get("google_connected") === "0" ? searchParams.get("error") || "unknown" : null
   );
   const [credentialsDialogOpen, setCredentialsDialogOpen] = useState(false);
+  const [runZoomCheck, setRunZoomCheck] = useState(false);
   const [presetsDialogOpen, setPresetsDialogOpen] = useState(false);
   const [backgroundsDialogOpen, setBackgroundsDialogOpen] = useState(false);
   const [filter, setFilter] = useState("all");
@@ -397,6 +398,9 @@ export default function AdminLiveSessionsPage() {
                   <ZoomSetupCard
                     status={zoomStatus}
                     onConfigure={() => setCredentialsDialogOpen(true)}
+                    // Opens the same dialog, but tells it to run the check immediately — the check
+                    // lives there, and duplicating the results UI on the card would drift.
+                    onCheck={() => { setRunZoomCheck(true); setCredentialsDialogOpen(true); }}
                     onConnect={handleZoomConnect}
                     onDisconnect={handleZoomDisconnect}
                     connecting={zoomConnecting}
@@ -525,6 +529,8 @@ export default function AdminLiveSessionsPage() {
       </Box>
 
       <ZoomCredentialsDialog
+          autoCheck={runZoomCheck}
+          onAutoCheckHandled={() => setRunZoomCheck(false)}
           open={credentialsDialogOpen}
           onClose={() => {
             setCredentialsDialogOpen(false);

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { clientTimezoneService } from "@/lib/services/client-timezone.service";
 import {
   Box,
   CircularProgress,
+  MenuItem,
   Paper,
   Stack,
   TextField,
@@ -328,6 +330,42 @@ export default function AdminSettingsPage() {
     }
   };
 
+  // Timezone is saved on its own, NOT with the branding Save button. It changes how every live
+  // session is scheduled and displayed, so it should not ride along with a logo edit — and it
+  // writes to a different endpoint.
+  const [tz, setTz] = useState("");
+  const [tzOptions, setTzOptions] = useState<string[]>([]);
+  const [tzSaving, setTzSaving] = useState(false);
+  const [tzMsg, setTzMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    clientTimezoneService
+      .get()
+      .then((d) => {
+        if (cancelled) return;
+        setTz(d.timezone || "");
+        setTzOptions(d.common_timezones || []);
+      })
+      .catch(() => undefined);
+    return () => { cancelled = true; };
+  }, []);
+
+  const saveTimezone = async (next: string) => {
+    setTzSaving(true);
+    setTzMsg(null);
+    try {
+      const d = await clientTimezoneService.set(next);
+      setTz(d.timezone || "");
+      setTzMsg("Timezone updated. New sessions will default to it.");
+    } catch (e) {
+      const detail = (e as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      setTzMsg(detail || "Couldn't update the timezone.");
+    } finally {
+      setTzSaving(false);
+    }
+  };
+
   const handleSave = async () => {
     const logo = logoUrl.trim();
     if (logo && logo.length > LOGO_URL_MAX) {
@@ -477,6 +515,34 @@ export default function AdminSettingsPage() {
               placeholder="e.g. Learn faster. Grow further."
               sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
             />
+          </SettingCard>
+
+          <SettingCard
+            icon="mdi:earth-clock"
+            title="Institution timezone"
+            description="The zone your live sessions are scheduled and displayed in. Set this to where your learners are, not where you are — otherwise a session booked from another country shows everyone the wrong local time."
+          >
+            <TextField
+              select
+              fullWidth
+              size="small"
+              value={tz}
+              disabled={tzSaving}
+              onChange={(e) => saveTimezone(e.target.value)}
+              helperText={
+                tzMsg ??
+                (tz
+                  ? "Saved automatically. Existing sessions keep the zone they were created in."
+                  : "Not set — sessions fall back to the platform default.")
+              }
+              sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+            >
+              {(tzOptions.length ? tzOptions : [tz].filter(Boolean)).map((z) => (
+                <MenuItem key={z} value={z}>
+                  {z.replace(/_/g, " ")}
+                </MenuItem>
+              ))}
+            </TextField>
           </SettingCard>
 
           <CourseVisibilitySetting />

--- a/components/admin/live-sessions/ZoomCredentialsDialog.tsx
+++ b/components/admin/live-sessions/ZoomCredentialsDialog.tsx
@@ -26,6 +26,9 @@ import { config } from "@/lib/config";
 import { ZoomSetupGuide } from "./ZoomSetupGuide";
 
 interface ZoomCredentialsDialogProps {
+  /** Run the connection check as soon as the dialog opens (from the card's Check button). */
+  autoCheck?: boolean;
+  onAutoCheckHandled?: () => void;
   open: boolean;
   onClose: () => void;
 }
@@ -54,7 +57,7 @@ function getApiErrorMessage(e: unknown): string {
   return "Something went wrong. Please try again.";
 }
 
-export function ZoomCredentialsDialog({ open, onClose }: ZoomCredentialsDialogProps) {
+export function ZoomCredentialsDialog({ open, onClose, autoCheck, onAutoCheckHandled}: ZoomCredentialsDialogProps) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [loading, setLoading] = useState(false);
@@ -108,6 +111,13 @@ export function ZoomCredentialsDialog({ open, onClose }: ZoomCredentialsDialogPr
    * should be able to re-check at any time without re-entering the client secret (which the GET
    * never returns), and the check is read-only so it can be run before every term starts.
    */
+  useEffect(() => {
+    if (!open || !autoCheck) return;
+    void handleCheckConnection();
+    onAutoCheckHandled?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, autoCheck]);
+
   const handleCheckConnection = async () => {
     setChecking(true);
     setCheckError(null);

--- a/components/admin/live-sessions/ZoomSetupCard.tsx
+++ b/components/admin/live-sessions/ZoomSetupCard.tsx
@@ -21,6 +21,9 @@ export interface ZoomSetupStatus {
 interface ZoomSetupCardProps {
   status: ZoomSetupStatus;
   onConfigure: () => void;
+  /** Run the end-to-end connection check. Promoted onto the card because a pre-flight check
+   *  buried inside the credentials dialog is one nobody runs. */
+  onCheck?: () => void;
   /** Start the one-click OAuth connect (redirects to Zoom). */
   onConnect?: () => void;
   /** Disconnect the OAuth-connected Zoom account. */
@@ -32,7 +35,7 @@ interface ZoomSetupCardProps {
  * Surfaces the Zoom connection state at the top of the admin live-sessions page so admins always
  * know what's set up and what's left - replacing the easy-to-miss header button + once-only auto-open.
  */
-export function ZoomSetupCard({ status, onConfigure, onConnect, onDisconnect, connecting }: ZoomSetupCardProps) {
+export function ZoomSetupCard({ status, onConfigure, onConnect, onDisconnect, connecting, onCheck }: ZoomSetupCardProps) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
 
@@ -188,6 +191,16 @@ export function ZoomSetupCard({ status, onConfigure, onConnect, onDisconnect, co
                 <IconWrapper icon="mdi:content-copy" size={18} />
               </IconButton>
             </Tooltip>
+          )}
+          {onCheck && (
+            <Button
+              size="small"
+              onClick={onCheck}
+              startIcon={<IconWrapper icon="mdi:shield-check-outline" size={16} />}
+              sx={{ textTransform: "none", color: accent }}
+            >
+              {t("adminLiveSessions.checkZoomConnection", "Check connection")}
+            </Button>
           )}
           <Button size="small" onClick={onConfigure} sx={{ textTransform: "none", color: accent }}>
             {t("adminLiveSessions.manageZoom", "Manage")}

--- a/lib/services/client-timezone.service.ts
+++ b/lib/services/client-timezone.service.ts
@@ -1,0 +1,16 @@
+import apiClient from "./api";
+import { config } from "../config";
+
+export interface ClientTimezoneResponse {
+  timezone: string;
+  /** Ranked shortlist for the picker. Not a whitelist — the API accepts any valid IANA zone. */
+  common_timezones: string[];
+}
+
+const url = () => `/accounts/clients/${config.clientId}/timezone/`;
+
+export const clientTimezoneService = {
+  get: async (): Promise<ClientTimezoneResponse> => (await apiClient.get<ClientTimezoneResponse>(url())).data,
+  set: async (timezone: string): Promise<ClientTimezoneResponse> =>
+    (await apiClient.patch<ClientTimezoneResponse>(url(), { timezone })).data,
+};


### PR DESCRIPTION
Closes the two things reported as *"I still can't see these"*. Needs **BE #471** for the timezone
endpoint.

## 1. Timezone — it genuinely wasn't there

`Client.timezone` shipped in BE #469 and was seeded across all 44 tenants, but **only a management
command could change it**. From inside the product the feature simply didn't exist. My omission.

Adds a card on the admin settings page.

**Saved on its own, not with the branding Save button.** It writes to a different endpoint, and it
changes how every live session is scheduled and displayed — it shouldn't ride along with a logo edit.

The helper text states that **existing sessions keep the zone they were created in**, because
*"will this move my 50 booked sessions?"* is the first thing an admin will wonder before touching it.

## 2. Check connection — it was shipped, just buried

The button landed in #1164 but sat at the **bottom of the credentials dialog**, two clicks deep
behind *Manage*. As a pre-flight check, that's somewhere nobody would ever run it.

It's now on the **Zoom card itself**, next to the connection status.

Clicking it opens the same dialog and runs the check immediately, rather than duplicating the results
UI on the card — one implementation, so the two can't drift.

## Verification

- `tsc --noEmit` **clean**.
- `eslint` on all five files → 1 error + 1 warning, both pre-existing in untouched code.
- Not seen rendered (`next build` can't run in a worktree). On staging: **Admin → Settings** should
  show *Institution timezone* (AgileOlogy `Asia/Kolkata`, InUn `Asia/Riyadh`), and **Admin → Live
  Sessions → Integrations → Zoom card** should show *Check connection* without opening Manage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)