### PR TITLE
feat(payments): currency picker in the course pricing dialog

### DIFF
--- a/components/admin/adaptive-course/CoursePricingDialog.tsx
+++ b/components/admin/adaptive-course/CoursePricingDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { currenciesService, type CurrencyOption } from "@/lib/services/currencies.service";
 import {
   Alert,
   Box,
@@ -31,7 +32,11 @@ import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-
  * "connect Razorpay first" message without losing what the admin typed.
  */
 
-const CURRENCIES = [{ code: "INR", label: "₹ INR" }];
+/**
+ * Loaded from the server, never hard-coded. The backend validator and this list are the same
+ * table, so the dropdown cannot offer a currency the server would reject — which would let an
+ * admin create a course nobody can buy.
+ */
 
 export function CoursePricingDialog({
   open,
@@ -49,11 +54,18 @@ export function CoursePricingDialog({
   const [price, setPrice] = useState(course.price ?? "");
   const [currency, setCurrency] = useState(course.currency || "INR");
   const [saving, setSaving] = useState(false);
+  const [currencies, setCurrencies] = useState<CurrencyOption[]>([]);
+  const [currencyFrozen, setCurrencyFrozen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [settingsUrl, setSettingsUrl] = useState<string | null>(null);
   const [grandfathered, setGrandfathered] = useState<number | null>(null);
 
   // Re-seed each time it opens, so a cancelled edit does not persist into the next visit.
+  useEffect(() => {
+    if (!open) return;
+    void currenciesService.list().then(setCurrencies).catch(() => setCurrencies([]));
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     setIsPaid(course.is_paid);
@@ -80,6 +92,7 @@ export function CoursePricingDialog({
         is_paid: isPaid,
         // Turning paid off clears the price server-side too; sending null keeps the two in step.
         price: isPaid ? String(numericPrice) : null,
+        currency,
       });
       const patch = {
         is_paid: res.is_paid,
@@ -98,6 +111,13 @@ export function CoursePricingDialog({
     } catch (e: unknown) {
       const resp = (e as { response?: { status?: number; data?: Record<string, unknown> } })?.response;
       const detail = typeof resp?.data?.detail === "string" ? resp.data.detail : null;
+      if (resp?.status === 409 && detail && /currency/i.test(detail)) {
+        // Frozen because money already moved against this course — not a Razorpay problem.
+        setCurrencyFrozen(true);
+        setCurrency(course.currency || "INR");
+        setError(detail);
+        return;
+      }
       if (resp?.status === 409) {
         const url = typeof resp.data?.settings_url === "string" ? resp.data.settings_url : null;
         // Only an in-app path is trusted — this URL comes off the wire.
@@ -208,13 +228,18 @@ export function CoursePricingDialog({
                 size="small"
                 label="Currency"
                 value={currency}
-                disabled
-                helperText="Payments settle in INR through your Razorpay account."
+                disabled={saving || currencyFrozen || currencies.length === 0}
+                onChange={(e) => setCurrency(e.target.value)}
+                helperText={
+                  currencyFrozen
+                    ? "Locked: this course already has payment activity. Re-pricing in another currency means a new course."
+                    : "Your Razorpay account must be enabled for the currency you choose."
+                }
                 sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
               >
-                {CURRENCIES.map((c) => (
+                {(currencies.length ? currencies : [{ code: currency, name: currency, symbol: "", decimals: 2 }]).map((c) => (
                   <MenuItem key={c.code} value={c.code}>
-                    {c.label}
+                    {c.symbol ? `${c.symbol} ` : ""}{c.code} — {c.name}
                   </MenuItem>
                 ))}
               </TextField>

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -573,6 +573,8 @@ export const adminAdaptiveCourseService = {
       is_paid?: boolean;
       /** Send as a string; the server validates it as a Decimal. */
       price?: string | null;
+      /** ISO code. Frozen server-side once the course has payment activity. */
+      currency?: string;
     },
   ): Promise<AdminAdaptiveCourseDetail & { grandfathered_students?: number }> {
     const { data } = await apiClient.patch<AdminAdaptiveCourseDetail & { grandfathered_students?: number }>(

--- a/lib/services/currencies.service.ts
+++ b/lib/services/currencies.service.ts
@@ -1,0 +1,23 @@
+import apiClient from "./api";
+
+export interface CurrencyOption {
+  code: string;
+  name: string;
+  symbol: string;
+  /** Decimal places in the minor unit: 0 for JPY-likes, 3 for the Gulf dinars, 2 otherwise. */
+  decimals: number;
+}
+
+/**
+ * What a course may be priced in.
+ *
+ * Served from the same module the backend validator reads, so the dropdown can never offer a
+ * currency the server would reject — which would otherwise let an admin create a course nobody
+ * can buy.
+ */
+export const currenciesService = {
+  list: async (): Promise<CurrencyOption[]> => {
+    const res = await apiClient.get<{ currencies: CurrencyOption[] }>("/payment-gateway/api/currencies/");
+    return res.data?.currencies ?? [];
+  },
+};


### PR DESCRIPTION
Pairs with the backend multi-currency PR.

The currency select was a **disabled control with one hard-coded INR option**. It now loads from `GET /payment-gateway/api/currencies/` — the same table the backend validator reads — so the dropdown cannot offer a currency the server would reject and leave an admin holding a course nobody can buy.

- Sends `currency` on save
- Handles the **409** the server returns when a course already has payment activity: the field locks, reverts to the stored currency, and explains that re-pricing in another currency means a new course, not an edit
- `formatMoney` already read the currency off the server rather than assuming rupees, so card and preview prices follow automatically

## Verified

`tsc --noEmit` clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)