### PR TITLE
fix(dashboard): align the right rail with the briefing card

### DIFF
--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -129,11 +129,11 @@ export function DashboardV2() {
       </Box>
 
       <Stack spacing={2}>
-        {/* First in the rail: it only appears for a learner who has something to fix, and it is
-            the thing standing between them and three whole modules. */}
-        <Box data-tour-id="dash-profile">
-          <ProfileCompletionPanel />
-        </Box>
+        {/* First in the rail, and it renders NOTHING for a learner with nothing to fix.
+            Deliberately not wrapped in a <Box> here: an empty wrapper still occupies a
+            Stack spacing slot, which pushed the whole rail 16px out of alignment with the
+            briefing card next to it. The tour anchor lives on the panel's own card instead. */}
+        <ProfileCompletionPanel />
         {data.todayGoal && (
           <Box data-tour-id="dash-goal">
             <TodayGoalPanel goal={data.todayGoal} />

--- a/components/dashboard/v2/ProfileCompletionPanel.tsx
+++ b/components/dashboard/v2/ProfileCompletionPanel.tsx
@@ -36,7 +36,7 @@ export function ProfileCompletionPanel() {
     .filter(Boolean);
 
   return (
-    <PanelCard sx={{ mb: 0 }}>
+    <PanelCard sx={{ mb: 0 }} data-tour-id="dash-profile">
       <SectionHeader
         icon="mdi:account-check-outline"
         title="Complete your profile"

--- a/components/dashboard/v2/parts.tsx
+++ b/components/dashboard/v2/parts.tsx
@@ -40,9 +40,21 @@ export function avatarColor(name: string): string {
 }
 
 // --- atoms ---
-export function PanelCard({ children, sx }: { children: ReactNode; sx?: object }) {
+export function PanelCard({
+  children,
+  sx,
+  // Forwarded so a panel can carry a tour anchor on its own card. Wrapping a panel in an extra
+  // <Box> to hold the anchor is not equivalent: a panel that renders null still leaves the
+  // wrapper behind, and an empty wrapper occupies a Stack spacing slot.
+  ...rest
+}: {
+  children: ReactNode;
+  sx?: object;
+  [key: `data-${string}`]: string | undefined;
+}) {
   return (
     <Box
+      {...rest}
       sx={{
         p: 2,
         mb: 2,


### PR DESCRIPTION
Reported: Today's Goal sits lower than the AI Briefing card. **My bug**, from the profile-gating PR.

## Cause

I wrapped the profile completion panel to carry a tour anchor:

```tsx
<Box data-tour-id="dash-profile">
  <ProfileCompletionPanel />
</Box>
```

`ProfileCompletionPanel` returns `null` for anyone whose profile is complete or exempt — which is most users, and **every** staff account. But the **wrapper still renders**. An empty `<div>` is still a child of `<Stack spacing={2}>`, so it consumed a 16px gap and pushed the entire rail down.

Ironically the panel that caused the misalignment is the one you can't see.

## Fix

The wrapper is gone. The tour anchor moved onto the panel's own `PanelCard`, which only exists when the panel does — so a `null` render now contributes no DOM node at all.

`PanelCard` forwards `data-*` attributes to make that possible. Wrapping a panel to hold an anchor is **not** equivalent to putting the anchor on the panel, precisely because of the null case, and there's a comment at both ends saying so.

## Verified

Rendered both states side by side rather than reasoning about flex gaps. Before: the rail card sits 16px low. After: tops align.

`tsc --noEmit` clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)