### PR TITLE
release: sidebar lock/info collision + dashboard rail alignment

### DIFF
--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -129,11 +129,11 @@ export function DashboardV2() {
       </Box>
 
       <Stack spacing={2}>
-        {/* First in the rail: it only appears for a learner who has something to fix, and it is
-            the thing standing between them and three whole modules. */}
-        <Box data-tour-id="dash-profile">
-          <ProfileCompletionPanel />
-        </Box>
+        {/* First in the rail, and it renders NOTHING for a learner with nothing to fix.
+            Deliberately not wrapped in a <Box> here: an empty wrapper still occupies a
+            Stack spacing slot, which pushed the whole rail 16px out of alignment with the
+            briefing card next to it. The tour anchor lives on the panel's own card instead. */}
+        <ProfileCompletionPanel />
         {data.todayGoal && (
           <Box data-tour-id="dash-goal">
             <TodayGoalPanel goal={data.todayGoal} />

--- a/components/dashboard/v2/ProfileCompletionPanel.tsx
+++ b/components/dashboard/v2/ProfileCompletionPanel.tsx
@@ -36,7 +36,7 @@ export function ProfileCompletionPanel() {
     .filter(Boolean);
 
   return (
-    <PanelCard sx={{ mb: 0 }}>
+    <PanelCard sx={{ mb: 0 }} data-tour-id="dash-profile">
       <SectionHeader
         icon="mdi:account-check-outline"
         title="Complete your profile"

--- a/components/dashboard/v2/parts.tsx
+++ b/components/dashboard/v2/parts.tsx
@@ -40,9 +40,21 @@ export function avatarColor(name: string): string {
 }
 
 // --- atoms ---
-export function PanelCard({ children, sx }: { children: ReactNode; sx?: object }) {
+export function PanelCard({
+  children,
+  sx,
+  // Forwarded so a panel can carry a tour anchor on its own card. Wrapping a panel in an extra
+  // <Box> to hold the anchor is not equivalent: a panel that renders null still leaves the
+  // wrapper behind, and an empty wrapper occupies a Stack spacing slot.
+  ...rest
+}: {
+  children: ReactNode;
+  sx?: object;
+  [key: `data-${string}`]: string | undefined;
+}) {
   return (
     <Box
+      {...rest}
       sx={{
         p: 2,
         mb: 2,

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -215,12 +215,19 @@ function SidebarNavButton({
   shell,
   indent = false,
   locked = false,
+  hasInfo = false,
 }: {
   icon: string;
   label: string;
   isActive: boolean;
   /** Reachable, but gated. The row dims and shows a padlock; the link stays live on purpose. */
   locked?: boolean;
+  /**
+   * Whether the (i) tooltip button is rendered for this row. It is absolutely positioned at
+   * right: 4, outside this component, so the padlock has to reserve room for it or the two
+   * icons stack on top of each other.
+   */
+  hasInfo?: boolean;
   collapsed: boolean;
   rtl: boolean;
   shell: ReturnType<typeof useTenantShellTheme>;
@@ -296,7 +303,24 @@ function SidebarNavButton({
         />
       )}
       {locked && !collapsed && (
-        <IconWrapper icon="mdi:lock-outline" size={14} style={{ opacity: 0.75, flexShrink: 0 }} />
+        <Box
+          component="span"
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            flexShrink: 0,
+            opacity: 0.75,
+            // The (i) button sits absolutely at right: 4 and is ~18px wide including its
+            // padding. Without this the padlock renders underneath it.
+            ...(hasInfo
+              ? rtl
+                ? { ml: "22px" }
+                : { mr: "22px" }
+              : {}),
+          }}
+        >
+          <IconWrapper icon="mdi:lock-outline" size={14} />
+        </Box>
       )}
     </ListItemButton>
   );
@@ -869,6 +893,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
               rtl={rtl}
               shell={shell}
               locked={isGated(item)}
+              hasInfo={Boolean(desc && !collapsed)}
             />
           </Link>
           {desc && !collapsed && (


### PR DESCRIPTION
Promotes `stagging` to production. Two visual fixes, both regressions from the profile-gating work.

## #1194 — sidebar: lock and ⓘ overlapped

The ⓘ tooltip button is `position: absolute; right: 4`, rendered **outside** `SidebarNavButton`. The padlock added for gated modules is the **last flex child inside** it — so both landed in the same few pixels and drew on top of each other.

`SidebarNavButton` now reserves a 22px gutter, but **only when the ⓘ actually renders**, so an unlocked row keeps its full width instead of carrying a permanent empty gap. Mirrored for RTL.

## #1195 — dashboard: right rail sat 16px low

The profile completion panel was wrapped in `<Box data-tour-id="dash-profile">` to carry a tour anchor. The panel returns `null` for anyone complete or exempt — most users, and every staff account — but **the wrapper still rendered**. An empty `<div>` is still a child of `<Stack spacing={2}>`, so it consumed a gap and pushed the whole rail down.

The panel causing the misalignment was the one you couldn't see.

Anchor moved onto the panel's own `PanelCard`, which only exists when the panel does. `PanelCard` forwards `data-*` for this, with comments at both ends noting that wrapping-to-anchor is not equivalent to anchoring-the-thing, precisely because of the null case.

## Verification

Both were verified by **rendering the markup and looking at it**, not by reasoning about CSS — before/after screenshots of identical structures. Given three frontend defects reached production earlier in this run from inspection-only checks, that felt like the minimum bar.

`tsc --noEmit` and production build clean on both.

## Standing recommendation

The repo still has **no frontend test runner**. Every frontend defect this session reached production because `tsc` + build cannot catch a render loop, a hook dependency mistake, an empty wrapper in a flex gap, or two icons at the same coordinates. Worth standing up vitest + testing-library before the next feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)