### PR TITLE
chore: promote stagging to main — pricing dialog, Pay verb, assessment timezone + currencies

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -440,6 +440,8 @@ export default function AssessmentEditPage() {
   const [isPaid, setIsPaid] = useState(false);
   const [price, setPrice] = useState<string>("");
   const [currency, setCurrency] = useState<string>("INR");
+  // Blank means "use the institution's timezone" — the same default the backend resolves to.
+  const [timezone, setTimezone] = useState<string>("");
   const [isActive, setIsActive] = useState(true);
   const [courseIds, setCourseIds] = useState<number[]>([]);
   const [colleges, setColleges] = useState<string[]>([]);
@@ -599,6 +601,7 @@ export default function AssessmentEditPage() {
           : ""
       );
       setCurrency(anyData.currency ?? "INR");
+      setTimezone(anyData.timezone ?? "");
       setIsActive(data.is_active ?? true);
       const anyDataCourses = (data as any);
       const loadedCourseIds = Array.isArray(anyDataCourses.course_ids)
@@ -900,6 +903,9 @@ export default function AssessmentEditPage() {
         is_paid: isPaid,
         price: isPaid ? (price ? Number(price) : null) : null,
         currency: isPaid ? currency : undefined,
+        // Sent even when blank: clearing it back to the institution's zone is a real
+        // edit, and omitting the key would silently keep the old override.
+        timezone,
         is_active: isActive,
         proctoring_enabled: proctoringEnabled,
         live_streaming: canConfigureLiveStreaming ? liveStreaming : false,
@@ -1866,6 +1872,8 @@ export default function AssessmentEditPage() {
                   onPaidChange={setIsPaid}
                   onPriceChange={setPrice}
                   onCurrencyChange={setCurrency}
+                  timezone={timezone}
+                  onTimezoneChange={setTimezone}
                   onActiveChange={setIsActive}
                   onCourseIdsChange={setCourseIds}
                   onCollegesChange={setColleges}

--- a/app/admin/assessment/create/page.tsx
+++ b/app/admin/assessment/create/page.tsx
@@ -99,6 +99,8 @@ function CreateAssessmentPageContent() {
   const [isPaid, setIsPaid] = useState(false);
   const [price, setPrice] = useState<string>("");
   const [currency, setCurrency] = useState<string>("INR");
+  // Blank means "use the institution's timezone" — the same default the backend resolves to.
+  const [timezone, setTimezone] = useState<string>("");
   const [isActive, setIsActive] = useState(true);
   const [courseIds, setCourseIds] = useState<number[]>([]);
   const [colleges, setColleges] = useState<string[]>([]);
@@ -1179,6 +1181,9 @@ function CreateAssessmentPageContent() {
         is_paid: isPaid,
         price: isPaid ? (price ? Number(price) : null) : null,
         currency: isPaid ? currency : undefined,
+        // Sent even when blank: clearing it back to the institution's zone is a real
+        // edit, and omitting the key would silently keep the old override.
+        timezone,
         is_active: isActive,
         proctoring_enabled: proctoringEnabled,
         live_streaming: canConfigureLiveStreaming ? liveStreaming : false,
@@ -1686,6 +1691,8 @@ function CreateAssessmentPageContent() {
               onPaidChange={setIsPaid}
               onPriceChange={setPrice}
               onCurrencyChange={setCurrency}
+              timezone={timezone}
+              onTimezoneChange={setTimezone}
               onActiveChange={setIsActive}
               onCourseIdsChange={setCourseIds}
               onCollegesChange={setColleges}

--- a/app/assessments/[slug]/page.tsx
+++ b/app/assessments/[slug]/page.tsx
@@ -280,8 +280,8 @@ export default function AssessmentDetailPage({
               }}
             >
               {purchaseWall.price
-                ? `Buy for ${formatMoney(purchaseWall.price, purchaseWall.currency)}`
-                : "Buy this assessment"}
+                ? `Pay ${formatMoney(purchaseWall.price, purchaseWall.currency)}`
+                : "Pay for this assessment"}
             </LoadingButton>
           </Container>
         </MainLayout>
@@ -375,8 +375,8 @@ export default function AssessmentDetailPage({
   // and "Already submitted" or a consent checkbox is not the question in front of them.
   const ctaLabel = needsPurchase
     ? assessment?.price
-      ? `Buy for ${formatMoney(assessment.price, assessment.currency)}`
-      : "Buy this assessment"
+      ? `Pay ${formatMoney(assessment.price, assessment.currency)}`
+      : "Pay for this assessment"
     : isExpired
     ? t("assessments.expired")
     : canReattempt && isAlreadySubmitted

--- a/components/admin/adaptive-course/CoursePricingDialog.tsx
+++ b/components/admin/adaptive-course/CoursePricingDialog.tsx
@@ -45,7 +45,16 @@ export function CoursePricingDialog({
   onSaved,
 }: {
   open: boolean;
-  course: { id: number; is_paid: boolean; price: string | null; currency: string; auto_enroll: boolean };
+  course: {
+    id: number;
+    is_paid: boolean;
+    price: string | null;
+    currency: string;
+    auto_enroll: boolean;
+    /** Catalog master. It has no tenant to collect the money, so it can never be priced. */
+    is_template?: boolean;
+    title?: string;
+  };
   onClose: () => void;
   onSaved: (patch: { is_paid: boolean; price: string | null; currency: string }) => void;
 }) {
@@ -81,7 +90,16 @@ export function CoursePricingDialog({
   // Checked client-side so the admin gets a sentence instead of a bounced request — but the
   // server enforces all three independently, and its wording wins if one still gets through.
   const blockedByAutoEnroll = isPaid && course.auto_enroll;
-  const canSave = !saving && (!isPaid || (priceValid && !blockedByAutoEnroll));
+  /**
+   * A catalog template can never be priced, so say so BEFORE the admin fills anything in.
+   *
+   * The dialog used to accept a price and a currency and only refuse on Save — the server was
+   * right to refuse, but the admin had already made every decision the form asks for. Worse, the
+   * message named a rule rather than the next step, so the natural conclusion was "templates are
+   * broken" rather than "price the tenant's copy".
+   */
+  const isTemplate = course.is_template === true;
+  const canSave = !saving && !isTemplate && (!isPaid || (priceValid && !blockedByAutoEnroll));
 
   async function handleSave() {
     setSaving(true);
@@ -191,10 +209,29 @@ export function CoursePricingDialog({
                 their access for free.
               </Typography>
             </Box>
-            <Switch checked={isPaid} disabled={saving} onChange={(e) => setIsPaid(e.target.checked)} />
+            <Switch
+              checked={isPaid && !isTemplate}
+              disabled={saving || isTemplate}
+              onChange={(e) => setIsPaid(e.target.checked)}
+            />
           </Box>
 
-          <Collapse in={isPaid} unmountOnExit>
+          {isTemplate && (
+            <Alert severity="info" sx={{ borderRadius: 2, fontSize: "0.85rem" }}>
+              <Typography sx={{ fontWeight: 700, fontSize: "0.88rem", mb: 0.5 }}>
+                This is a catalog template
+              </Typography>
+              A template is the master copy. It is mapped into each institution and is never shown
+              to learners directly, so there is no institution here to collect the payment.
+              <Box sx={{ mt: 1 }}>
+                Price the institution&apos;s own copy instead — open{" "}
+                <strong>{course.title || "this course"}</strong> from that institution&apos;s course
+                list, not from the catalog.
+              </Box>
+            </Alert>
+          )}
+
+          <Collapse in={isPaid && !isTemplate} unmountOnExit>
             <Stack spacing={2}>
               {blockedByAutoEnroll && (
                 <Alert severity="warning" sx={{ borderRadius: 2, fontSize: "0.83rem" }}>

--- a/components/admin/assessment/AssessmentSettingsSection.tsx
+++ b/components/admin/assessment/AssessmentSettingsSection.tsx
@@ -24,6 +24,8 @@ import {
   FormControlLabel,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { timezoneOptions } from "@/lib/utils/session-time";
+import { currenciesService, type CurrencyOption } from "@/lib/services/currencies.service";
 
 /** Lead times (minutes before start) offered as reminder checkboxes. Mirrors the
  *  backend's ALLOWED_REMINDER_OFFSETS in assessment/reminders.py. */
@@ -38,10 +40,20 @@ import {
   type EmailNotificationEditorHandle,
 } from "@/components/admin/assessment/EmailNotificationEditor";
 
+/** Shown under both date fields so the zone is never implied by a label that can drift. */
+function zoneLabelFor(tz: string): string {
+  const zone = (tz || "").trim();
+  if (!zone) return "In your institution's timezone";
+  return `In ${zone.replace(/_/g, " ")}`;
+}
+
 interface AssessmentSettingsSectionProps {
   durationMinutes: number;
   startTime: string;
   endTime: string;
+  /** IANA zone the window is expressed in. Blank means "use the institution's zone". */
+  timezone?: string;
+  onTimezoneChange?: (value: string) => void;
   /** Omitted or undefined is normalized via default params so MUI Switch stays controlled. */
   isPaid?: boolean;
   price: string;
@@ -572,6 +584,8 @@ export function AssessmentSettingsSection({
   onPaidChange,
   onPriceChange,
   onCurrencyChange,
+  timezone = "",
+  onTimezoneChange,
   onActiveChange,
   onProctoringEnabledChange,
   onLiveStreamingChange,
@@ -591,6 +605,32 @@ export function AssessmentSettingsSection({
   onCollegesChange,
   readOnly = false,
 }: AssessmentSettingsSectionProps) {
+  const zoneHelper = zoneLabelFor(timezone);
+
+  /**
+   * Loaded from the server, never hard-coded.
+   *
+   * This list used to name five currencies while the platform accepts ten, so an admin could not
+   * price an assessment in AED, QAR, KWD, BHD or OMR at all. The server's validator and this
+   * dropdown are the same table, which also means the dropdown can never offer a currency the
+   * server would reject — the failure the adaptive course builder already avoids this way.
+   */
+  const [currencies, setCurrencies] = useState<CurrencyOption[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void currenciesService
+      .list()
+      .then((list) => {
+        if (!cancelled) setCurrencies(list);
+      })
+      .catch(() => {
+        // Keep whatever is already selected usable rather than emptying the control.
+        if (!cancelled) setCurrencies([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const { t } = useTranslation("common");
   // Mount the email editor lazily once and keep it mounted so toggling
   // on/off becomes a CSS display swap (no Tiptap re-init, no Collapse height
@@ -878,17 +918,39 @@ export function AssessmentSettingsSection({
                 label="Start date & time (optional)"
                 value={startTime}
                 onChange={onStartTimeChange}
-                helperText="IST timezone"
+                helperText={zoneHelper}
                 disabled={readOnly}
               />
               <DateTimePartsField
                 label="End date & time (optional)"
                 value={endTime}
                 onChange={onEndTimeChange}
-                helperText="IST timezone"
+                helperText={zoneHelper}
                 disabled={readOnly}
               />
             </Box>
+
+            {/* The window was labelled "IST timezone" while actually reading the browser clock.
+                For an Indian admin those agreed, which is why it survived; for a Riyadh admin
+                picking 9:00 AM the stored window was three and a half hours from what the label
+                promised, and nothing recorded which zone was meant. */}
+            <TextField
+              select
+              fullWidth
+              label="Timezone"
+              value={timezone || ""}
+              onChange={(e) => onTimezoneChange?.(e.target.value)}
+              disabled={readOnly || !onTimezoneChange}
+              helperText="The times above are in this zone. Learners always see their own local time as well."
+              sx={{ mt: 2 }}
+            >
+              <MenuItem value="">Use the institution&apos;s timezone</MenuItem>
+              {timezoneOptions(timezone).map((z) => (
+                <MenuItem key={z.value} value={z.value}>
+                  {z.label}
+                </MenuItem>
+              ))}
+            </TextField>
           </FieldGroup>
         </Box>
       </SettingsGroupCard>
@@ -953,11 +1015,11 @@ export function AssessmentSettingsSection({
                     label="Currency"
                     disabled={readOnly}
                   >
-                    <MenuItem value="INR">INR (₹)</MenuItem>
-                    <MenuItem value="USD">USD ($)</MenuItem>
-                    <MenuItem value="EUR">EUR (€)</MenuItem>
-                    <MenuItem value="GBP">GBP (£)</MenuItem>
-                    <MenuItem value="SAR">SAR (﷼)</MenuItem>
+                    {currencies.map((c) => (
+                      <MenuItem key={c.code} value={c.code}>
+                        {c.symbol ? `${c.symbol} ` : ""}{c.code} — {c.name}
+                      </MenuItem>
+                    ))}
                   </Select>
                 </FormControl>
               </Box>

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -224,8 +224,8 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
     if (needsPurchase) {
       return {
         buttonLabel: assessment.price
-          ? `Buy · ${formatMoney(assessment.price, assessment.currency)}`
-          : "Buy",
+          ? `Pay · ${formatMoney(assessment.price, assessment.currency)}`
+          : "Pay",
         isClickable: true,
       };
     }

--- a/components/courses/CatalogCourseCard.tsx
+++ b/components/courses/CatalogCourseCard.tsx
@@ -172,7 +172,7 @@ export function CatalogCourseCard({
             ? "Opening checkout…"
             : "Enrolling…"
           : mustBuy
-            ? `Buy ${formatMoney(course.price, course.currency)}`
+            ? `Pay ${formatMoney(course.price, course.currency)}`
             : "Enroll"}
       </Button>
     </Box>

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -209,6 +209,8 @@ export interface CreateAssessmentPayload {
   is_paid?: boolean;
   price?: string | number | null;
   currency?: string;
+  /** IANA zone the start/end window is expressed in. Blank uses the institution's zone. */
+  timezone?: string;
   is_active?: boolean;
   /** When true, server keeps assessment inactive and hidden from learners until published. */
   is_draft?: boolean;


### PR DESCRIPTION
Promotes #1219 (catalog-template pricing dialog + Buy→Pay) and #1220 (assessment timezone picker + full currency list).

Pairs with BE #509 and #510, both live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)