### PR TITLE
chore: promote stagging to main — auth success tick on every path

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -26,7 +26,6 @@ import { AuthLayout } from "@/components/auth/AuthLayout";
 import { loginSchema } from "@/lib/schemas/auth.schema";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 import { Eye, EyeOff } from "lucide-react";
-import { SuccessTick } from "@/components/common/SuccessTick";
 
 interface LoginFormValues {
   email: string;
@@ -43,6 +42,8 @@ export default function LoginPage() {
     user,
     requiresProfileActivation,
     loading: authLoading,
+    celebrate,
+    celebrating,
   } = useAuth();
   const { showToast } = useToast();
   const [loading, setLoading] = useState(false);
@@ -60,9 +61,11 @@ export default function LoginPage() {
   // Wait for auth bootstrap + loadUser so requiresProfileActivation is correct (avoids racing to dashboard).
   useEffect(() => {
     if (authLoading) return;
-    // Held while a submit is in flight and while the success tick plays. Without this the effect
-    // navigated away the moment login() resolved and the tick never painted at all.
-    if (holdAutoRedirect || isRedirecting) return;
+    // Held while ANY sign-in is in flight and while its tick plays — including one started by
+    // the Google button, which is a child component and could never have set this page's state.
+    // Without the hold the effect navigated away the moment login() resolved and the tick never
+    // painted at all.
+    if (celebrating || holdAutoRedirect || isRedirecting) return;
     if (!isAuthenticated || !user?.role || requiresProfileActivation) return;
     const path = resolvePostLoginPath(user.role, searchParams.get("redirect"));
     router.replace(path);
@@ -70,6 +73,7 @@ export default function LoginPage() {
     authLoading,
     isAuthenticated,
     isRedirecting,
+    celebrating,
     holdAutoRedirect,
     user?.role,
     requiresProfileActivation,
@@ -96,12 +100,12 @@ export default function LoginPage() {
         return;
       }
 
-      // No toast. The success tick takes the screen for a beat instead — a corner toast competes
-      // with the dashboard already mounting underneath and is usually gone before anyone reads it.
+      // No toast. The tick takes the screen for a beat instead — a corner toast competes with
+      // the dashboard already mounting underneath and is usually gone before anyone reads it.
+      // The animation now belongs to the auth provider, so this page and the Google button play
+      // exactly the same one.
       setIsRedirecting(true);
-      // Let the mark draw before navigating. The ring and check finish by ~700ms; the effect
-      // above is held for exactly this window, so nothing else can navigate underneath us.
-      await new Promise((r) => setTimeout(r, 950));
+      await celebrate("signin");
 
       const role = Cookies.get("user_role") ?? "";
       const target = resolvePostLoginPath(role, searchParams.get("redirect"));
@@ -122,11 +126,6 @@ export default function LoginPage() {
       setHoldAutoRedirect(false);
     }
   };
-
-  // Conditional return AFTER all hooks
-  if (isRedirecting) {
-    return <SuccessTick label={t("auth.loginSuccess")} sublabel={t("auth.takingYouIn", "Taking you in…")} />;
-  }
 
   return (
     <AuthLayout slogan={t("auth.slogan")}>

--- a/app/auth/handoff/page.tsx
+++ b/app/auth/handoff/page.tsx
@@ -35,7 +35,7 @@ interface ExchangeResponse {
 function HandoffInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { refreshUser } = useAuth();
+  const { refreshUser, celebrate } = useAuth();
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -72,6 +72,10 @@ function HandoffInner() {
         }
         Cookies.set("client_id", String(data.client_id), { expires: 30 });
         await refreshUser();
+        // The SSO lane is a sign-in like any other, so it ends the same way. Without this it
+        // finished on a bare spinner — the one path where a user hands off to another domain and
+        // comes back is arguably the one that most needs telling that it worked.
+        await celebrate("signin");
         const role = authUtils.getUserRole() ?? data.role ?? "";
         const target = resolvePostLoginPath(role, returnTo);
         router.replace(target);

--- a/components/auth/GoogleSignIn.tsx
+++ b/components/auth/GoogleSignIn.tsx
@@ -76,7 +76,7 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
   disabled = false,
 }) => {
   const { t } = useTranslation("common");
-  const { googleLogin } = useAuth();
+  const { googleLogin, celebrate } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const { showToast } = useToast();
@@ -84,7 +84,14 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
   const googleButtonRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isMounted, setIsMounted] = useState(false);
-  const [isRedirecting, setIsRedirecting] = useState(false);
+  /**
+   * Leaving this page FOR Google — a genuine loading state, worth a spinner.
+   *
+   * This used to also mean "signed in successfully", and one flag covering both is why the
+   * success case rendered a grey spinner: the two states want opposite treatments, and the
+   * spinner won.
+   */
+  const [leavingForGoogle, setLeavingForGoogle] = useState(false);
   const [buttonWidth, setButtonWidth] = useState(300);
   // True only once Google has ACTUALLY injected its rendered button (iframe).
   // Until then the visible button stays the real, clickable redirect fallback
@@ -96,13 +103,16 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
       try {
         const result = await googleLogin(response.credential);
         if (!result.profileActive) {
-          setIsRedirecting(false);
+          setLeavingForGoogle(false);
           router.replace("/dashboard");
           return;
         }
 
-        showToast(t("auth.loginSuccess"), "success");
-        setIsRedirecting(true);
+        // The success tick, not a toast — and the SAME tick the password form plays. This path
+        // showed a green "Login successful!" snackbar while the password path had long since
+        // moved to the animation, because the tick used to be local state on the login page and
+        // this is a child component that cannot reach it.
+        await celebrate("signin");
         const role = Cookies.get("user_role") ?? "";
         const redirectUrl = resolvePostLoginPath(
           role,
@@ -118,10 +128,10 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
           getAxiosErrorDetail(error, t("auth.googleSignInFailed")),
           "error"
         );
-        setIsRedirecting(false);
+        setLeavingForGoogle(false);
       }
     },
-    [googleLogin, router, showToast, searchParams, t]
+    [googleLogin, celebrate, router, showToast, searchParams, t]
   );
 
   // GSI-INDEPENDENT fallback. A plain top-level redirect to Google's OAuth
@@ -154,7 +164,7 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
     const redirectParam = searchParams.get("redirect");
     if (redirectParam) params.set("state", redirectParam);
 
-    setIsRedirecting(true);
+    setLeavingForGoogle(true);
     window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
   }, [disabled, searchParams]);
 
@@ -345,7 +355,10 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
     // No cleanup: load once, never remove the script.
   }, [isMounted, showToast, t]);
 
-  if (isRedirecting) {
+  // Only for the trip OUT to Google. On the way back in, the provider's success tick owns the
+  // screen — and this spinner sits at zIndex 9999 against the tick's 2000, so leaving it wired to
+  // the success case would have hidden the animation completely.
+  if (leavingForGoogle) {
     return <SignInLoader />;
   }
 

--- a/components/common/AuthCelebration.tsx
+++ b/components/common/AuthCelebration.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import { SuccessTick } from "@/components/common/SuccessTick";
+
+/**
+ * The sign-in / sign-out tick, and the rule for when it comes down.
+ *
+ * It stays up across the navigation that follows it. That is the point: the caller awaits the
+ * animation, then navigates, and the destination mounts underneath the tick instead of flashing
+ * an empty page or a row of shimmers at someone who has just been told they are signed in.
+ *
+ * Two ways down, and it needs both:
+ *   - the route changed, which means the destination is mounted — the normal case;
+ *   - a hard cap, for when it did not. A tick that never lifts is a locked screen, so a failed
+ *     navigation must not be able to trap the user behind a confirmation.
+ */
+export function AuthCelebration({
+  kind,
+  onDone,
+}: {
+  kind: "signin" | "signout";
+  onDone: () => void;
+}) {
+  const { t } = useTranslation("common");
+  const pathname = usePathname();
+  const startedAt = useRef(pathname);
+
+  useEffect(() => {
+    // The route moved: the destination has mounted. A short beat lets it paint before the
+    // tick lifts, otherwise the handover is visible as a flicker.
+    if (pathname !== startedAt.current) {
+      const id = setTimeout(onDone, 180);
+      return () => clearTimeout(id);
+    }
+    // Never navigated. Come down anyway rather than hold the screen hostage.
+    const cap = setTimeout(onDone, 2600);
+    return () => clearTimeout(cap);
+  }, [pathname, onDone]);
+
+  return kind === "signin" ? (
+    <SuccessTick
+      label={t("auth.loginSuccess")}
+      sublabel={t("auth.takingYouIn", "Taking you in…")}
+    />
+  ) : (
+    <SuccessTick
+      label={t("auth.logoutSuccess", "Signed out")}
+      sublabel={t("auth.seeYouSoon", "See you soon")}
+    />
+  );
+}

--- a/components/layout/AppBar.tsx
+++ b/components/layout/AppBar.tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/auth-context";
 import {
   isAdminOnlyRole,
+  canPurchase,
   isClientOrgAdminRole,
   isInstructorRole,
 } from "@/lib/auth/role-utils";
@@ -55,7 +56,6 @@ import {
   NotificationPopover,
   NotificationBell,
 } from "@/components/notifications/NotificationPopover";
-import { SuccessTick } from "@/components/common/SuccessTick";
 
 interface AppBarProps {
   onMenuClick?: () => void;
@@ -138,7 +138,6 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const [signingOut, setSigningOut] = useState(false);
   const [leaderboardAnchorEl, setLeaderboardAnchorEl] =
     useState<null | HTMLElement>(null);
   const [streakAnchorEl, setStreakAnchorEl] = useState<null | HTMLElement>(
@@ -162,15 +161,12 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
 
   const handleLogout = async () => {
     handleMenuClose();
-    // Shown BEFORE the await: signing out hits the network, and a blank pause with nothing on
-    // screen reads as a hang. The tick covers the whole operation rather than flashing after it.
-    setSigningOut(true);
+    // logout() puts the tick up itself, before its own network call, and returns once the mark
+    // has finished drawing — so the redirect below cannot tear it down mid-stroke. Any future
+    // caller of logout() gets the same confirmation without having to know about it.
     try {
       await logout();
     } finally {
-      // Let the mark finish drawing before the page is torn down. Deliberately shorter than the
-      // full animation — the ring and check are done by ~700ms; the rest is just the caption.
-      await new Promise((r) => setTimeout(r, 900));
       // Hard-replace rather than router.push so the current page (and any
       // in-flight queries/toasts attached to it) is destroyed instead of
       // re-rendering against a now-null user and triggering 401 toasts.
@@ -330,18 +326,6 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
     }
     return "0m";
   };
-
-  // Checked BEFORE the auth guard, and that order is the whole fix. logout() clears the tokens,
-  // so isAuthenticated flips false the moment it resolves — with the guard first, this component
-  // returned null and the tick branch below was simply never reached.
-  if (signingOut) {
-    return (
-      <SuccessTick
-        label={t("auth.logoutSuccess", "Signed out")}
-        sublabel={t("auth.seeYouSoon", "See you soon")}
-      />
-    );
-  }
 
   if (!isAuthenticated) {
     return null;
@@ -1194,17 +1178,22 @@ export const AppBar: React.FC<AppBarProps> = ({ onMenuClick, DrawerWidth }) => {
               {t("common.profile")}
             </MenuItem>
 
-            <MenuItem
-              onClick={() => {
-                router.push("/purchases");
-                handleMenuClose();
-              }}
-            >
-              <Box component="span" sx={{ marginInlineEnd: 1.5, display: "inline-flex" }}>
-                <ReceiptText size={18} />
-              </Box>
-              {t("common.myPurchases", "My Purchases")}
-            </MenuItem>
+            {/* Learners only. Staff never buy anything, so for them this is a permanently empty
+                page. The route itself stays reachable — someone promoted from student to
+                instructor still has real receipts. */}
+            {canPurchase(role) && (
+              <MenuItem
+                onClick={() => {
+                  router.push("/purchases");
+                  handleMenuClose();
+                }}
+              >
+                <Box component="span" sx={{ marginInlineEnd: 1.5, display: "inline-flex" }}>
+                  <ReceiptText size={18} />
+                </Box>
+                {t("common.myPurchases", "My Purchases")}
+              </MenuItem>
+            )}
 
             {canSeeAdminSettings && (
               <MenuItem

--- a/lib/auth/auth-context.tsx
+++ b/lib/auth/auth-context.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useCallback,
   ReactNode,
 } from "react";
 import {
@@ -17,6 +18,7 @@ import { clearResumeData } from "@/components/profile/resume/utils";
 import { clearTimeTrackingSession } from "../services/activity.service";
 import { setLoggingOut } from "../services/api";
 import { clearProfileCache } from "@/lib/utils/profile-cache";
+import { AuthCelebration } from "@/components/common/AuthCelebration";
 
 export type AuthLoginResult =
   | { profileActive: true }
@@ -65,6 +67,20 @@ interface AuthContextType {
   googleLogin: (token: string) => Promise<AuthLoginResult>;
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
+  /**
+   * The sign-in / sign-out tick, owned here rather than by any one screen.
+   *
+   * It lived in the login page and in AppBar as local state, which meant every NEW way of signing
+   * in or out silently shipped without it: Google sign-in showed a toast, and a logout triggered
+   * anywhere other than the AppBar menu showed nothing at all. Two rounds of per-component fixes
+   * missed paths for exactly that reason.
+   *
+   * Awaiting this both plays the animation and holds the caller, so the navigation that follows
+   * cannot tear the tick down before it has painted.
+   */
+  celebrate: (kind: "signin" | "signout") => Promise<void>;
+  /** True while the tick is on screen. Redirect effects must stand down while it is. */
+  celebrating: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -90,6 +106,17 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [profileInactiveMessage, setProfileInactiveMessage] = useState<
     string | null
   >(null);
+  const [celebration, setCelebration] = useState<"signin" | "signout" | null>(null);
+  /**
+   * An auth flow is in progress: a sign-in request is in flight, or its tick is still playing.
+   *
+   * Redirect effects must stand down while this is true. It is raised INSIDE login()/googleLogin(),
+   * before the request, because the effect on the login page fires the instant isAuthenticated
+   * flips — which is earlier than any state a caller could set after its await resolves. Raising
+   * it in the provider is also what lets a child component like the Google button participate:
+   * it cannot reach into the login page's state, but it goes through this function.
+   */
+  const [authBusy, setAuthBusy] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
@@ -173,7 +200,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = async (email: string, password: string) => {
     setLoggingOut(false);
-    const response = await accountsService.login({ email, password });
+    setAuthBusy(true);
+    let response;
+    try {
+      response = await accountsService.login({ email, password });
+    } catch (err) {
+      // Released on failure, or a wrong password would leave every redirect effect frozen.
+      setAuthBusy(false);
+      throw err;
+    }
 
     if (!isLoginResponseProfileActive(response)) {
       const msg = response.inactive_message?.trim() || null;
@@ -183,6 +218,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         setUser(mapResponseUserToProfile(response.user));
       }
       setLoading(false);
+      // An inactive profile is not a celebration; the caller routes to the blocker instead.
+      setAuthBusy(false);
       return {
         profileActive: false as const,
         inactiveMessage: response.inactive_message?.trim() ?? "",
@@ -196,7 +233,15 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const googleLogin = async (token: string) => {
     setLoggingOut(false);
-    const response = await accountsService.googleLogin(token);
+    setAuthBusy(true);
+    let response;
+    try {
+      response = await accountsService.googleLogin(token);
+    } catch (err) {
+      // Released on failure, or a wrong password would leave every redirect effect frozen.
+      setAuthBusy(false);
+      throw err;
+    }
 
     if (!isLoginResponseProfileActive(response)) {
       const msg = response.inactive_message?.trim() || null;
@@ -206,6 +251,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         setUser(mapResponseUserToProfile(response.user));
       }
       setLoading(false);
+      // An inactive profile is not a celebration; the caller routes to the blocker instead.
+      setAuthBusy(false);
       return {
         profileActive: false as const,
         inactiveMessage: response.inactive_message?.trim() ?? "",
@@ -217,6 +264,37 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     return { profileActive: true as const };
   };
 
+  /**
+   * Play the tick and hold until it has been seen.
+   *
+   * 950ms is the animation window: the ring closes and the check finishes stroking by ~700ms,
+   * and the remainder keeps the completed mark on screen long enough to register as a
+   * confirmation rather than a flicker. Callers await this BEFORE navigating.
+   *
+   * Under prefers-reduced-motion there is nothing to draw, so the hold collapses to a brief
+   * acknowledgement rather than making that user wait out an animation they are not getting.
+   */
+  const showTick = useCallback((kind: "signin" | "signout") => {
+    setCelebration(kind);
+    const reduced =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    // Resolves when the mark has finished drawing. Returned rather than awaited so a caller can
+    // put the tick up FIRST and do its work underneath it.
+    return new Promise((r) => setTimeout(r, reduced ? 300 : 950));
+  }, []);
+
+  const celebrate = useCallback(
+    async (kind: "signin" | "signout") => {
+      await showTick(kind);
+      // Deliberately NOT cleared here. The caller navigates immediately after awaiting, and
+      // clearing first would flash the old screen for a frame between the tick and the new route.
+      // AuthCelebration takes it down once the destination has mounted.
+    },
+    [showTick]
+  );
+
   const logout = async () => {
     // Flag the in-progress logout before anything async or token-clearing
     // happens. The axios interceptor uses this to swallow 401s from
@@ -224,6 +302,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // notifications, etc.) so the user doesn't see a "credentials not
     // provided" toast between clearTokens() and the /login redirect.
     setLoggingOut(true);
+    // Up BEFORE the network call, not after it. Signing out hits the server, and a blank pause
+    // with nothing on screen reads as a hang; the tick covers the whole operation instead of
+    // appearing once it is already over. The two run concurrently and the wait below is whatever
+    // is left of the animation, so a slow logout never adds to it.
+    const drawn = showTick("signout");
     try {
       await accountsService.logout();
     } catch {
@@ -241,6 +324,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setRequiresProfileActivation(false);
       setProfileInactiveMessage(null);
     }
+    await drawn;
   };
 
   const refreshUser = async () => {
@@ -261,7 +345,28 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     googleLogin,
     logout,
     refreshUser,
+    celebrate,
+    celebrating: celebration !== null || authBusy,
   };
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+      {/* Rendered by the provider, above whatever is mounted. This is what makes the tick
+          impossible to miss: it does not belong to the login page or to the AppBar, so it
+          cannot be lost to an early return, a component that unmounts mid-navigation, or a
+          new sign-in surface whose author did not know to wire it up. */}
+      {celebration && (
+        <AuthCelebration
+          kind={celebration}
+          onDone={() => {
+            setCelebration(null);
+            // End of the flow. Left raised, a later visit to /login while already signed in
+            // would never redirect.
+            setAuthBusy(false);
+          }}
+        />
+      )}
+    </AuthContext.Provider>
+  );
 };

--- a/lib/auth/role-utils.ts
+++ b/lib/auth/role-utils.ts
@@ -83,6 +83,19 @@ export function canAccessAdminArea(role: string | undefined | null): boolean {
   return isFullAdminRole(role) || isAdminOnlyRole(role);
 }
 
+/**
+ * Whether a role buys things.
+ *
+ * Only learners do. Admins, instructors and course managers are staff of the institution — a
+ * receipts entry in their menu is an item that will always be empty for them.
+ *
+ * Note this gates the MENU, not the page. Someone promoted from student to instructor still has
+ * real receipts, and hiding a menu item should not put their purchase history out of reach.
+ */
+export function canPurchase(role: string | undefined | null): boolean {
+  return !canAccessAdminArea(role) && !isInstructorRole(role) && !isCourseManagerRole(role);
+}
+
 const DEFAULT_STUDENT_HOME = "/dashboard";
 const DEFAULT_ADMIN_HOME = "/admin/dashboard";
 const INSTRUCTOR_HOME = "/instructor/dashboard";


### PR DESCRIPTION
Promotes #1208.

- The sign-in / sign-out tick moves from per-screen local state into `AuthProvider`, so Google sign-in (which showed a toast and a grey spinner) and the SSO handoff now play the same animation the password form does, and every logout gets it regardless of where it was triggered.
- `GoogleSignIn`'s `isRedirecting` split into a real loading state vs a success state — `SignInLoader` at `zIndex 9999` was covering the tick at `2000`.
- My Purchases hidden from staff roles; the route stays reachable.

`tsc --noEmit` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)