### PR TITLE
fix(jobs): memoize reportError — an unstable identity was an infinite fetch loop

### DIFF
--- a/app/jobs-v2/page.tsx
+++ b/app/jobs-v2/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { ProfileLockModal } from "@/components/common/ProfileLockModal";
 import { useModuleLocked } from "@/lib/contexts/ProfileGateContext";
 import Link from "next/link";
@@ -235,17 +235,32 @@ export default function JobsV2Page() {
   }, [filters.location, filters.job_type, filters.employment_type, filters.search, showToast,
       reportProfileLock]);
 
+  // The effect below refetches on the FILTER VALUES, never on fetchJobs' identity.
+  //
+  // This page shipped an infinite fetch loop twice: fetchJobs is a useCallback, one of its deps
+  // was an unmemoized function, so every render produced a new fetchJobs, which re-fired the
+  // effect, which set state, which rendered again. The request succeeded every time — thousands
+  // of 200s — and the spinner never cleared because setLoading(true) ran again immediately.
+  //
+  // Memoizing that dep fixes today's cause. Depending on primitives instead of a function
+  // identity removes the whole CLASS, so the next unstable dep added here cannot resurrect it.
+  const filterKey = [
+    filters.location ?? "",
+    filters.job_type ?? "",
+    filters.employment_type ?? "",
+    filters.search?.trim() ?? "",
+  ].join("|");
+
+  const fetchJobsRef = useRef(fetchJobs);
+  fetchJobsRef.current = fetchJobs;
+
   useEffect(() => {
     // Always fetch. An earlier version held this until the profile gate resolved, which coupled
-    // this page to an unrelated request: while the gate was still loading, `loading` (initialised
-    // true, and cleared only in fetchJobs' finally) never cleared and the page sat on
-    // "Loading jobs..." indefinitely.
-    //
-    // The 403 IS the reliable signal — it comes from the server, which is the authority anyway.
-    // Its catch calls reportProfileLock and the modal appears. One wasted request is a much
-    // better trade than a page that can hang on someone else's latency.
-    fetchJobs();
-  }, [fetchJobs]);
+    // this page to an unrelated request and left `loading` (initialised true, cleared only in
+    // fetchJobs' finally) stuck on. The 403 is the reliable signal — it comes from the server,
+    // which is the authority anyway — and its catch raises the lock modal.
+    void fetchJobsRef.current();
+  }, [filterKey]);
 
   const handleSearchClick = useCallback(() => {
     setFilters((prev) => ({

--- a/lib/contexts/ProfileGateContext.tsx
+++ b/lib/contexts/ProfileGateContext.tsx
@@ -153,14 +153,22 @@ export function useModuleLocked(moduleKey: string): {
   const ready = status !== "loading";
   const locked = lockedModules.includes(moduleKey);
 
-  const reportError = (err: unknown): boolean => {
-    const lock = readProfileLock(err);
-    if (!lock) return false;
-    // The server is authoritative. If it says locked, lock — even when the cached completion
-    // disagreed, because the cache can be stale and the API cannot.
-    applyServerLock(lock);
-    return true;
-  };
+  // MEMOIZED, and that is load-bearing rather than a micro-optimisation. Callers put this in a
+  // useCallback dependency array; an unstable identity there recreates their fetch on every
+  // render, which re-fires their effect, which sets state, which renders again — an infinite
+  // fetch loop that presents as a spinner that never clears. That is exactly what happened to
+  // the Jobs page.
+  const reportError = useCallback(
+    (err: unknown): boolean => {
+      const lock = readProfileLock(err);
+      if (!lock) return false;
+      // The server is authoritative. If it says locked, lock — even when the cached completion
+      // disagreed, because the cache can be stale and the API cannot.
+      applyServerLock(lock);
+      return true;
+    },
+    [applyServerLock],
+  );
 
   return { locked, ready, showLock: ready && locked, reportError };
 }


### PR DESCRIPTION
Jobs **still** hung on "Loading jobs…" after #1190, because #1190 fixed the wrong mechanism.

## The actual cause

`reportError` was a plain function, recreated every render. `fetchJobs` is a `useCallback` that **depends on it**:

```
render → new reportError → new fetchJobs → useEffect fires
      → setLoading(true) → setState → render → new reportError → …
```

An **infinite fetch loop**. The spinner never cleared because `setLoading(true)` ran again the instant each request finished.

The backend was healthy the whole time — **200 in 0.23s with 4 jobs** — so those requests were all *succeeding*. Thousands of them.

## Why I missed it twice

I introduced this in #1187 by adding `reportProfileLock` to that dependency array. The `gateBlocked` guard I removed in #1190 had been **masking** the loop by stopping the effect from running at all; removing the guard exposed what was underneath.

So #1190 wasn't wrong — the coupling it removed was real and worth removing — but it wasn't the cause, and I shipped it without checking it against a running page. Both RCAs were plausible mechanisms consistent with the symptom, which is exactly the trap.

## Fix

`reportError` wrapped in `useCallback` with a stable dependency. The chain is verifiable link by link:

| | deps | stable? |
|---|---|---|
| `applyServerLock` | `[]` | forever |
| `reportError` | `[applyServerLock]` | forever |
| `fetchJobs` | `[…filters, showToast, reportProfileLock]` | only on real change |

`showToast` was already memoized — which is why this page worked before I touched it.

The comment on `reportError` states that the memoization is **load-bearing, not a micro-optimisation**, so the next person to "tidy" it doesn't reintroduce a production hang.

## Note on verification

The frontend has no test runner, so I verified the identity chain statically rather than with a test. Given I've now been wrong twice by inspection here, that's worth flagging rather than glossing: this needs a look at a real page before it's called done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)