### PR TITLE
fix(auth): the success tick never actually rendered — two ordering bugs

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -49,15 +49,28 @@ export default function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
+  /**
+   * Held from BEFORE the login request, not after it.
+   *
+   * The redirect effect fires the instant login() flips isAuthenticated — which is earlier than
+   * any state the submit handler sets once the await resolves. Setting the hold afterwards is
+   * always too late, so this is raised first and released only if the attempt fails.
+   */
+  const [holdAutoRedirect, setHoldAutoRedirect] = useState(false);
   // Wait for auth bootstrap + loadUser so requiresProfileActivation is correct (avoids racing to dashboard).
   useEffect(() => {
     if (authLoading) return;
+    // Held while a submit is in flight and while the success tick plays. Without this the effect
+    // navigated away the moment login() resolved and the tick never painted at all.
+    if (holdAutoRedirect || isRedirecting) return;
     if (!isAuthenticated || !user?.role || requiresProfileActivation) return;
     const path = resolvePostLoginPath(user.role, searchParams.get("redirect"));
     router.replace(path);
   }, [
     authLoading,
     isAuthenticated,
+    isRedirecting,
+    holdAutoRedirect,
     user?.role,
     requiresProfileActivation,
     router,
@@ -71,19 +84,24 @@ export default function LoginPage() {
 
   const onSubmit = async (values: LoginFormValues) => {
     setLoading(true);
+    // Raised BEFORE the request, so the redirect effect cannot fire the moment auth flips.
+    setHoldAutoRedirect(true);
 
     try {
       const result = await login(values.email, values.password);
       if (!result.profileActive) {
         setLoading(false);
+        setHoldAutoRedirect(false);
         router.replace("/dashboard");
         return;
       }
 
-      // No toast. The success tick below takes over the screen for a beat instead — a corner
-      // toast competes with the dashboard already mounting underneath and is usually gone
-      // before anyone reads it.
+      // No toast. The success tick takes the screen for a beat instead — a corner toast competes
+      // with the dashboard already mounting underneath and is usually gone before anyone reads it.
       setIsRedirecting(true);
+      // Let the mark draw before navigating. The ring and check finish by ~700ms; the effect
+      // above is held for exactly this window, so nothing else can navigate underneath us.
+      await new Promise((r) => setTimeout(r, 950));
 
       const role = Cookies.get("user_role") ?? "";
       const target = resolvePostLoginPath(role, searchParams.get("redirect"));
@@ -100,6 +118,8 @@ export default function LoginPage() {
       showToast(getAxiosErrorDetail(err, t("auth.loginFailed")), "error");
       setLoading(false);
       setIsRedirecting(false);
+      // Released so a second attempt, or an already-authenticated visit, can redirect normally.
+      setHoldAutoRedirect(false);
     }
   };
 

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -329,14 +329,20 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
     return "0m";
   };
 
-  if (!isAuthenticated) {
-    return null;
+  // Checked BEFORE the auth guard, and that order is the whole fix. logout() clears the tokens,
+  // so isAuthenticated flips false the moment it resolves — with the guard first, this component
+  // returned null and the tick branch below was simply never reached.
+  if (signingOut) {
+    return (
+      <SuccessTick
+        label={t("auth.logoutSuccess", "Signed out")}
+        sublabel={t("auth.seeYouSoon", "See you soon")}
+      />
+    );
   }
 
-  if (signingOut) {
-
-    return <SuccessTick label={t("auth.logoutSuccess", "Signed out")} sublabel={t("auth.seeYouSoon", "See you soon")} />;
-
+  if (!isAuthenticated) {
+    return null;
   }
 
 


### PR DESCRIPTION
Reported: no tick on login **or** logout, and no toast either. Both mine, both ordering bugs, and neither would ever have appeared.

## Logout — guard order

```js
if (!isAuthenticated) return null;      // ← runs first
if (signingOut) return <SuccessTick/>;  // ← unreachable
```

`logout()` clears the tokens, so `isAuthenticated` flips false the moment it resolves and the component returns `null`. The tick branch was never reached. Swapped.

## Login — the redirect effect wins the race

An effect fires `router.replace` the instant `login()` flips `isAuthenticated` — which is **earlier** than any state the submit handler can set after its `await`. The page navigated away before `setIsRedirecting(true)` ran, so the tick never painted.

**My first attempt held the effect on `isRedirecting`, which does not work** — that flag is still `false` at the moment the effect first fires. The hold has to be raised **before** the request. `holdAutoRedirect` is now set on submit and released only if the attempt fails.

The toast is genuinely gone from both paths, which is why the screen showed *nothing* rather than falling back to the old behaviour.

## Verified by simulation, not by reading

```
LOGOUT  guards auth-first   -> null   <-- bug
        guards tick-first   -> TICK   ok

LOGIN   hold-before-request=false -> navigated early, tick never painted  <-- bug
        hold-before-request=true  -> tick painted                          ok
```

That second login row is what caught my insufficient first fix — I had the hold in the wrong place and the model showed it still failing.

`tsc --noEmit` clean, production build clean.

## Note

This is the third time an ordering/lifecycle bug in this area has reached production, and the reason is unchanged: **there is no frontend test runner**, so nothing exercises a component's render path. Each of these is a handful of lines to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)