### PR TITLE
fix(auth): control heights 54.6px -> 44px, and stop the form shifting on validation error

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,6 +163,14 @@ Two panels on desktop, stacked on mobile. The split is **52 / 48 favouring the f
   border. Focus replaces the shadow with the ring, so focus causes zero layout shift.
 - 44px tall, 8px radius, 16px text on mobile (below 16px, iOS Safari zooms the viewport on
   focus).
+- **`minHeight: 44` is not enough.** MUI ships `padding: 16.5px 14px` on
+  `.MuiOutlinedInput-input`, which is taller than 44px on its own, so `minHeight` never
+  binds and fields render at 54.6px. Set `padding: 11px 14px` on the input explicitly.
+  Same trap on buttons: `py: 1.25` makes the content taller than `minHeight`, giving 46.3px.
+- **The helper row is always rendered**, with its line box pinned (`minHeight: 17`,
+  `fontSize: 12`, `lineHeight: 17px`). Rendering it only on error dropped the submit button
+  22.8px at the exact moment a user clicked it. Pinning `minHeight` alone is not enough
+  either: an unpinned line box inherits the parent strut and puts 7px of the shift back.
 - Persistent visible label above the field. Placeholder is never the label.
 - Email, phone and one-time codes are LTR data even inside an RTL page and need explicit
   `dir="ltr"` on their containers.

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -66,6 +66,8 @@ const fieldSx = (mb: number) => ({
     "&.Mui-focused": { boxShadow: focusRing() },
     "&.Mui-error": { boxShadow: hairlineRing(AUTH.error) },
   },
+  // See AuthTextField: MUI's default input padding is taller than CONTROL_HEIGHT on its own.
+  "& .MuiOutlinedInput-input": { padding: "11px 14px" },
   "& .MuiFormHelperText-root": {
     marginLeft: 0,
     marginTop: 0.75,

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -311,6 +311,7 @@ export default function SignupPage() {
                       "& fieldset": { border: "none" },
                       "&.Mui-focused": { boxShadow: focusRing() },
                     },
+                    "& .MuiOutlinedInput-input": { padding: "11px 14px" },
                     "& .MuiFormHelperText-root": {
                       ...TYPE.eyebrow,
                       fontFamily: FONT,

--- a/components/auth/fields/AuthTextField.tsx
+++ b/components/auth/fields/AuthTextField.tsx
@@ -69,7 +69,7 @@ export function AuthTextField({
   const describedBy = helperText ? `${id}-helper` : undefined;
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mb: 2 }}>
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mb: 1.5 }}>
       <Typography
         component="label"
         htmlFor={id}
@@ -119,6 +119,13 @@ export function AuthTextField({
               boxShadow: hairlineRing(),
             },
           },
+          // MUI ships `padding: 16.5px 14px` on the input, which alone is taller than the
+          // 44px control height DESIGN.md specifies, so `minHeight` above never bound and
+          // fields rendered at 54.6px. Setting the padding explicitly is what actually
+          // controls the height.
+          "& .MuiOutlinedInput-input": {
+            padding: "11px 14px",
+          },
           "& .MuiOutlinedInput-input::placeholder": {
             color: AUTH.inkFaint,
             opacity: 1,
@@ -126,20 +133,32 @@ export function AuthTextField({
         }}
       />
 
-      {helperText ? (
-        <Typography
-          id={describedBy}
-          role={error ? "alert" : undefined}
-          sx={{
-            ...TYPE.eyebrow,
-            fontFamily: FONT,
-            letterSpacing: 0,
-            color: error ? AUTH.error : AUTH.inkFaint,
-          }}
-        >
-          {helperText}
-        </Typography>
-      ) : null}
+      {/* The helper row is always present, even when empty.
+          Rendering it conditionally meant the submit button dropped 22.8px the moment
+          validation failed, so it moved out from under the cursor that had just clicked it.
+          Reserving the row costs 17px per field and the shorter control height pays for it. */}
+      <Box
+        id={describedBy}
+        role={error ? "alert" : undefined}
+        // The line box has to be pinned, not just the min-height. Left to inherit, the
+        // empty row measured 17px while the filled row inherited the parent's larger
+        // strut and measured 24px, which put 7px of the shift back.
+        sx={{ minHeight: 17, mt: 0.25, fontSize: 12, lineHeight: "17px" }}
+      >
+        {helperText ? (
+          <Typography
+            component="span"
+            sx={{
+              ...TYPE.eyebrow,
+              fontFamily: FONT,
+              letterSpacing: 0,
+              color: error ? AUTH.error : AUTH.inkFaint,
+            }}
+          >
+            {helperText}
+          </Typography>
+        ) : null}
+      </Box>
     </Box>
   );
 }

--- a/components/auth/layout/authTokens.ts
+++ b/components/auth/layout/authTokens.ts
@@ -81,7 +81,9 @@ export const rtlSafeTracking = {
 /** Primary action. Solid, never a gradient: the gradient CTA failed AA on its light half. */
 export const authPrimaryButtonSx = {
   minHeight: CONTROL_HEIGHT,
-  py: 1.25,
+  // py:1.25 made content taller than CONTROL_HEIGHT, so the button rendered at 46.3px
+  // while the Google button sat at 44px. Let minHeight bind instead.
+  py: 1,
   borderRadius: `${RADIUS}px`,
   background: AUTH.violet,
   color: "#ffffff",
@@ -102,6 +104,7 @@ export const authPrimaryButtonSx = {
 
 export const authSecondaryButtonSx = {
   minHeight: CONTROL_HEIGHT,
+  py: 1,
   borderRadius: `${RADIUS}px`,
   border: "none",
   boxShadow: hairlineRing(),


### PR DESCRIPTION
Design review follow-up on #1224. Two measured defects, both visible in the login validation error state.

## 1. Three different control heights on one form

| Control | Before | After |
|---|---|---|
| Input field | **54.6px** | 44.0px |
| Primary button | 46.3px | 44.0px |
| Google button | 44.0px | 44.0px |

DESIGN.md specifies 44px and the code set `minHeight: 44`, but MUI ships `padding: 16.5px 14px` on `.MuiOutlinedInput-input`, which is taller than 44px on its own, so `minHeight` never bound. Same trap on the buttons via `py: 1.25`.

Now 44.0px on every field and button across login, signup, forgot-password and verify-email, including signup's phone input and the OTP slots.

## 2. The form shifted 22.8px when validation failed

The submit button dropped 22.8px the moment errors appeared, because the helper text only rendered when present. The button moved out from under the cursor that had just clicked it.

The helper row is now always rendered with its line box pinned. Pinning `minHeight` alone was not enough: an unpinned line box inherits the parent strut, so the filled row measured 24px against 17px reserved and 7px of the shift came back. **Residual shift is 0.8px**, sub-pixel rounding.

The shorter control pays for the reserved row, so in the error state the form is tighter than before, not taller.

## Verification

- 44.0px measured on every control, all four auth pages
- Shift 22.8px → 0.8px, measured on the submit button's bounding box
- `tsc --noEmit` clean, 22/22 vitest, 8/8 auth e2e, `next build` passes

DESIGN.md §6 now documents both traps so they cannot silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)