### PR TITLE
chore(adaptive): remove the stats strip from the student courses page

### DIFF
--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -19,7 +19,7 @@ import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { ViewToggle, SegmentedTabs, SearchFilterBar, type ListView } from "@/components/common/list";
-import { KpiRail, Reveal } from "@/components/scorecard/shared";
+import { Reveal } from "@/components/scorecard/shared";
 import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
 import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
@@ -55,18 +55,6 @@ export default function AdaptiveCourseListPage() {
       cancelled = true;
     };
   }, [featureOn]);
-
-  const stats = useMemo(() => {
-    let modules = 0;
-    let quizzes = 0;
-    let articles = 0;
-    for (const c of items) {
-      modules += c.module_count;
-      quizzes += c.quiz_count;
-      articles += c.article_count;
-    }
-    return { courses: items.length, modules, quizzes, articles };
-  }, [items]);
 
   // Difficulty facets are derived from whatever the catalog actually uses.
   const difficultyOptions = useMemo(() => {
@@ -139,19 +127,6 @@ export default function AdaptiveCourseListPage() {
           </HeaderActionButton>
         }
       />
-
-      {items.length > 0 && (
-            <Box data-tour-id="adaptive-stats">
-              <KpiRail
-                items={[
-                  { value: stats.courses, label: "Courses available", accent: "#6366f1" },
-                  { value: stats.modules, label: "Modules", accent: "#a855f7" },
-                  { value: stats.articles, label: "Adaptive articles", accent: "#10b981" },
-                  { value: stats.quizzes, label: "Adaptive quizzes", accent: "#ec4899" },
-                ]}
-              />
-            </Box>
-          )}
 
           {loading && <AdaptiveCourseListSkeleton />}
 

--- a/lib/guide/registry.ts
+++ b/lib/guide/registry.ts
@@ -300,14 +300,6 @@ export const PAGE_GUIDES: Record<string, PageGuideContent> = {
         color: "#a78bfa",
       },
       {
-        targetId: "adaptive-stats",
-        title: "Your catalogue at a glance",
-        narration: "This strip sums up everything available to you - how many courses, modules, adaptive articles and quizzes are ready for you to dive into.",
-        placement: "bottom",
-        icon: "mdi:chart-box-outline",
-        color: "#6366f1",
-      },
-      {
         targetId: "adaptive-levels",
         title: "Filter by difficulty",
         narration: "Use these level tabs to narrow the catalogue to a difficulty that suits you. Each tab shows a live count so you know how many courses match.",


### PR DESCRIPTION
Removes the "Courses available / Modules / Adaptive articles / Adaptive quizzes" strip from `/adaptive-courses`.

## Three things went with it

Rather than leaving orphans behind:

- the `stats` `useMemo` that fed it, now computing nothing
- the `KpiRail` import, now unused on this page
- **the "Your catalogue at a glance" guide step**, which targeted `data-tour-id="adaptive-stats"`

That last one is the one worth flagging: removing the element without removing the step would have left the product tour pointing at an id that no longer exists, so the guide would have stalled or skipped oddly on this page. Grep confirms nothing references `adaptive-stats` anywhere now.

`tsc --noEmit` clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)