### PR TITLE
fix(profile): stop one account seeing another's profile on a shared browser

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef } from "react";
+import { loadProfileCache } from "@/lib/utils/profile-cache";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import {
@@ -40,6 +41,7 @@ import {
   POST_TYPE_CONFIG,
   UserXP,
   ReportReason,
+  Author,
 } from "@/lib/services/community.service";
 import { useToast } from "@/components/common/Toast";
 import { config } from "@/lib/config";
@@ -60,20 +62,32 @@ interface ThreadExtras {
 
 const POST_TYPES = Object.keys(POST_TYPE_CONFIG) as PostType[];
 const THREAD_EXTRAS_KEY = `community_thread_extras_${config.clientId}`;
-const PROFILE_LOCAL_KEY = `user_profile_extra_${config.clientId}`;
 
-function getCurrentUserAuthor() {
+
+/** Shape this page reads out of the local profile cache. */
+interface CachedAuthor {
+  id?: number;
+  user_name?: string;
+  name?: string;
+  full_name?: string;
+  profile_pic_url?: string;
+  avatar?: string;
+  role?: string;
+}
+
+function getCurrentUserAuthor(): Author | null {
   try {
-    const raw = localStorage.getItem(PROFILE_LOCAL_KEY);
-    if (raw) {
-      const p = JSON.parse(raw);
+    // User-scoped and cleared on logout. Previously this read a TENANT-scoped blob, so a fresh
+    // account on a shared browser posted under the previous user's name and avatar.
+    const p = loadProfileCache<CachedAuthor>();
+    if (Object.keys(p).length) {
       return {
         id: p.id ?? 0,
         user_name: p.user_name ?? "",
         name: p.name ?? p.full_name ?? p.user_name ?? "You",
         profile_pic_url: p.profile_pic_url ?? p.avatar ?? "",
         role: p.role ?? "student",
-      };
+      } as Author;
     }
   } catch {}
   return null;
@@ -100,7 +114,7 @@ function saveThreadExtras(extras: Map<number, ThreadExtras>): void {
 
 function getCurrentUserName(): string | null {
   try {
-    const raw = localStorage.getItem(PROFILE_LOCAL_KEY);
+    const raw = JSON.stringify(loadProfileCache<Record<string, unknown>>());
     if (raw) {
       const profile = JSON.parse(raw);
       return profile.user_name || null;

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { loadProfileCache, saveProfileCache } from "@/lib/utils/profile-cache";
 import { useTranslation } from "react-i18next";
 import { Box, CircularProgress } from "@mui/material";
 import { motion } from "framer-motion";
@@ -28,12 +29,6 @@ import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { config } from "@/lib/config";
 import { IconWrapper } from "@/components/common/IconWrapper";
 
-const PROFILE_LOCAL_KEY_PREFIX = "user_profile_extra";
-
-function getProfileLocalKey(): string {
-  return `${PROFILE_LOCAL_KEY_PREFIX}_${config.clientId}`;
-}
-
 function isEmptyValue(val: unknown): boolean {
   if (val === undefined || val === null || val === "") return true;
   if (Array.isArray(val) && val.length === 0) return true;
@@ -41,23 +36,11 @@ function isEmptyValue(val: unknown): boolean {
 }
 
 function loadLocalProfile(): Partial<UserProfile> {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = localStorage.getItem(getProfileLocalKey());
-    return raw ? JSON.parse(raw) : {};
-  } catch {
-    return {};
-  }
+  return loadProfileCache<UserProfile>();
 }
 
 function saveLocalProfile(data: Partial<UserProfileUpdate>) {
-  if (typeof window === "undefined") return;
-  try {
-    const existing = loadLocalProfile();
-    localStorage.setItem(getProfileLocalKey(), JSON.stringify({ ...existing, ...data }));
-  } catch {
-    // storage unavailable
-  }
+  saveProfileCache<UserProfileUpdate>(data);
 }
 
 function mergeWithLocalFallback(apiProfile: UserProfile): UserProfile {

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -16,6 +16,7 @@ import { authUtils } from "./auth-utils";
 import { clearResumeData } from "@/components/profile/resume/utils";
 import { clearTimeTrackingSession } from "../services/activity.service";
 import { setLoggingOut } from "../services/api";
+import { clearProfileCache } from "@/lib/utils/profile-cache";
 
 export type AuthLoginResult =
   | { profileActive: true }
@@ -233,6 +234,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       clearTimeTrackingSession();
       if (typeof window !== "undefined") {
         localStorage.removeItem("admin_mode");
+        // The profile cache is per-user, but it must not survive a logout on a shared machine.
+        clearProfileCache();
       }
       setUser(null);
       setRequiresProfileActivation(false);

--- a/lib/utils/profile-cache.ts
+++ b/lib/utils/profile-cache.ts
@@ -1,0 +1,108 @@
+import Cookies from "js-cookie";
+import { config } from "@/lib/config";
+
+/**
+ * The local profile cache — keyed by USER, and cleared when they leave.
+ *
+ * It used to be keyed by tenant alone (`user_profile_extra_<clientId>`), which meant one browser
+ * had one profile cache shared by every account that ever signed in on it. Sign out, sign up as
+ * somebody new, and the profile page merged the previous person's name, phone and date of birth
+ * into the new account's empty fields — and the community page built post authors from the same
+ * blob. Pressing Save then wrote that data to the new account for real.
+ *
+ * Two independent defences, because either alone is not enough:
+ *   1. The key includes the user id from the access token, so two accounts cannot collide even
+ *      if the cache is never cleared.
+ *   2. `clearProfileCache()` runs on logout, so nothing is left behind on a shared machine.
+ *
+ * Legacy tenant-only keys are deleted on first read. They belong to whoever used the browser
+ * before and must never be merged into anyone.
+ */
+
+const PREFIX = "user_profile_extra";
+
+/** The `user_id` claim from the access token, or null when signed out. */
+function currentUserId(): string | null {
+  try {
+    const token = Cookies.get("access_token");
+    if (!token) return null;
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const json = JSON.parse(
+      decodeURIComponent(
+        atob(payload.replace(/-/g, "+").replace(/_/g, "/"))
+          .split("")
+          .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+          .join(""),
+      ),
+    );
+    const id = json.user_id ?? json.userId ?? json.sub ?? null;
+    return id === null || id === undefined ? null : String(id);
+  } catch {
+    return null;
+  }
+}
+
+function legacyKey(): string {
+  return `${PREFIX}_${config.clientId}`;
+}
+
+/** Null when we cannot identify the user — in which case nothing is read or written. */
+export function profileCacheKey(): string | null {
+  const uid = currentUserId();
+  return uid ? `${PREFIX}_${config.clientId}_u${uid}` : null;
+}
+
+/** Remove any pre-user-scoping cache. It cannot be attributed to anyone, so it cannot be used. */
+function dropLegacy(): void {
+  try {
+    localStorage.removeItem(legacyKey());
+  } catch {
+    // storage unavailable
+  }
+}
+
+export function loadProfileCache<T extends object>(): Partial<T> {
+  if (typeof window === "undefined") return {};
+  dropLegacy();
+  const key = profileCacheKey();
+  // No identifiable user => no cache. Returning {} is the safe answer: showing SOMEONE's data
+  // is worse than showing none.
+  if (!key) return {};
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as Partial<T>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveProfileCache<T extends object>(data: Partial<T>): void {
+  if (typeof window === "undefined") return;
+  const key = profileCacheKey();
+  if (!key) return;
+  try {
+    const existing = loadProfileCache<T>();
+    localStorage.setItem(key, JSON.stringify({ ...existing, ...data }));
+  } catch {
+    // storage unavailable
+  }
+}
+
+/** Called on logout. Clears this user's cache and any legacy blob still lying around. */
+export function clearProfileCache(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const key = profileCacheKey();
+    if (key) localStorage.removeItem(key);
+    dropLegacy();
+    // Belt and braces: sweep every profile cache on this device. Logging out on a shared
+    // machine should not leave another account's details recoverable.
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith(PREFIX)) localStorage.removeItem(k);
+    }
+  } catch {
+    // storage unavailable
+  }
+}


### PR DESCRIPTION
Reported: a brand-new account, **first ever login**, already showed someone else's name, phone number, date of birth and college.

## Root cause

The local profile cache was keyed by **tenant alone**:

```ts
`user_profile_extra_${config.clientId}`   // no user id
```

So one browser had **one** profile cache shared by every account that ever signed in on it:

1. Account A fills their profile → written to `user_profile_extra_29`
2. Account A logs out — **logout never cleared it**; only `admin_mode` was removed
3. Account B signs up on the same browser → API correctly returns an empty profile
4. `mergeWithLocalFallback` fills every empty field from that key — with **Account A's data**

The junk values in the report (`British Indian Ocean Territory`, city `245: 4773`) corroborate it: those are stale fragments from earlier testing, not values the new account could have produced.

## Why it's worse than a display bug

- **Pressing Save writes the other person's phone number and date of birth into the new account for real.** The leak becomes permanent server-side data.
- The **community page** builds post authors from the same blob, so a fresh account posts under the previous user's name and avatar.

**Not caused by the profile-gating work** — this predates it. But the gating made it visible by putting those fields in front of people.

## Fix — two independent defences

1. **The key includes the user id** from the access token, so two accounts cannot collide even if the cache is never cleared.
2. **`clearProfileCache()` on logout**, sweeping every profile key on the device, so nothing is recoverable on a shared machine.

Legacy tenant-only keys are **deleted on first read** — they cannot be attributed to anyone, so they must never be merged into anyone. When no user can be identified, nothing is read or written at all: showing *someone's* data is worse than showing none.

## Verified

Simulated the key scheme across a logout/login on one browser:

```
BEFORE (tenant-only key)         account B sees: {"first_name":"Utkarsh","phone_number":"+91…"}  <-- LEAK
AFTER (user-scoped key)          account B sees: nothing  ok
AFTER, signed out (no user id)   account B sees: nothing  ok
```

`tsc --noEmit` clean, production build clean.

## Recommended follow-up

Anyone who was affected may have **saved** another person's details onto their own profile. Worth a query for profiles sharing an identical `phone_number` or `date_of_birth` across different users on the same tenant, to see whether any of this reached the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)