### PR TITLE
feat(settings): descriptive Razorpay setup guide + webhook configuration

### DIFF
--- a/components/admin/settings/PaymentAccountCard.tsx
+++ b/components/admin/settings/PaymentAccountCard.tsx
@@ -1,11 +1,23 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Button, Chip, Stack, TextField, Typography } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Collapse,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { Icon } from "@iconify/react";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { useToast } from "@/components/common/Toast";
 import { razorpayService, type RazorpayStatus } from "@/lib/services/razorpay.service";
+import { config } from "@/lib/config";
+import { RazorpaySetupGuide } from "./RazorpaySetupGuide";
 
 /**
  * Connect this institution's own Razorpay account.
@@ -18,6 +30,11 @@ import { razorpayService, type RazorpayStatus } from "@/lib/services/razorpay.se
  * The secret is write-only. It is sent once and never returned, so the field is always blank on
  * load — that is not a bug, and the helper text says so rather than leaving an admin wondering
  * whether their key was lost.
+ *
+ * "Connected" and "webhook active" are shown as two separate facts on purpose. Keys alone open a
+ * checkout; only the webhook makes a payment settle. Collapsing them into one green tick is how an
+ * institution ends up charging learners and granting nothing — which is exactly what happened here
+ * before, so the card refuses to look healthy while the webhook is missing.
  */
 export function PaymentAccountCard() {
   const { showToast } = useToast();
@@ -26,6 +43,8 @@ export function PaymentAccountCard() {
   const [saving, setSaving] = useState(false);
   const [keyId, setKeyId] = useState("");
   const [keySecret, setKeySecret] = useState("");
+  const [webhookSecret, setWebhookSecret] = useState("");
+  const [showGuide, setShowGuide] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -51,10 +70,13 @@ export function PaymentAccountCard() {
       const next = await razorpayService.save({
         key_id: keyId.trim(),
         key_secret: keySecret.trim(),
+        // Only sent when the admin actually typed one — an empty string would wipe a stored secret.
+        ...(webhookSecret.trim() ? { webhook_secret: webhookSecret.trim() } : {}),
       });
       setStatus(next);
       setKeyId("");
       setKeySecret("");
+      setWebhookSecret("");
       showToast("Payment account connected", "success");
     } catch (e: unknown) {
       const msg =
@@ -63,6 +85,37 @@ export function PaymentAccountCard() {
     } finally {
       setSaving(false);
     }
+  };
+
+  /** The webhook can be added on its own, without re-entering the API secret. */
+  const saveWebhook = async () => {
+    if (!webhookSecret.trim()) {
+      showToast("Enter the webhook secret you set in Razorpay", "warning");
+      return;
+    }
+    setSaving(true);
+    try {
+      const next = await razorpayService.save({ webhook_secret: webhookSecret.trim() });
+      setStatus(next);
+      setWebhookSecret("");
+      showToast(
+        next.webhook_ready ? "Webhook secret saved" : "Saved, but the webhook is still not active",
+        next.webhook_ready ? "success" : "warning"
+      );
+    } catch {
+      showToast("Couldn't save the webhook secret", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const copyWebhookUrl = () => {
+    const url = status?.credentials?.webhook_url;
+    if (!url) return;
+    navigator.clipboard.writeText(url).then(
+      () => showToast("Webhook URL copied", "success"),
+      () => showToast("Couldn't copy — select the text instead", "error")
+    );
   };
 
   const setActive = async (active: boolean) => {
@@ -86,7 +139,14 @@ export function PaymentAccountCard() {
 
   const creds = status?.credentials ?? null;
   const connected = Boolean(status?.connected);
+  const webhookReady = Boolean(status?.webhook_ready);
   const onPlatformAccount = creds?.settles_to === "platform";
+  // The endpoint is deterministic, so it can be shown before any account exists — an admin
+  // following the guide needs it in Part 3, which is the same visit as Part 1. The server value
+  // wins when present because it is built from the request host, not a build-time env var.
+  const webhookUrl =
+    creds?.webhook_url ||
+    (config.apiBaseUrl ? `${config.apiBaseUrl}/webhooks/clients/${config.clientId}/razorpay/` : "");
 
   return (
     <Stack spacing={2}>
@@ -103,6 +163,21 @@ export function PaymentAccountCard() {
             color: connected ? "#047857" : "#b45309",
           }}
         />
+        {/* Shown only once keys exist: "no webhook" is meaningless before an account is connected. */}
+        {creds && (
+          <Chip
+            size="small"
+            icon={<Icon icon={webhookReady ? "mdi:webhook" : "mdi:alert-outline"} width={15} />}
+            label={webhookReady ? "Webhook active" : "Webhook missing"}
+            sx={{
+              fontWeight: 700,
+              bgcolor: webhookReady
+                ? "color-mix(in srgb,#10b981 14%,transparent)"
+                : "color-mix(in srgb,#ef4444 16%,transparent)",
+              color: webhookReady ? "#047857" : "#b91c1c",
+            }}
+          />
+        )}
         {creds?.key_id_masked && (
           <Typography sx={{ fontSize: "0.78rem", color: "var(--font-secondary)", fontFamily: "monospace" }}>
             {creds.key_id_masked}
@@ -127,6 +202,20 @@ export function PaymentAccountCard() {
               Payments settle directly into <strong>your institution&apos;s</strong> Razorpay account.
             </>
           )}
+        </Alert>
+      )}
+
+      {/* The failure this whole card exists to prevent: charging without a way to confirm payment. */}
+      {creds && !webhookReady && (
+        <Alert
+          severity="error"
+          icon={<Icon icon="mdi:alert-octagon-outline" width={20} />}
+          sx={{ borderRadius: 2, fontSize: "0.83rem" }}
+        >
+          <strong>No webhook is configured.</strong> Your keys will open a checkout, but a learner is
+          only granted access if their browser returns to this site after paying — close the tab or
+          lose signal and they are charged with nothing to show for it. Follow{" "}
+          <strong>Part 3</strong> of the setup guide below.
         </Alert>
       )}
 
@@ -164,6 +253,55 @@ export function PaymentAccountCard() {
             }
             sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
           />
+
+          {/* The URL you paste into Razorpay. Shown before connecting too — Part 3 needs it. */}
+          {webhookUrl && (
+            <Box>
+              <Typography
+                variant="caption"
+                sx={{ color: "var(--font-secondary)", mb: 0.5, display: "block" }}
+              >
+                Webhook URL (paste this into Razorpay)
+              </Typography>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <TextField
+                  fullWidth
+                  size="small"
+                  value={webhookUrl}
+                  InputProps={{ readOnly: true }}
+                  sx={{
+                    "& .MuiInputBase-input": { fontSize: "0.8rem", fontFamily: "monospace" },
+                    "& .MuiOutlinedInput-root": { borderRadius: 2 },
+                  }}
+                />
+                <IconButton size="small" onClick={copyWebhookUrl} aria-label="Copy webhook URL">
+                  <Icon icon="mdi:content-copy" width={18} />
+                </IconButton>
+              </Stack>
+              <Typography
+                variant="caption"
+                sx={{ color: "var(--font-tertiary)", mt: 0.5, display: "block" }}
+              >
+                Unique to your institution — it settles only your orders.
+              </Typography>
+            </Box>
+          )}
+
+          <TextField
+            fullWidth
+            size="small"
+            type="password"
+            label="Webhook Secret"
+            value={webhookSecret}
+            disabled={saving}
+            onChange={(e) => setWebhookSecret(e.target.value)}
+            helperText={
+              creds?.webhook_configured
+                ? "A webhook secret is stored. It is never shown again — enter it only to replace it."
+                : "Razorpay does not generate this — you invent it when creating the webhook, and it must match exactly."
+            }
+            sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+          />
         </>
       )}
 
@@ -177,6 +315,19 @@ export function PaymentAccountCard() {
             startIcon={<Icon icon="mdi:link-variant" width={16} />}
           >
             {creds ? "Update account" : "Connect account"}
+          </LoadingButton>
+        )}
+        {/* The common case after Part 3: the account is already connected and only the webhook is
+            being added. That must not require re-entering the API secret. */}
+        {creds && !onPlatformAccount && (
+          <LoadingButton
+            variant={webhookReady ? "outlined" : "contained"}
+            loading={saving}
+            loadingText="Saving"
+            onClick={saveWebhook}
+            startIcon={<Icon icon="mdi:webhook" width={16} />}
+          >
+            {webhookReady ? "Replace webhook secret" : "Save webhook secret"}
           </LoadingButton>
         )}
         {creds && (
@@ -197,6 +348,28 @@ export function PaymentAccountCard() {
           Paused. No new charges can be created, and your saved key is kept.
         </Typography>
       )}
+
+      {/* Collapsed by default, like the Zoom setup guide — long enough to bury the card otherwise. */}
+      <Box>
+        <Button
+          size="small"
+          onClick={() => setShowGuide((v) => !v)}
+          startIcon={<Icon icon={showGuide ? "mdi:chevron-up" : "mdi:book-open-page-variant"} width={16} />}
+          sx={{
+            textTransform: "none",
+            fontWeight: 600,
+            color: "var(--accent-indigo)",
+            "&:hover": {
+              backgroundColor: "color-mix(in srgb, var(--accent-indigo) 10%, var(--surface) 90%)",
+            },
+          }}
+        >
+          {showGuide ? "Hide setup guide" : "First time? View the step-by-step Razorpay setup guide"}
+        </Button>
+        <Collapse in={showGuide}>
+          <RazorpaySetupGuide webhookUrl={webhookUrl} />
+        </Collapse>
+      </Box>
     </Stack>
   );
 }

--- a/components/admin/settings/RazorpaySetupGuide.tsx
+++ b/components/admin/settings/RazorpaySetupGuide.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { Box, Typography, Link } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+/** Inline monospace value token. */
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <Box
+      component="code"
+      sx={{
+        fontFamily: "monospace",
+        fontSize: "0.72rem",
+        bgcolor: "var(--surface)",
+        border: "1px solid var(--border-default)",
+        borderRadius: 0.5,
+        px: 0.5,
+        py: "1px",
+        color: "var(--font-primary)",
+        wordBreak: "break-all",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function StepHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <Typography variant="subtitle2" sx={{ fontWeight: 700, color: "var(--font-primary)", mt: 2, mb: 0.75 }}>
+      {children}
+    </Typography>
+  );
+}
+
+const extLink = { color: "var(--accent-indigo)", fontWeight: 600 };
+const liSx = { mb: 0.75, color: "var(--font-secondary)", fontSize: "0.8125rem", lineHeight: 1.55 };
+
+/**
+ * Step-by-step Razorpay setup guide, shown (collapsed by default) under the payment account card.
+ *
+ * Deliberately mirrors the Zoom setup guide: exact dashboard navigation, direct links, and the
+ * tenant's own webhook URL inlined so it can be copied rather than assembled by hand.
+ *
+ * Part 3 (the webhook) is not optional and the guide says so in those words. Keys alone make the
+ * checkout *open*; only the webhook makes a payment *settle*. Skipping it produces the exact
+ * failure this platform already lived through - learners charged, access never granted, because
+ * settlement depended on their browser coming back to the return URL.
+ */
+export function RazorpaySetupGuide({ webhookUrl }: { webhookUrl: string }) {
+  return (
+    <Box
+      sx={{
+        mt: 1,
+        p: 2,
+        bgcolor: "var(--surface)",
+        borderRadius: 1.5,
+        border: "1px solid var(--border-default)",
+      }}
+    >
+      {/* Prerequisites */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1,
+          alignItems: "flex-start",
+          p: 1.25,
+          mb: 1,
+          borderRadius: 1,
+          bgcolor: "color-mix(in srgb, var(--warning-500) 10%, var(--surface) 90%)",
+          border: "1px solid color-mix(in srgb, var(--warning-500) 28%, var(--border-default) 72%)",
+        }}
+      >
+        <IconWrapper icon="mdi:shield-key-outline" size={18} color="var(--warning-500)" />
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", lineHeight: 1.5 }}>
+          You need a Razorpay account that has completed <strong>KYC activation</strong> - until
+          Razorpay activates the account you can only generate <Code>rzp_test_…</Code> keys, which
+          take no real money. You must be the account <strong>Owner</strong> or an{" "}
+          <strong>Admin</strong> to see Settings → API Keys. Money settles into{" "}
+          <strong>your</strong> bank account, on Razorpay&apos;s own settlement cycle - AI Linc
+          never holds it.
+        </Typography>
+      </Box>
+
+      {/* Part 1 */}
+      <StepHeading>Part 1 - Create your API key</StepHeading>
+      <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          Sign in to the{" "}
+          <Link href="https://dashboard.razorpay.com/" target="_blank" rel="noopener" sx={extLink}>
+            Razorpay Dashboard
+          </Link>
+          .
+        </Box>
+        <Box component="li" sx={liSx}>
+          Check the <strong>Test / Live</strong> switch at the top-left of the dashboard. Set it to{" "}
+          <strong>Live</strong> before generating keys, unless you are deliberately testing - test
+          keys never charge anyone, and a checkout opened with them looks identical.
+        </Box>
+        <Box component="li" sx={liSx}>
+          Left sidebar → <strong>Account &amp; Settings</strong> → under <em>Website and app
+          settings</em> click <strong>API Keys</strong> (
+          <Link
+            href="https://dashboard.razorpay.com/app/website-app-settings/api-keys"
+            target="_blank"
+            rel="noopener"
+            sx={extLink}
+          >
+            direct link
+          </Link>
+          ).
+        </Box>
+        <Box component="li" sx={liSx}>
+          Click <strong>Generate Live Key</strong> (or <strong>Regenerate</strong> if one already
+          exists - note that regenerating <em>immediately breaks</em> any other system using the old
+          key).
+        </Box>
+        <Box component="li" sx={liSx}>
+          A dialog shows <strong>Key Id</strong> (<Code>rzp_live_…</Code>) and{" "}
+          <strong>Key Secret</strong>.
+          <Box component="ul" sx={{ mt: 0.5, mb: 0, pl: 2 }}>
+            <Box component="li" sx={liSx}>
+              ⚠️ The <strong>Key Secret is shown exactly once</strong>. Download the credentials or
+              copy it now - if you close this dialog you cannot recover it, only regenerate a new
+              pair.
+            </Box>
+          </Box>
+        </Box>
+        <Box component="li" sx={liSx}>
+          Paste both into <strong>Razorpay Key ID</strong> and <strong>Razorpay Key Secret</strong>{" "}
+          on this screen, then click <strong>Connect account</strong>.
+        </Box>
+      </Box>
+
+      {/* Part 2 */}
+      <StepHeading>Part 2 - Turn on the payment methods you want</StepHeading>
+      <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          Razorpay Dashboard → <strong>Account &amp; Settings</strong> →{" "}
+          <strong>Configuration</strong> →{" "}
+          <Link
+            href="https://dashboard.razorpay.com/app/website-app-settings/payment-methods"
+            target="_blank"
+            rel="noopener"
+            sx={extLink}
+          >
+            Payment Methods
+          </Link>
+          .
+        </Box>
+        <Box component="li" sx={liSx}>
+          Enable at least <strong>UPI</strong> and <strong>Cards</strong>. Whatever is switched off
+          here simply will not appear in your learners&apos; checkout - this platform does not
+          override it.
+        </Box>
+        <Box component="li" sx={liSx}>
+          Optional but recommended: <strong>Netbanking</strong> and <strong>Wallets</strong>.
+        </Box>
+      </Box>
+
+      {/* Part 3 - the one that actually matters */}
+      <StepHeading>Part 3 - Add the webhook (not optional)</StepHeading>
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1,
+          alignItems: "flex-start",
+          p: 1.25,
+          mb: 1.25,
+          borderRadius: 1,
+          bgcolor: "color-mix(in srgb, var(--error-500) 10%, var(--surface) 90%)",
+          border:
+            "1px solid color-mix(in srgb, var(--error-500) 28%, var(--border-default) 72%)",
+        }}
+      >
+        <IconWrapper icon="mdi:alert-octagon-outline" size={18} color="var(--error-500)" />
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", lineHeight: 1.5 }}>
+          The keys above make the checkout <em>open</em>. The webhook is what makes a payment{" "}
+          <em>count</em>. Without it, a learner is granted access only if their browser makes it
+          back to this site after paying - so closing the tab, a dropped network or a dead battery
+          means they are charged and get nothing. Do not skip this part.
+        </Typography>
+      </Box>
+      <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          Razorpay Dashboard → <strong>Account &amp; Settings</strong> → under <em>Website and app
+          settings</em> click <strong>Webhooks</strong> (
+          <Link
+            href="https://dashboard.razorpay.com/app/website-app-settings/webhooks"
+            target="_blank"
+            rel="noopener"
+            sx={extLink}
+          >
+            direct link
+          </Link>
+          ) → <strong>+ Add New Webhook</strong>.
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>Webhook URL</strong> - paste your institution&apos;s own endpoint:
+          <Box sx={{ mt: 0.5 }}>
+            <Code>{webhookUrl || "shown on this screen once the page has loaded your account"}</Code>
+          </Box>
+          <Box sx={{ ...liSx, mt: 0.5, mb: 0, opacity: 0.85 }}>
+            (Use the copy button next to <strong>Webhook URL</strong> on this screen - the address is
+            specific to your institution and settles only your orders.)
+          </Box>
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>Secret</strong> - type any strong random string you invent (Razorpay does not
+          generate one for you). Keep it to letters and digits, 20+ characters. Paste the{" "}
+          <em>same</em> string into <strong>Webhook Secret</strong> on this screen.
+          <Box component="ul" sx={{ mt: 0.5, mb: 0, pl: 2 }}>
+            <Box component="li" sx={liSx}>
+              This is what proves a delivery genuinely came from Razorpay. If the two do not match,
+              every notification is rejected and nothing settles.
+            </Box>
+          </Box>
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>Alert Email</strong> - your finance or ops address. Razorpay emails it when
+          deliveries start failing.
+        </Box>
+        <Box component="li" sx={liSx}>
+          <strong>Active Events</strong> - tick exactly these three:
+          <Box component="ul" sx={{ mt: 0.5, mb: 0, pl: 2 }}>
+            <Box component="li" sx={liSx}>
+              <Code>payment.captured</Code> <em>(the money arrived — this is the one that grants
+              access)</em>
+            </Box>
+            <Box component="li" sx={liSx}>
+              <Code>order.paid</Code> <em>(belt and braces: the order is fully paid)</em>
+            </Box>
+            <Box component="li" sx={liSx}>
+              <Code>payment.failed</Code> <em>(closes the attempt so a learner can retry cleanly)</em>
+            </Box>
+          </Box>
+        </Box>
+        <Box component="li" sx={liSx}>
+          Click <strong>Create Webhook</strong>. It should appear with status <strong>Active</strong>.
+        </Box>
+        <Box component="li" sx={liSx}>
+          Come back here and confirm the card shows <strong>Webhook active</strong>. If it still
+          says the webhook is missing, the secret was not saved on this screen.
+        </Box>
+      </Box>
+
+      {/* Part 4 */}
+      <StepHeading>Part 4 - Check it end to end</StepHeading>
+      <Box component="ol" sx={{ m: 0, pl: 2.5 }}>
+        <Box component="li" sx={liSx}>
+          Price one course, open it as a learner, and pay the real amount with UPI (₹1 works if you
+          temporarily price it at ₹1).
+        </Box>
+        <Box component="li" sx={liSx}>
+          The learner should land on the success screen and the course should open immediately.
+        </Box>
+        <Box component="li" sx={liSx}>
+          In Razorpay → <strong>Webhooks</strong> → your webhook → <strong>Recent Deliveries</strong>,
+          the <Code>payment.captured</Code> delivery should read <strong>200</strong>. A{" "}
+          <Code>401</Code> or <Code>400</Code> means the secret does not match; a <Code>503</Code>{" "}
+          means no secret is saved on this screen.
+        </Box>
+        <Box component="li" sx={liSx}>
+          Refund yourself from the Razorpay dashboard afterwards if you used a real amount.
+        </Box>
+      </Box>
+
+      {/* Live vs test note */}
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1,
+          alignItems: "flex-start",
+          mt: 2,
+          p: 1.25,
+          borderRadius: 1,
+          bgcolor: "color-mix(in srgb, var(--accent-indigo) 9%, var(--surface) 91%)",
+          border: "1px solid color-mix(in srgb, var(--accent-indigo) 28%, var(--border-default) 72%)",
+        }}
+      >
+        <IconWrapper icon="mdi:swap-horizontal" size={18} color="var(--accent-indigo)" />
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", lineHeight: 1.5 }}>
+          Test and Live are separate worlds in Razorpay: separate keys <em>and</em> separate
+          webhooks. If you set this up in Test mode first, remember to repeat Part 1 and Part 3 in
+          Live mode - a live key with only a test webhook takes real money and settles nothing.
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/lib/services/razorpay.service.ts
+++ b/lib/services/razorpay.service.ts
@@ -20,6 +20,10 @@ export interface RazorpayCredentials {
   use_platform_account: boolean;
   /** Whose Razorpay account the money actually reaches. */
   settles_to: "institution" | "platform";
+  /** Whether a webhook signing secret is stored. Write-only, like the key secret. */
+  webhook_configured: boolean;
+  /** This institution's own endpoint, to paste into the Razorpay dashboard. */
+  webhook_url: string;
   created_at: string;
   updated_at: string;
 }
@@ -28,6 +32,12 @@ export interface RazorpayStatus {
   credentials: RazorpayCredentials | null;
   /** False whenever this institution cannot take a payment — including "never configured". */
   connected: boolean;
+  /**
+   * Deliberately separate from `connected`. Valid keys with no webhook still open a checkout, but
+   * settlement then depends on the learner's browser returning — so this is the difference between
+   * "can charge" and "can charge safely", and the UI must be able to say so.
+   */
+  webhook_ready: boolean;
 }
 
 export const razorpayService = {
@@ -44,6 +54,7 @@ export const razorpayService = {
   save: async (payload: {
     key_id?: string;
     key_secret?: string;
+    webhook_secret?: string;
     is_active?: boolean;
   }): Promise<RazorpayStatus> => {
     const res = await apiClient.put<RazorpayStatus>(`${BASE}/razorpay-credentials/`, payload);


### PR DESCRIPTION
Pairs with backend #490.

## Why

Connecting Razorpay was two unlabelled fields and no instructions — and **no way to configure the webhook at all**.

That let an admin reach the worst possible state: **Connected**, able to charge learners, unable to confirm a single payment. Without a webhook, access is granted only if the learner's browser makes it back to the site after paying. That is the failure that left 468 of 570 production transactions stuck at `INITIATED` before the ledger reset.

## What

**Setup guide** (`RazorpaySetupGuide.tsx`, collapsed by default, mirroring `ZoomSetupGuide`):
- Part 1 — generate the API key, with the direct dashboard link, the Test/Live switch, and the warning that the Key Secret is shown exactly once
- Part 2 — payment methods (whatever is off in Razorpay simply won't appear at checkout)
- Part 3 — **the webhook, labelled not optional**: direct link, the tenant's own URL, the fact that Razorpay does *not* generate the secret for you, and exactly three events to tick (`payment.captured`, `order.paid`, `payment.failed`)
- Part 4 — how to verify from Razorpay's own Recent Deliveries log, including what a 400/401/503 each mean
- A closing note that Test and Live have separate keys *and* separate webhooks

**Card:**
- "Connected" and "Webhook active" are two separate chips — a green tick can no longer sit over a broken pipeline
- Red alert while the webhook is missing, in plain language
- The tenant's own webhook URL, copyable (server value preferred; derived if the account doesn't exist yet, so it's available during Part 3)
- "Save webhook secret" saves on its own — adding the webhook later must not require re-entering an API secret Razorpay showed once

## Verified

`tsc --noEmit` clean, production build clean.

Backend contract verified live on production (demo client 34): connect-without-webhook reports `connected=true, webhook_ready=false`; a webhook-only PUT flips it true; the API key secret survives the partial PUT; the webhook secret is never returned on read; `webhook_url` is the tenant's own endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)