### PR TITLE
feat: brand assessment reports with the institution, and let a trainer start early

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -76,6 +76,7 @@ import { buildAssessmentNotificationEmailHtml } from "@/lib/utils/email-template
 import { extractSavedEmailAttachment } from "@/lib/utils/assessment-email-attachment";
 import { generateAssessmentResultPdfVector } from "@/lib/utils/assessment-result-pdf.utils";
 import { preloadPdfBrandAssets } from "@/lib/utils/assessment-pdf-assets";
+import { resolveCertificateLogoUrl } from "@/lib/utils/resolveCertificateLogoUrl";
 import { generateAssessmentAnalyticsPdfVector } from "@/lib/utils/assessment-analytics-pdf.utils";
 import { AssessmentAnalyticsCharts } from "@/components/admin/assessment/AssessmentAnalyticsCharts";
 import JSZip from "jszip";
@@ -1374,7 +1375,10 @@ export default function AssessmentEditPage() {
       if (!submissionsData) return;
       try {
         // Load the AiLinc logo + cursive font once so the report renders fully branded.
-        await preloadPdfBrandAssets();
+        await preloadPdfBrandAssets({
+        name: clientInfo?.name,
+        logoUrl: resolveCertificateLogoUrl(clientInfo),
+      });
         const result = mapSubmissionsExportRowToAssessmentResult(
           submissionsData,
           submission,
@@ -1415,7 +1419,10 @@ export default function AssessmentEditPage() {
     setDownloadingAllSubmissionPdfs(true);
     try {
       // Load the AiLinc logo + cursive font once; every report in the zip reuses the cache.
-      await preloadPdfBrandAssets();
+      await preloadPdfBrandAssets({
+        name: clientInfo?.name,
+        logoUrl: resolveCertificateLogoUrl(clientInfo),
+      });
       const zip = new JSZip();
       const usedFileNames = new Set<string>();
 

--- a/app/assessments/result/[slug]/page.tsx
+++ b/app/assessments/result/[slug]/page.tsx
@@ -30,6 +30,8 @@ import { buildAssessmentFeedbackPoints } from "@/lib/utils/assessment-feedback.u
 import { useAuth } from "@/lib/auth/auth-context";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { generateAssessmentResultPdfVector } from "@/lib/utils/assessment-result-pdf.utils";
+import { preloadPdfBrandAssets } from "@/lib/utils/assessment-pdf-assets";
+import { resolveCertificateLogoUrl } from "@/lib/utils/resolveCertificateLogoUrl";
 import { getMockPsychometricData } from "@/lib/mock-data/assessment-mock-data";
 import {
   buildAssessmentAppreciationCertificate,
@@ -456,7 +458,7 @@ export default function AssessmentResultPage() {
       ? `You scored ${heroScore} out of ${heroMax} (${Math.round(heroPct)}%) - ${heroBand.label.toLowerCase()} performance.`
       : "Your submission has been evaluated.";
 
-  const handleDownloadResultPdf = () => {
+  const handleDownloadResultPdf = async () => {
     if (!assessmentResult || pdfExporting) return;
 
     setPdfExporting(true);
@@ -480,6 +482,14 @@ export default function AssessmentResultPage() {
               email: user.email || undefined,
             }
           : undefined;
+
+      // The report carries the INSTITUTION's mark, not ours — a learner keeps this document and
+      // may forward it. Awaited because the generator below is synchronous and reads whatever has
+      // been loaded by the time it runs; skip this and every tenant's report is AI Linc-branded.
+      await preloadPdfBrandAssets({
+        name: clientInfo?.name,
+        logoUrl: resolveCertificateLogoUrl(clientInfo),
+      });
 
       generateAssessmentResultPdfVector(
         assessmentResult,

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -317,6 +317,10 @@ function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttenda
   const isLive = status === "live";
   const today = isToday(s.class_datetime, now);
   const viewerTime = sessionTimeParts(s.class_datetime, s.timezone).viewerTime;
+  // Thirty minutes is enough to open the room, share a screen and settle before students arrive,
+  // without putting a Start button on every session in next month's list.
+  const minutesToStart = (new Date(s.class_datetime).getTime() - now) / 60000;
+  const canStartEarly = minutesToStart > 0 && minutesToStart <= 30;
   const hasStats = s.registered > 0 && s.turnout != null && (status === "ended" || s.attendance > 0);
 
   const outlineBtn = { textTransform: "none", fontWeight: 700, color: "#6366f1", px: 1.75, py: 0.9, borderRadius: 2, border: "1px solid var(--border-default)" } as const;
@@ -369,13 +373,19 @@ function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttenda
         )}
 
         <Stack direction="row" spacing={1} alignItems="center">
-          {status === "live" && s.hostable && (
+          {/* Also before the clock says "live".
+              A trainer opens the room to set up, and a session the platform still calls
+              "scheduled" was previously unstartable from here — the button only appeared once the
+              start time had already passed. That also matters beyond convenience: where a tenant
+              gates student Join on the host actually starting, this button is the only thing that
+              produces that signal. */}
+          {(status === "live" || (status === "scheduled" && canStartEarly)) && s.hostable && (
             <Button onClick={onHost} disabled={hosting}
               startIcon={hosting ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:video" width={16} />}
               sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2, py: 0.9, borderRadius: 2,
                 background: "linear-gradient(135deg,#10b981,#059669)", "&:hover": { filter: "brightness(1.06)" },
                 "&.Mui-disabled": { color: "rgba(255,255,255,0.8)" } }}>
-              Start hosting
+              {status === "live" ? "Start hosting" : "Start early"}
             </Button>
           )}
           {status === "scheduled" && (

--- a/lib/utils/assessment-pdf-assets.ts
+++ b/lib/utils/assessment-pdf-assets.ts
@@ -9,7 +9,20 @@
 // White monochrome mark so the logo reads cleanly on the violet→pink header gradient.
 const LOGO_SVG_URL = "/logos/ai-linc-mark-white.svg";
 
+export interface PdfLogo {
+  dataUrl: string;
+  w: number;
+  h: number;
+  /** True for the AI Linc mark, which is white-on-transparent and sits directly on the gradient.
+   *  A tenant logo is arbitrary artwork and needs a light plate behind it to stay legible. */
+  isMonochromeMark: boolean;
+}
+
 let _logoPng: { dataUrl: string; w: number; h: number } | null | undefined;
+//: Per-URL cache. A bulk export renders many reports for one tenant; re-fetching and
+//: re-rasterizing the same logo per report is the difference between a fast zip and a slow one.
+const _tenantLogos = new Map<string, PdfLogo | null>();
+let _activeBrand: { name: string; logo: PdfLogo | null } | null = null;
 
 /** The AiLinc logo mark rasterized to a PNG data URL (retina-scaled), or null if unavailable. */
 export async function loadLogoPng(): Promise<{ dataUrl: string; w: number; h: number } | null> {
@@ -50,9 +63,90 @@ export async function loadLogoPng(): Promise<{ dataUrl: string; w: number; h: nu
   return _logoPng;
 }
 
-/** Preload the logo (call before a bulk export so each item reuses the cache). */
-export async function preloadPdfBrandAssets(): Promise<void> {
-  await loadLogoPng();
+/**
+ * Rasterize a tenant's own logo for the report header.
+ *
+ * Returns null on ANY failure, and the caller falls back to the AI Linc mark rather than dropping
+ * the header — a report with no branding is worse than one with ours.
+ *
+ * `crossOrigin` is set because the canvas is read back with toDataURL: without it a logo served
+ * from S3 or a CDN taints the canvas and the read throws, which would take the whole PDF down
+ * rather than just the logo.
+ */
+export async function loadTenantLogoPng(url: string): Promise<PdfLogo | null> {
+  const key = (url || "").trim();
+  if (!key) return null;
+  if (_tenantLogos.has(key)) return _tenantLogos.get(key) ?? null;
+  if (typeof window === "undefined" || typeof document === "undefined") return null;
+
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const im = new Image();
+      im.crossOrigin = "anonymous";
+      im.onload = () => resolve(im);
+      im.onerror = () => reject(new Error("tenant logo decode failed"));
+      im.src = key;
+    });
+    const w = img.naturalWidth || img.width;
+    const h = img.naturalHeight || img.height;
+    if (!w || !h) {
+      _tenantLogos.set(key, null);
+      return null;
+    }
+    // Cap the raster so a 4000px logo does not bloat every report in a bulk export.
+    const scale = Math.min(4, Math.max(1, 1200 / Math.max(w, h)));
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(w * scale);
+    canvas.height = Math.round(h * scale);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      _tenantLogos.set(key, null);
+      return null;
+    }
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    const out: PdfLogo = {
+      dataUrl: canvas.toDataURL("image/png"),
+      w,
+      h,
+      isMonochromeMark: false,
+    };
+    _tenantLogos.set(key, out);
+    return out;
+  } catch {
+    // Most often a CORS-less host. Cached as a miss so a bulk export does not retry per report.
+    _tenantLogos.set(key, null);
+    return null;
+  }
+}
+
+/**
+ * Preload branding for the report header (call before a bulk export so each item reuses the cache).
+ *
+ * Passing the tenant makes the report say who it is from. Without it the export is AI Linc-branded
+ * for every institution, which is wrong on a document a learner keeps and may forward.
+ */
+export async function preloadPdfBrandAssets(brand?: {
+  name?: string | null;
+  logoUrl?: string | null;
+}): Promise<void> {
+  const fallback = await loadLogoPng();
+  const tenantLogo = brand?.logoUrl ? await loadTenantLogoPng(brand.logoUrl) : null;
+  _activeBrand = {
+    name: (brand?.name || "").trim(),
+    logo:
+      tenantLogo ??
+      (fallback ? { ...fallback, isMonochromeMark: true } : null),
+  };
+}
+
+/** The branding the (synchronous) PDF generator should draw. Falls back to the AI Linc mark. */
+export function getActivePdfBrand(): { name: string; logo: PdfLogo | null } {
+  if (_activeBrand) return _activeBrand;
+  const fallback = getCachedLogoPng();
+  return {
+    name: "",
+    logo: fallback ? { ...fallback, isMonochromeMark: true } : null,
+  };
 }
 
 /** Synchronous cache read for the (sync) PDF generator - null until preloaded. */

--- a/lib/utils/assessment-result-pdf.utils.ts
+++ b/lib/utils/assessment-result-pdf.utils.ts
@@ -1,5 +1,5 @@
 import jsPDF from "jspdf";
-import { getCachedLogoPng } from "@/lib/utils/assessment-pdf-assets";
+import { getActivePdfBrand } from "@/lib/utils/assessment-pdf-assets";
 import type {
   AssessmentResult,
   CodingProblemResponseItem,
@@ -697,27 +697,47 @@ function drawBrandHeader(
   const bandH = 34;
   drawHorizontalGradient(pdf, 0, 0, pageW, bandH, GRADIENT_START, GRADIENT_END);
 
-  // Logo mark (rasterized) top-left, on a soft translucent chip for contrast.
-  const logo = getCachedLogoPng();
+  // The institution's own mark and name — this is their document, not ours. Falls back to the
+  // AI Linc mark when a tenant has no logo, or when theirs could not be loaded.
+  const brand = getActivePdfBrand();
+  const logo = brand.logo;
   let textX = margin;
   if (logo) {
     const logoH = 13;
-    const logoW = (logo.w / logo.h) * logoH;
-    // White monochrome mark sits directly on the gradient - no plate, so it reads as one with
-    // the white wordmark + title.
+    const logoW = Math.min((logo.w / logo.h) * logoH, 34);
     try {
-      pdf.addImage(logo.dataUrl, "PNG", margin, 8.5, logoW, logoH);
+      if (logo.isMonochromeMark) {
+        // The AI Linc mark is white-on-transparent and reads as one with the white wordmark, so
+        // it sits directly on the gradient with no plate.
+        pdf.addImage(logo.dataUrl, "PNG", margin, 8.5, logoW, logoH);
+      } else {
+        // A tenant logo is arbitrary artwork — usually dark ink, often on a transparent
+        // background. On a violet→pink gradient that is close to invisible, so it gets a light
+        // plate. Without this the "branding" a client asked for reads as a smudge.
+        const padX = 2.4;
+        const padY = 1.8;
+        pdf.setFillColor(255, 255, 255);
+        pdf.roundedRect(
+          margin - padX, 8.5 - padY, logoW + padX * 2, logoH + padY * 2, 1.6, 1.6, "F",
+        );
+        pdf.addImage(logo.dataUrl, "PNG", margin, 8.5, logoW, logoH);
+      }
     } catch {
       /* logo optional */
     }
-    textX = margin + logoW + 5;
+    textX = margin + logoW + (logo.isMonochromeMark ? 5 : 7);
   }
 
-  // "AILINC" wordmark + elegant serif-italic report title
+  // Institution wordmark + elegant serif-italic report title
   pdf.setTextColor(255, 255, 255);
   pdf.setFont(PDF_FONT, "bold");
   pdf.setFontSize(9);
-  pdf.text("AILINC", textX, 12.5, { charSpace: 1.1 });
+  // Upper-cased for the wordmark treatment, and truncated rather than allowed to collide with
+  // the assessment name on the right.
+  const wordmark = (brand.name || "AILINC").toUpperCase();
+  pdf.text(pdf.splitTextToSize(wordmark, pageW / 2 - textX)[0] ?? wordmark, textX, 12.5, {
+    charSpace: 1.1,
+  });
 
   pdf.setFont("times", "italic");
   pdf.setFontSize(23);


### PR DESCRIPTION
Two Agileology asks, both frontend-only.

### 1. The report is the institution's, not ours
`drawBrandHeader` hard-coded `pdf.text("AILINC")` and a bundled mark, so **every** institution's assessment report was AI Linc-branded — on a document a learner keeps and may forward. It now draws the tenant's own logo and name, falling back to the AI Linc mark only when a tenant has none.

Two details that would each have shipped as *"it looks broken"*:

- **A tenant logo needs a plate.** Our mark is white-on-transparent, drawn for that violet→pink gradient. A client's logo is usually dark ink on transparent — on that gradient, close to invisible. Tenant logos get a white rounded plate; ours keeps sitting directly on the gradient.
- **`crossOrigin` on the image load** — and this one breaks the feature rather than just looking wrong. The canvas is read back with `toDataURL`, and a logo served without CORS headers **taints** it: the read throws and takes the *whole PDF* down, not just the logo. Any failure caches as a miss and falls back, so a bulk export doesn't retry per report.

Preloading is **awaited** at all three export sites (student result + both admin exports). The generator is synchronous and draws whatever happens to be loaded, so an un-awaited preload silently produces the old branding.

### 2. A trainer can open the room before the clock says live
`Start hosting` only rendered when `status === "live"` — the same clock-derived flag behind the *"students see Join before I've started"* report. A trainer could not open the room early to set up. There's now **Start early** from 30 minutes out.

This matters beyond convenience: **pressing it is the only thing in the product that makes Zoom emit `meeting.started`**, which is the signal a tenant's `require_host_start` gate waits on. Platform-wide only **1 of 107** Zoom sessions has ever recorded a start — the chain was broken at both ends, and this is the end nobody had noticed.

**Permissions needed no change.** `can_host_live_session` already authorises on the instructor's *assigned scope*, not on who created the session — so an admin-created session is startable by its assigned instructor. That was the open question; the answer is it already works.

`tsc --noEmit` clean, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)