### PR TITLE
feat(payments): paid adaptive courses — card tags, pricing dialog, buy flow

### DIFF
--- a/app/adaptive-courses/catalog/page.tsx
+++ b/app/adaptive-courses/catalog/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { usePayment } from "@/hooks/usePayment";
+import { PaymentType } from "@/lib/services/payment.service";
 import { Box, Chip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
@@ -26,6 +28,7 @@ export default function AdaptiveCourseCatalogPage() {
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [enrollingId, setEnrollingId] = useState<number | null>(null);
+  const { handlePayment } = usePayment();
 
   useEffect(() => {
     if (!featureOn) {
@@ -59,8 +62,46 @@ export default function AdaptiveCourseCatalogPage() {
     );
   }, [items, query]);
 
+  /**
+   * Buy a paid course, then let the normal enroll path finish the job.
+   *
+   * The card is NOT removed optimistically the way the free path removes it. Money is involved:
+   * a card that vanishes before the payment is confirmed tells the learner they own something
+   * they may not. It only leaves the catalog once the server says the payment settled.
+   */
+  function startPurchase(course: AdaptiveCourseListItem) {
+    void handlePayment({
+      typeId: String(course.id),
+      paymentType: PaymentType.ADAPTIVE_COURSE,
+      description: course.title,
+      busyKey: String(course.id),
+      onOutcome: (outcome) => {
+        setEnrollingId(null);
+        if (outcome.kind === "verified") {
+          setItems((prev) => prev.filter((c) => c.id !== course.id));
+          showToast(`You're enrolled in "${course.title}".`, "success");
+          push(`/adaptive-courses/${course.id}`);
+        } else if (outcome.kind === "settling") {
+          // Charged; the webhook will grant access. Do NOT call this a failure and do NOT
+          // pretend it succeeded either — say what is true and let them refresh.
+          showToast(outcome.message, "info");
+        } else if (outcome.kind === "failed") {
+          showToast(outcome.message, "error");
+        }
+      },
+    });
+  }
+
   async function handleEnroll(course: AdaptiveCourseListItem) {
     if (enrollingId !== null) return;
+
+    // Priced and unbought — go straight to checkout without a pointless round trip.
+    if (course.is_paid && !course.purchased) {
+      setEnrollingId(course.id);
+      startPurchase(course);
+      return;
+    }
+
     setEnrollingId(course.id);
     try {
       await adaptiveCourseService.selfEnroll(course.id);
@@ -69,8 +110,16 @@ export default function AdaptiveCourseCatalogPage() {
       showToast(`You're enrolled in "${course.title}".`, "success");
       push(`/adaptive-courses/${course.id}`);
     } catch (e) {
+      // A 402 means the course became paid while this page was open, or the card was
+      // rendered before the price landed. Converge on the same checkout rather than
+      // showing the learner an error for something they can simply buy.
+      const resp = (e as { response?: { status?: number; data?: { payment_required?: boolean } } })
+        ?.response;
+      if (resp?.status === 402 && resp.data?.payment_required) {
+        startPurchase(course);
+        return;
+      }
       showToast(e instanceof Error ? e.message : "Couldn't enroll in that course.", "error");
-    } finally {
       setEnrollingId(null);
     }
   }

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth/auth-context";
+import { CoursePricingDialog } from "@/components/admin/adaptive-course/CoursePricingDialog";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
+import { formatMoney } from "@/lib/utils/money";
 import { useParams } from "next/navigation";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import {
@@ -93,6 +97,9 @@ export default function AdminAdaptiveCourseDetailPage() {
   const [savingDetails, setSavingDetails] = useState(false);
   const [genDesc, setGenDesc] = useState(false);
   const [assignCohortsOpen, setAssignCohortsOpen] = useState(false);
+  const [pricingOpen, setPricingOpen] = useState(false);
+  const { user } = useAuth();
+  const canSetPricing = isClientOrgAdminRole(user?.role);
 
   function handleQuizSaved(configId: number, mcqCount: number) {
     setCourse((prev) =>
@@ -454,6 +461,19 @@ export default function AdminAdaptiveCourseDetailPage() {
                       <Icon icon={course.self_enroll_enabled ? "mdi:account-plus" : "mdi:account-plus-outline"} width={16} />
                       {course.self_enroll_enabled ? "Self-enroll on" : "Self-enroll off"}
                     </ButtonBase>
+                    {/* Pricing is a commercial decision, so only org admins see it — the backend
+                        403s a course_manager on these keys, and showing a control that always
+                        fails is worse than not showing it. */}
+                    {canSetPricing && (
+                      <ButtonBase
+                        onClick={() => setPricingOpen(true)}
+                        sx={pillBtnSx("outline")}
+                        title="Set what learners pay to enrol in this course."
+                      >
+                        <Icon icon={course.is_paid ? "mdi:cash-multiple" : "mdi:cash-off"} width={16} />
+                        {course.is_paid ? formatMoney(course.price, course.currency) : "Free"}
+                      </ButtonBase>
+                    )}
                     <ButtonBase
                       onClick={() => setAssignCohortsOpen(true)}
                       sx={pillBtnSx("outline")}
@@ -839,6 +859,15 @@ export default function AdminAdaptiveCourseDetailPage() {
           onClose={() => setAssignCohortsOpen(false)}
           courseId={course.id}
           courseTitle={course.title}
+        />
+      )}
+
+      {course && canSetPricing && (
+        <CoursePricingDialog
+          open={pricingOpen}
+          course={course}
+          onClose={() => setPricingOpen(false)}
+          onSaved={(patch) => setCourse({ ...course, ...patch })}
         />
       )}
 

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { PriceTag } from "@/components/common/PriceTag";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
@@ -276,23 +277,32 @@ function CourseCard({
       }}
     >
       <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1.25 }}>
-        <Box
-          component="span"
-          sx={{
-            px: 1,
-            py: 0.3,
-            borderRadius: 999,
-            fontSize: "0.66rem",
-            fontWeight: 800,
-            textTransform: "uppercase",
-            letterSpacing: 0.4,
-            color: course.is_published ? "#10b981" : "#94a3b8",
-            bgcolor: course.is_published
-              ? "color-mix(in srgb, #10b981 14%, transparent)"
-              : "color-mix(in srgb, #94a3b8 16%, transparent)",
-          }}
-        >
-          {course.is_published ? "Published" : "Draft"}
+        {/* Two pills of the same family — status and price read together at a glance. */}
+        <Box sx={{ display: "inline-flex", alignItems: "center", gap: 0.75, minWidth: 0 }}>
+          <Box
+            component="span"
+            sx={{
+              px: 1,
+              py: 0.3,
+              borderRadius: 999,
+              fontSize: "0.66rem",
+              fontWeight: 800,
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+              color: course.is_published ? "#10b981" : "#94a3b8",
+              bgcolor: course.is_published
+                ? "color-mix(in srgb, #10b981 14%, transparent)"
+                : "color-mix(in srgb, #94a3b8 16%, transparent)",
+            }}
+          >
+            {course.is_published ? "Published" : "Draft"}
+          </Box>
+          <PriceTag
+            isPaid={course.is_paid}
+            price={course.price}
+            currency={course.currency}
+            withAmount
+          />
         </Box>
         <ButtonBase onClick={onDelete} sx={{ p: 0.5, borderRadius: 2, color: "#ef4444" }}>
           <Icon icon="mdi:trash-can-outline" width={18} />
@@ -420,9 +430,13 @@ function CourseRow({
         <Typography sx={{ fontWeight: 800, fontSize: "0.98rem", lineHeight: 1.3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
           {course.title}
         </Typography>
-        <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.82rem", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-          {course.is_published ? "Published" : "Draft"} · {course.submodule_count} submodules · {course.article_count} articles
-        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, minWidth: 0 }}>
+          {/* A real pill, not another "·" segment — price is a different kind of fact from a count. */}
+          <PriceTag isPaid={course.is_paid} price={course.price} currency={course.currency} withAmount />
+          <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.82rem", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+            {course.is_published ? "Published" : "Draft"} · {course.submodule_count} submodules · {course.article_count} articles
+          </Typography>
+        </Box>
       </Box>
 
       <Stack direction="row" spacing={2.5} sx={{ display: { xs: "none", md: "flex" }, flexShrink: 0 }}>

--- a/app/courses/[id]/page.tsx
+++ b/app/courses/[id]/page.tsx
@@ -138,24 +138,23 @@ export default function CourseDetailPage() {
 
     if (!isFree && parseFloat(price) > 0) {
       await handlePayment({
-        amount: price,
-        currency: "INR",
         typeId: courseId.toString(),
         paymentType: PaymentType.COURSE,
         description: `Access for ${course.course_title}`,
-        onSuccess: (res) => {
-          showToast(
-            t("courses.paymentVerified"),
-            "success"
-          );
-          loadCourseDetail();
-          loadDashboard();
-        },
-        onError: (err) => {
-          showToast(
-            err.message || "Payment failed. Please try again.",
-            "error"
-          );
+        onOutcome: (outcome) => {
+          if (outcome.kind === "verified") {
+            showToast(t("courses.paymentVerified"), "success");
+            loadCourseDetail();
+            loadDashboard();
+          } else if (outcome.kind === "settling") {
+            // Charged, confirmation catching up. Reload anyway — the webhook may already
+            // have settled it — but never call this a failure.
+            showToast(outcome.message, "info");
+            loadCourseDetail();
+            loadDashboard();
+          } else if (outcome.kind === "failed") {
+            showToast(outcome.message, "error");
+          }
         },
       });
       return;

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -258,25 +258,22 @@ export default function CoursesPage() {
 
     if (!course.is_free && parseFloat(course.price) > 0) {
       await handlePayment({
-        amount: course.price,
-        currency: "INR", // Default to INR, can be made dynamic if needed
         typeId: courseId.toString(),
         paymentType: PaymentType.COURSE,
         description: `Access for ${course.title}`,
-        onSuccess: (res) => {
-          showToast(t("courses.paymentVerified"), "success");
+        busyKey: String(courseId),
+        onOutcome: (outcome) => {
+          // Cleared on EVERY outcome. It used to leak on success, leaving the card spinning.
           setEnrollingCourseId(null);
-          loadCourses(); // Reload to update UI
-        },
-        onError: (err) => {
-          showToast(
-            err.message || "Payment failed. Please try again.",
-            "error"
-          );
-          setEnrollingCourseId(null);
-        },
-        onDismiss: () => {
-          setEnrollingCourseId(null);
+          if (outcome.kind === "verified") {
+            showToast(t("courses.paymentVerified"), "success");
+            loadCourses();
+          } else if (outcome.kind === "settling") {
+            showToast(outcome.message, "info");
+            loadCourses();
+          } else if (outcome.kind === "failed") {
+            showToast(outcome.message, "error");
+          }
         },
       });
       return;

--- a/components/admin/adaptive-course/CoursePricingDialog.tsx
+++ b/components/admin/adaptive-course/CoursePricingDialog.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useRouter } from "next/navigation";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { formatMoney } from "@/lib/utils/money";
+import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
+
+/**
+ * Set what learners pay to enrol in an adaptive course.
+ *
+ * A dialog rather than another toolbar pill: a price needs a number, and the toolbar is already
+ * carrying seven pills. It also gives the two things a toggle cannot — room to explain that
+ * turning a course paid does NOT charge the students already in it, and somewhere to put the
+ * "connect Razorpay first" message without losing what the admin typed.
+ */
+
+const CURRENCIES = [{ code: "INR", label: "₹ INR" }];
+
+export function CoursePricingDialog({
+  open,
+  course,
+  onClose,
+  onSaved,
+}: {
+  open: boolean;
+  course: { id: number; is_paid: boolean; price: string | null; currency: string; auto_enroll: boolean };
+  onClose: () => void;
+  onSaved: (patch: { is_paid: boolean; price: string | null; currency: string }) => void;
+}) {
+  const router = useRouter();
+  const [isPaid, setIsPaid] = useState(course.is_paid);
+  const [price, setPrice] = useState(course.price ?? "");
+  const [currency, setCurrency] = useState(course.currency || "INR");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [settingsUrl, setSettingsUrl] = useState<string | null>(null);
+  const [grandfathered, setGrandfathered] = useState<number | null>(null);
+
+  // Re-seed each time it opens, so a cancelled edit does not persist into the next visit.
+  useEffect(() => {
+    if (!open) return;
+    setIsPaid(course.is_paid);
+    setPrice(course.price ?? "");
+    setCurrency(course.currency || "INR");
+    setError(null);
+    setSettingsUrl(null);
+    setGrandfathered(null);
+  }, [open, course.is_paid, course.price, course.currency]);
+
+  const numericPrice = Number(price);
+  const priceValid = price.trim() !== "" && Number.isFinite(numericPrice) && numericPrice >= 1;
+  // Checked client-side so the admin gets a sentence instead of a bounced request — but the
+  // server enforces all three independently, and its wording wins if one still gets through.
+  const blockedByAutoEnroll = isPaid && course.auto_enroll;
+  const canSave = !saving && (!isPaid || (priceValid && !blockedByAutoEnroll));
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setSettingsUrl(null);
+    try {
+      const res = await adminAdaptiveCourseService.updateCourse(course.id, {
+        is_paid: isPaid,
+        // Turning paid off clears the price server-side too; sending null keeps the two in step.
+        price: isPaid ? String(numericPrice) : null,
+      });
+      const patch = {
+        is_paid: res.is_paid,
+        price: res.price,
+        currency: res.currency || currency,
+      };
+      onSaved(patch);
+
+      // Only surfaced when it is non-zero AND this was the transition to paid. A toast is a bad
+      // place for "N people keep free access" — it is the one consequence an admin must not miss.
+      if (res.grandfathered_students && res.grandfathered_students > 0) {
+        setGrandfathered(res.grandfathered_students);
+      } else {
+        onClose();
+      }
+    } catch (e: unknown) {
+      const resp = (e as { response?: { status?: number; data?: Record<string, unknown> } })?.response;
+      const detail = typeof resp?.data?.detail === "string" ? resp.data.detail : null;
+      if (resp?.status === 409) {
+        const url = typeof resp.data?.settings_url === "string" ? resp.data.settings_url : null;
+        // Only an in-app path is trusted — this URL comes off the wire.
+        setSettingsUrl(url && url.startsWith("/") ? url : "/admin/settings");
+      }
+      setError(detail ?? "Couldn't save pricing.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (grandfathered !== null) {
+    return (
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle sx={{ fontWeight: 800 }}>Pricing saved</DialogTitle>
+        <DialogContent>
+          <Alert severity="info" sx={{ borderRadius: 2 }}>
+            <strong>
+              {grandfathered} student{grandfathered === 1 ? "" : "s"} already enrolled
+            </strong>{" "}
+            keep their access for free. The price applies to new enrolments only — nobody is
+            charged retroactively, and nobody was removed.
+          </Alert>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={onClose} variant="contained">
+            Done
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={open} onClose={saving ? undefined : onClose} fullWidth maxWidth="sm">
+      <DialogTitle sx={{ fontWeight: 800 }}>Course pricing</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2.5} sx={{ pt: 0.5 }}>
+          {settingsUrl && (
+            <Alert
+              severity="warning"
+              icon={<Icon icon="mdi:credit-card-off-outline" width={20} />}
+              sx={{ borderRadius: 2 }}
+              action={
+                <Button size="small" onClick={() => router.push(settingsUrl)}>
+                  Connect Razorpay
+                </Button>
+              }
+            >
+              {error}
+            </Alert>
+          )}
+          {error && !settingsUrl && (
+            <Alert severity="error" sx={{ borderRadius: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "flex-start",
+              justifyContent: "space-between",
+              gap: 2,
+            }}
+          >
+            <Box>
+              <Typography sx={{ fontWeight: 700 }}>Paid course</Typography>
+              <Typography sx={{ fontSize: "0.82rem", color: "var(--font-secondary)" }}>
+                Learners must buy this course before they can enrol. Students already enrolled keep
+                their access for free.
+              </Typography>
+            </Box>
+            <Switch checked={isPaid} disabled={saving} onChange={(e) => setIsPaid(e.target.checked)} />
+          </Box>
+
+          <Collapse in={isPaid} unmountOnExit>
+            <Stack spacing={2}>
+              {blockedByAutoEnroll && (
+                <Alert severity="warning" sx={{ borderRadius: 2, fontSize: "0.83rem" }}>
+                  <strong>Auto-enroll is on.</strong> It gives this course to every student of your
+                  institution for free, so it cannot be combined with a price. Turn auto-enroll off
+                  in the toolbar first.
+                </Alert>
+              )}
+              <TextField
+                fullWidth
+                size="small"
+                type="number"
+                label="Price"
+                value={price}
+                disabled={saving}
+                // Validated on blur/save, never clamped per keystroke — clamping destroys a
+                // decimal the moment someone types "12." on the way to "12.50".
+                onChange={(e) => setPrice(e.target.value)}
+                inputProps={{ min: 1, step: "0.01" }}
+                error={price.trim() !== "" && !priceValid}
+                helperText={
+                  price.trim() !== "" && !priceValid
+                    ? "Enter an amount of at least 1."
+                    : "What a learner pays once, for permanent access."
+                }
+                sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+              />
+              <TextField
+                select
+                fullWidth
+                size="small"
+                label="Currency"
+                value={currency}
+                disabled
+                helperText="Payments settle in INR through your Razorpay account."
+                sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+              >
+                {CURRENCIES.map((c) => (
+                  <MenuItem key={c.code} value={c.code}>
+                    {c.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+              {priceValid && (
+                <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)" }}>
+                  Learners will see{" "}
+                  <strong style={{ color: "var(--font-primary)" }}>
+                    {formatMoney(numericPrice, currency)}
+                  </strong>{" "}
+                  on the course card.
+                </Typography>
+              )}
+            </Stack>
+          </Collapse>
+
+          {!isPaid && course.is_paid && (
+            <Alert severity="info" sx={{ borderRadius: 2, fontSize: "0.83rem" }}>
+              Making this course free clears its price. Past purchases stay on record and nobody is
+              refunded automatically.
+            </Alert>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} color="inherit" disabled={saving}>
+          Cancel
+        </Button>
+        <LoadingButton
+          variant="contained"
+          loading={saving}
+          loadingText="Saving"
+          disabled={!canSave}
+          onClick={() => void handleSave()}
+          sx={{ background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" }}
+        >
+          Save
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/adaptive-course/CourseStudentsPanel.tsx
+++ b/components/admin/adaptive-course/CourseStudentsPanel.tsx
@@ -252,9 +252,12 @@ export function CourseStudentsPanel({ courseId, courseTitle }: Props) {
             >
               <StudentAvatar name={s.name} email={s.email} />
               <Box sx={{ minWidth: 0, flex: 1.4 }}>
-                <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }} noWrap>
-                  {s.name || s.email}
-                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, minWidth: 0 }}>
+                  <Typography sx={{ fontWeight: 700, fontSize: "0.9rem" }} noWrap>
+                    {s.name || s.email}
+                  </Typography>
+                  <AccessSourceChip paid={s.paid} source={s.access_source} />
+                </Box>
                 <Typography sx={{ color: "text.secondary", fontSize: "0.78rem" }} noWrap>
                   {s.email}
                 </Typography>
@@ -546,6 +549,51 @@ function ProgressRing({ value, size = 84 }: { value: number; size?: number }) {
       >
         <Typography sx={{ fontWeight: 800, fontSize: "1.25rem", lineHeight: 1 }}>{Math.round(v)}%</Typography>
       </Box>
+    </Box>
+  );
+}
+
+/**
+ * How this learner got access.
+ *
+ * "Paid" is read from the LEDGER, not from the enrolment row — money is the durable fact, it
+ * survives an unenroll-and-re-enroll, and it is what a refund would reverse. The other labels
+ * come from the enrolment's own provenance.
+ *
+ * Deliberately shows only WHETHER they paid, never how much. An instructor can see the roster;
+ * what a learner was charged is commercial data that belongs to admins.
+ */
+function AccessSourceChip({ paid, source }: { paid?: boolean; source?: string }) {
+  // Nothing known yet (an older serializer) — say nothing rather than guess.
+  if (paid === undefined && !source) return null;
+
+  const { label, hue } = paid
+    ? { label: "Paid", hue: "#f59e0b" }
+    : source === "self"
+      ? { label: "Self", hue: "#6366f1" }
+      : source === "bulk"
+        ? { label: "Import", hue: "#94a3b8" }
+        : source === "migration"
+          ? { label: "Legacy", hue: "#94a3b8" }
+          : { label: "Comped", hue: "#10b981" };
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        px: 0.75,
+        py: 0.15,
+        borderRadius: 999,
+        flexShrink: 0,
+        fontSize: "0.6rem",
+        fontWeight: 800,
+        textTransform: "uppercase",
+        letterSpacing: 0.4,
+        color: hue,
+        bgcolor: `color-mix(in srgb, ${hue} 15%, transparent)`,
+      }}
+    >
+      {label}
     </Box>
   );
 }

--- a/components/common/PriceTag.tsx
+++ b/components/common/PriceTag.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Box } from "@mui/material";
+import { formatMoney } from "@/lib/utils/money";
+
+/**
+ * The small Paid / Free pill on an adaptive course card.
+ *
+ * Geometry is deliberately identical to the Published/Draft badge so the two sit together as one
+ * family rather than looking like two different design decisions. Amber for Paid — emerald is
+ * already spoken for by Published, and reusing it would make "Paid" read as a status.
+ *
+ * Renders NOTHING when `isPaid` is undefined. That case is a course whose serializer has not sent
+ * the field yet, and labelling it "Free" would be a confident lie about money. Absent beats wrong.
+ */
+export function PriceTag({
+  isPaid,
+  price,
+  currency,
+  withAmount = false,
+}: {
+  isPaid?: boolean;
+  price?: string | number | null;
+  currency?: string | null;
+  /** Show the amount inside the pill ("₹1,499") rather than just "Paid". */
+  withAmount?: boolean;
+}) {
+  if (isPaid === undefined || isPaid === null) return null;
+
+  const amount = withAmount ? formatMoney(price, currency) : "";
+  const label = isPaid ? amount || "Paid" : "Free";
+  const hue = isPaid ? "#f59e0b" : "#94a3b8";
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        px: 1,
+        py: 0.3,
+        borderRadius: 999,
+        fontSize: "0.66rem",
+        fontWeight: 800,
+        textTransform: "uppercase",
+        letterSpacing: 0.4,
+        whiteSpace: "nowrap",
+        color: hue,
+        bgcolor: `color-mix(in srgb, ${hue} ${isPaid ? 16 : 16}%, transparent)`,
+      }}
+    >
+      {label}
+    </Box>
+  );
+}

--- a/components/courses/AdaptiveCourseCard.tsx
+++ b/components/courses/AdaptiveCourseCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, ButtonBase, Typography } from "@mui/material";
+import { PriceTag } from "@/components/common/PriceTag";
 import { Icon } from "@iconify/react";
 import type { AdaptiveCourseListItem } from "@/lib/services/adaptive-course.service";
 
@@ -58,6 +59,8 @@ export function AdaptiveCourseCard({
         <Box component="span" sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.65rem", fontWeight: 800, letterSpacing: 0.4, textTransform: "uppercase", color: "#a855f7", bgcolor: "color-mix(in srgb, #a855f7 14%, transparent)" }}>
           Adaptive
         </Box>
+        {/* Still shown after purchase: "Paid" is a fact about how they got access, not a CTA. */}
+        <PriceTag isPaid={course.is_paid} price={course.price} currency={course.currency} />
       </Box>
 
       <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{course.title}</Typography>

--- a/components/courses/CatalogCourseCard.tsx
+++ b/components/courses/CatalogCourseCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Button, CircularProgress, Typography } from "@mui/material";
+import { PriceTag } from "@/components/common/PriceTag";
 import { Icon } from "@iconify/react";
 import type { AdaptiveCourseListItem } from "@/lib/services/adaptive-course.service";
 
@@ -97,6 +98,7 @@ export function CatalogCourseCard({
         >
           Adaptive
         </Box>
+        <PriceTag isPaid={course.is_paid} price={course.price} currency={course.currency} withAmount />
       </Box>
 
       <Typography

--- a/components/courses/CatalogCourseCard.tsx
+++ b/components/courses/CatalogCourseCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Button, CircularProgress, Typography } from "@mui/material";
+import { formatMoney } from "@/lib/utils/money";
 import { PriceTag } from "@/components/common/PriceTag";
 import { Icon } from "@iconify/react";
 import type { AdaptiveCourseListItem } from "@/lib/services/adaptive-course.service";
@@ -21,6 +22,10 @@ export function CatalogCourseCard({
   disabled?: boolean;
   onEnroll: () => void;
 }) {
+  // A course that is priced and not yet bought. `purchased` comes from the server, so a
+  // payment that settled while this page was open resolves to a plain Enroll.
+  const mustBuy = Boolean(course.is_paid && !course.purchased);
+
   return (
     <Box
       sx={{
@@ -149,7 +154,7 @@ export function CatalogCourseCard({
           enrolling ? (
             <CircularProgress size={16} sx={{ color: "inherit" }} />
           ) : (
-            <Icon icon="mdi:account-plus" width={18} />
+            <Icon icon={mustBuy ? "mdi:cart-outline" : "mdi:account-plus"} width={18} />
           )
         }
         sx={{
@@ -162,7 +167,13 @@ export function CatalogCourseCard({
           "&.Mui-disabled": { color: "rgba(255,255,255,0.85)", opacity: 0.7 },
         }}
       >
-        {enrolling ? "Enrolling…" : "Enroll"}
+        {enrolling
+          ? mustBuy
+            ? "Opening checkout…"
+            : "Enrolling…"
+          : mustBuy
+            ? `Buy ${formatMoney(course.price, course.currency)}`
+            : "Enroll"}
       </Button>
     </Box>
   );

--- a/hooks/usePayment.ts
+++ b/hooks/usePayment.ts
@@ -1,132 +1,171 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { config } from "@/lib/config";
-import { 
-  paymentService, 
-  PaymentType, 
-  VerifyPaymentRequest 
+import {
+  paymentService,
+  PaymentType,
+  VerifyPaymentRequest,
 } from "@/lib/services/payment.service";
 import { loadRazorpayScript } from "@/lib/utils/razorpay";
-import { useRouter } from "next/navigation";
 
-interface PaymentOptions {
-  amount: string;
-  currency: string;
+/**
+ * Opening a Razorpay checkout for one purchase.
+ *
+ * Three things this hook deliberately does NOT do, each of which it used to:
+ *
+ * 1. **It does not send an amount.** The server prices the order from the product itself and
+ *    ignores anything the client sends. The field's mere existence in the request is how "any
+ *    course for a rupee" happened once already, so it is gone from the contract entirely.
+ * 2. **It does not leave a card spinning.** `isProcessing` was reset only in `ondismiss` and the
+ *    outer catch — never after a successful payment, and never after `payment.failed`. Any
+ *    surface trusting the flag stayed loading forever once a payment went through.
+ * 3. **It does not report a successful payment as a failure.** If the money reached Razorpay but
+ *    the verify call fails, the webhook still settles it server-side. Telling a learner their
+ *    payment failed, when they have been charged and will get access, is the worst thing this
+ *    hook can say.
+ */
+
+/** Which outcome the caller is being told about. `settling` is NOT a failure. */
+export type PaymentOutcome =
+  | { kind: "verified"; response: unknown }
+  | { kind: "settling"; message: string }
+  | { kind: "failed"; message: string }
+  | { kind: "dismissed" };
+
+export interface PaymentOptions {
   typeId: string;
   paymentType: PaymentType;
   description: string;
-  onSuccess?: (response: any) => void;
-  onError?: (error: any) => void;
-  onDismiss?: () => void;
+  /** Identifies WHICH item is mid-flight, so one card spins instead of the whole grid. */
+  busyKey?: string;
+  onOutcome?: (outcome: PaymentOutcome) => void;
 }
+
+const SETTLING_MESSAGE =
+  "Payment received. We're confirming it now — refresh in a moment and it will be there.";
 
 export const usePayment = () => {
   const { user } = useAuth();
   const { clientInfo } = useClientInfo();
-  const [isProcessing, setIsProcessing] = useState(false);
-  const router = useRouter();
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  // A ref, not state: a double-click fires again before React has re-rendered, so a state flag
+  // is too slow to stop a second Razorpay order being opened.
+  const inFlight = useRef(false);
 
-  const handlePayment = async (options: PaymentOptions) => {
-    try {
-      setIsProcessing(true);
-      const clientId = Number(config.clientId);
+  const handlePayment = useCallback(
+    async (options: PaymentOptions) => {
+      const report = (outcome: PaymentOutcome) => options.onOutcome?.(outcome);
+      const finish = () => {
+        inFlight.current = false;
+        setBusyKey(null);
+      };
 
-      if (!clientId) {
-        throw new Error("Invalid client ID");
-      }
+      if (inFlight.current) return;
+      inFlight.current = true;
+      setBusyKey(options.busyKey ?? options.typeId);
 
-      const scriptLoaded = await loadRazorpayScript();
-      if (!scriptLoaded) {
-        throw new Error("Razorpay SDK failed to load. Please check your connection.");
-      }
+      try {
+        const clientId = Number(config.clientId);
+        if (!clientId) throw new Error("Invalid client ID");
 
-      // 1. Create order
-      const orderData = await paymentService.createOrder(clientId, {
-        amount: options.amount,
-        currency: options.currency || "INR",
-        type_id: options.typeId,
-        payment_type: options.paymentType,
-        notes: {
+        const scriptLoaded = await loadRazorpayScript();
+        if (!scriptLoaded) {
+          throw new Error("Couldn't reach the payment provider. Check your connection and retry.");
+        }
+
+        // The server derives amount AND currency from the product. We send only what is bought.
+        const orderData = await paymentService.createOrder(clientId, {
+          type_id: options.typeId,
+          payment_type: options.paymentType,
+          notes: { description: options.description, userId: user?.id },
+        });
+
+        if (!orderData?.order_id || !orderData?.key) {
+          throw new Error("Couldn't start the payment. Please try again.");
+        }
+
+        const rzpOptions: Record<string, unknown> = {
+          key: orderData.key,
+          amount: orderData.amount,
+          currency: orderData.currency || "INR",
+          name: clientInfo?.name || "AI LINC",
           description: options.description,
-          userId: user?.id,
-        },
-      });
-
-      if (!orderData || !orderData.order_id || !orderData.key) {
-        throw new Error("Failed to create payment order.");
-      }
-
-      // 2. Launch Razorpay
-      const rzpOptions: any = {
-        key: orderData.key,
-        amount: orderData.amount, // backend might return amount in paise
-        currency: orderData.currency || "INR",
-        name: clientInfo?.name || "AI LINC",
-        description: options.description,
-        order_id: orderData.order_id,
-        handler: async function (response: any) {
-          try {
+          order_id: orderData.order_id,
+          handler: async function (response: Record<string, string>) {
             const verificationData: VerifyPaymentRequest = {
               razorpay_order_id: response.razorpay_order_id,
               razorpay_payment_id: response.razorpay_payment_id,
               razorpay_signature: response.razorpay_signature,
             };
-
-            // 3. Verify payment
-            const verifyRes = await paymentService.verifyPayment(clientId, verificationData);
-
-            if (verifyRes.status === "VERIFIED" || verifyRes.message?.toLowerCase().includes("success")) {
-              if (options.onSuccess) {
-                options.onSuccess(verifyRes);
+            try {
+              const verifyRes = await paymentService.verifyPayment(clientId, verificationData);
+              const ok =
+                verifyRes.status === "VERIFIED" ||
+                verifyRes.message?.toLowerCase().includes("success");
+              if (ok) {
+                report({ kind: "verified", response: verifyRes });
+              } else {
+                // The provider took the money; our confirmation disagreed. The webhook is the
+                // source of truth and will settle it — "catching up", not "failed".
+                report({ kind: "settling", message: SETTLING_MESSAGE });
               }
-            } else {
-              throw new Error(verifyRes.message || "Payment verification failed");
-            }
-          } catch (error: any) {
-            if (options.onError) {
-              options.onError(error);
-            }
-          }
-        },
-        modal: {
-          ondismiss: function () {
-            setIsProcessing(false);
-            if (options.onDismiss) {
-              options.onDismiss();
+            } catch {
+              report({ kind: "settling", message: SETTLING_MESSAGE });
+            } finally {
+              finish();
             }
           },
-        },
-        prefill: {
-          name: `${user?.first_name || ""} ${user?.last_name || ""}`.trim() || "User",
-          email: user?.email || "",
-          contact: user?.phone || "",
-        },
-        theme: {
-          color: "#6366f1", // primary color
-        },
-      };
+          modal: {
+            ondismiss: function () {
+              finish();
+              report({ kind: "dismissed" });
+            },
+          },
+          prefill: {
+            name: `${user?.first_name || ""} ${user?.last_name || ""}`.trim() || "User",
+            email: user?.email || "",
+            contact: user?.phone || "",
+          },
+          theme: { color: "#6366f1" },
+        };
 
-      const rzp = new (window as any).Razorpay(rzpOptions);
-      rzp.on("payment.failed", function (response: any) {
-        if (options.onError) {
-          options.onError(response.error);
-        }
-      });
-      rzp.open();
-    } catch (error: any) {
-      setIsProcessing(false);
-      if (options.onError) {
-        options.onError(error);
+        const RazorpayCtor = (
+          window as unknown as {
+            Razorpay: new (o: unknown) => {
+              open: () => void;
+              on: (e: string, cb: (r: { error?: { description?: string } }) => void) => void;
+            };
+          }
+        ).Razorpay;
+        const rzp = new RazorpayCtor(rzpOptions);
+        rzp.on("payment.failed", function (response) {
+          // This one IS a real failure — the charge did not go through.
+          finish();
+          report({
+            kind: "failed",
+            message: response?.error?.description || "The payment didn't go through.",
+          });
+        });
+        rzp.open();
+      } catch (error: unknown) {
+        finish();
+        report({
+          kind: "failed",
+          message: error instanceof Error ? error.message : "Couldn't start the payment.",
+        });
       }
-    }
-  };
+    },
+    [user, clientInfo],
+  );
 
   return {
     handlePayment,
-    isProcessing,
+    /** Which item is mid-payment, or null. Lets one card spin instead of the whole grid. */
+    busyKey,
+    /** Convenience for single-item surfaces. */
+    isProcessing: busyKey !== null,
   };
 };
-

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -125,6 +125,12 @@ export interface AdaptiveCourseModule {
 }
 
 export interface AdaptiveCourseListItem {
+  /** Optional so the Paid/Free tag can ship before every serializer carries it. */
+  is_paid?: boolean;
+  price?: string | null;
+  currency?: string;
+  /** This learner already holds a settled purchase for the course. */
+  purchased?: boolean;
   id: number;
   title: string;
   slug: string;

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -290,6 +290,11 @@ export interface AdminAdaptiveCourseListItem {
   /** When true, the published course is listed in the learner catalog and any active student of
    *  the tenant may enroll themselves (a pull, distinct from auto_enroll's push). */
   self_enroll_enabled: boolean;
+  /** Learners must purchase this course before they can enrol. */
+  is_paid: boolean;
+  /** DRF DecimalField — arrives as a string like "1499.00". Parse at render, never with float maths. */
+  price: string | null;
+  currency: string;
   /** Weekly cohort gate. False = every week open + full XP (admin toggle). */
   content_locked: boolean;
   module_count: number;
@@ -372,6 +377,10 @@ export interface EnrolledAdaptiveStudent {
   completed: number;
   total: number;
   last_activity: string | null;
+  /** Derived from the LEDGER, not the enrolment row — money is the durable fact. */
+  paid?: boolean;
+  /** How they got in: self | paid | admin | bulk | seed | migration. */
+  access_source?: string;
 }
 
 export interface EnrolledStudentsResponse {
@@ -547,12 +556,26 @@ export const adminAdaptiveCourseService = {
     return data;
   },
 
-  /** Edit course fields (title/description/content lock/auto-enroll). Returns the updated detail. */
+  /**
+   * Edit course fields (title/description/content lock/auto-enroll/self-enroll/pricing).
+   *
+   * `grandfathered_students` comes back only when a course is turned PAID: it counts the learners
+   * already enrolled, who keep free access and are never charged retroactively.
+   */
   async updateCourse(
     courseId: number,
-    payload: { title?: string; description?: string; content_locked?: boolean; auto_enroll?: boolean; self_enroll_enabled?: boolean },
-  ): Promise<AdminAdaptiveCourseDetail> {
-    const { data } = await apiClient.patch<AdminAdaptiveCourseDetail>(
+    payload: {
+      title?: string;
+      description?: string;
+      content_locked?: boolean;
+      auto_enroll?: boolean;
+      self_enroll_enabled?: boolean;
+      is_paid?: boolean;
+      /** Send as a string; the server validates it as a Decimal. */
+      price?: string | null;
+    },
+  ): Promise<AdminAdaptiveCourseDetail & { grandfathered_students?: number }> {
+    const { data } = await apiClient.patch<AdminAdaptiveCourseDetail & { grandfathered_students?: number }>(
       `${BASE}/courses/${courseId}/`,
       payload,
     );

--- a/lib/services/payment.service.ts
+++ b/lib/services/payment.service.ts
@@ -3,12 +3,19 @@ import { config } from "../config";
 
 export enum PaymentType {
   COURSE = "COURSE",
+  ADAPTIVE_COURSE = "ADAPTIVE_COURSE",
   ASSESSMENT = "ASSESSMENT",
 }
 
 export interface CreateOrderRequest {
-  amount: string;
-  currency: string;
+  /**
+   * WHAT is being bought — never how much it costs.
+   *
+   * `amount` and `currency` used to be here. The server derives both from the product and
+   * ignores whatever the client sends, so the fields were inert; but a price-shaped field in a
+   * payment request is an invitation to reintroduce client-authored pricing, which is exactly
+   * the bug that once let any course be bought for a rupee.
+   */
   type_id: string;
   payment_type: PaymentType;
   notes?: Record<string, any>;

--- a/lib/utils/money.ts
+++ b/lib/utils/money.ts
@@ -1,0 +1,60 @@
+/**
+ * Formatting money for display.
+ *
+ * There was no shared formatter — the only currency-symbol map in the codebase was a
+ * non-exported closure inside an assessment preview component, and several places simply
+ * hardcoded `₹`. That is fine while everything is INR and wrong the moment it isn't, which is a
+ * live risk on a platform with tenants in India and Saudi Arabia.
+ *
+ * The server always sends the currency alongside the amount. Read it; never assume rupees.
+ */
+
+const SYMBOLS: Record<string, string> = {
+  INR: "₹",
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  SAR: "﷼",
+  AED: "د.إ",
+};
+
+/** The bare symbol for a currency code, falling back to the code itself. */
+export function currencySymbol(currency?: string | null): string {
+  const code = (currency || "INR").toUpperCase();
+  return SYMBOLS[code] ?? code;
+}
+
+/**
+ * `formatMoney("1499.00", "INR")` → `"₹1,499"`.
+ *
+ * Prices on this platform are whole-rupee in practice, so trailing `.00` is noise on a card.
+ * A genuine fractional amount keeps its decimals rather than being silently rounded — showing
+ * someone a price they will not actually be charged is worse than an untidy number.
+ */
+export function formatMoney(
+  amount: string | number | null | undefined,
+  currency?: string | null,
+): string {
+  if (amount === null || amount === undefined || amount === "") return "";
+  const value = typeof amount === "number" ? amount : Number(amount);
+  if (!Number.isFinite(value)) return "";
+
+  const code = (currency || "INR").toUpperCase();
+  const hasFraction = Math.abs(value % 1) > 0;
+  const digits = hasFraction ? 2 : 0;
+
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: code,
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    }).format(value);
+  } catch {
+    // An unknown ISO code throws. Better a readable "SAR 1,499" than a crashed card.
+    return `${currencySymbol(code)}${value.toLocaleString(undefined, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    })}`;
+  }
+}


### PR DESCRIPTION
The UI for paid adaptive courses. The backend (BE #491) is already merged, deployed and prod-verified.

## What you can see

**Paid / Free tag on every adaptive course card** — admin grid, admin list row, student catalog card, student my-courses card. Same pill geometry as Published/Draft so they read as one family; amber for Paid, since emerald already means Published.

`PriceTag` renders **nothing** when `is_paid` is `undefined`. That is a course whose serializer hasn't sent the field yet, and labelling it "Free" would be a confident lie about money. Absent beats wrong.

**Pricing dialog in the builder** — a dialog, not an eighth toolbar pill. A price needs a number, the toolbar file already comments that seven pills crush the hero title, and a dialog gives room for the two things a toggle cannot:

- The three server-side 400s (no price / auto-enroll on / template) are pre-flighted client-side so an admin gets a sentence rather than a bounced request — but the server's wording still wins if one gets through.
- A **409** renders *inside* the dialog with a "Connect Razorpay" button, keeping every entered value. Never a toast. The `settings_url` comes off the wire, so only an in-app path is trusted.
- **`grandfathered_students`** gets its own confirmation panel. A 6-second snackbar is the wrong place for "N students keep free access" on a change that feels irreversible.

Only org admins see the control — the backend 403s a `course_manager` on those keys, and a control that always fails is worse than no control.

**Student buy flow** — a paid course reads "Buy ₹X" with a cart icon and opens checkout directly.

**Access-source chip** in the builder's Students panel: Paid / Self / Comped / Import / Legacy. Shows *whether* someone paid, never how much — an instructor can see the roster, but what a learner was charged is admin-only.

## Three real bugs fixed in `usePayment`

These were live, and none are adaptive-specific:

1. **It sent an `amount` from the client.** The server ignores it and prices the order itself, so the field was inert — but a price-shaped field in a payment request is a standing invitation to reintroduce client-authored pricing, which is the bug that once let any course be bought for a rupee. Removed from the contract.
2. **It leaked a stuck loading state.** `isProcessing` was reset in `ondismiss` and the outer catch only — never after a *successful* payment, and never after `payment.failed`. Any surface trusting the flag stayed loading forever once a payment went through.
3. **It reported successful payments as failures.** If the money reached Razorpay but our verify call failed, the webhook still settles it server-side. Telling a learner their payment failed when they've been charged and will get access is the worst thing this code can say. That is now a distinct `settling` outcome with its own message; a genuine `payment.failed` is still a failure.

Double-clicks are blocked with a ref, not state — a second click fires before React re-renders.

## Design decisions worth reviewing

- **The catalog card is not removed optimistically on the paid path**, unlike the free one. A card that vanishes before payment is confirmed tells someone they own something they may not.
- **A stale "Enroll" click that comes back 402** (the course was priced while the page was open) converges on the same checkout instead of showing an error for something the learner can simply buy.
- Adds `lib/utils/money.ts`. There was no shared formatter — one non-exported symbol map in an assessment component and hardcoded `₹` elsewhere, which is fine while everything is INR and wrong the moment it isn't.

## Verified

`tsc --noEmit` clean and production build clean at every step. Both pre-existing `usePayment` call sites migrated to the new outcome API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)