### PR TITLE
fix(jobs): stop the profile gate hanging the page on "Loading jobs…"

### DIFF
--- a/app/jobs-v2/page.tsx
+++ b/app/jobs-v2/page.tsx
@@ -205,7 +205,7 @@ export default function JobsV2Page() {
   const [activeTab, setActiveTab] = useState<"browse" | "applied">("browse");
   const [viewMode, setViewMode] = useState<ListView>("cards");
 
-  const { blocked: gateBlocked, showLock, reportError: reportProfileLock } = useModuleLocked("jobs");
+  const { showLock, reportError: reportProfileLock } = useModuleLocked("jobs");
 
   const fetchJobs = useCallback(async () => {
     try {
@@ -236,11 +236,16 @@ export default function JobsV2Page() {
       reportProfileLock]);
 
   useEffect(() => {
-    // Held while the gate is still resolving as well as while locked. Firing this early is what
-    // produced a 403-and-a-toast before the lock could render.
-    if (gateBlocked) return;
+    // Always fetch. An earlier version held this until the profile gate resolved, which coupled
+    // this page to an unrelated request: while the gate was still loading, `loading` (initialised
+    // true, and cleared only in fetchJobs' finally) never cleared and the page sat on
+    // "Loading jobs..." indefinitely.
+    //
+    // The 403 IS the reliable signal — it comes from the server, which is the authority anyway.
+    // Its catch calls reportProfileLock and the modal appears. One wasted request is a much
+    // better trade than a page that can hang on someone else's latency.
     fetchJobs();
-  }, [fetchJobs, gateBlocked]);
+  }, [fetchJobs]);
 
   const handleSearchClick = useCallback(() => {
     setFilters((prev) => ({

--- a/app/mock-interview/page.tsx
+++ b/app/mock-interview/page.tsx
@@ -21,7 +21,7 @@ import { Chip } from "@mui/material";
 export default function MockInterviewPage() {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
-  const { blocked: gateBlocked, showLock, reportError: reportProfileLock } = useModuleLocked("interview");
+  const { showLock, reportError: reportProfileLock } = useModuleLocked("interview");
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [interviews, setInterviews] = useState<MockInterview[]>([]);

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -19,7 +19,7 @@ import { buildResumeInitialData } from "@/lib/utils/buildResumeInitialData";
 export default function ResumePage() {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
-  const { blocked: gateBlocked, showLock, reportError: reportProfileLock } = useModuleLocked("resume");
+  const { showLock, reportError: reportProfileLock } = useModuleLocked("resume");
 
   useEffect(() => {
     let alive = true;

--- a/lib/contexts/ProfileGateContext.tsx
+++ b/lib/contexts/ProfileGateContext.tsx
@@ -66,6 +66,13 @@ export function ProfileGateProvider({ children }: { children: React.ReactNode })
 
   useEffect(() => {
     void load();
+    // Belt and braces. Nothing should depend on the gate resolving — that coupling is what broke
+    // the Jobs page — but a provider stuck on "loading" forever is still a bug in its own right,
+    // and a lock that never appears is better than one that appears at random minutes later.
+    const failsafe = setTimeout(() => {
+      setStatus((prev) => (prev === "loading" ? "error" : prev));
+    }, 15000);
+    return () => clearTimeout(failsafe);
   }, [load]);
 
   const applyServerLock = useCallback((body: { missing_fields?: string[] }) => {
@@ -122,20 +129,21 @@ export function useProfileGate(): ProfileGateValue {
 /**
  * The gate for one module, in the shape a page actually needs.
  *
- * `blocked` is the important one: it is true while the gate is still LOADING as well as when the
- * module is locked. Pages use it to hold their own fetches, which fixes the race that made the
- * first version useless — the page rendered its content while the gate was still resolving, fired
- * its request, got a 403, and fell through to a generic toast. Guarding the render but not the
- * fetch guards nothing.
+ * Deliberately does NOT offer a "hold your fetch until I resolve" flag. It used to, and that flag
+ * coupled every gated page to an unrelated request: while the profile was still loading the page's
+ * own `loading` state never cleared, and Jobs sat on "Loading jobs..." indefinitely.
  *
- * `showLock` is only true once we KNOW, so a learner with a complete profile never sees a flash
- * of "locked" on a page they are entitled to.
+ * Pages fetch immediately and feed any failure to `reportError`. The 403 is the reliable signal —
+ * it comes from the server, which is the authority regardless — and one wasted request beats a
+ * page that can hang on someone else's latency.
+ *
+ * `showLock` is only true once we KNOW, so a learner with a complete profile never sees a flash of
+ * "locked" on a page they are entitled to, and a learner we already know is locked sees the modal
+ * without waiting for a round trip.
  */
 export function useModuleLocked(moduleKey: string): {
   locked: boolean;
   ready: boolean;
-  /** Hold your data fetch while this is true. */
-  blocked: boolean;
   /** Render the lock modal while this is true. */
   showLock: boolean;
   /** Feed a caught error here; a profile_incomplete 403 flips the lock on. */
@@ -154,7 +162,7 @@ export function useModuleLocked(moduleKey: string): {
     return true;
   };
 
-  return { locked, ready, blocked: !ready || locked, showLock: ready && locked, reportError };
+  return { locked, ready, showLock: ready && locked, reportError };
 }
 
 /**


### PR DESCRIPTION
Jobs sat on "Loading jobs…" forever. **My bug, introduced in #1187.**

## Mechanism

```ts
const [loading, setLoading] = useState(true);   // starts true
...
if (gateBlocked) return;                        // fetchJobs never runs
fetchJobs();                                    // ...so setLoading(false) never happens
```

`setLoading(false)` lives **only** in `fetchJobs`' `finally`. I made the fetch conditional and left `loading` initialised `true`, so any time the gate blocked, the spinner never cleared.

Worse: `gateBlocked` is true while the profile request is merely **in flight**. So this coupled the Jobs page to an unrelated network call — with a 45s client timeout behind it, and no resolution at all if that call never settled.

## The design error, not just the typo

I traded *"one wasted 403"* for *"a hard dependency on another request completing"*. That's a bad trade, and the symptom was worse than the thing I was avoiding: a page that hangs is worse than a page that shows a lock a beat late.

The 403 **is** the reliable signal — it comes from the server, which is the authority regardless. So pages fetch immediately and feed any failure to `reportError`, which raises the modal.

## Fix

- `blocked` is **removed from `useModuleLocked` entirely**, not fixed at the one call site, so no page can reintroduce the coupling
- `showLock` stays: it short-circuits the round trip when we already know the learner is locked, which is the only part of the proactive path worth keeping
- A 15s failsafe so the provider always settles. Nothing depends on that now, but a context stuck on `loading` is a bug in its own right

`mock-interview` and `resume` never gated their fetches — Jobs was the only page affected. Verified by inspection of both.

## Verified

`tsc --noEmit` clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)