### PR TITLE
fix(settings): timezone dropdown rendered empty and claimed "Not set"

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { clientTimezoneService } from "@/lib/services/client-timezone.service";
+import { clientTimezoneService, FALLBACK_TIMEZONES } from "@/lib/services/client-timezone.service";
 import {
   Box,
   CircularProgress,
@@ -337,6 +337,7 @@ export default function AdminSettingsPage() {
   const [tzOptions, setTzOptions] = useState<string[]>([]);
   const [tzSaving, setTzSaving] = useState(false);
   const [tzMsg, setTzMsg] = useState<string | null>(null);
+  const [tzLoadFailed, setTzLoadFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -345,9 +346,16 @@ export default function AdminSettingsPage() {
       .then((d) => {
         if (cancelled) return;
         setTz(d.timezone || "");
-        setTzOptions(d.common_timezones || []);
+        setTzOptions(d.common_timezones?.length ? d.common_timezones : FALLBACK_TIMEZONES);
+        setTzLoadFailed(false);
       })
-      .catch(() => undefined);
+      .catch(() => {
+        // Do NOT swallow this. Silently leaving the list empty renders a blank dropdown that also
+        // claims "Not set", which is indistinguishable from a tenant with no zone configured.
+        if (cancelled) return;
+        setTzOptions(FALLBACK_TIMEZONES);
+        setTzLoadFailed(true);
+      });
     return () => { cancelled = true; };
   }, []);
 
@@ -531,13 +539,15 @@ export default function AdminSettingsPage() {
               onChange={(e) => saveTimezone(e.target.value)}
               helperText={
                 tzMsg ??
-                (tz
-                  ? "Saved automatically. Existing sessions keep the zone they were created in."
-                  : "Not set — sessions fall back to the platform default.")
+                (tzLoadFailed
+                  ? "Couldn't load the current timezone — pick one to set it, or reload the page."
+                  : tz
+                    ? "Saved automatically. Existing sessions keep the zone they were created in."
+                    : "Not set — sessions fall back to the platform default.")
               }
               sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
             >
-              {(tzOptions.length ? tzOptions : [tz].filter(Boolean)).map((z) => (
+              {(tzOptions.length ? tzOptions : FALLBACK_TIMEZONES).map((z) => (
                 <MenuItem key={z} value={z}>
                   {z.replace(/_/g, " ")}
                 </MenuItem>

--- a/lib/services/client-timezone.service.ts
+++ b/lib/services/client-timezone.service.ts
@@ -1,6 +1,25 @@
 import apiClient from "./api";
 import { config } from "../config";
 
+/**
+ * Shipped fallback list. The API returns its own ranked list, but if that request fails the picker
+ * must still be usable — an empty dropdown that also says "Not set" is indistinguishable from a
+ * tenant that genuinely has no zone, which is exactly how this shipped broken the first time.
+ */
+export const FALLBACK_TIMEZONES = [
+  "Asia/Kolkata", "Asia/Riyadh", "Asia/Dubai", "Asia/Karachi", "Asia/Dhaka",
+  "Asia/Colombo", "Asia/Kathmandu", "Asia/Singapore", "Asia/Kuala_Lumpur",
+  "Asia/Jakarta", "Asia/Manila", "Asia/Bangkok", "Asia/Hong_Kong", "Asia/Tokyo",
+  "Asia/Seoul", "Asia/Shanghai", "Asia/Tashkent", "Asia/Tehran", "Asia/Jerusalem",
+  "Europe/London", "Europe/Dublin", "Europe/Paris", "Europe/Berlin", "Europe/Madrid",
+  "Europe/Rome", "Europe/Amsterdam", "Europe/Warsaw", "Europe/Moscow", "Europe/Istanbul",
+  "Africa/Cairo", "Africa/Lagos", "Africa/Nairobi", "Africa/Johannesburg",
+  "America/New_York", "America/Chicago", "America/Denver", "America/Los_Angeles",
+  "America/Toronto", "America/Sao_Paulo", "America/Mexico_City",
+  "Australia/Sydney", "Australia/Melbourne", "Australia/Perth", "Pacific/Auckland",
+  "UTC",
+];
+
 export interface ClientTimezoneResponse {
   timezone: string;
   /** Ranked shortlist for the picker. Not a whitelist — the API accepts any valid IANA zone. */


### PR DESCRIPTION
## What you saw

Empty dropdown, helper text *"Not set — sessions fall back to the platform default"*.

## What was actually true

I verified the API against prod for InUn:

```
client 28  Client.timezone = 'Asia/Riyadh'
GET /accounts/clients/28/timezone/  ->  HTTP 200, timezone='Asia/Riyadh', 45 options
```

The backend was fine. **The bug was mine, in the loader:**

```ts
.catch(() => undefined);   // any failure -> tz="", options=[]
```

Which renders **identically** to a tenant with no zone configured. Most likely you loaded the page
before BE #471 finished deploying — but the point is the UI *couldn't tell*, and chose to assert the
more alarming of the two possibilities.

## Fix

- **A fallback zone list ships with the frontend**, so the picker is never empty and an admin can set
  a zone even when the GET fails.
- **The failure is recorded, not swallowed** — helper text says *"Couldn't load the current timezone"*
  rather than *"Not set"*.
- An **empty list from the API** also falls back rather than rendering nothing.

## Verification

- `tsc --noEmit` clean; `eslint` clean on both files.
- API behaviour confirmed directly against prod (200 / `Asia/Riyadh` / 45 options) before writing the
  fix, so this addresses the real cause rather than the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)