### PR TITLE
fix(sidebar): quiet the role pill to match the platform's pill language

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -27,7 +27,6 @@ import {
   getUserProfilePicture,
   getRoleLabel,
   getRoleAccent,
-  getRoleIcon,
 } from "@/lib/utils/user-utils";
 import { useClientInfo, useThemePreview } from "@/lib/contexts/ClientInfoContext";
 import { useAdminMode } from "@/lib/contexts/AdminModeContext";
@@ -1148,35 +1147,33 @@ export const Sidebar: React.FC<SidebarProps> = ({
                   >
                     {getUserDisplayName(user)}
                   </Typography>
-                  {/* A chip, not a caption. The role was raw lowercase text before, so
-                      `course_manager` rendered literally as "course_manager". */}
+                  {/* The role reads as a label, not as an award.
+                      It carried a filled accent background, a matching border, a crown icon,
+                      uppercase and letter-spacing all at once — five emphases on one 11px word,
+                      directly above a mode button wearing the same crown. It also introduced a
+                      fixed hue into the one surface that is entirely tenant-branded.
+                      This follows the platform's pill convention (dashboard `BandPill`): colour
+                      in the text, a neutral tint behind it, sentence case, no border, no icon. */}
                   <Box
                     component="span"
                     sx={{
-                      mt: 0.5,
-                      display: "inline-flex",
-                      alignItems: "center",
-                      gap: 0.5,
+                      mt: 0.4,
+                      display: "inline-block",
                       maxWidth: "100%",
                       px: 0.85,
-                      py: 0.3,
+                      py: 0.2,
                       borderRadius: 999,
                       fontSize: "0.68rem",
-                      fontWeight: 800,
-                      letterSpacing: 0.4,
-                      textTransform: "uppercase",
+                      fontWeight: 700,
+                      lineHeight: 1.5,
                       color: getRoleAccent(user?.role),
-                      bgcolor: `color-mix(in srgb, ${getRoleAccent(user?.role)} 18%, transparent)`,
-                      border: `1px solid color-mix(in srgb, ${getRoleAccent(user?.role)} 34%, transparent)`,
+                      bgcolor: shell.roleChipBg,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
                     }}
                   >
-                    <IconWrapper icon={getRoleIcon(user?.role)} size={12} />
-                    <Box
-                      component="span"
-                      sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
-                    >
-                      {getRoleLabel(user?.role)}
-                    </Box>
+                    {getRoleLabel(user?.role)}
                   </Box>
                 </Box>
               </Box>

--- a/lib/theme/useTenantShellTheme.ts
+++ b/lib/theme/useTenantShellTheme.ts
@@ -97,6 +97,8 @@ export function useTenantShellTheme() {
       navBorderHover: alpha(nav, 0.3),
       navHoverBg: alpha(nav, 0.05),
       navCaption: alpha(nav, 0.6),
+      /** Neutral tint behind a pill on the shell — the dark-ground convention from the dashboard. */
+      roleChipBg: alpha(nav, 0.1),
       activeBg: alpha(p500, 0.24),
       activeBgHover: alpha(p500, 0.36),
       logoGradStart: alpha(nav, 0.12),

--- a/lib/utils/user-utils.ts
+++ b/lib/utils/user-utils.ts
@@ -85,35 +85,31 @@ export const getRoleLabel = (role: string | null | undefined): string => {
     .join(" ");
 };
 
-/** Accent for a role chip. Student is deliberately the quiet one — it is the default. */
+/**
+ * Text colour for the role pill.
+ *
+ * These are the 300/400 tints, not the 500s, because the only place a role is shown is the
+ * sidebar footer — which sits on the tenant's dark shell. The saturated 500s were legible but
+ * loud: an indigo-500 on dark navy also lands near 3:1, which is thin for 11px text.
+ *
+ * The pill puts colour in the TEXT only, on a neutral tint of the tenant's own nav colour. That
+ * is the platform's convention for a pill on a dark ground (`BandPill dark` in the dashboard),
+ * and it keeps the sidebar in the tenant's palette instead of introducing a fixed hue that
+ * belongs to no brand.
+ */
 export const getRoleAccent = (role: string | null | undefined): string => {
   switch ((role || "").trim().toLowerCase()) {
     case "superadmin":
-      return "#f59e0b";
+      return "#fbbf24";
     case "admin":
-      return "#ec4899";
+      return "#f472b6";
     case "instructor":
-      return "#10b981";
+      return "#34d399";
     case "course_manager":
-      return "#6366f1";
+      return "#a5b4fc";
     default:
-      return "#94a3b8";
-  }
-};
-
-/** Icon for a role chip, so it is scannable without being read. */
-export const getRoleIcon = (role: string | null | undefined): string => {
-  switch ((role || "").trim().toLowerCase()) {
-    case "superadmin":
-      return "mdi:shield-crown-outline";
-    case "admin":
-      return "mdi:shield-account-outline";
-    case "instructor":
-      return "mdi:teach";
-    case "course_manager":
-      return "mdi:folder-account-outline";
-    default:
-      return "mdi:school-outline";
+      // Student is the default role; it should read as a label, not as a badge.
+      return "#cbd5e1";
   }
 };
 


### PR DESCRIPTION
The role pill was shouting.

It had a filled accent background, a matching border, a crown icon, uppercase **and** letter-spacing — five emphases on one 11px word — directly above a mode button wearing the same crown. Two crowns stacked in a 60px column.

It also put a fixed hue into the one surface that is entirely tenant-branded. Every other pixel in the sidebar derives from `theme_settings`; a hard `#f59e0b` belongs to no tenant's palette.

### What it follows now
The convention the dashboard already uses for a pill on a dark ground (`BandPill` in `components/dashboard/v2/parts.tsx`): colour in the **text** only, a neutral tint of the tenant's own nav colour behind it, sentence case, no border, no icon.

```
before   [ 👑 SUPER ADMIN ]   filled amber · amber border · uppercase · +0.4 tracking
after    ( Super Admin )      amber text · nav @ 10% · sentence case · no border
```

### Also
- Accents move from the 500s to the 300/400 tints — what actually reads on a dark shell. Indigo-500 (`course_manager`) on dark navy lands near 3:1, which is thin for 11px text.
- The tint is a new `roleChipBg` token on `useTenantShellTheme`, so it tracks the tenant's nav colour rather than being another literal.

`tsc --noEmit` clean. Styling only — no behaviour, no data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)