### PR TITLE
feat(settings): an institution can connect its own Razorpay account

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -11,6 +11,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { PaymentAccountCard } from "@/components/admin/settings/PaymentAccountCard";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { IconWrapper } from "@/components/common/IconWrapper";
@@ -523,6 +524,14 @@ export default function AdminSettingsPage() {
               placeholder="e.g. Learn faster. Grow further."
               sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
             />
+          </SettingCard>
+
+          <SettingCard
+            icon="mdi:credit-card-outline"
+            title="Payment account"
+            description="Connect your institution's own Razorpay account. Until you do, you cannot charge for courses or assessments — and when you do, the money goes straight to you."
+          >
+            <PaymentAccountCard />
           </SettingCard>
 
           <SettingCard

--- a/components/admin/settings/PaymentAccountCard.tsx
+++ b/components/admin/settings/PaymentAccountCard.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Alert, Button, Chip, Stack, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { useToast } from "@/components/common/Toast";
+import { razorpayService, type RazorpayStatus } from "@/lib/services/razorpay.service";
+
+/**
+ * Connect this institution's own Razorpay account.
+ *
+ * Payments FAIL CLOSED: until an account is connected here, this institution cannot charge for
+ * anything. That is deliberate — previously an unconfigured institution still took payments, but
+ * they settled into AI Linc's Razorpay account rather than its own, and nothing on any screen said
+ * so. The "where the money goes" line exists so that can never be invisible again.
+ *
+ * The secret is write-only. It is sent once and never returned, so the field is always blank on
+ * load — that is not a bug, and the helper text says so rather than leaving an admin wondering
+ * whether their key was lost.
+ */
+export function PaymentAccountCard() {
+  const { showToast } = useToast();
+  const [status, setStatus] = useState<RazorpayStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [keyId, setKeyId] = useState("");
+  const [keySecret, setKeySecret] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      setStatus(await razorpayService.get());
+    } catch {
+      showToast("Couldn't load the payment account", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const connect = async () => {
+    if (!keyId.trim() || !keySecret.trim()) {
+      showToast("Enter both the Key ID and the Key Secret", "warning");
+      return;
+    }
+    setSaving(true);
+    try {
+      const next = await razorpayService.save({
+        key_id: keyId.trim(),
+        key_secret: keySecret.trim(),
+      });
+      setStatus(next);
+      setKeyId("");
+      setKeySecret("");
+      showToast("Payment account connected", "success");
+    } catch (e: unknown) {
+      const msg =
+        (e as { response?: { data?: { error?: string; key_id?: string[] } } })?.response?.data;
+      showToast(msg?.error ?? msg?.key_id?.[0] ?? "Couldn't save the payment account", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const setActive = async (active: boolean) => {
+    setSaving(true);
+    try {
+      // No secret in this payload — the backend treats a partial PUT as a partial update, so
+      // pausing payments never means re-entering the key.
+      const next = await razorpayService.save({ is_active: active });
+      setStatus(next);
+      showToast(active ? "Payments resumed" : "Payments paused", "success");
+    } catch {
+      showToast("Couldn't update the payment account", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.85rem" }}>Loading…</Typography>;
+  }
+
+  const creds = status?.credentials ?? null;
+  const connected = Boolean(status?.connected);
+  const onPlatformAccount = creds?.settles_to === "platform";
+
+  return (
+    <Stack spacing={2}>
+      <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: "wrap", gap: 1 }}>
+        <Chip
+          size="small"
+          icon={<Icon icon={connected ? "mdi:check-circle" : "mdi:alert-circle-outline"} width={15} />}
+          label={connected ? "Connected" : "Not connected"}
+          sx={{
+            fontWeight: 700,
+            bgcolor: connected
+              ? "color-mix(in srgb,#10b981 14%,transparent)"
+              : "color-mix(in srgb,#f59e0b 16%,transparent)",
+            color: connected ? "#047857" : "#b45309",
+          }}
+        />
+        {creds?.key_id_masked && (
+          <Typography sx={{ fontSize: "0.78rem", color: "var(--font-secondary)", fontFamily: "monospace" }}>
+            {creds.key_id_masked}
+          </Typography>
+        )}
+      </Stack>
+
+      {/* The single most important fact on this card. */}
+      {creds && (
+        <Alert
+          severity={onPlatformAccount ? "warning" : "info"}
+          icon={<Icon icon={onPlatformAccount ? "mdi:bank-transfer" : "mdi:bank-check"} width={20} />}
+          sx={{ borderRadius: 2, fontSize: "0.83rem" }}
+        >
+          {onPlatformAccount ? (
+            <>
+              Payments from your learners currently settle into <strong>AI Linc&apos;s</strong>{" "}
+              Razorpay account, not yours. Contact AI Linc to change this arrangement.
+            </>
+          ) : (
+            <>
+              Payments settle directly into <strong>your institution&apos;s</strong> Razorpay account.
+            </>
+          )}
+        </Alert>
+      )}
+
+      {!connected && !creds && (
+        <Alert severity="warning" sx={{ borderRadius: 2, fontSize: "0.83rem" }}>
+          Until you connect an account, your institution cannot charge for courses or assessments.
+        </Alert>
+      )}
+
+      {!onPlatformAccount && (
+        <>
+          <TextField
+            fullWidth
+            size="small"
+            label="Razorpay Key ID"
+            placeholder="rzp_live_…"
+            value={keyId}
+            disabled={saving}
+            onChange={(e) => setKeyId(e.target.value)}
+            helperText="From Razorpay Dashboard → Settings → API Keys."
+            sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+          />
+          <TextField
+            fullWidth
+            size="small"
+            type="password"
+            label="Razorpay Key Secret"
+            value={keySecret}
+            disabled={saving}
+            onChange={(e) => setKeySecret(e.target.value)}
+            helperText={
+              creds?.secret_configured
+                ? "A secret is already stored. It is never shown again — enter it only to replace it."
+                : "Shown by Razorpay once, when you generate the key."
+            }
+            sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+          />
+        </>
+      )}
+
+      <Stack direction="row" spacing={1.5} sx={{ flexWrap: "wrap", gap: 1 }}>
+        {!onPlatformAccount && (
+          <LoadingButton
+            variant="contained"
+            loading={saving}
+            loadingText="Saving"
+            onClick={connect}
+            startIcon={<Icon icon="mdi:link-variant" width={16} />}
+          >
+            {creds ? "Update account" : "Connect account"}
+          </LoadingButton>
+        )}
+        {creds && (
+          <Button
+            variant="outlined"
+            disabled={saving}
+            onClick={() => setActive(!creds.is_active)}
+            startIcon={<Icon icon={creds.is_active ? "mdi:pause" : "mdi:play"} width={16} />}
+          >
+            {creds.is_active ? "Pause payments" : "Resume payments"}
+          </Button>
+        )}
+      </Stack>
+
+      {creds && !creds.is_active && (
+        <Typography sx={{ fontSize: "0.78rem", color: "var(--font-secondary)" }}>
+          {/* Worth stating: pausing used to reroute payments rather than stop them. */}
+          Paused. No new charges can be created, and your saved key is kept.
+        </Typography>
+      )}
+    </Stack>
+  );
+}

--- a/lib/services/razorpay.service.ts
+++ b/lib/services/razorpay.service.ts
@@ -1,0 +1,52 @@
+import apiClient from "./api";
+import { config } from "../config";
+
+/**
+ * A tenant's own Razorpay account (GET/PUT `accounts/clients/<id>/razorpay-credentials/`).
+ *
+ * The secret is write-only: it is sent when connecting and never comes back. The read side reports
+ * only whether one is stored, plus a masked key id — so this service has no field to hold a secret
+ * in, by design.
+ */
+const BASE = `/accounts/clients/${config.clientId}`;
+
+export interface RazorpayCredentials {
+  id: number;
+  /** e.g. `rzp_live_ab…3xY`. Enough to recognise the account, not enough to quote. */
+  key_id_masked: string;
+  secret_configured: boolean;
+  connected: boolean;
+  is_active: boolean;
+  use_platform_account: boolean;
+  /** Whose Razorpay account the money actually reaches. */
+  settles_to: "institution" | "platform";
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RazorpayStatus {
+  credentials: RazorpayCredentials | null;
+  /** False whenever this institution cannot take a payment — including "never configured". */
+  connected: boolean;
+}
+
+export const razorpayService = {
+  get: async (): Promise<RazorpayStatus> => {
+    const res = await apiClient.get<RazorpayStatus>(`${BASE}/razorpay-credentials/`);
+    return res.data;
+  },
+
+  /**
+   * Connect or update. `key_secret` is omitted when the admin is only toggling `is_active`, and the
+   * backend treats a partial payload as a partial update — so disconnecting does not require
+   * re-entering the secret.
+   */
+  save: async (payload: {
+    key_id?: string;
+    key_secret?: string;
+    is_active?: boolean;
+  }): Promise<RazorpayStatus> => {
+    const res = await apiClient.put<RazorpayStatus>(`${BASE}/razorpay-credentials/`, payload);
+    return res.data;
+  },
+};


### PR DESCRIPTION
Phase 1's **admin surface**. Until this existed a tenant could only be connected through the API — so
nobody could actually onboard.

A **Payment account** card in admin Settings: enter the Razorpay Key ID and Secret, update them, or
pause payments without re-entering the secret (the backend takes a partial PUT).

## It leads with where the money goes

That's the fact this whole phase exists to make visible. An unconfigured institution used to keep
taking payments — into **AI Linc's** Razorpay account rather than its own — and no screen anywhere
said so.

| State | What the admin sees |
|---|---|
| Own account | "Payments settle directly into **your institution's** Razorpay account." |
| Platform account | A warning naming AI Linc, and *contact us to change this* |
| Nothing connected | "You cannot charge for courses or assessments." |

## Two details that would otherwise read as bugs

**The secret field is always blank on load.** It's write-only and never returned, so the helper text
says a secret is stored and to enter one only to replace it.

**"Pause payments" keeps the saved key.** Worth stating on screen, because the old behaviour of
`is_active=False` was to *reroute* payments to the platform rather than stop them.

## Two deliberate choices

Key-ID validation is left to the **server** (which rejects anything not `rzp_test_`/`rzp_live_`) and
the error surfaced, rather than duplicating the rule here where it could drift.

The platform-settled case **hides the credential fields entirely** — that's a commercial arrangement
the tenant can't self-serve and the API rejects it, so offering inputs that will 403 would be a lie.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on both new files, and byte-identical to `origin/stagging` on the settings page
- Production `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)