### PR TITLE
perf(community,tickets): warm the detail route on hover

### DIFF
--- a/app/tickets/page.tsx
+++ b/app/tickets/page.tsx
@@ -447,6 +447,8 @@ export default function MyTicketsPage() {
                           },
                         }}
                         onClick={() => router.push(`/tickets/${t.id}`)}
+                        onMouseEnter={() => router.prefetch(`/tickets/${t.id}`)}
+                        onFocus={() => router.prefetch(`/tickets/${t.id}`)}
                       >
                         <TableCell
                           sx={{

--- a/components/community/ThreadCard.tsx
+++ b/components/community/ThreadCard.tsx
@@ -8,6 +8,7 @@ import remarkGfm from "remark-gfm";
 import { Box, Paper, Typography, Chip, Avatar, IconButton, Tooltip } from "@mui/material";
 
 import { POST_TYPE_CONFIG, type Thread } from "@/lib/services/community.service";
+import { usePrefetchOnHover } from "@/hooks/usePrefetchOnHover";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { VoteButtons } from "./VoteButtons";
 import { PollWidget } from "./PollWidget";
@@ -83,6 +84,10 @@ export function ThreadCard({
   const isAuthor = !!currentUserName && thread.author.user_name === currentUserName;
   const canOfferBounty = isAuthor && thread.post_type === "question" && !hasBounty && !isSaving;
 
+  // Warm the thread route on hover. Skipped while the card is mid-save (isSaving), which is the
+  // same condition that makes the click a no-op below.
+  const prefetchProps = usePrefetchOnHover(isSaving ? null : `/community/${thread.id}`);
+
   const handleThreadClick = () => {
     if (isSaving) return;
     router.push(`/community/${thread.id}`);
@@ -94,6 +99,7 @@ export function ThreadCard({
   return (
     <Paper
       elevation={0}
+      {...prefetchProps}
       sx={{
         border: "1px solid var(--border-default)",
         borderRadius: 2,


### PR DESCRIPTION
Change **#3**, and the last of the genuine gaps. Same envelope as #1174 and #1175: hover/focus
handlers only, **click path untouched**, scroll cannot move.

| Surface | Warmed |
|---|---|
| `ThreadCard` (community feed) | `/community/<id>` — skipped while `isSaving`, the same condition that already makes the click a no-op |
| Tickets table row | `/tickets/<id>` |

The tickets row calls `router.prefetch` **inline** rather than through the hook: that row renders
inside a `.map()`, where calling a hook would break the Rules of Hooks. Next's prefetch cache
dedupes repeat calls, so behaviour is the same.

## Scoping note — I checked instead of assuming

Three of the four surfaces I listed last time turned out **not** to be gaps:

- **jobs-v2** — already uses `component={Link}`, which prefetches by default
- **live-sessions** — has **no detail route at all** (`page.tsx` + `loading.tsx` only); its cards
  join an external meeting, so there is nothing to warm
- **community** — the gap was the **feed card** (`ThreadCard`), not the page-level pushes I first
  spotted

Together with the adaptive surfaces already being covered by the earlier perf work, this closes the
list→detail prefetch gaps on the student side.

## Verification

- `tsc --noEmit` clean
- `eslint` identical to the untouched files on `stagging` — ThreadCard 0/0, tickets 2 errors both
  before and after (pre-existing)
- Production `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)