### PR TITLE
fix(live-sessions): a recurring series' recording was counted but never shown

### DIFF
--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -196,19 +196,54 @@ export default function LiveSessionsPage() {
         out.push(s);
         continue;
       }
-      for (const o of occs) {
-        if (o.status === "cancelled" || o.meeting_status === "cancelled") continue;
+      const live = occs.filter(
+        (o) => o.status !== "cancelled" && o.meeting_status !== "cancelled"
+      );
+
+      // A recurring series' own zoom_recording_url is the SERIES-LATEST recording: Zoom returns the
+      // most recent occurrence's recording when asked about the series id. If the per-occurrence
+      // sync has not attributed it yet (no occurrence carries a url of its own), show it on the
+      // latest occurrence that has already happened — that is the one it actually belongs to.
+      //
+      // Not `o.has_recording ?? s.has_recording`, which was the bug: `??` only falls back on
+      // null/undefined, and the occurrence serializer always returns a real boolean, so `false ??
+      // true` stayed false and the parent's recording was silently dropped. The "Recordings left"
+      // KPI counts parents, so it said 1 while this list said 0 for the same session.
+      //
+      // Not `||` either — that would claim every one of the 50 occurrences has a recording.
+      const noneCarryTheirOwn = !live.some((o) => o.has_recording || o.zoom_recording_url);
+      const inheritIdx =
+        noneCarryTheirOwn && s.has_recording
+          ? live.reduce((best, o, i) => {
+              const t = new Date(o.occurrence_datetime ?? s.class_datetime ?? 0).getTime();
+              if (t > Date.now()) return best;
+              const bt =
+                best < 0
+                  ? -Infinity
+                  : new Date(live[best].occurrence_datetime ?? s.class_datetime ?? 0).getTime();
+              return t > bt ? i : best;
+            }, -1)
+          : -1;
+
+      live.forEach((o, i) => {
+        const inherits = i === inheritIdx;
         out.push({
           ...s,
           // Keep the parent id for API calls (feedback, reminders) but make the key unique per date.
           occurrence_id: o.id,
           class_datetime: o.occurrence_datetime ?? s.class_datetime,
           duration_minutes: o.duration_minutes ?? s.duration_minutes,
-          meeting_status: o.meeting_status ?? s.meeting_status,
-          has_recording: Boolean(o.has_recording ?? s.has_recording),
-          zoom_recording_url: o.zoom_recording_url ?? s.zoom_recording_url,
+          // `live` has already excluded cancelled occurrences, but .filter() does not narrow the
+          // union the way the old `continue` did — so exclude it explicitly rather than casting.
+          meeting_status:
+            o.meeting_status && o.meeting_status !== "cancelled"
+              ? o.meeting_status
+              : s.meeting_status,
+          has_recording: Boolean(o.has_recording || (inherits && s.has_recording)),
+          zoom_recording_url:
+            o.zoom_recording_url ?? (inherits ? s.zoom_recording_url : undefined),
         });
-      }
+      });
     }
     return out;
   }, [sessions]);


### PR DESCRIPTION
Reported on Agileology: **"Recordings left" read 1** while the **Recordings tab read 0** and listed
nothing — both describing the same session.

## Root cause

They count different things. `recordings_left` (`views_student.py:107`) counts **parent sessions**.
The tab counts `instances`, and the page **replaces a recurring parent with its occurrences** — so
session #191 gave the KPI one parent with a recording, and the tab 50 occurrences with none.

Verified on production: **#191 has `zoom_recording_url` on the parent and 0 of its 50 occurrences
carry one.** It's the only session on the platform in that state, which matches the single report.

The fallback meant to cover this **could never fire**:

```js
has_recording: Boolean(o.has_recording ?? s.has_recording)
```

`??` only falls back on `null`/`undefined`, but the occurrence serializer returns a real boolean —
so `false ?? true` stayed `false` and the parent's recording was silently dropped.

## Why not just use `||`

That's wrong in the other direction: it would claim **all 50** occurrences have a recording.

A recurring series' own `zoom_recording_url` is the **series-latest** recording — Zoom returns the
most recent occurrence's recording when asked about the series id. So when no occurrence carries one
of its own, it's attributed to the **latest occurrence that has already happened**, which is the one
it belongs to. An occurrence with its own recording disables inheritance entirely.

Simulated against #191's real shape: 50 expand, **exactly 1** shows a recording — matching the KPI.

## The root cause behind the root cause

There are **three** definitions of "has a recording":

| Where | Predicate |
|---|---|
| `views_student._has_recording` | zoom OR `google_recording_url` OR link |
| session serializer | zoom OR `google_recording_drive_file_id` OR link |
| occurrence serializer | zoom **only** |

They agree on today's data — I checked all 141 sessions — but three copies of one predicate is *why*
they drifted. Consolidating them is the durable fix and worth a follow-up.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on the touched file — **better than `origin/stagging`**, which has 2 errors there
- Production `next build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)