### PR TITLE
fix(guide): welcome the learner to their own institution, not to AI Linc

### DIFF
--- a/components/common/PageGuide.tsx
+++ b/components/common/PageGuide.tsx
@@ -6,6 +6,18 @@ import { Box, Button, ButtonBase, Dialog, DialogContent, IconButton, Tooltip, Ty
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { useTour } from "@/components/community/TourProvider";
 import { buildTour, type PageGuideContent } from "@/lib/guide/registry";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * Substitute `{brand}` with the tenant's own name.
+ *
+ * This is a white-label platform: an Agileology learner should be welcomed to Agileology, not to
+ * AI Linc. Falls back to "AI Linc" when the tenant has no name set, which matches how the rest of
+ * the product (emails, auth screens) treats a missing brand.
+ */
+function withBrand(text: string, brand: string): string {
+  return text.split("{brand}").join(brand);
+}
 
 /**
  * The one page-guide "?" used across every module header. Opens a modal that
@@ -31,6 +43,8 @@ export function PageGuide({
    *  the dashboard), navigate here first so the targets exist before the spotlight measures. */
   tourStartPath?: string;
 }) {
+  const { clientInfo } = useClientInfo();
+  const brandName = clientInfo?.name?.trim() || "AI Linc";
   const [open, setOpen] = useState(false);
   const { startTour } = useTour();
   const router = useRouter();
@@ -157,11 +171,11 @@ export function PageGuide({
           <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 0.5, pr: 4 }}>
             <IconWrapper icon="mdi:compass-outline" size={26} color="#fff" />
             <Typography variant="h6" fontWeight={700}>
-              {content.headerTitle}
+              {withBrand(content.headerTitle, brandName)}
             </Typography>
           </Box>
           <Typography variant="body2" sx={{ opacity: 0.92 }}>
-            {content.headerSubtitle}
+            {withBrand(content.headerSubtitle, brandName)}
           </Typography>
           <IconButton
             onClick={() => setOpen(false)}

--- a/lib/guide/registry.ts
+++ b/lib/guide/registry.ts
@@ -111,11 +111,14 @@ export const DASHBOARD_TOUR: TourStep[] = [
 
 /**
  * The platform-wide guide, opened from the "Guide" button in the top nav - a
- * bird's-eye overview of what AI Linc offers and where to find each area, plus an
+ * bird's-eye overview of what the platform offers and where to find each area, plus an
  * anchored tour of the student dashboard (the Guide starts it on /dashboard).
+ *
+ * `{brand}` is replaced at render time with the tenant's own name, so an Agileology learner is
+ * welcomed to Agileology rather than to AI Linc. See `PageGuide`.
  */
 export const PLATFORM_GUIDE: PageGuideContent = {
-  headerTitle: "Welcome to AI Linc",
+  headerTitle: "Welcome to {brand}",
   headerSubtitle: "Your learning platform at a glance - here's what you can do and where to find it.",
   tourSteps: DASHBOARD_TOUR,
   features: [


### PR DESCRIPTION
The platform guide opened with **"Welcome to AI Linc"** on every tenant. On a white-label platform
an Agileology learner should be welcomed to **Agileology**.

## The change

The registry string becomes `"Welcome to {brand}"`, and `PageGuide` substitutes the tenant's name at
render time from `ClientInfoContext` — the same source the auth screens and email previews already
use for the brand.

```
Agileology                        ->  "Welcome to Agileology"
InUn Academy For Arabic & Quranic ->  "Welcome to InUn Academy For Arabic & Quranic"
(no name set)                     ->  "Welcome to AI Linc"
```

The fallback matches how the rest of the product treats a missing brand — same rule as the email
branding work.

## Why a placeholder rather than a hardcoded swap

Any other guide copy can now pick up the tenant name just by writing `{brand}`, and **both** the
header title and the subtitle run through it. Strings without the placeholder are returned
untouched, so the other ~20 registry titles are unaffected.

## Safety

`useClientInfo` throws outside its provider — I checked. `ClientInfoProvider` wraps the whole tree
from the root `app/layout.tsx`, so every `PageGuide` is inside it.

## Verification

- Substitution checked against real tenant names, including one containing an ampersand
- `tsc --noEmit` clean; `eslint` clean on both touched files
- Production `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)