### PR TITLE
fix(admin): unenroll says what actually happened

### DIFF
--- a/components/admin/adaptive-course/CourseStudentsPanel.tsx
+++ b/components/admin/adaptive-course/CourseStudentsPanel.tsx
@@ -124,8 +124,26 @@ export function CourseStudentsPanel({ courseId, courseTitle }: Props) {
     }
     setBusyId(student.student_id);
     try {
-      await adminAdaptiveCourseService.unenrollStudents(courseId, [student.student_id]);
-      showToast("Student removed.", "success");
+      const result = await adminAdaptiveCourseService.unenrollStudents(courseId, [
+        student.student_id,
+      ]);
+
+      // The endpoint reports what it actually did, and this used to throw that away and toast
+      // success on any HTTP 200. A removal that matched no enrolment row therefore looked
+      // identical to one that worked — the admin saw "Student removed.", the student stayed in
+      // the list after the reload, and the only available conclusion was that the button is
+      // broken.
+      if ((result?.succeeded ?? 0) < 1) {
+        const reason = result?.failed?.[0]?.detail;
+        showToast(
+          reason ||
+            "Nothing was removed — they may already be off this course, or they were added by a cohort or auto-enrolment.",
+          "warning",
+        );
+      } else {
+        showToast("Student removed.", "success");
+      }
+
       // If we just removed the last row on a page, step back a page.
       const nextPage = rows.length === 1 && page > 1 ? page - 1 : page;
       setPage(nextPage);


### PR DESCRIPTION
Found while running the RCA on *"I couldn't unenroll from the course card's students section."*

The remove button **does** exist and **does** hit the right endpoint — but the panel discarded the result and toasted `"Student removed."` on any HTTP 200:

```tsx
await adminAdaptiveCourseService.unenrollStudents(courseId, [student.student_id]);
showToast("Student removed.", "success");   // ← regardless of what came back
```

A removal that matched **no enrolment row** was therefore indistinguishable from one that worked: success toast, student still in the list after the reload, and the only available conclusion is that the button is broken. Which is exactly what was reported.

The endpoint has always returned `{succeeded, skipped, failed, missing}`. The panel now reads it, and when nothing was removed it says so — naming the likely reason, since the usual cause is that the student is on the course via a **cohort or auto-enrolment** rather than the enrolment row this removes.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)