### PR TITLE
release: fix the Jobs infinite fetch loop

### DIFF
--- a/app/jobs-v2/page.tsx
+++ b/app/jobs-v2/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { ProfileLockModal } from "@/components/common/ProfileLockModal";
 import { useModuleLocked } from "@/lib/contexts/ProfileGateContext";
 import Link from "next/link";
@@ -235,17 +235,32 @@ export default function JobsV2Page() {
   }, [filters.location, filters.job_type, filters.employment_type, filters.search, showToast,
       reportProfileLock]);
 
+  // The effect below refetches on the FILTER VALUES, never on fetchJobs' identity.
+  //
+  // This page shipped an infinite fetch loop twice: fetchJobs is a useCallback, one of its deps
+  // was an unmemoized function, so every render produced a new fetchJobs, which re-fired the
+  // effect, which set state, which rendered again. The request succeeded every time — thousands
+  // of 200s — and the spinner never cleared because setLoading(true) ran again immediately.
+  //
+  // Memoizing that dep fixes today's cause. Depending on primitives instead of a function
+  // identity removes the whole CLASS, so the next unstable dep added here cannot resurrect it.
+  const filterKey = [
+    filters.location ?? "",
+    filters.job_type ?? "",
+    filters.employment_type ?? "",
+    filters.search?.trim() ?? "",
+  ].join("|");
+
+  const fetchJobsRef = useRef(fetchJobs);
+  fetchJobsRef.current = fetchJobs;
+
   useEffect(() => {
     // Always fetch. An earlier version held this until the profile gate resolved, which coupled
-    // this page to an unrelated request: while the gate was still loading, `loading` (initialised
-    // true, and cleared only in fetchJobs' finally) never cleared and the page sat on
-    // "Loading jobs..." indefinitely.
-    //
-    // The 403 IS the reliable signal — it comes from the server, which is the authority anyway.
-    // Its catch calls reportProfileLock and the modal appears. One wasted request is a much
-    // better trade than a page that can hang on someone else's latency.
-    fetchJobs();
-  }, [fetchJobs]);
+    // this page to an unrelated request and left `loading` (initialised true, cleared only in
+    // fetchJobs' finally) stuck on. The 403 is the reliable signal — it comes from the server,
+    // which is the authority anyway — and its catch raises the lock modal.
+    void fetchJobsRef.current();
+  }, [filterKey]);
 
   const handleSearchClick = useCallback(() => {
     setFilters((prev) => ({

--- a/lib/contexts/ProfileGateContext.tsx
+++ b/lib/contexts/ProfileGateContext.tsx
@@ -153,14 +153,22 @@ export function useModuleLocked(moduleKey: string): {
   const ready = status !== "loading";
   const locked = lockedModules.includes(moduleKey);
 
-  const reportError = (err: unknown): boolean => {
-    const lock = readProfileLock(err);
-    if (!lock) return false;
-    // The server is authoritative. If it says locked, lock — even when the cached completion
-    // disagreed, because the cache can be stale and the API cannot.
-    applyServerLock(lock);
-    return true;
-  };
+  // MEMOIZED, and that is load-bearing rather than a micro-optimisation. Callers put this in a
+  // useCallback dependency array; an unstable identity there recreates their fetch on every
+  // render, which re-fires their effect, which sets state, which renders again — an infinite
+  // fetch loop that presents as a spinner that never clears. That is exactly what happened to
+  // the Jobs page.
+  const reportError = useCallback(
+    (err: unknown): boolean => {
+      const lock = readProfileLock(err);
+      if (!lock) return false;
+      // The server is authoritative. If it says locked, lock — even when the cached completion
+      // disagreed, because the cache can be stale and the API cannot.
+      applyServerLock(lock);
+      return true;
+    },
+    [applyServerLock],
+  );
 
   return { locked, ready, showLock: ready && locked, reportError };
 }


### PR DESCRIPTION
Promotes `stagging` to production. Three commits, one fix.

## What this fixes

Jobs was calling `GET /jobs-v2/api/jobs/` **continuously** — confirmed from the network tab, every call returning 200 with real data — and the page sat on "Loading jobs…" permanently.

`fetchJobs` is a `useCallback` whose dependencies included `reportProfileLock`, an **unmemoized function**. New identity every render → new `fetchJobs` → effect re-fires → `setLoading(true)` + `setState` → render → new identity → forever. The spinner never cleared because `setLoading(true)` ran again the instant each request finished.

## Two changes, deliberately

1. **`reportError` memoized** — today's cause
2. **The effect keys on filter *values*, not function identity**, calling `fetchJobs` through a ref

The second is why this is worth two commits. Memoization alone is correct *only while every dependency in that array stays memoized*, and this page has shipped this same loop twice. Simulated dependency chain:

```
BEFORE (unmemoized, keyed on identity)   renders=50 fetches=50  <-- loop
memoized, keyed on identity              renders= 2 fetches= 1
memoized + primitive key                 renders= 2 fetches= 1
even if a dep regresses later            renders= 2 fetches= 1
```

The last row removes the class, not just the instance.

## Regression history, stated plainly

This is the third frontend defect in this line of work, all from the same PR family:

| | Defect | Cause |
|---|---|---|
| #1186 | country dropdown 404 | shipped a UI depending on an unmerged backend endpoint |
| #1187 | Jobs hung on load | gated a fetch behind a flag while `loading` stayed initialised `true` |
| #1190 | loop still present | removed the guard that had been *masking* the loop, not the loop |

All three passed `tsc` and a production build. **The repo has no frontend test runner** — no jest, no vitest, no testing-library — so nothing catches a render loop or a hook dependency mistake short of loading the page. Recommend standing that up before the next frontend feature; this bug is four lines of test.

## Please verify after deploy

Open Jobs with the network tab visible and confirm **one** request to `jobs/?client_id=…`, not a stream. I have claimed this fixed twice already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)