### PR TITLE
feat(live-sessions): study material on a session

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -49,6 +49,7 @@ import { WebinarEmailSection } from "@/components/admin/live-sessions/WebinarEma
 import { LiveSessionFeedbackSection } from "@/components/admin/live-sessions/LiveSessionFeedbackSection";
 import { LiveSessionNoticeDialog } from "@/components/admin/live-sessions/LiveSessionNoticeDialog";
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
+import { StudyMaterialManager } from "@/components/live-sessions/StudyMaterialManager";
 import { EditWebinarDialog } from "@/components/admin/live-sessions/EditWebinarDialog";
 import { formatSessionTime } from "@/lib/utils/session-time";
 
@@ -299,6 +300,9 @@ export default function LiveSessionDetailPage() {
   const isGoogleMeet = Boolean(activity?.is_google_meet);
   const tabs = useMemo(() => {
     const overview = { key: "overview", icon: "mdi:information-outline", label: t("adminLiveSessions.tabOverview", "Overview") };
+    // Study material is platform state, not provider state — every session type gets this tab,
+    // including a pasted-link session whose only other tab is Overview.
+    const materials = { key: "materials", icon: "mdi:paperclip", label: t("adminLiveSessions.tabMaterials", "Study material") };
     const recording = { key: "recording", icon: "mdi:play-circle-outline", label: t("adminLiveSessions.tabRecording", "Recording") };
     const transcript = { key: "transcript", icon: "mdi:text-box-outline", label: t("adminLiveSessions.tabTranscript", "Transcript") };
     // Google Meet sessions get the artifact tabs too (recording/transcript come from the Meet
@@ -308,10 +312,11 @@ export default function LiveSessionDetailPage() {
       return [
         overview,
         { key: "participants", icon: "mdi:account-group-outline", label: t("adminLiveSessions.tabParticipants", "Participants") },
+        materials,
         recording,
         transcript,
       ];
-    if (!isZoom) return [overview];
+    if (!isZoom) return [overview, materials];
     const base = [
       overview,
       { key: "attendance", icon: "mdi:account-group-outline", label: t("adminLiveSessions.tabAttendance", "Attendance") },
@@ -319,6 +324,7 @@ export default function LiveSessionDetailPage() {
       ...(isRecurring
         ? [{ key: "timeline", icon: "mdi:calendar-multiselect", label: t("adminLiveSessions.tabTimeline", "Timeline") }]
         : []),
+      materials,
       recording,
       transcript,
     ];
@@ -583,6 +589,10 @@ export default function LiveSessionDetailPage() {
                     <SectionCard><LiveSessionRosterSection liveClassId={activity.id} meetingStatus={activity.meeting_status ?? null} cohortName={activity.cohort_detail?.name ?? null} /></SectionCard>
                     <SectionCard><ZoomAttendanceSection liveClassId={activity.id} /></SectionCard>
                   </Box>
+                )}
+
+                {tabKey === "materials" && (
+                  <SectionCard><StudyMaterialManager liveClassId={activity.id} /></SectionCard>
                 )}
 
                 {/* Timeline (recurring Zoom) - per-occurrence date + who joined it + its recording */}

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -10,6 +10,7 @@ import { LiveSessionsEmptyState } from "@/components/live-sessions/LiveSessionsE
 import { LiveSessionsFeatureBlocked } from "@/components/live-sessions/LiveSessionsFeatureBlocked";
 import { useLiveSessions } from "@/components/live-sessions/useLiveSessions";
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
+import { SessionMaterialsDisclosure } from "@/components/live-sessions/SessionMaterialsDisclosure";
 import { StudentSessionSummaryDialog } from "@/components/live-sessions/StudentSessionSummaryDialog";
 import { LiveSessionFeedbackDialog } from "@/components/live-sessions/LiveSessionFeedbackDialog";
 import { COMMUNITY_FEATURE, HIDE_PARTICIPANT_COUNTS, useClientFeature, useClientOptIn } from "@/lib/hooks/useClientFeature";
@@ -762,6 +763,11 @@ function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind
           </Stack>
         </Box>
       )}
+      {/* Anything the trainer has already shared for this upcoming session — so a learner can
+          prepare before it starts, not only afterwards. */}
+      <Box sx={{ px: 2.25, pb: 1.75 }}>
+        <SessionMaterialsDisclosure liveClassId={s.id} />
+      </Box>
     </Box>
   );
 }
@@ -795,7 +801,8 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
 function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedback?: () => void }) {
   const attended = Boolean(s.my_attendance?.attended);
   return (
-    <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 1.75, display: "flex", gap: 1.5, alignItems: "center" }}>
+    <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 1.75 }}>
+    <Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
       <Icon icon={attended ? "mdi:check-circle" : "mdi:close-circle-outline"} width={22} style={{ color: attended ? "#10b981" : "#94a3b8", flexShrink: 0 }} />
       <Box sx={{ flex: 1, minWidth: 0 }}>
         <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }} noWrap>{s.topic_name}</Typography>
@@ -816,6 +823,10 @@ function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedba
           Rate
         </Button>
       )}
+    </Box>
+    {/* What the trainer shared for this session. Collapsed so a long history stays scannable, and
+        only fetched when opened. */}
+    <SessionMaterialsDisclosure liveClassId={s.id} dense />
     </Box>
   );
 }

--- a/components/live-sessions/SessionMaterialsDisclosure.tsx
+++ b/components/live-sessions/SessionMaterialsDisclosure.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Box, Button, Collapse } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { StudyMaterialList } from "./StudyMaterialList";
+import {
+  liveSessionMaterialsService,
+  type LiveSessionMaterial,
+} from "@/lib/services/live-session-materials.service";
+
+/**
+ * "Study material" toggle for a learner's session card or history row.
+ *
+ * Loads on first open, not on render. A learner's list can hold dozens of sessions, and fetching
+ * materials for every one of them to show a link most people never click would cost dozens of
+ * requests for nothing.
+ *
+ * Once opened it stays loaded, so re-opening is instant.
+ */
+export function SessionMaterialsDisclosure({
+  liveClassId,
+  label = "Study material",
+  dense = false,
+}: {
+  liveClassId: number;
+  label?: string;
+  dense?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<LiveSessionMaterial[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const toggle = useCallback(async () => {
+    const next = !open;
+    setOpen(next);
+    if (next && items === null && !loading) {
+      setLoading(true);
+      try {
+        setItems(await liveSessionMaterialsService.list(liveClassId));
+      } catch {
+        // A material list that cannot load must not break the card it hangs off — show "none"
+        // rather than an error state on what is a secondary detail.
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+  }, [open, items, loading, liveClassId]);
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Button
+        onClick={toggle}
+        size="small"
+        startIcon={<Icon icon="mdi:paperclip" width={15} />}
+        endIcon={<Icon icon={open ? "mdi:chevron-up" : "mdi:chevron-down"} width={16} />}
+        sx={{
+          textTransform: "none",
+          fontWeight: 700,
+          fontSize: "0.76rem",
+          color: "var(--font-secondary)",
+          px: 0.75,
+          minWidth: 0,
+        }}
+      >
+        {label}
+        {items !== null && items.length > 0 ? ` (${items.length})` : ""}
+      </Button>
+      <Collapse in={open} unmountOnExit>
+        <Box sx={{ pt: 0.75 }}>
+          <StudyMaterialList
+            materials={items ?? []}
+            dense={dense}
+            emptyLabel={loading ? "Loading…" : "No material shared for this session."}
+          />
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/components/live-sessions/StudyMaterialList.tsx
+++ b/components/live-sessions/StudyMaterialList.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Box, Typography, Stack } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import {
+  MATERIAL_ICONS,
+  formatFileSize,
+  type LiveSessionMaterial,
+} from "@/lib/services/live-session-materials.service";
+
+/**
+ * The read-only view of a session's study materials, used by learners on both the upcoming card and
+ * the History row.
+ *
+ * Rendered as a timeline — oldest first, each row carrying who added it and when — because that is
+ * what was asked for: a learner should be able to see what was shared and in what order, not just a
+ * bag of files.
+ *
+ * Attribution comes from `uploaded_by_label`, which the backend fills with the instructor CODE for
+ * learners. The component never reaches for `uploaded_by_name`; for a learner it is null anyway.
+ */
+export function StudyMaterialList({
+  materials,
+  emptyLabel,
+  dense = false,
+}: {
+  materials: LiveSessionMaterial[];
+  emptyLabel?: string;
+  dense?: boolean;
+}) {
+  if (!materials.length) {
+    return emptyLabel ? (
+      <Typography variant="body2" sx={{ color: "var(--font-secondary)", fontSize: "0.82rem" }}>
+        {emptyLabel}
+      </Typography>
+    ) : null;
+  }
+
+  return (
+    <Stack spacing={dense ? 0.75 : 1}>
+      {materials.map((m) => (
+        <Box
+          key={m.id}
+          component="a"
+          href={m.file_url ?? undefined}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            display: "flex",
+            alignItems: "flex-start",
+            gap: 1.25,
+            p: dense ? 1 : 1.25,
+            borderRadius: 2,
+            border: "1px solid var(--border-default)",
+            backgroundColor: "var(--card-bg)",
+            textDecoration: "none",
+            color: "inherit",
+            transition: "border-color .15s, background-color .15s",
+            "&:hover": {
+              borderColor: "var(--primary-400)",
+              backgroundColor: "var(--surface)",
+            },
+            // A material whose file could not be signed is shown but not clickable, rather than
+            // silently dropped — a learner should still see that it exists.
+            ...(m.file_url ? {} : { pointerEvents: "none", opacity: 0.6 }),
+          }}
+        >
+          <Box sx={{ mt: "1px", flexShrink: 0 }}>
+            <IconWrapper icon={MATERIAL_ICONS[m.file_type] ?? MATERIAL_ICONS.other} size={20} />
+          </Box>
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography
+              sx={{ fontWeight: 600, fontSize: dense ? "0.82rem" : "0.88rem", lineHeight: 1.35 }}
+            >
+              {m.title}
+            </Typography>
+            {m.description && (
+              <Typography
+                sx={{ color: "var(--font-secondary)", fontSize: "0.78rem", mt: 0.25 }}
+              >
+                {m.description}
+              </Typography>
+            )}
+            <Typography
+              sx={{ color: "var(--font-secondary)", fontSize: "0.72rem", mt: 0.4 }}
+            >
+              {m.uploaded_by_label ? `Added by ${m.uploaded_by_label}` : "Added"}
+              {" · "}
+              {new Date(m.created_at).toLocaleDateString(undefined, {
+                day: "numeric",
+                month: "short",
+              })}
+              {m.file_size ? ` · ${formatFileSize(m.file_size)}` : ""}
+            </Typography>
+          </Box>
+          {m.file_url && (
+            <Box sx={{ flexShrink: 0, mt: "1px" }}>
+              <IconWrapper icon="mdi:download-outline" size={18} />
+            </Box>
+          )}
+        </Box>
+      ))}
+    </Stack>
+  );
+}

--- a/components/live-sessions/StudyMaterialManager.tsx
+++ b/components/live-sessions/StudyMaterialManager.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton,
+  Stack, TextField, Tooltip, Typography,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { useToast } from "@/components/common/Toast";
+import {
+  MATERIAL_ICONS,
+  formatFileSize,
+  liveSessionMaterialsService,
+  type LiveSessionMaterial,
+} from "@/lib/services/live-session-materials.service";
+
+/**
+ * Staff-side management of a session's study materials: upload, retitle, re-describe, remove.
+ *
+ * Used on both the admin session page and the instructor's, because the permission decision lives
+ * in the backend — a caller who may not manage this session gets a 403 from the same endpoint — so
+ * there is nothing role-specific to fork here.
+ *
+ * Staff see `uploaded_by_name` (the real name) where a learner would see the instructor code; the
+ * backend decides which one it sends, and this simply prefers the name when present.
+ */
+export function StudyMaterialManager({ liveClassId }: { liveClassId: number }) {
+  const { showToast } = useToast();
+  const [items, setItems] = useState<LiveSessionMaterial[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const [editing, setEditing] = useState<LiveSessionMaterial | null>(null);
+  const [form, setForm] = useState({ title: "", description: "" });
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setItems(await liveSessionMaterialsService.list(liveClassId));
+    } catch {
+      showToast("Could not load study material", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [liveClassId, showToast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const pick = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setPendingFile(f);
+    // Seed the title from the filename so the common case is one click, while staying editable.
+    setForm({ title: f.name.replace(/\.[^.]+$/, ""), description: "" });
+    e.target.value = "";
+  };
+
+  const doUpload = async () => {
+    if (!pendingFile) return;
+    setUploading(true);
+    try {
+      const created = await liveSessionMaterialsService.upload(liveClassId, pendingFile, form);
+      setItems((prev) => [...prev, created]);
+      setPendingFile(null);
+      setForm({ title: "", description: "" });
+      showToast("Study material added", "success");
+    } catch (e: unknown) {
+      const msg =
+        (e as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        "Upload failed";
+      showToast(msg, "error");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const saveEdit = async () => {
+    if (!editing) return;
+    try {
+      const updated = await liveSessionMaterialsService.update(liveClassId, editing.id, form);
+      setItems((prev) => prev.map((m) => (m.id === updated.id ? updated : m)));
+      setEditing(null);
+      showToast("Updated", "success");
+    } catch {
+      showToast("Could not save", "error");
+    }
+  };
+
+  const remove = async (m: LiveSessionMaterial) => {
+    if (!window.confirm(`Remove "${m.title}" from this session?`)) return;
+    try {
+      await liveSessionMaterialsService.remove(liveClassId, m.id);
+      setItems((prev) => prev.filter((x) => x.id !== m.id));
+      showToast("Removed", "success");
+    } catch {
+      showToast("Could not remove", "error");
+    }
+  };
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1.5 }}>
+        <Typography sx={{ fontWeight: 700, fontSize: "0.95rem" }}>Study material</Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<IconWrapper icon="mdi:paperclip" size={16} />}
+          onClick={() => fileRef.current?.click()}
+        >
+          Add file
+        </Button>
+        {/* No accept filter: the product allows any file type, and the backend refuses only
+            executables. Constraining it here would silently contradict that. */}
+        <input ref={fileRef} type="file" hidden onChange={pick} />
+      </Stack>
+
+      {loading ? (
+        <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.82rem" }}>Loading…</Typography>
+      ) : items.length === 0 ? (
+        <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.82rem" }}>
+          Nothing shared yet. Add slides, notes or a dataset for this session.
+        </Typography>
+      ) : (
+        <Stack spacing={1}>
+          {items.map((m) => (
+            <Box
+              key={m.id}
+              sx={{
+                display: "flex", alignItems: "flex-start", gap: 1.25, p: 1.25,
+                border: "1px solid var(--border-default)", borderRadius: 2,
+                backgroundColor: "var(--card-bg)",
+              }}
+            >
+              <Box sx={{ mt: "1px" }}>
+                <IconWrapper icon={MATERIAL_ICONS[m.file_type] ?? MATERIAL_ICONS.other} size={20} />
+              </Box>
+              <Box sx={{ minWidth: 0, flex: 1 }}>
+                <Typography sx={{ fontWeight: 600, fontSize: "0.88rem" }}>{m.title}</Typography>
+                {m.description && (
+                  <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.78rem", mt: 0.25 }}>
+                    {m.description}
+                  </Typography>
+                )}
+                <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.72rem", mt: 0.4 }}>
+                  {m.uploaded_by_name || m.uploaded_by_label}
+                  {" · "}
+                  {new Date(m.created_at).toLocaleString(undefined, {
+                    day: "numeric", month: "short", hour: "numeric", minute: "2-digit",
+                  })}
+                  {m.file_size ? ` · ${formatFileSize(m.file_size)}` : ""}
+                </Typography>
+              </Box>
+              <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
+                {m.file_url && (
+                  <Tooltip title="Open">
+                    <IconButton size="small" component="a" href={m.file_url} target="_blank" rel="noopener noreferrer">
+                      <IconWrapper icon="mdi:open-in-new" size={16} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+                <Tooltip title="Edit title / description">
+                  <IconButton
+                    size="small"
+                    onClick={() => {
+                      setEditing(m);
+                      setForm({ title: m.title, description: m.description });
+                    }}
+                  >
+                    <IconWrapper icon="mdi:pencil-outline" size={16} />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Remove">
+                  <IconButton size="small" onClick={() => remove(m)}>
+                    <IconWrapper icon="mdi:trash-can-outline" size={16} />
+                  </IconButton>
+                </Tooltip>
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      {/* Upload — title/description are captured up front so a learner never sees a bare filename. */}
+      <Dialog open={Boolean(pendingFile)} onClose={() => !uploading && setPendingFile(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Add study material</DialogTitle>
+        <DialogContent>
+          <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.8rem", mb: 2 }}>
+            {pendingFile?.name} {pendingFile ? `· ${formatFileSize(pendingFile.size)}` : ""}
+          </Typography>
+          <TextField
+            fullWidth label="Title" value={form.title} sx={{ mb: 2 }}
+            onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+          />
+          <TextField
+            fullWidth multiline minRows={2} label="Description (optional)" value={form.description}
+            onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPendingFile(null)} disabled={uploading}>Cancel</Button>
+          <LoadingButton variant="contained" loading={uploading} loadingText="Uploading" onClick={doUpload}>
+            Upload
+          </LoadingButton>
+        </DialogActions>
+      </Dialog>
+
+      {/* Edit — title and description only; replacing a file means adding a new one, so the
+          timeline keeps an honest record of what was shared when. */}
+      <Dialog open={Boolean(editing)} onClose={() => setEditing(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit study material</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth label="Title" value={form.title} sx={{ mb: 2, mt: 1 }}
+            onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+          />
+          <TextField
+            fullWidth multiline minRows={2} label="Description" value={form.description}
+            onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditing(null)}>Cancel</Button>
+          <Button variant="contained" onClick={saveEdit}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/lib/services/live-session-materials.service.ts
+++ b/lib/services/live-session-materials.service.ts
@@ -1,0 +1,101 @@
+import apiClient from "./api";
+import { config } from "../config";
+
+/**
+ * Study materials attached to a live session.
+ *
+ * One service for every audience. The backend already decides what each caller may see and do — a
+ * learner reading the same endpoint gets the instructor CODE and no real name — so the frontend
+ * does not need (and must not invent) a second copy of that rule.
+ */
+const BASE = `/live-class/api/clients/${config.clientId}`;
+
+export type MaterialFileType =
+  | "pdf" | "image" | "document" | "spreadsheet" | "presentation"
+  | "text" | "video" | "audio" | "archive" | "code" | "other";
+
+export interface LiveSessionMaterial {
+  id: number;
+  title: string;
+  description: string;
+  file_url: string | null;
+  file_type: MaterialFileType;
+  file_size: number;
+  original_filename: string;
+  mime_type: string;
+  /** Learner-facing uploader identity — the instructor code. Always present. */
+  uploaded_by_label: string;
+  /** Real name. Null for learners by design, so it cannot leak through the payload. */
+  uploaded_by_name: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Human file size — "2.4 MB". Bytes are meaningless to a learner deciding whether to download. */
+export function formatFileSize(bytes: number): string {
+  if (!bytes || bytes < 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  return `${mb < 10 ? mb.toFixed(1) : Math.round(mb)} MB`;
+}
+
+/** Icon per file type — keep in step with the backend's classifier. */
+export const MATERIAL_ICONS: Record<MaterialFileType, string> = {
+  pdf: "mdi:file-pdf-box",
+  image: "mdi:file-image-outline",
+  document: "mdi:file-document-outline",
+  spreadsheet: "mdi:file-table-outline",
+  presentation: "mdi:file-presentation-box",
+  text: "mdi:text-box-outline",
+  video: "mdi:file-video-outline",
+  audio: "mdi:file-music-outline",
+  archive: "mdi:folder-zip-outline",
+  code: "mdi:file-code-outline",
+  other: "mdi:file-outline",
+};
+
+export const liveSessionMaterialsService = {
+  list: async (liveClassId: number): Promise<LiveSessionMaterial[]> => {
+    const res = await apiClient.get<LiveSessionMaterial[]>(
+      `${BASE}/live-activities/${liveClassId}/materials/`
+    );
+    return Array.isArray(res.data) ? res.data : [];
+  },
+
+  upload: async (
+    liveClassId: number,
+    file: File,
+    meta: { title?: string; description?: string }
+  ): Promise<LiveSessionMaterial> => {
+    const form = new FormData();
+    form.append("file", file);
+    if (meta.title) form.append("title", meta.title);
+    if (meta.description) form.append("description", meta.description);
+    // Content-Type is left to the browser so it can set the multipart boundary.
+    const res = await apiClient.post<LiveSessionMaterial>(
+      `${BASE}/live-activities/${liveClassId}/materials/`,
+      form
+    );
+    return res.data;
+  },
+
+  update: async (
+    liveClassId: number,
+    materialId: number,
+    patch: { title?: string; description?: string }
+  ): Promise<LiveSessionMaterial> => {
+    const res = await apiClient.patch<LiveSessionMaterial>(
+      `${BASE}/live-activities/${liveClassId}/materials/${materialId}/`,
+      patch
+    );
+    return res.data;
+  },
+
+  remove: async (liveClassId: number, materialId: number): Promise<void> => {
+    await apiClient.delete(
+      `${BASE}/live-activities/${liveClassId}/materials/${materialId}/`
+    );
+  },
+};


### PR DESCRIPTION
Frontend for **BE #486**, which is merged and live on prod.

## Admin

A **"Study material" tab** on the session page: attach any file with a title and description, both
editable afterwards, and remove one. Added for **every session type** — including a pasted-link
session whose only other tab is Overview — because material is platform state, not Zoom state.

## Learner

Two places, matching the ask:

- **Upcoming card** — so they can prepare *before* the session, not only after it.
- **Each History row** — so a past session keeps its attachments.

Both render as a **timeline**: oldest first, each entry showing **who added it and when**.

Attribution is whatever the backend sends — a learner receives the instructor **code** and a `null`
real name; staff receive the name. The frontend never chooses between them, so there's no second
copy of that rule to drift.

## Three deliberate calls

**Collapsed and lazily fetched.** A history can hold dozens of sessions; eagerly fetching material
for each to render a link most people never click would cost dozens of requests for nothing.

**No `accept` filter on the file input.** The product allows any file type and the backend refuses
only executables — constraining the picker here would silently contradict that.

**Editing covers title and description, not the file.** Replacing a file means adding a new one, so
the timeline stays an honest record of what was shared when.

A material whose URL couldn't be signed still renders, greyed and non-clickable, rather than
vanishing — a learner should see that it exists.

One manager component serves both admin and instructor: the permission decision is the backend's,
and a caller who may not manage the session gets a 403 from the same endpoint.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on all four new files, and **byte-identical to `origin/stagging`** on the two
  touched pages
- Production `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)