### PR TITLE
perf(assessments): warm the assessment route on hover

### DIFF
--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { Assessment } from "@/lib/services/assessment.service";
+import { usePrefetchOnHover } from "@/hooks/usePrefetchOnHover";
 import { useRouter } from "next/navigation";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
@@ -301,6 +302,17 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
     [isRtl, isClickable, ctaAppearance]
   );
 
+  // Mirror exactly where handleClick below will land, so the route being warmed is the route the
+  // click actually opens. Null when the card isn't clickable — nothing to warm.
+  // The device-allowed check stays out of this: it reads the environment and belongs at click time,
+  // and warming a route the user turns out not to visit costs one request and breaks nothing.
+  const prefetchHref = !isClickable
+    ? null
+    : submissionComplete && showResults
+      ? `/assessments/result/${assessment.slug}`
+      : `/assessments/${assessment.slug}`;
+  const prefetchProps = usePrefetchOnHover(prefetchHref);
+
   const handleClick = () => {
     if (!isClickable || loadingAction) return;
     if (submissionComplete && showResults) {
@@ -349,6 +361,7 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
         }}
         role={isClickable ? "button" : undefined}
         tabIndex={isClickable ? 0 : undefined}
+        {...prefetchProps}
         onClick={handleClick}
         onKeyDown={
           isClickable


### PR DESCRIPTION
Change **#2**, same shape and same safety envelope as #1174: hover/focus handlers only, **click path
untouched**, so scroll behaviour cannot move.

## What it does

The assessment card's destination depends on its state, so the prefetch mirrors `handleClick`
exactly rather than assuming a single route:

| State | Warmed |
|---|---|
| submitted + results visible | `/assessments/result/<slug>` |
| otherwise | `/assessments/<slug>` |
| not clickable | nothing |

The device-allowed check is deliberately **not** consulted here — it reads the environment and
belongs at click time. Warming a route the user then doesn't visit costs one request and breaks
nothing, whereas calling it during render risks a hydration mismatch.

## A correction worth recording

While scoping this I found the **adaptive surfaces are already hover-prefetched** — journey board,
submodule page, dashboard panels, instructor cohorts, admin adaptive courses, courses nav tabs. My
earlier framing of *"246 unprefetched `router.push` calls"* **overstated the gap**: the adaptive
product was already covered by the previous perf work.

The genuine gaps are the older surfaces. That's where #1174 (student course list) and this one sit.
Remaining, in order: student live-sessions, community, tickets, jobs.

## Verification

- `tsc --noEmit` clean
- `eslint` output **identical to the untouched file on `stagging`** — 3 errors + 6 warnings, all
  pre-existing `react-hooks/purity` in code this change doesn't touch. I diffed against the baseline
  rather than assume.
- Production `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)