### PR TITLE
perf(courses): prefetch the course route on hover instead of waiting for the click

### DIFF
--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -28,6 +28,7 @@ import {
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { CourseCard } from "@/components/course/CourseCard";
+import { usePrefetchOnHover } from "@/hooks/usePrefetchOnHover";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { ViewToggle, type ListView } from "@/components/common/list";
 import { useToast } from "@/components/common/Toast";
@@ -738,6 +739,7 @@ export default function CoursesPage() {
               <CourseRow
                 key={course.id}
                 course={course}
+                href={`/courses/${course.id}`}
                 onOpen={() => router.push(`/courses/${course.id}`)}
               />
             ))}
@@ -868,10 +870,15 @@ export default function CoursesPage() {
 function CourseRow({
   course,
   onOpen,
+  href,
 }: {
   course: CourseCardCourse;
   onOpen: () => void;
+  href: string;
 }) {
+  // Same reason as the grid card: onOpen is a router.push(), which never prefetches, so without
+  // this the route only starts loading once the row is clicked.
+  const prefetchProps = usePrefetchOnHover(href);
   const isEnrolled = course.is_enrolled;
   const s = course.stats;
   const totalLessons =
@@ -895,6 +902,7 @@ function CourseRow({
   return (
     <Box
       onClick={onOpen}
+      {...prefetchProps}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {

--- a/components/course/CourseCard.tsx
+++ b/components/course/CourseCard.tsx
@@ -15,6 +15,7 @@ import { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { usePrefetchOnHover } from "@/hooks/usePrefetchOnHover";
 import { Course } from "./interfaces";
 
 interface CourseCardProps {
@@ -38,9 +39,12 @@ export const CourseCard = memo(
     const difficultyKey = course.difficulty_level && DIFFICULTY_KEYS[course.difficulty_level];
     const difficultyLabel = difficultyKey ? t(difficultyKey) : t("courses.difficultyBeginner");
 
+    const href = `/courses/${course.id}`;
+    const prefetchProps = usePrefetchOnHover(isEnrolled ? href : null);
+
     const handleClick = useCallback(() => {
-      router.push(`/courses/${course.id}`);
-    }, [router, course.id]);
+      router.push(href);
+    }, [router, href]);
 
     const handleEnroll = useCallback(
       (e: React.MouseEvent) => {
@@ -67,6 +71,10 @@ export const CourseCard = memo(
 
     return (
       <Card
+        // Warm /courses/[id] while the pointer is on the card. The CTA below uses router.push(),
+        // which does no prefetching of its own, so without this the route only starts loading after
+        // the click. Handlers only — nothing about the card's markup or click path changes.
+        {...prefetchProps}
         sx={{
           height: "100%",
           minHeight: 320,

--- a/hooks/usePrefetchOnHover.ts
+++ b/hooks/usePrefetchOnHover.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Warm a route while the user is still deciding to click it.
+ *
+ * `<Link>` prefetches on its own; `router.push()` does not. Most navigation in this app is an
+ * imperative push from a card or a row, so the route only begins loading *after* the click — the
+ * user waits through the whole round trip while looking at the old screen.
+ *
+ * Hover and keyboard focus are the earliest honest signals of intent, and they arrive a few hundred
+ * milliseconds before the click. That is usually enough for the route to be ready by the time the
+ * click lands.
+ *
+ * Returns props to spread onto the clickable element. It deliberately changes nothing else:
+ *
+ * * **No markup change.** Only event handlers, so layout, styling and accessibility are untouched.
+ * * **No effect on navigation.** The click path still runs exactly as before, so scroll behaviour —
+ *   which differs between `<Link>` and `router.push()` in subtle ways — cannot shift.
+ * * **Fires once per href.** Hovering along a list of cards prefetches each at most once, and
+ *   sweeping the mouse across a grid will not re-request anything.
+ * * **Cannot break a click.** `prefetch` is best-effort: a failure (offline, a route that 404s) is
+ *   swallowed, and the click then behaves as it does today.
+ *
+ * Hover is intent-driven, so this stays bounded — only routes the user actually points at are
+ * fetched, unlike viewport-based prefetching which would pull every card in a long list.
+ *
+ * ```tsx
+ * const prefetch = usePrefetchOnHover(`/courses/${course.id}`);
+ * <Card onClick={open} {...prefetch}>…</Card>
+ * ```
+ */
+export function usePrefetchOnHover(href: string | null | undefined) {
+  const router = useRouter();
+  const doneRef = useRef<string | null>(null);
+
+  const warm = useCallback(() => {
+    if (!href || doneRef.current === href) return;
+    doneRef.current = href;
+    try {
+      router.prefetch(href);
+    } catch {
+      // Best-effort only — never let warming a route interfere with using the page.
+    }
+  }, [router, href]);
+
+  return { onMouseEnter: warm, onFocus: warm };
+}


### PR DESCRIPTION
First step of the navigation-speed work, scoped to **one surface** so it can be judged on its own.

## Why

`<Link>` prefetches. `router.push()` does not. This app navigates almost entirely by imperative
push — **246 `router.push` calls against 27 `<Link>`** — so for most navigations the route only
begins loading *after* the click, and the user sits on the old screen for the whole round trip.

The student course list is the most-travelled of those paths, so it goes first.

Hover and keyboard focus are the earliest honest signals of intent and land a few hundred
milliseconds before the click — usually enough for the route to be ready when it arrives.

## Why this is safe

You asked specifically that scroll not regress. **The click path is untouched** — this adds
`onMouseEnter` / `onFocus` handlers and nothing else, so navigation behaves exactly as it does
today.

I checked the scroll surface before writing anything:

- The only `{ scroll: false }` uses in the codebase are `router.replace` calls that sync query
  strings for filters and pagination (`admin/assessment/[id]/edit`, `admin/manage-students`).
  **Neither is touched.**
- No `router.push` anywhere sets a scroll option, so they all use the default — which is the *same*
  default `<Link>` uses. Nothing can drift.

Other guarantees:

- **No markup change** — handlers only, so layout, styling and a11y are untouched.
- **Fires once per href** — sweeping the mouse across a grid re-requests nothing.
- **Cannot break a click** — `prefetch` failures are swallowed; a route that can't be warmed still
  clicks through as it does today.
- **Skipped when not enrolled** — that card's CTA is *Enroll*, so warming the course route would be
  wasted.

Hover is intent-driven, so this stays bounded: only routes the user actually points at get fetched,
unlike viewport prefetching which would pull every card in a long list.

## On BFCache — deliberately not done

It only applies to full-document back/forward navigations. This is an App Router SPA (in-app routes
are client-side) and its external links open in **new tabs** (`window.open(_blank)` for Zoom/Meet),
so there are almost no such navigations to accelerate. Nothing disqualifies the app from it either —
no bare `unload` handlers, no `Cache-Control: no-store` — so there is nothing to fix. `beforeunload`
is present but does not block BFCache.

## Verification

- `tsc --noEmit` clean
- `eslint` 0 errors (7 pre-existing warnings, none from this change)
- **Production `next build` succeeds**

Worth an eyeball on staging: hover a course card with DevTools → Network filtered to `RSC`, and
confirm the route payload is fetched on hover rather than on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)