### PR TITLE
feat(tickets): instructors triage their cohorts; admins see cohort + assignee

### DIFF
--- a/app/admin/tickets/[id]/page.tsx
+++ b/app/admin/tickets/[id]/page.tsx
@@ -391,6 +391,27 @@ export default function AdminTicketDetailPage() {
                     Created {formatDateTime(ticket.created_at)}
                   </Typography>
                 </Stack>
+                {/* Which batch it came from — the context that says which instructor owns it. */}
+                {ticket.cohort_name && (
+                  <Stack direction="row" spacing={0.75} alignItems="center">
+                    <IconWrapper icon="mdi:account-group-outline" size={14} color="var(--font-tertiary)" />
+                    <Typography variant="caption" sx={{ fontSize: "0.75rem" }}>
+                      {ticket.cohort_name}
+                    </Typography>
+                  </Stack>
+                )}
+                {ticket.assigned_to_user && (
+                  <Stack direction="row" spacing={0.75} alignItems="center">
+                    <IconWrapper icon="mdi:account-check-outline" size={14} color="var(--font-tertiary)" />
+                    <Typography variant="caption" sx={{ fontSize: "0.75rem" }}>
+                      Assigned to {ticket.assigned_to_user.full_name}
+                      {/* No assigner means the system auto-routed it rather than a human triaging. */}
+                      {ticket.assigned_by_user === null
+                        ? " (auto-routed)"
+                        : ` by ${ticket.assigned_by_user.full_name}`}
+                    </Typography>
+                  </Stack>
+                )}
                 {ticket.resolved_at && (
                   <Stack direction="row" spacing={0.75} alignItems="center">
                     <IconWrapper

--- a/app/admin/tickets/page.tsx
+++ b/app/admin/tickets/page.tsx
@@ -503,6 +503,10 @@ export default function AdminTicketsPage() {
                         "ID",
                         "Subject",
                         "From",
+                        // Which batch it came from and who owns it — the two things needed to
+                        // decide whether a ticket is already someone's problem.
+                        "Cohort",
+                        "Assigned to",
                         "Category",
                         "Status",
                         "Created",
@@ -599,6 +603,28 @@ export default function AdminTicketsPage() {
                           >
                             {t.raised_by?.email}
                           </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ color: "var(--ticket-text-strong)" }}>
+                            {t.cohort_name || "—"}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          {t.assigned_to_user ? (
+                            <>
+                              <Typography variant="body2" sx={{ color: "var(--ticket-text-strong)", fontWeight: 500 }}>
+                                {t.assigned_to_user.full_name}
+                              </Typography>
+                              <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontSize: "0.72rem" }}>
+                                {/* No assigner means the system routed it, not a human. */}
+                                {t.assigned_by_user === null ? "auto-routed" : `by ${t.assigned_by_user.full_name}`}
+                              </Typography>
+                            </>
+                          ) : (
+                            <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+                              Unassigned
+                            </Typography>
+                          )}
                         </TableCell>
                         <TableCell>
                           <Chip

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
+import { StudyMaterialManager } from "@/components/live-sessions/StudyMaterialManager";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import {
   instructorService,
@@ -110,6 +111,7 @@ export default function InstructorLiveSessionsPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<InstructorLiveSession | null>(null);
   const [attendanceFor, setAttendanceFor] = useState<InstructorLiveSession | null>(null);
+  const [materialsFor, setMaterialsFor] = useState<InstructorLiveSession | null>(null);
 
   const reload = useCallback(async () => {
     try {
@@ -249,6 +251,7 @@ export default function InstructorLiveSessionsPage() {
             onCopy={() => copyLink(s.join_link)}
             onEdit={() => setEditing(s)}
             onAttendance={() => setAttendanceFor(s)}
+            onMaterials={() => setMaterialsFor(s)}
             onRecording={() => s.recording_url && window.open(s.recording_url, "_blank", "noopener")}
             onDelete={() => removeSession(s)}
           />
@@ -266,6 +269,15 @@ export default function InstructorLiveSessionsPage() {
       <EditSessionDialog session={editing} onClose={() => setEditing(null)}
         onSaved={() => { setToast({ text: "Session updated.", sev: "success" }); void reload(); }} />
       <AttendanceDialog session={attendanceFor} onClose={() => setAttendanceFor(null)} />
+      <Dialog open={Boolean(materialsFor)} onClose={() => setMaterialsFor(null)} maxWidth="sm" fullWidth>
+        <DialogTitle>{materialsFor?.topic_name || "Study material"}</DialogTitle>
+        <DialogContent>
+          {materialsFor && <StudyMaterialManager liveClassId={materialsFor.id} />}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setMaterialsFor(null)}>Close</Button>
+        </DialogActions>
+      </Dialog>
 
       <Snackbar open={!!toast} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: "bottom", horizontal: "center" }}>
         {toast ? <Alert severity={toast.sev} variant="filled" onClose={() => setToast(null)} sx={{ fontWeight: 600 }}>{toast.text}</Alert> : undefined}
@@ -296,9 +308,9 @@ function TurnoutBlock({ label, attendance, registered, turnout }: {
   );
 }
 
-function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttendance, onRecording, onDelete }: {
+function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttendance, onMaterials, onRecording, onDelete }: {
   s: InstructorLiveSession; status: SessionStatus; now: number; hosting: boolean;
-  onHost: () => void; onCopy: () => void; onEdit: () => void; onAttendance: () => void; onRecording: () => void; onDelete: () => void;
+  onHost: () => void; onCopy: () => void; onEdit: () => void; onAttendance: () => void; onMaterials: () => void; onRecording: () => void; onDelete: () => void;
 }) {
   const m = STATUS_META[status];
   const p = PROVIDER_META[s.provider] ?? PROVIDER_META.manual;
@@ -396,6 +408,9 @@ function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttenda
               <Button onClick={onAttendance} startIcon={<Icon icon="mdi:calendar-check-outline" width={16} />} sx={outlineBtn}>Attendance</Button>
             </>
           )}
+          {/* Material is shared both before a class (prep) and after it (notes), so this is not
+              gated on the session having ended. */}
+          <Button onClick={onMaterials} startIcon={<Icon icon="mdi:paperclip" width={16} />} sx={outlineBtn}>Material</Button>
           {s.created_by_me && (
             <IconButton size="small" onClick={onDelete} sx={{ color: "text.secondary", "&:hover": { color: "#ef4444" } }} aria-label="Delete session">
               <Icon icon="mdi:trash-can-outline" width={18} />

--- a/app/instructor/tickets/page.tsx
+++ b/app/instructor/tickets/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { Reveal } from "@/components/scorecard/shared";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { config } from "@/lib/config";
+import { ticketService, type Ticket, type TicketStatus } from "@/lib/services/ticket.service";
+
+/**
+ * An instructor's ticket queue: the doubts raised by students in the cohorts they staff.
+ *
+ * This is the surface that replaces "My Tickets" for a teacher. The distinction matters — an
+ * instructor is not a person filing support requests, they are the person answering their batch's
+ * questions, and the previous menu entry pointed them at the learner raise-flow instead.
+ *
+ * Scoping is entirely the backend's: `tickets/instructor/` returns every ticket from a cohort this
+ * caller staffs plus anything assigned to them directly, and nothing else. There is deliberately no
+ * client-side filter standing in for that, so the two cannot disagree.
+ */
+
+const STATUS_TONES: Record<string, { bg: string; fg: string }> = {
+  OPEN: { bg: "color-mix(in srgb,#f59e0b 14%,transparent)", fg: "#b45309" },
+  IN_PROGRESS: { bg: "color-mix(in srgb,#6366f1 14%,transparent)", fg: "#4338ca" },
+  RESOLVED: { bg: "color-mix(in srgb,#10b981 14%,transparent)", fg: "#047857" },
+  CLOSED: { bg: "color-mix(in srgb,#64748b 14%,transparent)", fg: "#475569" },
+};
+
+const FILTERS = [
+  { key: "", label: "All" },
+  { key: "OPEN", label: "Open" },
+  { key: "IN_PROGRESS", label: "In progress" },
+  { key: "RESOLVED", label: "Resolved" },
+];
+
+export default function InstructorTicketsPage() {
+  const { push } = useInstantNavigation();
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const rows = await ticketService.listInstructor(
+          config.clientId,
+          status ? { status: status as TicketStatus } : undefined
+        );
+        if (!cancelled) setTickets(rows);
+      } catch {
+        if (!cancelled) setTickets([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [status]);
+
+  const counts = useMemo(() => {
+    const open = tickets.filter((t) => t.status === "OPEN").length;
+    return { total: tickets.length, open };
+  }, [tickets]);
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Support"
+        icon="mdi:ticket-confirmation-outline"
+        title="Cohort tickets"
+        description="Doubts raised by students in the batches you teach."
+      />
+
+      <Reveal>
+        <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: "wrap", gap: 1 }}>
+          {FILTERS.map((f) => (
+            <Chip
+              key={f.key || "all"}
+              label={f.label}
+              onClick={() => setStatus(f.key)}
+              sx={{
+                fontWeight: 700,
+                cursor: "pointer",
+                bgcolor: status === f.key ? "var(--primary-500)" : "var(--card-bg)",
+                color: status === f.key ? "#fff" : "var(--font-secondary)",
+                border: "1px solid var(--border-default)",
+              }}
+            />
+          ))}
+        </Stack>
+      </Reveal>
+
+      {loading ? (
+        <Typography sx={{ color: "var(--font-secondary)" }}>Loading…</Typography>
+      ) : tickets.length === 0 ? (
+        <Reveal>
+          <Box
+            sx={{
+              borderRadius: 3,
+              border: "1px dashed var(--border-default)",
+              p: 4,
+              textAlign: "center",
+              bgcolor: "var(--card-bg)",
+            }}
+          >
+            <Icon icon="mdi:ticket-outline" width={34} style={{ color: "#94a3b8" }} />
+            <Typography sx={{ fontWeight: 700, mt: 1 }}>No tickets yet</Typography>
+            {/* The most likely cause by far, so say it plainly rather than let a teacher
+                conclude the page is broken. */}
+            <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mt: 0.5 }}>
+              Tickets from students in the cohorts you teach appear here. If you expect to see some,
+              ask an admin to confirm you are assigned to that cohort.
+            </Typography>
+          </Box>
+        </Reveal>
+      ) : (
+        <Stack spacing={1.25}>
+          <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.8rem" }}>
+            {counts.total} ticket{counts.total === 1 ? "" : "s"}
+            {counts.open ? ` · ${counts.open} open` : ""}
+          </Typography>
+          {tickets.map((t) => {
+            const tone = STATUS_TONES[t.status] ?? STATUS_TONES.CLOSED;
+            return (
+              <Reveal key={t.id}>
+                <Box
+                  onClick={() => push(`/tickets/${t.id}`)}
+                  sx={{
+                    borderRadius: 3,
+                    border: "1px solid var(--border-default)",
+                    bgcolor: "var(--card-bg)",
+                    p: 1.75,
+                    cursor: "pointer",
+                    transition: "border-color .15s",
+                    "&:hover": { borderColor: "var(--primary-400)" },
+                  }}
+                >
+                  <Stack direction="row" spacing={1.25} alignItems="flex-start">
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography sx={{ fontWeight: 700, fontSize: "0.94rem" }} noWrap>
+                        {t.subject}
+                      </Typography>
+                      <Typography
+                        sx={{ color: "var(--font-secondary)", fontSize: "0.78rem", mt: 0.3 }}
+                      >
+                        {t.raised_by?.full_name || "A student"}
+                        {t.cohort_name ? ` · ${t.cohort_name}` : ""}
+                        {` · ${t.category_display}`}
+                      </Typography>
+                    </Box>
+                    <Box
+                      sx={{
+                        px: 1, py: 0.3, borderRadius: 999, fontSize: "0.68rem", fontWeight: 800,
+                        bgcolor: tone.bg, color: tone.fg, flexShrink: 0,
+                      }}
+                    >
+                      {t.status_display || t.status}
+                    </Box>
+                  </Stack>
+                  {/* Assigned vs unassigned is the triage signal a teacher scans for. */}
+                  {t.assigned_to_user && (
+                    <Typography
+                      sx={{ color: "var(--font-secondary)", fontSize: "0.72rem", mt: 0.6 }}
+                    >
+                      <Icon icon="mdi:account-check-outline" width={13} style={{ verticalAlign: -2 }} />{" "}
+                      {t.assigned_to_user.full_name}
+                      {t.assigned_by_user === null ? " (auto-routed)" : ""}
+                    </Typography>
+                  )}
+                </Box>
+              </Reveal>
+            );
+          })}
+        </Stack>
+      )}
+    </PageShell>
+  );
+}

--- a/components/common/ReportIssueFAB.tsx
+++ b/components/common/ReportIssueFAB.tsx
@@ -10,7 +10,7 @@ import { useAuth } from "@/lib/auth/auth-context";
 export function ReportIssueFAB() {
   const pathname = usePathname();
   const params = useParams();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
   const [showReportDialog, setShowReportDialog] = useState(false);
 
   // Exclude routes: assessments/[slug]/take and mock-interview/[id]/take
@@ -25,6 +25,13 @@ export function ReportIssueFAB() {
 
   // Don't show if not authenticated or on excluded routes
   if (!isAuthenticated || shouldHide) {
+    return null;
+  }
+
+  // Not for teaching staff. Their ticket surface is the cohort queue at /instructor/tickets —
+  // a floating "report an issue" button pushed them into the learner raise-flow instead.
+  const normalizedRole = String(user?.role ?? "").trim().toLowerCase().replace(/\s+/g, "_");
+  if (["instructor", "course_manager"].includes(normalizedRole)) {
     return null;
   }
 

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -100,6 +100,10 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
   const { showToast } = useToast();
 
   const role = user?.role;
+  // Instructors and course managers triage their cohorts' tickets rather than raising their own.
+  const isTeachingRole = ["instructor", "course_manager"].includes(
+    String(role ?? "").trim().toLowerCase().replace(/\s+/g, "_")
+  );
   // Instructors get a teacher top bar — none of the student gamification (leaderboard, streak, guide).
   const isInstructor = isInstructorRole(role);
   // Instructors no longer toggle into student/admin views — only org admins keep the toggle.
@@ -1175,14 +1179,16 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
               </MenuItem>
             )}
 
+            {/* A teacher answers their batch's doubts; they are not a person filing support
+                requests. Pointing them at the learner raise-flow was the wrong destination. */}
             <MenuItem
               onClick={() => {
-                router.push("/tickets");
+                router.push(isTeachingRole ? "/instructor/tickets" : "/tickets");
                 handleMenuClose();
               }}
             >
               <Box component="span" sx={{ marginInlineEnd: 1.5, display: "inline-flex" }}><Ticket size={18} /></Box>
-              My Tickets
+              {isTeachingRole ? "Cohort Tickets" : "My Tickets"}
             </MenuItem>
 
             <Divider />

--- a/lib/services/ticket.service.ts
+++ b/lib/services/ticket.service.ts
@@ -34,6 +34,15 @@ export interface Ticket {
   page_url: string;
   raised_by: TicketUserMini | null;
   resolved_by_user: TicketUserMini | null;
+  /** The cohort the raiser belongs to. Set at creation by the backend's auto-routing, and the
+   *  column the instructor queue is scoped on. Null on tickets raised by someone in no cohort. */
+  cohort: number | null;
+  cohort_name: string | null;
+  /** Who owns this ticket. `assigned_by_user === null` while `assigned_to_user` is set means the
+   *  system auto-routed it rather than a human triaging it. */
+  assigned_to_user: TicketUserMini | null;
+  assigned_by_user: TicketUserMini | null;
+  assigned_at: string | null;
   resolved_at: string | null;
   /** Timestamp of the most recent RESOLVED→OPEN transition (user reopen or
    *  admin status-update). Null if the ticket has never been reopened. */
@@ -211,6 +220,20 @@ export const ticketService = {
     } catch (e) {
       throw unwrapError(e, "Failed to fetch your tickets");
     }
+  },
+
+  /**
+   * The tickets an instructor owns: every ticket from a cohort they staff, plus anything assigned
+   * to them directly. Backend-scoped — an instructor cannot widen this by asking.
+   */
+  async listInstructor(
+    clientId: string | number,
+    params?: Pick<ListTicketsParams, "status" | "category">
+  ): Promise<Ticket[]> {
+    const res = await apiClient.get<Ticket[]>(
+      `/api/clients/${clientId}/tickets/instructor/${buildQuery(params ?? {})}`
+    );
+    return Array.isArray(res.data) ? res.data : [];
   },
 
   async listAdmin(


### PR DESCRIPTION
Frontend for **BE #485** (merged and deployed). Closes out the instructor ticket flow and the last
live-session material surface.

## Instructor — stop offering the raise-flow, start showing the queue

The avatar menu's **"My Tickets"** pointed *every* role at `/tickets`, the student raise page. For a
teacher it now reads **"Cohort Tickets"** and opens a new **`/instructor/tickets`**: every ticket
from a cohort they staff plus anything assigned to them, with status filters and the raiser, cohort
and assignee on each row. The floating *report an issue* button is hidden for teaching roles for the
same reason.

Scoping is left **entirely to the API** — there's no client-side cohort filter standing in for it,
so the two can't disagree.

The empty state names the likely cause outright — *"ask an admin to confirm you are assigned to that
cohort"* — because almost no cohort currently has staff, and a bare "no tickets" would read as a
broken page rather than a missing assignment.

## Admin — show what was already on the wire

`TicketSerializer` has been sending `cohort`, `cohort_name`, `assigned_to_user`, `assigned_by_user`
and `assigned_at` **all along**; the FE `Ticket` interface simply didn't declare them, so the data
was discarded at the type boundary.

Now declared, plus a **Cohort** and **Assigned to** column on the list and both on the detail meta
row. `assigned_by_user === null` alongside an assignee means the system auto-routed it, so that
renders as **"auto-routed"** rather than a blank.

## Instructor live sessions

A **Material** action per session opens the same `StudyMaterialManager` the admin page uses. Not
gated on the session having ended — material is shared before a class as prep and after it as notes.

## Deliberately not touched

`lib/auth/role-utils.ts::isFullAdminRole` still includes `"instructor"`. It drives the entire admin
shell and the student↔admin toggle, so narrowing it here would break the instructor workspace to fix
a ticket-shaped problem. The backend already returns 403 on the admin ticket endpoints, which is the
boundary that actually matters.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on the new page, and **byte-identical to `origin/stagging`** on all six touched
  files
- Production `next build` succeeds and registers `/instructor/tickets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)