### PR TITLE
feat(assessments): let a learner actually buy a paid assessment

### DIFF
--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -27,6 +27,12 @@ import { AssessmentDeviceStatusPanel } from "@/components/assessment/AssessmentD
 import { AssessmentReadinessPanel } from "@/components/assessment/AssessmentReadinessPanel";
 import { StatusChip, StatStrip } from "@/components/admin/assessment/shared";
 import { stripHtmlTags } from "@/lib/utils/html-utils";
+import { formatMoney } from "@/lib/utils/money";
+import {
+  readPurchaseRequired,
+  useAssessmentPurchase,
+  type PurchaseRequiredPayload,
+} from "@/hooks/useAssessmentPurchase";
 
 function parseAssessmentStartTime(
   s: string | undefined | null
@@ -57,6 +63,11 @@ export default function AssessmentDetailPage({
   const { showToast } = useToast();
   const [startTimeTick, setStartTimeTick] = useState(0);
   const [consented, setConsented] = useState(false);
+  /** Set only after the server confirms a payment settled — never optimistically. */
+  const [justBought, setJustBought] = useState(false);
+  /** Set when the detail read itself came back 402, so the page can still show a price. */
+  const [purchaseWall, setPurchaseWall] = useState<PurchaseRequiredPayload | null>(null);
+  const { buy, buyingSlug } = useAssessmentPurchase();
 
   const assessmentStartAt = useMemo(
     () => parseAssessmentStartTime(assessment?.start_time),
@@ -133,7 +144,14 @@ export default function AssessmentDetailPage({
 
       setAssessment(data);
     } catch (error: any) {
-      showToast(t("assessments.failedToLoadDetails"), "error");
+      const locked = readPurchaseRequired(error);
+      if (locked) {
+        // The detail read itself is gated for a paid assessment. Keep enough of the product on
+        // screen to justify the price rather than dead-ending on an error.
+        setPurchaseWall(locked);
+      } else {
+        showToast(t("assessments.failedToLoadDetails"), "error");
+      }
     } finally {
       setLoading(false);
     }
@@ -141,8 +159,34 @@ export default function AssessmentDetailPage({
 
   const canReattempt = assessment?.can_reattempt === true;
 
+  const needsPurchase =
+    (assessment?.requires_purchase ?? false) && !assessment?.purchased && !justBought;
+  const isBuying = assessment ? buyingSlug === assessment.slug : false;
+
+  const startPurchase = () => {
+    if (!assessment) return;
+    buy(assessment, {
+      onOwned: () => {
+        setJustBought(true);
+        showToast(`You now have access to "${assessment.title}".`, "success");
+        // Refetch so the page reflects server truth rather than only the local flag — the
+        // status, the window and the retake state all come from the same payload.
+        void loadAssessmentDetail();
+      },
+      onSettling: (message) => showToast(message, "info"),
+      onFailed: (message) => showToast(message, "error"),
+    });
+  };
+
   const handleStart = () => {
     if (!assessment) return;
+
+    // Before every other rule. Somebody who has not bought this cannot start it whatever the
+    // window, the device or the submission state says.
+    if (needsPurchase) {
+      startPurchase();
+      return;
+    }
 
     // SECURITY: never re-enter the take flow if this assessment is already
     // submitted/finalized - UNLESS an admin has granted this learner a
@@ -189,6 +233,60 @@ export default function AssessmentDetailPage({
   }
 
   if (!assessment) {
+    // The detail read came back 402. The listing is not gated today, so this is defensive —
+    // but if the gate ever moves, a learner must land on a price rather than on "couldn't load",
+    // which reads as a broken page for something they can simply buy.
+    if (purchaseWall) {
+      return (
+        <MainLayout>
+          <Container sx={{ py: 8, maxWidth: 560 }}>
+            <Typography sx={{ fontWeight: 800, fontSize: "1.4rem", mb: 1 }}>
+              {purchaseWall.title || "This assessment is paid"}
+            </Typography>
+            <Typography sx={{ color: "var(--font-secondary)", mb: 3 }}>
+              Buy it once and it stays on your account.
+            </Typography>
+            <LoadingButton
+              variant="contained"
+              size="large"
+              startIcon={<IconWrapper icon="mdi:lock-open-outline" size={22} />}
+              disabled={buyingSlug === slug}
+              onClick={() =>
+                buy(
+                  {
+                    id: Number(purchaseWall.type_id),
+                    slug,
+                    title: purchaseWall.title || "Assessment",
+                  },
+                  {
+                    onOwned: () => {
+                      setPurchaseWall(null);
+                      setLoading(true);
+                      void loadAssessmentDetail();
+                    },
+                    onSettling: (message) => showToast(message, "info"),
+                    onFailed: (message) => showToast(message, "error"),
+                  },
+                )
+              }
+              sx={{
+                background: "var(--gradient-ai)",
+                color: "#fff",
+                fontWeight: 800,
+                py: 1.5,
+                px: 4,
+                borderRadius: 2.5,
+                textTransform: "none",
+              }}
+            >
+              {purchaseWall.price
+                ? `Buy for ${formatMoney(purchaseWall.price, purchaseWall.currency)}`
+                : "Buy this assessment"}
+            </LoadingButton>
+          </Container>
+        </MainLayout>
+      );
+    }
     return (
       <MainLayout>
         <Container>
@@ -273,7 +371,13 @@ export default function AssessmentDetailPage({
       "Mark any question to revisit later, then jump back to your flagged items before you submit.",
   });
 
-  const ctaLabel = isExpired
+  // Buying comes before every other CTA state. Someone who has not bought this cannot start it,
+  // and "Already submitted" or a consent checkbox is not the question in front of them.
+  const ctaLabel = needsPurchase
+    ? assessment?.price
+      ? `Buy for ${formatMoney(assessment.price, assessment.currency)}`
+      : "Buy this assessment"
+    : isExpired
     ? t("assessments.expired")
     : canReattempt && isAlreadySubmitted
     ? t("assessments.reattempt", { defaultValue: "Re-attempt" })
@@ -281,7 +385,9 @@ export default function AssessmentDetailPage({
     ? t("assessments.alreadySubmitted", { defaultValue: "Already submitted" })
     : "Continue to device check →";
 
-  const ctaIcon = isExpired
+  const ctaIcon = needsPurchase
+    ? "mdi:lock-open-outline"
+    : isExpired
     ? "mdi:clock-alert-outline"
     : canReattempt && isAlreadySubmitted
     ? "mdi:replay"
@@ -289,11 +395,15 @@ export default function AssessmentDetailPage({
     ? "mdi:check-circle-outline"
     : "mdi:play-circle-outline";
 
-  const ctaDisabled =
-    isExpired ||
-    (isAlreadySubmitted && !canReattempt) ||
-    !canStartAssessment ||
-    (proctored && !consented);
+  const ctaDisabled = needsPurchase
+    // The proctoring consent and the start window gate TAKING the assessment, not buying it.
+    // Leaving them in the way would make a paid assessment unbuyable outside its own window,
+    // which is the opposite of what a price is for.
+    ? isBuying
+    : isExpired ||
+      (isAlreadySubmitted && !canReattempt) ||
+      !canStartAssessment ||
+      (proctored && !consented);
 
   return (
     <MainLayout fullWidthContent>

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -15,6 +15,8 @@ import { usePrefetchOnHover } from "@/hooks/usePrefetchOnHover";
 import { useRouter } from "next/navigation";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
+import { formatMoney } from "@/lib/utils/money";
+import { useAssessmentPurchase } from "@/hooks/useAssessmentPurchase";
 import {
   isPsychometricAssessment,
   getPsychometricTags,
@@ -84,6 +86,17 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   const isRtl = theme.direction === "rtl";
   const router = useRouter();
   const { showToast } = useToast();
+  const { buy, buyingSlug } = useAssessmentPurchase();
+  /**
+   * Optimistically owned after a CONFIRMED payment, so the card flips to Start without a refetch.
+   * Never set before the server confirms — a card that says "Start" on an unsettled payment sends
+   * the learner into a 402.
+   */
+  const [justBought, setJustBought] = useState(false);
+  const needsPurchase =
+    (assessment.requires_purchase ?? false) && !assessment.purchased && !justBought;
+  const isBuying = buyingSlug === assessment.slug;
+
   const submissionComplete = isLearnerAssessmentSubmissionComplete(assessment);
   const normalizedStatus = normalizeLearnerAssessmentStatus(assessment);
 
@@ -205,6 +218,17 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   }, [assessment.start_time, assessment.end_time]);
 
   const { buttonLabel, isClickable } = useMemo(() => {
+    // Price first, ahead of every availability rule. A learner who has not bought this cannot
+    // start it whatever the window says, and "Starts 3 Aug" on something they must buy first
+    // answers a question they did not ask.
+    if (needsPurchase) {
+      return {
+        buttonLabel: assessment.price
+          ? `Buy · ${formatMoney(assessment.price, assessment.currency)}`
+          : "Buy",
+        isClickable: true,
+      };
+    }
     if (submissionComplete && showResults) {
       return { buttonLabel: t("assessments.viewResults"), isClickable: true };
     }
@@ -254,6 +278,9 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
       isClickable: canStartNow,
     };
   }, [
+    needsPurchase,
+    assessment.price,
+    assessment.currency,
     submissionComplete,
     showResults,
     normalizedStatus,
@@ -306,7 +333,7 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   // click actually opens. Null when the card isn't clickable — nothing to warm.
   // The device-allowed check stays out of this: it reads the environment and belongs at click time,
   // and warming a route the user turns out not to visit costs one request and breaks nothing.
-  const prefetchHref = !isClickable
+  const prefetchHref = !isClickable || needsPurchase
     ? null
     : submissionComplete && showResults
       ? `/assessments/result/${assessment.slug}`
@@ -314,7 +341,22 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   const prefetchProps = usePrefetchOnHover(prefetchHref);
 
   const handleClick = () => {
-    if (!isClickable || loadingAction) return;
+    if (!isClickable || loadingAction || isBuying) return;
+
+    if (needsPurchase) {
+      buy(assessment, {
+        onOwned: () => {
+          setJustBought(true);
+          showToast(`You now have access to "${assessment.title}".`, "success");
+        },
+        // Charged, but the webhook has not landed. Say exactly that — calling it a failure is
+        // wrong and calling it a success sends them into a 402.
+        onSettling: (message) => showToast(message, "info"),
+        onFailed: (message) => showToast(message, "error"),
+      });
+      return;
+    }
+
     if (submissionComplete && showResults) {
       setLoadingAction("primary");
       router.push(`/assessments/result/${assessment.slug}`);
@@ -395,6 +437,20 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             let tone: ChipTone = "success";
             const now = Date.now();
             const end = parseDateTime(assessment.end_time);
+            // Ahead of the availability states, for the same reason the CTA is: an unbought
+            // assessment is not "Available", and a window it cannot be opened in is noise.
+            if (needsPurchase) {
+              return (
+                <StatusChip
+                  label={
+                    assessment.price
+                      ? formatMoney(assessment.price, assessment.currency)
+                      : "Paid"
+                  }
+                  tone="info"
+                />
+              );
+            }
             if (submissionComplete && showResults) {
               label = "Completed";
               tone = "success";

--- a/hooks/useAssessmentPurchase.ts
+++ b/hooks/useAssessmentPurchase.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { PaymentType } from "@/lib/services/payment.service";
+import { usePayment } from "@/hooks/usePayment";
+import type { Assessment } from "@/lib/services/assessment.service";
+
+/**
+ * Buying an assessment, in one place.
+ *
+ * The card and the detail page both need this, and the failure mode of duplicating it is not
+ * cosmetic: the backend gates six separate routes, so a surface that opens checkout with the
+ * wrong payment type or the wrong id quietly buys nothing and leaves the learner charged with
+ * no access.
+ */
+
+/** What the backend sends with a 402 so the client never has to re-fetch the product to charge. */
+export interface PurchaseRequiredPayload {
+  payment_required?: boolean;
+  payment_type?: string;
+  type_id?: string;
+  price?: string | null;
+  currency?: string;
+  title?: string;
+}
+
+/**
+ * A 402 from ANY assessment route, or null if this error is something else.
+ *
+ * Read from the error rather than from the assessment, because the two can disagree: a card
+ * rendered before a price landed, or an admin pricing an assessment while the page is open, both
+ * produce a 402 on a card that says "Start".
+ */
+export function readPurchaseRequired(err: unknown): PurchaseRequiredPayload | null {
+  const resp = (err as { response?: { status?: number; data?: PurchaseRequiredPayload } })?.response;
+  if (resp?.status !== 402) return null;
+  if (!resp.data?.payment_required) return null;
+  return resp.data;
+}
+
+export function useAssessmentPurchase() {
+  const { handlePayment } = usePayment();
+  const [buyingSlug, setBuyingSlug] = useState<string | null>(null);
+
+  /**
+   * Open checkout for `assessment`.
+   *
+   * `onOwned` fires only once the server has confirmed the payment settled — never optimistically.
+   * Money is involved: telling a learner they own an assessment before the webhook lands is a
+   * promise the platform may not be able to keep, and the assessment they then cannot open is a
+   * support ticket rather than a refresh.
+   */
+  const buy = useCallback(
+    (
+      assessment: Pick<Assessment, "id" | "slug" | "title">,
+      handlers: {
+        onOwned: () => void;
+        onSettling: (message: string) => void;
+        onFailed: (message: string) => void;
+      },
+    ) => {
+      setBuyingSlug(assessment.slug);
+      void handlePayment({
+        typeId: String(assessment.id),
+        paymentType: PaymentType.ASSESSMENT,
+        description: assessment.title,
+        busyKey: assessment.slug,
+        onOutcome: (outcome) => {
+          setBuyingSlug(null);
+          if (outcome.kind === "verified") handlers.onOwned();
+          else if (outcome.kind === "settling") handlers.onSettling(outcome.message);
+          else if (outcome.kind === "failed") handlers.onFailed(outcome.message);
+          // "dismissed" is the learner closing the Razorpay sheet. Deliberately silent — they
+          // know they closed it, and a toast telling them so reads as an error.
+        },
+      });
+    },
+    [handlePayment],
+  );
+
+  return { buy, buyingSlug };
+}

--- a/lib/services/assessment.service.ts
+++ b/lib/services/assessment.service.ts
@@ -17,6 +17,17 @@ export interface Assessment {
   duration_minutes: number;
   is_paid: boolean;
   price: number | null;
+  /** ISO-4217 code the price is in. Never assume rupees — a SAR assessment shown as ₹ is a 23x lie. */
+  currency?: string;
+  /**
+   * Whether money stands between this learner and the paper.
+   *
+   * Not the same as `is_paid`: an assessment flagged paid with no price is free in practice, and
+   * opening a checkout for it would fail. Always prefer this over reading `is_paid` directly.
+   */
+  requires_purchase?: boolean;
+  /** Whether this learner already holds access — by purchase or by an admin-comped grant. */
+  purchased?: boolean;
   amount?: number;
   is_active: boolean;
   number_of_questions: number;


### PR DESCRIPTION
The frontend half of [BE #505](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/505). The backend made assessments purchasable and gates six routes, but nothing rendered a price — so a paid assessment was buyable **only by API**: a learner opening one got a bare `402` and no way forward.

### One hook, two surfaces
`useAssessmentPurchase` is shared by the card and the detail page. Duplicating it isn't a cosmetic risk: a surface that opens checkout with the wrong payment type or the wrong id buys nothing and leaves the learner **charged with no access**.

| surface | before | after |
|---|---|---|
| card | `Start assessment` → 402 | price chip + `Buy · ₹999` |
| detail | `Continue to device check →` → 402 | `Buy for ₹999` |

### Ordering is the design
Buying is placed **ahead of every availability rule** on both surfaces. Someone who has not bought this cannot start it whatever the window says, and *"Starts 3 Aug"* or *"Already submitted"* on a paid assessment answers a question they did not ask.

On the detail page the **proctoring consent and start window no longer block the purchase**. They gate *taking* the assessment; leaving them wired to the CTA would make a paid assessment unbuyable outside its own window — the opposite of what a price is for.

### Money-specific care
- **Ownership flips only after the server confirms settlement**, never optimistically. Telling someone they own an assessment before the webhook lands is a promise the platform may not keep, and the 402 they then hit is a support ticket rather than a refresh. A `settling` outcome says exactly that rather than claiming success *or* failure.
- **Prices use the assessment's own currency.** A SAR assessment rendered with a rupee sign is a 23× lie about what is about to be charged.
- A `dismissed` outcome (closing the Razorpay sheet) is deliberately **silent** — they know they closed it, and a toast reads as an error.
- Prefetch is suppressed for unbought assessments; no point warming a route that 402s.

### Also
`readPurchaseRequired` converges on checkout when a **402 arrives on a card that says Start** — a card rendered before a price landed, or an admin pricing the assessment while the page is open. The detail page renders a price screen rather than *"couldn't load"* if the gate ever moves onto the detail read (it is not gated today — that is deliberate, since hiding paid assessments means nobody can buy one).

`tsc --noEmit` clean, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)