### PR TITLE
release: profile cache leak fix, auth success tick, adaptive stats strip removal

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -26,6 +26,7 @@ import { AuthLayout } from "@/components/auth/AuthLayout";
 import { loginSchema } from "@/lib/schemas/auth.schema";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 import { Eye, EyeOff } from "lucide-react";
+import { SuccessTick } from "@/components/common/SuccessTick";
 
 interface LoginFormValues {
   email: string;
@@ -79,7 +80,9 @@ export default function LoginPage() {
         return;
       }
 
-      showToast(t("auth.loginSuccess"), "success");
+      // No toast. The success tick below takes over the screen for a beat instead — a corner
+      // toast competes with the dashboard already mounting underneath and is usually gone
+      // before anyone reads it.
       setIsRedirecting(true);
 
       const role = Cookies.get("user_role") ?? "";
@@ -102,7 +105,7 @@ export default function LoginPage() {
 
   // Conditional return AFTER all hooks
   if (isRedirecting) {
-    return <SignInLoader />;
+    return <SuccessTick label={t("auth.loginSuccess")} sublabel={t("auth.takingYouIn", "Taking you in…")} />;
   }
 
   return (

--- a/app/adaptive-courses/page.tsx
+++ b/app/adaptive-courses/page.tsx
@@ -19,7 +19,7 @@ import { useIsAdaptiveQuizEnabled } from "@/lib/contexts/ClientInfoContext";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { ViewToggle, SegmentedTabs, SearchFilterBar, type ListView } from "@/components/common/list";
-import { KpiRail, Reveal } from "@/components/scorecard/shared";
+import { Reveal } from "@/components/scorecard/shared";
 import { AdaptiveCourseCard } from "@/components/courses/AdaptiveCourseCard";
 import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
@@ -55,18 +55,6 @@ export default function AdaptiveCourseListPage() {
       cancelled = true;
     };
   }, [featureOn]);
-
-  const stats = useMemo(() => {
-    let modules = 0;
-    let quizzes = 0;
-    let articles = 0;
-    for (const c of items) {
-      modules += c.module_count;
-      quizzes += c.quiz_count;
-      articles += c.article_count;
-    }
-    return { courses: items.length, modules, quizzes, articles };
-  }, [items]);
 
   // Difficulty facets are derived from whatever the catalog actually uses.
   const difficultyOptions = useMemo(() => {
@@ -139,19 +127,6 @@ export default function AdaptiveCourseListPage() {
           </HeaderActionButton>
         }
       />
-
-      {items.length > 0 && (
-            <Box data-tour-id="adaptive-stats">
-              <KpiRail
-                items={[
-                  { value: stats.courses, label: "Courses available", accent: "#6366f1" },
-                  { value: stats.modules, label: "Modules", accent: "#a855f7" },
-                  { value: stats.articles, label: "Adaptive articles", accent: "#10b981" },
-                  { value: stats.quizzes, label: "Adaptive quizzes", accent: "#ec4899" },
-                ]}
-              />
-            </Box>
-          )}
 
           {loading && <AdaptiveCourseListSkeleton />}
 

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef } from "react";
+import { loadProfileCache } from "@/lib/utils/profile-cache";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import {
@@ -40,6 +41,7 @@ import {
   POST_TYPE_CONFIG,
   UserXP,
   ReportReason,
+  Author,
 } from "@/lib/services/community.service";
 import { useToast } from "@/components/common/Toast";
 import { config } from "@/lib/config";
@@ -60,20 +62,32 @@ interface ThreadExtras {
 
 const POST_TYPES = Object.keys(POST_TYPE_CONFIG) as PostType[];
 const THREAD_EXTRAS_KEY = `community_thread_extras_${config.clientId}`;
-const PROFILE_LOCAL_KEY = `user_profile_extra_${config.clientId}`;
 
-function getCurrentUserAuthor() {
+
+/** Shape this page reads out of the local profile cache. */
+interface CachedAuthor {
+  id?: number;
+  user_name?: string;
+  name?: string;
+  full_name?: string;
+  profile_pic_url?: string;
+  avatar?: string;
+  role?: string;
+}
+
+function getCurrentUserAuthor(): Author | null {
   try {
-    const raw = localStorage.getItem(PROFILE_LOCAL_KEY);
-    if (raw) {
-      const p = JSON.parse(raw);
+    // User-scoped and cleared on logout. Previously this read a TENANT-scoped blob, so a fresh
+    // account on a shared browser posted under the previous user's name and avatar.
+    const p = loadProfileCache<CachedAuthor>();
+    if (Object.keys(p).length) {
       return {
         id: p.id ?? 0,
         user_name: p.user_name ?? "",
         name: p.name ?? p.full_name ?? p.user_name ?? "You",
         profile_pic_url: p.profile_pic_url ?? p.avatar ?? "",
         role: p.role ?? "student",
-      };
+      } as Author;
     }
   } catch {}
   return null;
@@ -100,7 +114,7 @@ function saveThreadExtras(extras: Map<number, ThreadExtras>): void {
 
 function getCurrentUserName(): string | null {
   try {
-    const raw = localStorage.getItem(PROFILE_LOCAL_KEY);
+    const raw = JSON.stringify(loadProfileCache<Record<string, unknown>>());
     if (raw) {
       const profile = JSON.parse(raw);
       return profile.user_name || null;

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { loadProfileCache, saveProfileCache } from "@/lib/utils/profile-cache";
 import { useTranslation } from "react-i18next";
 import { Box, CircularProgress } from "@mui/material";
 import { motion } from "framer-motion";
@@ -28,12 +29,6 @@ import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { config } from "@/lib/config";
 import { IconWrapper } from "@/components/common/IconWrapper";
 
-const PROFILE_LOCAL_KEY_PREFIX = "user_profile_extra";
-
-function getProfileLocalKey(): string {
-  return `${PROFILE_LOCAL_KEY_PREFIX}_${config.clientId}`;
-}
-
 function isEmptyValue(val: unknown): boolean {
   if (val === undefined || val === null || val === "") return true;
   if (Array.isArray(val) && val.length === 0) return true;
@@ -41,23 +36,11 @@ function isEmptyValue(val: unknown): boolean {
 }
 
 function loadLocalProfile(): Partial<UserProfile> {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = localStorage.getItem(getProfileLocalKey());
-    return raw ? JSON.parse(raw) : {};
-  } catch {
-    return {};
-  }
+  return loadProfileCache<UserProfile>();
 }
 
 function saveLocalProfile(data: Partial<UserProfileUpdate>) {
-  if (typeof window === "undefined") return;
-  try {
-    const existing = loadLocalProfile();
-    localStorage.setItem(getProfileLocalKey(), JSON.stringify({ ...existing, ...data }));
-  } catch {
-    // storage unavailable
-  }
+  saveProfileCache<UserProfileUpdate>(data);
 }
 
 function mergeWithLocalFallback(apiProfile: UserProfile): UserProfile {

--- a/components/common/SuccessTick.tsx
+++ b/components/common/SuccessTick.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+
+/**
+ * The Razorpay-style success tick: a ring draws itself, then the check strokes in.
+ *
+ * Used for sign-in and sign-out instead of a toast. A toast is the wrong instrument here — it
+ * appears in the corner, competes with the page already navigating underneath it, and is gone
+ * before anyone reads it. The moment deserves the whole screen for a beat.
+ *
+ * Both shapes animate with stroke-dashoffset rather than scale/opacity, which is what gives the
+ * "drawn" feel; the ring leads and the check follows, so it reads as one gesture rather than two
+ * things appearing at once.
+ *
+ * Under prefers-reduced-motion the mark is simply present — no drawing, no pop. Someone who has
+ * asked the OS for less movement should not get a flourish on every login.
+ */
+export function SuccessTick({
+  label,
+  sublabel,
+}: {
+  label: string;
+  sublabel?: string;
+}) {
+  return (
+    <Box
+      role="status"
+      aria-live="polite"
+      sx={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 2000,
+        display: "grid",
+        placeItems: "center",
+        bgcolor: "var(--page-bg, #ffffff)",
+        // Keep the underlying page from showing through mid-navigation.
+        backdropFilter: "blur(2px)",
+        "@keyframes tickRing": { to: { strokeDashoffset: 0 } },
+        "@keyframes tickCheck": { to: { strokeDashoffset: 0 } },
+        "@keyframes tickFade": { from: { opacity: 0, transform: "translateY(6px)" }, to: { opacity: 1, transform: "none" } },
+      }}
+    >
+      <Box sx={{ textAlign: "center", px: 3 }}>
+        <Box
+          component="svg"
+          viewBox="0 0 72 72"
+          sx={{
+            width: 88,
+            height: 88,
+            display: "block",
+            mx: "auto",
+            "& .ring": {
+              fill: "none",
+              stroke: "#10b981",
+              strokeWidth: 4,
+              strokeLinecap: "round",
+              // 2πr for r=32
+              strokeDasharray: 201,
+              strokeDashoffset: 201,
+              transformOrigin: "center",
+              transform: "rotate(-90deg)",
+              animation: "tickRing 520ms cubic-bezier(0.65, 0, 0.35, 1) forwards",
+            },
+            "& .check": {
+              fill: "none",
+              stroke: "#10b981",
+              strokeWidth: 5,
+              strokeLinecap: "round",
+              strokeLinejoin: "round",
+              strokeDasharray: 40,
+              strokeDashoffset: 40,
+              animation: "tickCheck 320ms cubic-bezier(0.65, 0, 0.35, 1) 380ms forwards",
+            },
+            "@media (prefers-reduced-motion: reduce)": {
+              "& .ring, & .check": { animation: "none", strokeDashoffset: 0 },
+            },
+          }}
+        >
+          <circle className="ring" cx="36" cy="36" r="32" />
+          <path className="check" d="M22 37.5 L32 47 L50 27" />
+        </Box>
+
+        <Typography
+          sx={{
+            mt: 2.5,
+            fontWeight: 800,
+            fontSize: "1.05rem",
+            color: "var(--font-primary, #0f172a)",
+            animation: "tickFade 300ms ease 520ms both",
+            "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+          }}
+        >
+          {label}
+        </Typography>
+        {sublabel && (
+          <Typography
+            sx={{
+              mt: 0.5,
+              fontSize: "0.85rem",
+              color: "var(--font-secondary, #64748b)",
+              animation: "tickFade 300ms ease 620ms both",
+              "@media (prefers-reduced-motion: reduce)": { animation: "none" },
+            }}
+          >
+            {sublabel}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -53,6 +53,7 @@ import {
   NotificationPopover,
   NotificationBell,
 } from "@/components/notifications/NotificationPopover";
+import { SuccessTick } from "@/components/common/SuccessTick";
 
 interface AppBarProps {
   onMenuClick?: () => void;
@@ -134,6 +135,8 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
   const navStreak = streakCel.primed ? streakCel.navCount : streak?.current_streak ?? 0;
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const [signingOut, setSigningOut] = useState(false);
   const [leaderboardAnchorEl, setLeaderboardAnchorEl] =
     useState<null | HTMLElement>(null);
   const [streakAnchorEl, setStreakAnchorEl] = useState<null | HTMLElement>(
@@ -157,12 +160,21 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
 
   const handleLogout = async () => {
     handleMenuClose();
-    await logout();
-    // Hard-replace rather than router.push so the current page (and any
-    // in-flight queries/toasts attached to it) is destroyed instead of
-    // re-rendering against a now-null user and triggering 401 toasts.
-    if (typeof window !== "undefined") {
-      window.location.replace("/login");
+    // Shown BEFORE the await: signing out hits the network, and a blank pause with nothing on
+    // screen reads as a hang. The tick covers the whole operation rather than flashing after it.
+    setSigningOut(true);
+    try {
+      await logout();
+    } finally {
+      // Let the mark finish drawing before the page is torn down. Deliberately shorter than the
+      // full animation — the ring and check are done by ~700ms; the rest is just the caption.
+      await new Promise((r) => setTimeout(r, 900));
+      // Hard-replace rather than router.push so the current page (and any
+      // in-flight queries/toasts attached to it) is destroyed instead of
+      // re-rendering against a now-null user and triggering 401 toasts.
+      if (typeof window !== "undefined") {
+        window.location.replace("/login");
+      }
     }
   };
 
@@ -320,6 +332,13 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
   if (!isAuthenticated) {
     return null;
   }
+
+  if (signingOut) {
+
+    return <SuccessTick label={t("auth.logoutSuccess", "Signed out")} sublabel={t("auth.seeYouSoon", "See you soon")} />;
+
+  }
+
 
   return (
     <MuiAppBar

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -16,6 +16,7 @@ import { authUtils } from "./auth-utils";
 import { clearResumeData } from "@/components/profile/resume/utils";
 import { clearTimeTrackingSession } from "../services/activity.service";
 import { setLoggingOut } from "../services/api";
+import { clearProfileCache } from "@/lib/utils/profile-cache";
 
 export type AuthLoginResult =
   | { profileActive: true }
@@ -233,6 +234,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       clearTimeTrackingSession();
       if (typeof window !== "undefined") {
         localStorage.removeItem("admin_mode");
+        // The profile cache is per-user, but it must not survive a logout on a shared machine.
+        clearProfileCache();
       }
       setUser(null);
       setRequiresProfileActivation(false);

--- a/lib/guide/registry.ts
+++ b/lib/guide/registry.ts
@@ -300,14 +300,6 @@ export const PAGE_GUIDES: Record<string, PageGuideContent> = {
         color: "#a78bfa",
       },
       {
-        targetId: "adaptive-stats",
-        title: "Your catalogue at a glance",
-        narration: "This strip sums up everything available to you - how many courses, modules, adaptive articles and quizzes are ready for you to dive into.",
-        placement: "bottom",
-        icon: "mdi:chart-box-outline",
-        color: "#6366f1",
-      },
-      {
         targetId: "adaptive-levels",
         title: "Filter by difficulty",
         narration: "Use these level tabs to narrow the catalogue to a difficulty that suits you. Each tab shows a live count so you know how many courses match.",

--- a/lib/utils/profile-cache.ts
+++ b/lib/utils/profile-cache.ts
@@ -1,0 +1,108 @@
+import Cookies from "js-cookie";
+import { config } from "@/lib/config";
+
+/**
+ * The local profile cache — keyed by USER, and cleared when they leave.
+ *
+ * It used to be keyed by tenant alone (`user_profile_extra_<clientId>`), which meant one browser
+ * had one profile cache shared by every account that ever signed in on it. Sign out, sign up as
+ * somebody new, and the profile page merged the previous person's name, phone and date of birth
+ * into the new account's empty fields — and the community page built post authors from the same
+ * blob. Pressing Save then wrote that data to the new account for real.
+ *
+ * Two independent defences, because either alone is not enough:
+ *   1. The key includes the user id from the access token, so two accounts cannot collide even
+ *      if the cache is never cleared.
+ *   2. `clearProfileCache()` runs on logout, so nothing is left behind on a shared machine.
+ *
+ * Legacy tenant-only keys are deleted on first read. They belong to whoever used the browser
+ * before and must never be merged into anyone.
+ */
+
+const PREFIX = "user_profile_extra";
+
+/** The `user_id` claim from the access token, or null when signed out. */
+function currentUserId(): string | null {
+  try {
+    const token = Cookies.get("access_token");
+    if (!token) return null;
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const json = JSON.parse(
+      decodeURIComponent(
+        atob(payload.replace(/-/g, "+").replace(/_/g, "/"))
+          .split("")
+          .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+          .join(""),
+      ),
+    );
+    const id = json.user_id ?? json.userId ?? json.sub ?? null;
+    return id === null || id === undefined ? null : String(id);
+  } catch {
+    return null;
+  }
+}
+
+function legacyKey(): string {
+  return `${PREFIX}_${config.clientId}`;
+}
+
+/** Null when we cannot identify the user — in which case nothing is read or written. */
+export function profileCacheKey(): string | null {
+  const uid = currentUserId();
+  return uid ? `${PREFIX}_${config.clientId}_u${uid}` : null;
+}
+
+/** Remove any pre-user-scoping cache. It cannot be attributed to anyone, so it cannot be used. */
+function dropLegacy(): void {
+  try {
+    localStorage.removeItem(legacyKey());
+  } catch {
+    // storage unavailable
+  }
+}
+
+export function loadProfileCache<T extends object>(): Partial<T> {
+  if (typeof window === "undefined") return {};
+  dropLegacy();
+  const key = profileCacheKey();
+  // No identifiable user => no cache. Returning {} is the safe answer: showing SOMEONE's data
+  // is worse than showing none.
+  if (!key) return {};
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as Partial<T>) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveProfileCache<T extends object>(data: Partial<T>): void {
+  if (typeof window === "undefined") return;
+  const key = profileCacheKey();
+  if (!key) return;
+  try {
+    const existing = loadProfileCache<T>();
+    localStorage.setItem(key, JSON.stringify({ ...existing, ...data }));
+  } catch {
+    // storage unavailable
+  }
+}
+
+/** Called on logout. Clears this user's cache and any legacy blob still lying around. */
+export function clearProfileCache(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const key = profileCacheKey();
+    if (key) localStorage.removeItem(key);
+    dropLegacy();
+    // Belt and braces: sweep every profile cache on this device. Logging out on a shared
+    // machine should not leave another account's details recoverable.
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith(PREFIX)) localStorage.removeItem(k);
+    }
+  } catch {
+    // storage unavailable
+  }
+}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -14,7 +14,7 @@
     "pendingInstructors": "Instructors",
     "instructors": "Instructors",
     "courseBuilder": "Course Builder",
-    "adminCohortCourseMapping": "Courses \u2194 Cohorts",
+    "adminCohortCourseMapping": "Courses ↔ Cohorts",
     "adminCohorts": "Cohorts",
     "emails": "Emails",
     "notifications": "Notifications",
@@ -363,7 +363,10 @@
     "instructorSignupApprovalNote": "Kindly verify your email address and await administrative approval. You will be able to sign in once your account has been approved.",
     "passwordResetOtpResent": "A new verification code has been sent.",
     "passwordResetResendHint": "Only the latest code is valid.",
-    "resendFailed": "We couldn’t resend the code just now. Please try again in a moment."
+    "resendFailed": "We couldn’t resend the code just now. Please try again in a moment.",
+    "logoutSuccess": "Signed out",
+    "takingYouIn": "Taking you in…",
+    "seeYouSoon": "See you soon"
   },
   "dashboard": {
     "welcomeHello": "Hello {{name}}!",


### PR DESCRIPTION
Promotes `stagging` to production. Three changes.

## #1197 — cross-account profile leak (the important one)

A brand-new account, first ever login, showed another user's name, phone, date of birth and college.

The local profile cache was keyed by **tenant alone** (`user_profile_extra_<clientId>`), so one browser had **one** cache shared by every account that ever signed in on it. Logout never cleared it — only `admin_mode` was removed. `mergeWithLocalFallback` then filled the new account's empty fields from the previous person's blob.

Worse than a display bug: **pressing Save writes that data to the new account for real**, and the community page built post authors from the same blob.

Fixed with two independent defences — the key now includes the user id from the access token, *and* logout sweeps every profile key on the device. Legacy tenant-only keys are deleted on read; when no user can be identified, nothing is read or written at all.

Predates the profile-gating work; the gating just made it visible.

## #1198 — success tick on sign-in and sign-out

Razorpay-style: the ring draws, then the check strokes in. Both toasts removed — they appeared in a corner, competed with the dashboard mounting underneath, and were usually gone before anyone read them.

Logout shows the tick **before** awaiting the request, since a blank pause during a network call reads as a hang. Honours `prefers-reduced-motion` (mark present, no drawing).

## #1199 — remove the adaptive stats strip

Also removed the `stats` memo, the now-unused `KpiRail` import, and the guide step targeting `adaptive-stats` — leaving that step would have pointed the product tour at an id that no longer exists.

## Verification note

All three were verified by rendering and inspecting output where visual (tick frames at 300/560/900ms) or by simulating the mechanism where behavioural (the cache key across a logout/login). The repo still has no frontend test runner, which remains the standing recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)