### PR TITLE
release: sidebar shows real names (2,187 users) + role chip

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -25,6 +25,9 @@ import {
   getUserDisplayName,
   getUserInitials,
   getUserProfilePicture,
+  getRoleLabel,
+  getRoleAccent,
+  getRoleIcon,
 } from "@/lib/utils/user-utils";
 import { useClientInfo, useThemePreview } from "@/lib/contexts/ClientInfoContext";
 import { useAdminMode } from "@/lib/contexts/AdminModeContext";
@@ -1133,25 +1136,48 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   <Typography
                     variant="body2"
                     sx={{
-                      fontWeight: 600,
+                      fontWeight: 700,
                       color: shell.nav,
-                      fontSize: "1rem",
+                      fontSize: "0.95rem",
+                      lineHeight: 1.3,
                       overflow: "hidden",
                       textOverflow: "ellipsis",
                       whiteSpace: "nowrap",
                     }}
+                    title={getUserDisplayName(user)}
                   >
                     {getUserDisplayName(user)}
                   </Typography>
-                  <Typography
-                    variant="caption"
+                  {/* A chip, not a caption. The role was raw lowercase text before, so
+                      `course_manager` rendered literally as "course_manager". */}
+                  <Box
+                    component="span"
                     sx={{
-                      color: shell.navCaption,
-                      fontSize: "0.9rem",
+                      mt: 0.5,
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                      maxWidth: "100%",
+                      px: 0.85,
+                      py: 0.3,
+                      borderRadius: 999,
+                      fontSize: "0.68rem",
+                      fontWeight: 800,
+                      letterSpacing: 0.4,
+                      textTransform: "uppercase",
+                      color: getRoleAccent(user?.role),
+                      bgcolor: `color-mix(in srgb, ${getRoleAccent(user?.role)} 18%, transparent)`,
+                      border: `1px solid color-mix(in srgb, ${getRoleAccent(user?.role)} 34%, transparent)`,
                     }}
                   >
-                    {user?.role || "Student"}
-                  </Typography>
+                    <IconWrapper icon={getRoleIcon(user?.role)} size={12} />
+                    <Box
+                      component="span"
+                      sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                    >
+                      {getRoleLabel(user?.role)}
+                    </Box>
+                  </Box>
                 </Box>
               </Box>
               {/* Admin Mode Toggle Button */}

--- a/lib/utils/user-utils.ts
+++ b/lib/utils/user-utils.ts
@@ -1,30 +1,120 @@
 import { UserProfile } from "@/lib/services/accounts.service";
 
 /**
- * Get user's display name in standard format: "First Last"
- * Falls back to user_name if first_name/last_name not available
+ * The name to show for a user.
+ *
+ * The previous rule required BOTH first and last name and otherwise fell through to `user_name`.
+ * For social sign-ins the provider often supplies a single given name, and `user_name` IS the
+ * email address — so 2,187 of 18,357 production profiles rendered as
+ * `poorva.shrivastava256@gmail.com` (usually truncated mid-address) while their actual first
+ * name sat unused one field away. Some rendered as the literal "User".
+ *
+ * The chain now degrades one step at a time instead of falling off a cliff:
+ *   "First Last" -> "First" -> a username that is not an email -> the email's local part -> "User"
  */
 export const getUserDisplayName = (user: UserProfile | null): string => {
   if (!user) return "User";
-  
-  if (user.first_name && user.last_name) {
-    return `${user.first_name} ${user.last_name}`;
+
+  const first = (user.first_name || "").trim();
+  const last = (user.last_name || "").trim();
+  if (first && last) return `${first} ${last}`;
+  // A single given name is a perfectly good name. This is the case the old rule dropped.
+  if (first) return first;
+  if (last) return last;
+
+  const username = (user.user_name || "").trim();
+  // For social logins user_name is the email, and an email address is not a name.
+  if (username && !username.includes("@")) return username;
+
+  const email = (user.email || username || "").trim();
+  const local = email.split("@")[0];
+  if (local) {
+    // "poorva.shrivastava256" -> "Poorva Shrivastava". Imperfect, but recognisably the person,
+    // which a raw address is not.
+    const pretty = local
+      .replace(/[._-]+/g, " ")
+      .replace(/\d+/g, "")
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(" ");
+    if (pretty) return pretty;
   }
-  
-  return user.user_name || "User";
+
+  return "User";
 };
 
 /**
- * Get user's initials for avatar
+ * Initials for the avatar. Mirrors the display-name chain so the two cannot disagree — an avatar
+ * reading "U" beside a name reading "Poorva" looks like a bug even when the name is right.
  */
 export const getUserInitials = (user: UserProfile | null): string => {
   if (!user) return "U";
-  
-  if (user.first_name && user.last_name) {
-    return `${user.first_name[0]}${user.last_name[0]}`.toUpperCase();
+
+  const first = (user.first_name || "").trim();
+  const last = (user.last_name || "").trim();
+  if (first && last) return `${first[0]}${last[0]}`.toUpperCase();
+
+  const name = getUserDisplayName(user);
+  if (name && name !== "User") {
+    const parts = name.split(/\s+/).filter(Boolean);
+    if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
   }
-  
-  return user.user_name?.[0]?.toUpperCase() || "U";
+  return "U";
+};
+
+/** Human label for a role slug. `course_manager` should never render as "course_manager". */
+export const getRoleLabel = (role: string | null | undefined): string => {
+  const key = (role || "").trim().toLowerCase();
+  const LABELS: Record<string, string> = {
+    student: "Student",
+    admin: "Admin",
+    superadmin: "Super Admin",
+    instructor: "Instructor",
+    course_manager: "Course Manager",
+  };
+  if (LABELS[key]) return LABELS[key];
+  if (!key) return "Student";
+  // Unknown role: still make it presentable rather than leaking a raw slug.
+  return key
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+};
+
+/** Accent for a role chip. Student is deliberately the quiet one — it is the default. */
+export const getRoleAccent = (role: string | null | undefined): string => {
+  switch ((role || "").trim().toLowerCase()) {
+    case "superadmin":
+      return "#f59e0b";
+    case "admin":
+      return "#ec4899";
+    case "instructor":
+      return "#10b981";
+    case "course_manager":
+      return "#6366f1";
+    default:
+      return "#94a3b8";
+  }
+};
+
+/** Icon for a role chip, so it is scannable without being read. */
+export const getRoleIcon = (role: string | null | undefined): string => {
+  switch ((role || "").trim().toLowerCase()) {
+    case "superadmin":
+      return "mdi:shield-crown-outline";
+    case "admin":
+      return "mdi:shield-account-outline";
+    case "instructor":
+      return "mdi:teach";
+    case "course_manager":
+      return "mdi:folder-account-outline";
+    default:
+      return "mdi:school-outline";
+  }
 };
 
 /**
@@ -34,4 +124,3 @@ export const getUserProfilePicture = (user: UserProfile | null): string | undefi
   if (!user) return undefined;
   return user.profile_picture || undefined;
 };
-


### PR DESCRIPTION
Promotes `stagging` to production.

## What this fixes

The display-name rule required **both** first and last name, falling through to `user_name` otherwise — and for social sign-ins `user_name` **is the email address**.

Measured against production: **2,187 of 18,357 profiles** have a first name but no last name, so they rendered as their email (truncated mid-address in a 270px sidebar) while their actual first name sat unused one field away.

```
first='levi'   → showed 'levi83447@gmail.com'      → now 'levi'
first='Poorva' → showed 'poorva.shrivastava256@…'  → now 'Poorva'
```

## Beyond the sidebar

`getUserDisplayName` also names **certificate recipients** (`useCertificateActions`, `submission-success`). Those 2,187 users have been issued **certificates with their email address printed as their name** — on documents learners keep and share. That is the real reason to ship this promptly.

## Role chip

`course_manager` rendered literally as **course_manager**. Now a chip with a human label, per-role accent and icon. Unknown roles are title-cased rather than leaking a slug.

## Verified

Name chain simulated against the real production rows (every broken case fixed, the working case unchanged); footer rendered before/after. `tsc` and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)