### PR TITLE
fix(pricing): refuse a catalog template up front, and say Pay rather than Buy

### DIFF
--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -280,8 +280,8 @@ export default function AssessmentDetailPage({
               }}
             >
               {purchaseWall.price
-                ? `Buy for ${formatMoney(purchaseWall.price, purchaseWall.currency)}`
-                : "Buy this assessment"}
+                ? `Pay ${formatMoney(purchaseWall.price, purchaseWall.currency)}`
+                : "Pay for this assessment"}
             </LoadingButton>
           </Container>
         </MainLayout>
@@ -375,8 +375,8 @@ export default function AssessmentDetailPage({
   // and "Already submitted" or a consent checkbox is not the question in front of them.
   const ctaLabel = needsPurchase
     ? assessment?.price
-      ? `Buy for ${formatMoney(assessment.price, assessment.currency)}`
-      : "Buy this assessment"
+      ? `Pay ${formatMoney(assessment.price, assessment.currency)}`
+      : "Pay for this assessment"
     : isExpired
     ? t("assessments.expired")
     : canReattempt && isAlreadySubmitted

--- a/components/admin/adaptive-course/CoursePricingDialog.tsx
+++ b/components/admin/adaptive-course/CoursePricingDialog.tsx
@@ -45,7 +45,16 @@ export function CoursePricingDialog({
   onSaved,
 }: {
   open: boolean;
-  course: { id: number; is_paid: boolean; price: string | null; currency: string; auto_enroll: boolean };
+  course: {
+    id: number;
+    is_paid: boolean;
+    price: string | null;
+    currency: string;
+    auto_enroll: boolean;
+    /** Catalog master. It has no tenant to collect the money, so it can never be priced. */
+    is_template?: boolean;
+    title?: string;
+  };
   onClose: () => void;
   onSaved: (patch: { is_paid: boolean; price: string | null; currency: string }) => void;
 }) {
@@ -81,7 +90,16 @@ export function CoursePricingDialog({
   // Checked client-side so the admin gets a sentence instead of a bounced request — but the
   // server enforces all three independently, and its wording wins if one still gets through.
   const blockedByAutoEnroll = isPaid && course.auto_enroll;
-  const canSave = !saving && (!isPaid || (priceValid && !blockedByAutoEnroll));
+  /**
+   * A catalog template can never be priced, so say so BEFORE the admin fills anything in.
+   *
+   * The dialog used to accept a price and a currency and only refuse on Save — the server was
+   * right to refuse, but the admin had already made every decision the form asks for. Worse, the
+   * message named a rule rather than the next step, so the natural conclusion was "templates are
+   * broken" rather than "price the tenant's copy".
+   */
+  const isTemplate = course.is_template === true;
+  const canSave = !saving && !isTemplate && (!isPaid || (priceValid && !blockedByAutoEnroll));
 
   async function handleSave() {
     setSaving(true);
@@ -191,10 +209,29 @@ export function CoursePricingDialog({
                 their access for free.
               </Typography>
             </Box>
-            <Switch checked={isPaid} disabled={saving} onChange={(e) => setIsPaid(e.target.checked)} />
+            <Switch
+              checked={isPaid && !isTemplate}
+              disabled={saving || isTemplate}
+              onChange={(e) => setIsPaid(e.target.checked)}
+            />
           </Box>
 
-          <Collapse in={isPaid} unmountOnExit>
+          {isTemplate && (
+            <Alert severity="info" sx={{ borderRadius: 2, fontSize: "0.85rem" }}>
+              <Typography sx={{ fontWeight: 700, fontSize: "0.88rem", mb: 0.5 }}>
+                This is a catalog template
+              </Typography>
+              A template is the master copy. It is mapped into each institution and is never shown
+              to learners directly, so there is no institution here to collect the payment.
+              <Box sx={{ mt: 1 }}>
+                Price the institution&apos;s own copy instead — open{" "}
+                <strong>{course.title || "this course"}</strong> from that institution&apos;s course
+                list, not from the catalog.
+              </Box>
+            </Alert>
+          )}
+
+          <Collapse in={isPaid && !isTemplate} unmountOnExit>
             <Stack spacing={2}>
               {blockedByAutoEnroll && (
                 <Alert severity="warning" sx={{ borderRadius: 2, fontSize: "0.83rem" }}>

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -224,8 +224,8 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
     if (needsPurchase) {
       return {
         buttonLabel: assessment.price
-          ? `Buy · ${formatMoney(assessment.price, assessment.currency)}`
-          : "Buy",
+          ? `Pay · ${formatMoney(assessment.price, assessment.currency)}`
+          : "Pay",
         isClickable: true,
       };
     }

--- a/components/courses/CatalogCourseCard.tsx
+++ b/components/courses/CatalogCourseCard.tsx
@@ -172,7 +172,7 @@ export function CatalogCourseCard({
             ? "Opening checkout…"
             : "Enrolling…"
           : mustBuy
-            ? `Buy ${formatMoney(course.price, course.currency)}`
+            ? `Pay ${formatMoney(course.price, course.currency)}`
             : "Enroll"}
       </Button>
     </Box>


### PR DESCRIPTION
Reported: pricing *Introduction to C++* returned **"Catalog templates cannot be priced."**

The server was right to refuse — a template is the master copy, mapped into each institution and never shown to learners directly, so **there is no institution there to collect the payment**. The problem is the dialog: it accepted a price *and* a currency and only refused on Save, then stated a rule rather than a next step. The admin had already made every decision the form asks for, and the natural conclusion is *"templates are broken"* rather than *"price the tenant's copy"*.

Now the toggle is **disabled with the explanation before anything is filled in**, and it names what to do instead. The tenant's copy is a separate course row and is already priceable — in production, `id 8` is the template and `id 31` is Demo Client's clone.

Pairs with BE #509, which exposes `is_template` on the admin course payload.

### Also: Buy → Pay
One verb for one action. `Buy` and `Pay` sitting on adjacent surfaces for the same thing reads as two different flows — renamed across the course card and both assessment surfaces.

`tsc --noEmit` clean, 22 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)