### PR TITLE
feat(auth): redesign the login and signup surface (stagging -> prod)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,6 +163,14 @@ Two panels on desktop, stacked on mobile. The split is **52 / 48 favouring the f
   border. Focus replaces the shadow with the ring, so focus causes zero layout shift.
 - 44px tall, 8px radius, 16px text on mobile (below 16px, iOS Safari zooms the viewport on
   focus).
+- **`minHeight: 44` is not enough.** MUI ships `padding: 16.5px 14px` on
+  `.MuiOutlinedInput-input`, which is taller than 44px on its own, so `minHeight` never
+  binds and fields render at 54.6px. Set `padding: 11px 14px` on the input explicitly.
+  Same trap on buttons: `py: 1.25` makes the content taller than `minHeight`, giving 46.3px.
+- **The helper row is always rendered**, with its line box pinned (`minHeight: 17`,
+  `fontSize: 12`, `lineHeight: 17px`). Rendering it only on error dropped the submit button
+  22.8px at the exact moment a user clicked it. Pinning `minHeight` alone is not enough
+  either: an unpinned line box inherits the parent strut and puts 7px of the shift back.
 - Persistent visible label above the field. Placeholder is never the label.
 - Email, phone and one-time codes are LTR data even inside an RTL page and need explicit
   `dir="ltr"` on their containers.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,258 @@
+# DESIGN.md
+
+Design source of truth for the AI Linc learning platform. Written during the auth
+surface redesign (`feat/auth-redesign`), scoped so the rest of the product can adopt it
+incrementally.
+
+**The memorable thing:** anyone can learn anything from scratch and get somewhere,
+on a path that is theirs. The product should feel like a serious instrument for that,
+not a course catalogue with a login form in front of it.
+
+---
+
+## 1. The constraint that shapes everything
+
+This is a white-label platform, but **not** in the way the code suggests at first glance.
+
+`lib/theme/normalizeThemeSettings.ts:144` ends with `Object.assign(merged, FIXED_MIDNIGHT_HYPER)`,
+which stamps one fixed violet palette over every tenant's stored `theme_settings`. Color
+customization is off platform-wide. `/admin/branding` is a redirect stub that says so.
+
+What actually varies per tenant:
+
+| Varies | Fixed for everyone |
+|---|---|
+| Logo (`resolveClientLogoUrl`) | Every color token |
+| Hero image (`login_img_url`) | Type scale, spacing, radius, motion |
+| Slogan text + its typography override | Component structure |
+| Font family (allowlisted imports) | |
+
+So the design does not need to survive an arbitrary brand hue. It needs to survive an
+**arbitrary logo and an arbitrary uploaded image**, which is the failure we can see on
+staging today: a small tenant image blown up to 720px wide, pixelated, with dark text
+laid over it and no scrim.
+
+**Design rule that follows:** tenant assets are accents inside a composition that is
+already good without them. Never let an uploaded asset carry the quality of the screen.
+
+---
+
+## 2. Identity: match the dashboard, do not invent a second one
+
+The student dashboard (`components/dashboard/v2/*`) and `components/common/ModulePageHeader.tsx`
+already define the product's visual identity: a dark violet to indigo surface with a warm
+pink accent, sitting on a light canvas. The auth screens currently share none of it, so
+signing in feels like a different product from the one you land in.
+
+Authoritative values, taken from the shipped dashboard rather than the token file, because
+the two disagree (`--primary-500` is `#a855f7`, dashboard violet is `#7c3aed`):
+
+```
+ink            #0f172a   headings, primary text on light
+ink-muted      #475569   secondary text
+ink-faint      #64748b   hints, helper text
+canvas         #fbfbfd   page background, never pure white
+surface        #ffffff   raised surface on canvas
+hairline       #e6e8ef   1px borders, the only separator we use
+violet         #7c3aed   THE accent
+violet-deep    #5b21b6   pressed / gradient stop on dark surfaces
+pink           #ec4899   secondary accent, dark surfaces only
+night          #140b2b   dark brand panel base
+night-2        #1e1040   dark brand panel gradient stop
+```
+
+These live as literal constants in `components/auth/layout/authTokens.ts`, not as new CSS
+custom properties. Adding a new `--var` requires registering it in `CAMEL_TO_CSS`,
+`DEFAULT_THEME_FLAT`, `ALLOWED_THEME_KEYS` and the Python serializer, or it is silently
+dropped. Static constants avoid that whole chain.
+
+**The accent budget is three.** Violet appears as: the primary button, the focus ring, and
+links. Nowhere else. No violet borders, no violet backgrounds, no violet icons. If a fourth
+use appears, one of the first three was wrong.
+
+---
+
+## 3. What we are deleting, and why
+
+The current auth screen carries five of the most recognisable AI-generated-design signals
+of 2026. All five go.
+
+| Deleted | Where it lives now | Why |
+|---|---|---|
+| Gradient CTA `linear-gradient(135deg, --primary-400, --primary-600)` | copy-pasted 8 times across 4 pages | Its light half fails WCAG AA on white text at 15px. Disabled state measures 2.13:1. |
+| 4px colored top strip on the card | `AuthLeftPanel.tsx:38` | The colored edge strip is the single most reliable AI tell. It is decoration wearing the costume of semantic state. |
+| The card itself | `AuthLeftPanel.tsx:16-40` | Border plus shadow plus 20px radius doing the job hierarchy should do. Borderless is the 2026 default: whitespace first, lightness shift second, border only if both fail. |
+| Glassmorphism variant (`backdrop-filter: blur(12px)`) | `AuthLeftPanel.tsx:42-67` | 2021 Apple cosplay, on every slop checklist. |
+| Five blurred floating blobs | `AuthRightPanelDefault.tsx` default branch | The v0/Cursor signature background. |
+
+Replacement principle: **depth comes from a surface ladder and 1px hairlines, never from
+drop shadows or gradients.** canvas `#fbfbfd` → surface `#ffffff` → hairline `#e6e8ef`.
+
+---
+
+## 4. Typography
+
+Typeface stays **Satoshi** (`--font-family-primary`, already loaded). It is a good grotesk
+with real character in the geometric forms, and switching would break the tenant font
+override allowlist for no gain.
+
+**Three weights only: 400, 500, 600. There is no 700 in this system.** Emphasis comes from
+size, spacing and color. Bold-as-emphasis is what makes a screen look generic.
+
+Tracking tightens as size grows, which is the single highest-leverage typographic move
+available and it costs nothing:
+
+| Role | Size / line-height | Weight | Tracking |
+|---|---|---|---|
+| Display (brand panel headline) | 44px / 1.06 | 500 | -1.4px |
+| Page title ("Welcome back") | 30px / 1.15 | 600 | -0.6px |
+| Section | 20px / 1.3 | 600 | -0.3px |
+| Body | 15px / 1.5 | 400 | 0 |
+| Label (above inputs) | 13px / 1.4 | 500 | 0 |
+| Eyebrow / meta | 12px / 1.4 | 500 | +0.4px |
+
+The opposing directions, negative on display and positive on the eyebrow tier, do the
+hierarchy work a second typeface would otherwise be hired for.
+
+**Arabic:** never apply `letterSpacing` or `textTransform: uppercase` to translated strings.
+Letter-spacing disconnects the cursive joins in Arabic script and uppercase is a no-op.
+The eyebrow tier must drop its tracking under `[dir="rtl"]`.
+
+---
+
+## 5. Layout and composition
+
+Two panels on desktop, stacked on mobile. The split is **52 / 48 favouring the form**, not
+50/50, so the form column reads as the subject of the page rather than a twin.
+
+**Form side (left, canvas `#fbfbfd`)**
+
+- Single column, `max-width: 400px`, left-aligned internally, optically centered in its
+  panel with the content block sitting slightly above true center.
+- No card, no border, no shadow. The canvas-to-surface shift and whitespace do the work.
+- Vertical rhythm on a 4px base: 8 / 12 / 16 / 24 / 32 / 48.
+- Small tenant logo top-left of the form column at 28px tall, so mobile users see the brand
+  even when the dark panel is not on screen. This is what fixes the branding loss.
+
+**Brand side (right, dark)**
+
+- Base is a `night → night-2` surface with a soft violet radial at the lower-left, matching
+  `ModulePageHeader`'s treatment so auth and the app agree.
+- Carries the promise in one display line plus one supporting sentence, both translator-safe.
+- Tenant hero image, when `login_img_url` is set, sits **behind** that at low opacity with a
+  scrim and `object-fit: cover`, plus a slight blur. A 400px-wide upload can no longer wreck
+  the screen, which is the actual failure mode on staging today.
+- Tenant logo renders through a plain `<img>`, never `next/image`. Admin-supplied SVGs and
+  unoptimizable hosts get silently dropped by the optimizer.
+
+**Mobile**
+
+- The shell must not use `height: 100vh` + `overflow: hidden`. That combination is why the
+  brand panel is currently unreachable on phones, and `100vh` also collides with the iOS
+  Safari address bar. Use `min-height: 100dvh` and let the page scroll.
+- The dark panel becomes a compact 96px header carrying the logo and the product name, with
+  the form below it.
+
+---
+
+## 6. Controls
+
+**Inputs**
+
+- Border drawn as `box-shadow: 0 0 0 1px hairline` on a transparent background, not a CSS
+  border. Focus replaces the shadow with the ring, so focus causes zero layout shift.
+- 44px tall, 8px radius, 16px text on mobile (below 16px, iOS Safari zooms the viewport on
+  focus).
+- Persistent visible label above the field. Placeholder is never the label.
+- Email, phone and one-time codes are LTR data even inside an RTL page and need explicit
+  `dir="ltr"` on their containers.
+
+**Focus ring, the one detail that matters most**
+
+```
+box-shadow: 0 0 0 2px #fbfbfd, 0 0 0 4px #7c3aed;
+```
+
+The inner canvas-colored buffer ring is the trick: it guarantees separation from whatever
+sits behind the control. Currently the entire auth surface defines `focus-visible` exactly
+once, on the signup instructor toggle. Every interactive element gets this.
+
+**Buttons**
+
+- Primary: solid `violet`, white text, 8px radius, 44px tall, weight 500. No gradient.
+- 8px radius on everything. Pills (`9999px`) are reserved for toggles only. Rejecting the
+  pill CTA is most of what separates a 2026 screen from a 2021 one.
+- The loading state keeps the verb: "Signing in…", never a bare spinner. `LoadingButton`
+  already blocks interaction with `pointerEvents` rather than `disabled`, deliberately, so
+  the label stays legible. Keep that.
+
+**Errors**
+
+- Inline and field-anchored, wired with `aria-describedby` plus a live region. Toasts are
+  for system failures only, never for "wrong password".
+- Never wipe the email when the password is wrong.
+- Color alone fails AA. Every error carries text.
+
+---
+
+## 7. Motion
+
+- Entrances 200ms, overlays 300ms, easing `cubic-bezier(.175,.885,.32,1.1)`, entering at
+  `scale(0.96)`. Everything else is still.
+- Nothing on this screen animates on load except the form column, once, on first paint.
+- `prefers-reduced-motion` is already honoured by `SuccessTick` and the 300ms shortened hold
+  in `auth-context`. Any new motion must respect it the same way.
+
+---
+
+## 8. Load-bearing logic the redesign must not break
+
+Discovered during the audit. These are not style choices, they are fought-for fixes:
+
+1. **Never put `overflow: hidden` on an ancestor of the Google button.** A clipping plus
+   rounded ancestor breaks click hit-testing on the cross-origin GSI iframe: the button
+   renders and silently stops responding. `AuthLeftPanel.tsx:23-27`.
+2. **Keep the login redirect-hold ordering.** `setHoldAutoRedirect(true)` is raised *before*
+   `await login()`, and the redirect effect bails on
+   `celebrating || holdAutoRedirect || isRedirecting`. Setting it after the await is always
+   too late.
+3. **Navigate with `router.replace`, never `window.location.href` or a delayed timeout.**
+   The old 500ms pattern caused a second full-document navigation, the white flash and the
+   double shimmer.
+4. **The celebration tick belongs to `AuthProvider`**, as a sibling of `{children}`, so it
+   survives the login page unmounting mid-navigation.
+5. **Tenant logos stay plain `<img>`.**
+6. **`app/(auth)/loading.tsx` must exist**, or auth routes fall through to the root loader
+   and flash the full app chrome at a logged-out visitor.
+7. **Keep `OtpDigitInput`'s input semantics** (sequential entry, backspace-borrow,
+   paste-fills-all, `autoComplete="one-time-code"` on slot 0 only).
+8. **Render correctly in three states:** `clientInfoLoading` skeleton, `FALLBACK_CLIENT_INFO`
+   (backend down, no logo), and the hero variant versus the plain variant.
+
+---
+
+## 9. Known defects this redesign fixes
+
+- Mobile shows zero tenant branding, because the shell clips it. `AuthLayoutShell.tsx:14-20`.
+- Gradient CTA fails AA; its disabled state measures 2.13:1. All four pages.
+- `focus-visible` is defined once across the entire auth surface.
+- The password visibility toggle has no accessible name on any of its three instances, and
+  misses the 44px touch target.
+- Two hardcoded brand gradients that ignore the token system: the `--accent-pink` strip
+  (`AuthLeftPanel.tsx:38`) and the orange to pink slogan highlight (`authBrandStyles.ts:12`).
+- The signup Google button reads "Sign in with Google" directly above a divider reading
+  "Or sign up with email".
+- The slogan highlight is keyed on the literal English words `"the"` and `"world"`, so it
+  does nothing in Arabic and nothing for any tenant-authored slogan.
+
+## 10. Known defects this redesign does NOT fix
+
+Flagged, out of scope, worth their own branch:
+
+- Arabic is unreachable for a logged-out visitor: no language switcher exists on any auth
+  page, and the stored language is never restored on reload (`I18nProvider` is a passthrough).
+- RTL is half-wired. `stylis-plugin-rtl` is absent, so MUI physical properties never flip.
+- `OtpDigitInput` strips Arabic-Indic digits (`/\D/g` without the `u` flag) while the Arabic
+  locale itself uses ٠١٢٣.
+- The signup name regex `^[a-zA-Z\s]+$` rejects Arabic names outright.
+- All ~25 Yup validation messages are hardcoded English.

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -66,6 +66,8 @@ const fieldSx = (mb: number) => ({
     "&.Mui-focused": { boxShadow: focusRing() },
     "&.Mui-error": { boxShadow: hairlineRing(AUTH.error) },
   },
+  // See AuthTextField: MUI's default input padding is taller than CONTROL_HEIGHT on its own.
+  "& .MuiOutlinedInput-input": { padding: "11px 14px" },
   "& .MuiFormHelperText-root": {
     marginLeft: 0,
     marginTop: 0.75,

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -24,50 +24,54 @@ import { AuthLayout } from "@/components/auth/AuthLayout";
 import { OtpDigitInput } from "@/components/auth/OtpDigitInput";
 import { useToast } from "@/components/common/Toast";
 import { LoadingButton } from "@/components/common/LoadingButton";
+import {
+  AUTH,
+  CONTROL_HEIGHT,
+  EASE,
+  FONT,
+  RADIUS,
+  TYPE,
+  authPrimaryButtonSx,
+  authSecondaryButtonSx,
+  focusRing,
+  hairlineRing,
+} from "@/components/auth/layout/authTokens";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const primaryBtnSx = {
-  py: 1.25,
-  background:
-    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-  color: "var(--font-light)",
-  fontWeight: 600,
-  fontSize: "0.9375rem",
-  textTransform: "none",
-  boxShadow: "none",
-  "&:hover": {
-    background:
-      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
-    boxShadow:
-      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
-  },
-  "&:disabled": {
-    background:
-      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-    opacity: 0.6,
-  },
+  ...authPrimaryButtonSx,
+  "&:disabled": { background: AUTH.violet, color: "#ffffff", opacity: 0.45 },
 } as const;
 
 const resendBtnSx = {
-  py: 1.25,
+  ...authSecondaryButtonSx,
   mb: 0.5,
-  borderColor: "var(--border-default)",
-  borderWidth: 1.5,
-  color: "var(--font-primary)",
-  textTransform: "none",
-  fontWeight: 500,
-  fontSize: "0.875rem",
-  "&:hover": {
-    borderColor: "color-mix(in srgb, var(--border-default) 70%, var(--font-primary))",
-    backgroundColor: "color-mix(in srgb, var(--surface) 70%, var(--background))",
-    borderWidth: 1.5,
-  },
-  "&:disabled": { borderColor: "var(--border-default)", opacity: 0.5 },
+  "&:disabled": { boxShadow: hairlineRing(), opacity: 0.5 },
 } as const;
 
+/** Shared input styling. See DESIGN.md: the border is a shadow so focus costs no layout. */
 const fieldSx = (mb: number) => ({
   mb,
-  "& .MuiFormHelperText-root": { marginTop: 0.5, fontSize: "0.75rem" },
+  "& .MuiOutlinedInput-root": {
+    minHeight: CONTROL_HEIGHT,
+    borderRadius: `${RADIUS}px`,
+    backgroundColor: AUTH.surface,
+    fontFamily: FONT,
+    fontSize: { xs: 16, sm: 15 },
+    color: AUTH.ink,
+    boxShadow: hairlineRing(),
+    transition: `box-shadow 160ms ${EASE}`,
+    "& fieldset": { border: "none" },
+    "&:hover": { boxShadow: hairlineRing("#d5d8e3") },
+    "&.Mui-focused": { boxShadow: focusRing() },
+    "&.Mui-error": { boxShadow: hairlineRing(AUTH.error) },
+  },
+  "& .MuiFormHelperText-root": {
+    marginLeft: 0,
+    marginTop: 0.75,
+    fontFamily: FONT,
+    fontSize: "0.75rem",
+  },
 });
 
 const STEP_KEYS = [
@@ -177,30 +181,29 @@ export default function ForgotPasswordPage() {
 
   return (
     <AuthLayout slogan={t("auth.slogan")}>
-      <Box sx={{ width: "100%", maxWidth: 440, display: "flex", flexDirection: "column" }}>
+      <Box sx={{ width: "100%", display: "flex", flexDirection: "column" }}>
         <Typography
           component="h1"
-          variant="h4"
           sx={{
+            ...TYPE.title,
+            fontFamily: FONT,
+            color: AUTH.ink,
             mb: 0.5,
-            fontWeight: 700,
-            color: "text.primary",
-            fontSize: { xs: "1.75rem", sm: "2rem" },
-            letterSpacing: "-0.02em",
+            '[dir="rtl"] &': { letterSpacing: "normal" },
           }}
         >
           {t(titleKey)}
         </Typography>
         <Typography
-          variant="caption"
           sx={{
+            ...TYPE.eyebrow,
+            fontFamily: FONT,
             display: "block",
-            mb: 2.5,
-            color: "text.secondary",
-            fontWeight: 500,
-            letterSpacing: "0.04em",
+            mb: 3,
+            color: AUTH.inkFaint,
             textTransform: "uppercase",
-            fontSize: "0.6875rem",
+            // Uppercase is a no-op in Arabic and tracking breaks its cursive joins.
+            '[dir="rtl"] &': { textTransform: "none", letterSpacing: "normal" },
           }}
         >
           {t(badgeKey)}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,13 +3,10 @@
 import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
-import { SignInLoader } from "@/components/common/SignInLoader";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import {
-  TextField,
   Typography,
   Box,
-  Divider,
   Checkbox,
   FormControlLabel,
   IconButton,
@@ -23,6 +20,15 @@ import { resolvePostLoginPath } from "@/lib/auth/role-utils";
 import { useToast } from "@/components/common/Toast";
 import { GoogleSignIn } from "@/components/auth/GoogleSignIn";
 import { AuthLayout } from "@/components/auth/AuthLayout";
+import { AuthTextField } from "@/components/auth/fields/AuthTextField";
+import {
+  AUTH,
+  FONT,
+  TYPE,
+  authLinkSx,
+  authPrimaryButtonSx,
+  focusRing,
+} from "@/components/auth/layout/authTokens";
 import { loginSchema } from "@/lib/schemas/auth.schema";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 import { Eye, EyeOff } from "lucide-react";
@@ -129,244 +135,186 @@ export default function LoginPage() {
 
   return (
     <AuthLayout slogan={t("auth.slogan")}>
-      <Box
-        sx={{
-          width: "100%",
-          maxWidth: 440,
-          display: "flex",
-          flexDirection: "column",
-          textAlign: "start",
-        }}
-      >
-        {/* Logo */}
-
-        {/* Title */}
+      <Box sx={{ width: "100%", textAlign: "start" }}>
         <Typography
           component="h1"
-          variant="h4"
           sx={{
-            mb: 3,
-            fontWeight: 700,
-            color: "text.primary",
-            fontSize: { xs: "1.75rem", sm: "2rem" },
+            ...TYPE.title,
+            fontFamily: FONT,
+            color: AUTH.ink,
+            mb: 0.75,
+            '[dir="rtl"] &': { letterSpacing: "normal" },
           }}
         >
-          {t("auth.login")}
+          {t("auth.welcomeBack", { defaultValue: "Welcome back" })}
         </Typography>
+        {/* Mobile only: the dark panel shrinks to a logo bar below md, so the promise would
+            otherwise disappear entirely on a phone. On desktop the panel already carries it,
+            and showing it twice on one screen is just noise. */}
+        <Typography
+          sx={{
+            ...TYPE.body,
+            fontFamily: FONT,
+            color: AUTH.inkFaint,
+            mb: 4,
+            display: { xs: "block", md: "none" },
+          }}
+        >
+          {t("auth.supporting", {
+            defaultValue:
+              "Start from scratch, or from where you left off. Your path adapts as you go.",
+          })}
+        </Typography>
+        <Box sx={{ display: { xs: "none", md: "block" }, mb: 4 }} />
 
-        {/* Google Sign In Button */}
-        <Box sx={{ mb: 2.5 }}>
+        <Box sx={{ mb: 3 }}>
           <GoogleSignIn disabled={loading} />
         </Box>
 
-        {/* Divider */}
-        <Box sx={{ display: "flex", alignItems: "center", mb: 2.5 }}>
-          <Divider sx={{ flexGrow: 1 }} />
+        {/* Hairline divider. One rule, no boxes. */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 3 }}>
+          <Box sx={{ flexGrow: 1, height: "1px", backgroundColor: AUTH.hairline }} />
           <Typography
-            variant="body2"
-            sx={{ px: 2, color: "text.secondary", fontSize: "0.875rem" }}
+            sx={{
+              ...TYPE.eyebrow,
+              fontFamily: FONT,
+              color: AUTH.inkFaint,
+              '[dir="rtl"] &': { letterSpacing: "normal" },
+            }}
           >
             {t("auth.orSignInWithEmail")}
           </Typography>
-          <Divider sx={{ flexGrow: 1 }} />
+          <Box sx={{ flexGrow: 1, height: "1px", backgroundColor: AUTH.hairline }} />
         </Box>
 
-        {/* Form */}
         <Formik
           initialValues={initialValues}
           validationSchema={loginSchema}
           onSubmit={onSubmit}
         >
           {({ errors, touched }) => (
-            <Form>
+            <Form noValidate>
               <Field name="email">
                 {({ field }: any) => (
-                  <TextField
+                  <AuthTextField
                     {...field}
-                    fullWidth
-                    required
                     id="email"
                     label={t("auth.email")}
-                    placeholder={t("auth.email")}
-                    autoComplete="username"
-                    size="small"
-                    error={touched.email && !!errors.email}
+                    type="email"
+                    // Passkeys surface inside the browser's own autofill dropdown, so a user
+                    // without a credential never hits a dead modal.
+                    autoComplete="username webauthn"
+                    placeholder="you@example.com"
+                    required
+                    dir="ltr"
+                    error={Boolean(touched.email && errors.email)}
                     helperText={touched.email && errors.email}
-                    sx={{
-                      mb: 1.5,
-                      "& .MuiFormHelperText-root": {
-                        marginTop: 0.5,
-                        fontSize: "0.75rem",
-                      },
-                    }}
                   />
                 )}
               </Field>
 
               <Field name="password">
                 {({ field }: any) => (
-                  <TextField
+                  <AuthTextField
                     {...field}
-                    fullWidth
-                    required
-                    label={t("auth.password")}
-                    placeholder={t("auth.password")}
-                    type={showPassword ? "text" : "password"}
                     id="password"
+                    label={t("auth.password")}
+                    type={showPassword ? "text" : "password"}
                     autoComplete="current-password"
-                    size="small"
-                    error={touched.password && !!errors.password}
+                    required
+                    error={Boolean(touched.password && errors.password)}
                     helperText={touched.password && errors.password}
-                    sx={{
-                      mb: 1.5,
-                      "& .MuiFormHelperText-root": {
-                        marginTop: 0.5,
-                        fontSize: "0.75rem",
-                      },
-                    }}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            onClick={() => setShowPassword(!showPassword)}
-                            edge="end"
-                            size="small"
-                            sx={{ color: "text.secondary" }}
-                          >
-                            {showPassword ? (
-                              <EyeOff size={18} />
-                            ) : (
-                              <Eye size={18} />
-                            )}
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    }}
+                    endAdornment={
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={() => setShowPassword(!showPassword)}
+                          edge="end"
+                          // Was nameless on all three instances across the surface, and under
+                          // the 44px touch target.
+                          aria-label={
+                            showPassword
+                              ? t("auth.hidePassword", { defaultValue: "Hide password" })
+                              : t("auth.showPassword", { defaultValue: "Show password" })
+                          }
+                          aria-pressed={showPassword}
+                          sx={{
+                            width: 44,
+                            height: 44,
+                            color: AUTH.inkFaint,
+                            "&:focus-visible": {
+                              outline: "none",
+                              boxShadow: focusRing(AUTH.surface),
+                            },
+                          }}
+                        >
+                          {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                        </IconButton>
+                      </InputAdornment>
+                    }
                   />
                 )}
               </Field>
 
-              {/* Remember me and Forgot password */}
               <Box
                 sx={{
                   display: "flex",
                   justifyContent: "space-between",
                   alignItems: "center",
-                  mb: 2,
+                  gap: 2,
+                  mb: 3,
+                  mt: 0.5,
                 }}
               >
                 <FormControlLabel
+                  sx={{ mr: 0 }}
                   control={
                     <Checkbox
                       checked={rememberMe}
                       onChange={(e) => setRememberMe(e.target.checked)}
                       sx={{
-                        color: "primary.main",
-                        "&.Mui-checked": {
-                          color: "primary.main",
-                        },
+                        color: AUTH.hairline,
+                        "&.Mui-checked": { color: AUTH.violet },
+                        "&.Mui-focusVisible": { boxShadow: focusRing() },
                       }}
                     />
                   }
                   label={
                     <Typography
-                      variant="body2"
-                      sx={{
-                        fontSize: "0.875rem",
-                        color: "var(--font-primary)",
-                        fontWeight: 400,
-                      }}
+                      sx={{ ...TYPE.body, fontFamily: FONT, color: AUTH.inkMuted }}
                     >
                       {t("auth.keepMeLoggedIn")}
                     </Typography>
                   }
                 />
-                <Link
-                  href="/forgot-password"
-                  style={{
-                    color: "inherit",
-                    textDecoration: "none",
-                    fontSize: "0.875rem",
-                  }}
-                >
-                  <Typography
-                    variant="body2"
-                    component="span"
-                    sx={{
-                      color: "primary.main",
-                      fontSize: "0.875rem",
-                      "&:hover": {
-                        textDecoration: "underline",
-                      },
-                    }}
-                  >
+                <Link href="/forgot-password" style={{ textDecoration: "none" }}>
+                  <Typography component="span" sx={{ ...TYPE.body, ...authLinkSx }}>
                     {t("auth.forgotPasswordLink")}
                   </Typography>
                 </Link>
               </Box>
 
-              {/* Login Button */}
               <LoadingButton
                 type="submit"
                 fullWidth
                 variant="contained"
                 loading={loading}
+                // Keeps the verb instead of collapsing to a bare spinner, so nobody has to
+                // remember what they clicked.
                 loadingText={t("auth.signingIn")}
-                sx={{
-                  py: 1.25,
-                  mb: 2,
-                  background:
-                    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-                  color: "var(--font-light)",
-                  fontWeight: 600,
-                  fontSize: "0.9375rem",
-                  textTransform: "none",
-                  boxShadow: "none",
-                  "&:hover": {
-                    background:
-                      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
-                    boxShadow:
-                      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
-                  },
-                  "&:disabled": {
-                    background:
-                      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-                    opacity: 0.6,
-                  },
-                }}
+                sx={authPrimaryButtonSx}
               >
                 {t("auth.login")}
               </LoadingButton>
 
-              {/* Sign up link */}
-              <Box sx={{ textAlign: "center", mt: 1 }}>
+              <Box sx={{ textAlign: "center", mt: 3 }}>
                 <Typography
-                  variant="body2"
                   component="span"
-                  sx={{ color: "text.secondary", fontSize: "0.875rem" }}
+                  sx={{ ...TYPE.body, fontFamily: FONT, color: AUTH.inkFaint }}
                 >
                   {t("auth.noAccount")}{" "}
                 </Typography>
-                <Link
-                  href="/signup"
-                  style={{
-                    color: "inherit",
-                    textDecoration: "none",
-                  }}
-                >
-                  <Typography
-                    variant="body2"
-                    component="span"
-                    sx={{
-                      color: "primary.main",
-                      textDecoration: "none",
-                      fontWeight: 500,
-                      fontSize: "0.875rem",
-                      "&:hover": {
-                        textDecoration: "underline",
-                      },
-                    }}
-                  >
+                <Link href="/signup" style={{ textDecoration: "none" }}>
+                  <Typography component="span" sx={{ ...TYPE.body, ...authLinkSx }}>
                     {t("auth.signUp")}
                   </Typography>
                 </Link>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -311,6 +311,7 @@ export default function SignupPage() {
                       "& fieldset": { border: "none" },
                       "&.Mui-focused": { boxShadow: focusRing() },
                     },
+                    "& .MuiOutlinedInput-input": { padding: "11px 14px" },
                     "& .MuiFormHelperText-root": {
                       ...TYPE.eyebrow,
                       fontFamily: FONT,

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -4,25 +4,35 @@ import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import {
-  TextField,
   Button,
   Typography,
   Box,
-  Divider,
   IconButton,
   InputAdornment,
   Switch,
 } from "@mui/material";
 import { LoadingButton } from "@/components/common/LoadingButton";
-import { alpha } from "@mui/material/styles";
 import Link from "next/link";
-import { Formik, Form, Field, ErrorMessage } from "formik";
+import { Formik, Form, Field } from "formik";
 import { MuiTelInput } from "mui-tel-input";
 import { accountsService } from "@/lib/services/accounts.service";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { useToast } from "@/components/common/Toast";
 import { GoogleSignIn } from "@/components/auth/GoogleSignIn";
 import { AuthLayout } from "@/components/auth/AuthLayout";
+import { AuthTextField } from "@/components/auth/fields/AuthTextField";
+import {
+  AUTH,
+  CONTROL_HEIGHT,
+  EASE,
+  FONT,
+  RADIUS,
+  TYPE,
+  authLinkSx,
+  authPrimaryButtonSx,
+  focusRing,
+  hairlineRing,
+} from "@/components/auth/layout/authTokens";
 import { signupSchema } from "@/lib/schemas/auth.schema";
 import {
   getAxiosErrorDetail,
@@ -80,12 +90,17 @@ export default function SignupPage() {
     const isPdfByName = file.name.toLowerCase().endsWith(".pdf");
     if (!isPdfByType || !isPdfByName) {
       setCvFile(null);
-      setCvError("CV must be a PDF file.");
+      setCvError(t("auth.cvMustBePdf", { defaultValue: "CV must be a PDF file." }));
       return;
     }
     if (file.size > CV_MAX_SIZE_BYTES) {
       setCvFile(null);
-      setCvError(`CV file size must not exceed ${CV_MAX_SIZE_MB}MB.`);
+      setCvError(
+        t("auth.cvTooLarge", {
+          defaultValue: `CV file size must not exceed ${CV_MAX_SIZE_MB}MB.`,
+          max: CV_MAX_SIZE_MB,
+        })
+      );
       return;
     }
     setCvFile(file);
@@ -102,7 +117,11 @@ export default function SignupPage() {
 
   const onSubmit = async (values: SignupFormValues) => {
     if (values.signup_as_instructor && !cvFile) {
-      setCvError("Please upload your CV before continuing.");
+      setCvError(
+        t("auth.cvRequired", {
+          defaultValue: "Please upload your CV before continuing.",
+        })
+      );
       return;
     }
     setLoading(true);
@@ -134,146 +153,170 @@ export default function SignupPage() {
 
   return (
     <AuthLayout slogan={t("auth.slogan")}>
-      <Box
-        sx={{
-          width: "100%",
-          maxWidth: 440,
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        {/* Title */}
+      <Box sx={{ width: "100%", textAlign: "start" }}>
         <Typography
           component="h1"
-          variant="h4"
           sx={{
-            mb: 3,
-            fontWeight: 700,
-            color: "text.primary",
-            fontSize: { xs: "1.75rem", sm: "2rem" },
+            ...TYPE.title,
+            fontFamily: FONT,
+            color: AUTH.ink,
+            mb: 0.75,
+            '[dir="rtl"] &': { letterSpacing: "normal" },
           }}
         >
-          {t("auth.signUp")}
+          {t("auth.createAccount", { defaultValue: "Create your account" })}
         </Typography>
+        {/* Mobile only: the dark panel shrinks to a logo bar below md, so the promise would
+            otherwise disappear entirely on a phone. On desktop the panel already carries it,
+            and showing it twice on one screen is just noise. */}
+        <Typography
+          sx={{
+            ...TYPE.body,
+            fontFamily: FONT,
+            color: AUTH.inkFaint,
+            mb: 4,
+            display: { xs: "block", md: "none" },
+          }}
+        >
+          {t("auth.supporting", {
+            defaultValue:
+              "Start from scratch, or from where you left off. Your path adapts as you go.",
+          })}
+        </Typography>
+        <Box sx={{ display: { xs: "none", md: "block" }, mb: 4 }} />
 
-        {/* Google Sign In Button */}
-        <Box sx={{ mb: 2.5 }}>
-          <GoogleSignIn disabled={loading} />
+        <Box sx={{ mb: 3 }}>
+          {/* Was the shared default, "Sign in with Google", sitting directly above a
+              divider that reads "Or sign up with email". */}
+          <GoogleSignIn
+            disabled={loading}
+            label={t("auth.signUpWithGoogle", {
+              defaultValue: "Sign up with Google",
+            })}
+          />
         </Box>
 
-        {/* Divider */}
-        <Box sx={{ display: "flex", alignItems: "center", mb: 2.5 }}>
-          <Divider sx={{ flexGrow: 1 }} />
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 3 }}>
+          <Box sx={{ flexGrow: 1, height: "1px", backgroundColor: AUTH.hairline }} />
           <Typography
-            variant="body2"
-            sx={{ px: 2, color: "text.secondary", fontSize: "0.875rem" }}
+            sx={{
+              ...TYPE.eyebrow,
+              fontFamily: FONT,
+              color: AUTH.inkFaint,
+              '[dir="rtl"] &': { letterSpacing: "normal" },
+            }}
           >
             {t("auth.orSignUpWithEmail")}
           </Typography>
-          <Divider sx={{ flexGrow: 1 }} />
+          <Box sx={{ flexGrow: 1, height: "1px", backgroundColor: AUTH.hairline }} />
         </Box>
 
-        {/* Form */}
         <Formik
           initialValues={initialValues}
           validationSchema={signupSchema}
           onSubmit={onSubmit}
         >
-          {({
-            values,
-            errors,
-            touched,
-            handleChange,
-            handleBlur,
-            setFieldValue,
-          }) => (
-            <Form>
-              <Box sx={{ display: "flex", gap: 1.5, mb: 1.5 }}>
+          {({ values, errors, touched, handleBlur, setFieldValue }) => (
+            <Form noValidate>
+              <Box sx={{ display: "flex", gap: 1.5 }}>
                 <Field name="first_name">
                   {({ field }: any) => (
-                    <TextField
-                      {...field}
-                      fullWidth
-                      required
-                      id="first_name"
-                      label="First Name"
-                      placeholder="First Name"
-                      size="small"
-                      error={touched.first_name && !!errors.first_name}
-                      helperText={touched.first_name && errors.first_name}
-                      sx={{
-                        "& .MuiFormHelperText-root": {
-                          marginTop: 0.5,
-                          fontSize: "0.75rem",
-                        },
-                      }}
-                    />
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <AuthTextField
+                        {...field}
+                        id="first_name"
+                        label={t("auth.firstName", { defaultValue: "First name" })}
+                        autoComplete="given-name"
+                        required
+                        error={Boolean(touched.first_name && errors.first_name)}
+                        helperText={touched.first_name && errors.first_name}
+                      />
+                    </Box>
                   )}
                 </Field>
                 <Field name="last_name">
                   {({ field }: any) => (
-                    <TextField
-                      {...field}
-                      fullWidth
-                      required
-                      id="last_name"
-                      label={t("auth.lastName")}
-                      placeholder={t("auth.lastName")}
-                      size="small"
-                      error={touched.last_name && !!errors.last_name}
-                      helperText={touched.last_name && errors.last_name}
-                      sx={{
-                        "& .MuiFormHelperText-root": {
-                          marginTop: 0.5,
-                          fontSize: "0.75rem",
-                        },
-                      }}
-                    />
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <AuthTextField
+                        {...field}
+                        id="last_name"
+                        label={t("auth.lastName")}
+                        autoComplete="family-name"
+                        required
+                        error={Boolean(touched.last_name && errors.last_name)}
+                        helperText={touched.last_name && errors.last_name}
+                      />
+                    </Box>
                   )}
                 </Field>
               </Box>
 
               <Field name="email">
                 {({ field }: any) => (
-                  <TextField
+                  <AuthTextField
                     {...field}
-                    fullWidth
-                    required
                     id="email"
-                    label="Email"
-                    placeholder="Email"
-                    autoComplete="off"
-                    size="small"
-                    error={touched.email && !!errors.email}
+                    label={t("auth.email")}
+                    type="email"
+                    // Was autoComplete="off", which WCAG 2.2 SC 3.3.8 treats as a failure
+                    // because it blocks password managers on an authentication field.
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    required
+                    dir="ltr"
+                    error={Boolean(touched.email && errors.email)}
                     helperText={touched.email && errors.email}
-                    sx={{
-                      mb: 1.5,
-                      "& .MuiFormHelperText-root": {
-                        marginTop: 0.5,
-                        fontSize: "0.75rem",
-                      },
-                    }}
                   />
                 )}
               </Field>
 
-              <Box sx={{ mb: 1.5 }}>
+              <Box sx={{ mb: 2 }}>
+                <Typography
+                  component="label"
+                  htmlFor="phone"
+                  sx={{
+                    ...TYPE.label,
+                    fontFamily: FONT,
+                    color: AUTH.inkMuted,
+                    display: "block",
+                    mb: 0.75,
+                  }}
+                >
+                  {t("auth.phoneNumber")}
+                </Typography>
                 <MuiTelInput
+                  id="phone"
                   value={values.phone}
                   onChange={(value) => setFieldValue("phone", value)}
                   onBlur={handleBlur("phone")}
                   defaultCountry="IN"
                   fullWidth
                   required
-                  size="small"
-                  label={t("auth.phoneNumber")}
-                  placeholder={t("auth.phoneNumber")}
-                  error={touched.phone && !!errors.phone}
+                  // Phone numbers are LTR data even inside an RTL page.
+                  dir="ltr"
+                  error={Boolean(touched.phone && errors.phone)}
                   helperText={touched.phone && errors.phone}
                   sx={{
+                    "& .MuiOutlinedInput-root": {
+                      minHeight: CONTROL_HEIGHT,
+                      borderRadius: `${RADIUS}px`,
+                      backgroundColor: AUTH.surface,
+                      fontFamily: FONT,
+                      fontSize: { xs: 16, sm: 15 },
+                      color: AUTH.ink,
+                      boxShadow: hairlineRing(
+                        touched.phone && errors.phone ? AUTH.error : AUTH.hairline
+                      ),
+                      transition: `box-shadow 160ms ${EASE}`,
+                      "& fieldset": { border: "none" },
+                      "&.Mui-focused": { boxShadow: focusRing() },
+                    },
                     "& .MuiFormHelperText-root": {
-                      marginTop: 0.5,
-                      fontSize: "0.75rem",
+                      ...TYPE.eyebrow,
+                      fontFamily: FONT,
+                      letterSpacing: 0,
+                      marginLeft: 0,
+                      marginTop: 0.75,
                     },
                   }}
                 />
@@ -281,96 +324,96 @@ export default function SignupPage() {
 
               <Field name="password">
                 {({ field }: any) => (
-                  <TextField
+                  <AuthTextField
                     {...field}
-                    fullWidth
-                    required
-                    label="Password"
-                    placeholder="Password"
-                    type={showPassword ? "text" : "password"}
                     id="password"
-                    size="small"
-                    error={touched.password && !!errors.password}
+                    label={t("auth.password")}
+                    type={showPassword ? "text" : "password"}
+                    autoComplete="new-password"
+                    required
+                    error={Boolean(touched.password && errors.password)}
                     helperText={touched.password && errors.password}
-                    sx={{
-                      mb: 1.5,
-                      "& .MuiFormHelperText-root": {
-                        marginTop: 0.5,
-                        fontSize: "0.75rem",
-                      },
-                    }}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            onClick={() => setShowPassword(!showPassword)}
-                            edge="end"
-                            size="small"
-                            sx={{ color: "text.secondary" }}
-                          >
-                            {showPassword ? (
-                              <EyeOff size={18} />
-                            ) : (
-                              <Eye size={18} />
-                            )}
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    }}
+                    endAdornment={
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={() => setShowPassword(!showPassword)}
+                          edge="end"
+                          aria-label={
+                            showPassword
+                              ? t("auth.hidePassword", { defaultValue: "Hide password" })
+                              : t("auth.showPassword", { defaultValue: "Show password" })
+                          }
+                          aria-pressed={showPassword}
+                          sx={{
+                            width: 44,
+                            height: 44,
+                            color: AUTH.inkFaint,
+                            "&:focus-visible": {
+                              outline: "none",
+                              boxShadow: focusRing(AUTH.surface),
+                            },
+                          }}
+                        >
+                          {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                        </IconButton>
+                      </InputAdornment>
+                    }
                   />
                 )}
               </Field>
 
               <Field name="confirm_password">
                 {({ field }: any) => (
-                  <TextField
+                  <AuthTextField
                     {...field}
-                    fullWidth
-                    required
-                    label={t("auth.confirmPassword")}
-                    placeholder={t("auth.confirmPassword")}
-                    type={showConfirmPassword ? "text" : "password"}
                     id="confirm_password"
-                    size="small"
-                    error={
-                      touched.confirm_password && !!errors.confirm_password
-                    }
+                    label={t("auth.confirmPassword")}
+                    type={showConfirmPassword ? "text" : "password"}
+                    autoComplete="new-password"
+                    required
+                    error={Boolean(
+                      touched.confirm_password && errors.confirm_password
+                    )}
                     helperText={
                       touched.confirm_password && errors.confirm_password
                     }
-                    sx={{
-                      mb: 2,
-                      "& .MuiFormHelperText-root": {
-                        marginTop: 0.5,
-                        fontSize: "0.75rem",
-                      },
-                    }}
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position="end">
-                          <IconButton
-                            onClick={() =>
-                              setShowConfirmPassword(!showConfirmPassword)
-                            }
-                            edge="end"
-                            size="small"
-                            sx={{ color: "text.secondary" }}
-                          >
-                            {showConfirmPassword ? (
-                              <EyeOff size={18} />
-                            ) : (
-                              <Eye size={18} />
-                            )}
-                          </IconButton>
-                        </InputAdornment>
-                      ),
-                    }}
+                    endAdornment={
+                      <InputAdornment position="end">
+                        <IconButton
+                          onClick={() =>
+                            setShowConfirmPassword(!showConfirmPassword)
+                          }
+                          edge="end"
+                          aria-label={
+                            showConfirmPassword
+                              ? t("auth.hidePassword", { defaultValue: "Hide password" })
+                              : t("auth.showPassword", { defaultValue: "Show password" })
+                          }
+                          aria-pressed={showConfirmPassword}
+                          sx={{
+                            width: 44,
+                            height: 44,
+                            color: AUTH.inkFaint,
+                            "&:focus-visible": {
+                              outline: "none",
+                              boxShadow: focusRing(AUTH.surface),
+                            },
+                          }}
+                        >
+                          {showConfirmPassword ? (
+                            <EyeOff size={18} />
+                          ) : (
+                            <Eye size={18} />
+                          )}
+                        </IconButton>
+                      </InputAdornment>
+                    }
                   />
                 )}
               </Field>
 
               {!instructorFlagLoading && allowInstructorSelfSignup && (
-                <Box sx={{ mb: 2 }}>
+                <Box sx={{ mb: 3 }}>
                   <Box
                     component="button"
                     type="button"
@@ -382,90 +425,62 @@ export default function SignupPage() {
                       }
                     }}
                     aria-pressed={values.signup_as_instructor}
-                    sx={(theme) => {
-                      const on = values.signup_as_instructor;
-                      return {
-                        width: "100%",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 1.5,
-                        p: 1.75,
-                        borderRadius: 2,
-                        border: "2px solid",
-                        borderColor: on
-                          ? theme.palette.primary.main
-                          : alpha(theme.palette.primary.main, 0.35),
-                        textAlign: "left",
-                        cursor: "pointer",
-                        font: "inherit",
-                        background: on
-                          ? `linear-gradient(135deg, ${alpha(
-                              theme.palette.primary.main,
-                              0.16
-                            )} 0%, ${alpha(theme.palette.primary.main, 0.07)} 50%, ${alpha(
-                              theme.palette.primary.main,
-                              0.04
-                            )} 100%)`
-                          : `linear-gradient(135deg, ${alpha(
-                              theme.palette.primary.main,
-                              0.1
-                            )} 0%, ${alpha(theme.palette.primary.main, 0.035)} 100%)`,
-                        boxShadow: on
-                          ? `0 0 0 3px ${alpha(theme.palette.primary.main, 0.2)}, 0 8px 24px ${alpha(
-                              theme.palette.primary.main,
-                              0.18
-                            )}`
-                          : `0 2px 12px ${alpha(theme.palette.primary.main, 0.08)}`,
-                        transition:
-                          "border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease",
-                        "&:hover": {
-                          borderColor: theme.palette.primary.main,
-                          boxShadow: `0 0 0 3px ${alpha(
-                            theme.palette.primary.main,
-                            0.12
-                          )}, 0 10px 28px ${alpha(
-                            theme.palette.primary.main,
-                            0.14
-                          )}`,
-                        },
-                        "&:focus-visible": {
-                          outline: `2px solid ${theme.palette.primary.main}`,
-                          outlineOffset: 2,
-                        },
-                      };
+                    sx={{
+                      width: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 1.5,
+                      p: 1.75,
+                      borderRadius: `${RADIUS}px`,
+                      border: "none",
+                      textAlign: "left",
+                      cursor: "pointer",
+                      font: "inherit",
+                      // Was a tinted gradient with a 3px glow ring. Selection now reads as a
+                      // single hairline going violet, which is the whole accent budget.
+                      backgroundColor: values.signup_as_instructor
+                        ? AUTH.violetSoft
+                        : AUTH.surface,
+                      boxShadow: hairlineRing(
+                        values.signup_as_instructor ? AUTH.violet : AUTH.hairline
+                      ),
+                      transition: `box-shadow 160ms ${EASE}, background-color 160ms ${EASE}`,
+                      "&:hover": {
+                        boxShadow: hairlineRing(
+                          values.signup_as_instructor ? AUTH.violet : "#d5d8e3"
+                        ),
+                      },
+                      "&:focus-visible": { outline: "none", boxShadow: focusRing() },
                     }}
                   >
                     <Box
-                      sx={(theme) => ({
+                      sx={{
                         flexShrink: 0,
-                        width: 44,
-                        height: 44,
-                        borderRadius: 2,
+                        width: 40,
+                        height: 40,
+                        borderRadius: `${RADIUS}px`,
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",
                         backgroundColor: values.signup_as_instructor
-                          ? alpha(theme.palette.primary.main, 0.22)
-                          : alpha(theme.palette.primary.main, 0.12),
-                        color: "primary.main",
-                        transition: "background-color 0.2s ease",
-                      })}
+                          ? "#ffffff"
+                          : AUTH.canvas,
+                        color: values.signup_as_instructor
+                          ? AUTH.violet
+                          : AUTH.inkFaint,
+                      }}
                     >
-                      <GraduationCap
-                        size={24}
-                        strokeWidth={2.25}
-                        aria-hidden
-                      />
+                      <GraduationCap size={20} strokeWidth={2} aria-hidden />
                     </Box>
                     <Box sx={{ flex: 1, minWidth: 0 }}>
                       <Typography
                         component="span"
                         sx={{
+                          ...TYPE.body,
+                          fontFamily: FONT,
+                          fontWeight: 500,
+                          color: AUTH.ink,
                           display: "block",
-                          fontWeight: 700,
-                          fontSize: "0.9375rem",
-                          color: "text.primary",
-                          lineHeight: 1.35,
                         }}
                       >
                         {t("auth.signUpAsInstructor")}
@@ -484,59 +499,54 @@ export default function SignupPage() {
                       inputProps={{
                         "aria-label": t("auth.signUpAsInstructor"),
                       }}
-                      sx={(theme) => ({
+                      sx={{
                         flexShrink: 0,
                         "& .MuiSwitch-switchBase.Mui-checked": {
-                          color: theme.palette.primary.main,
+                          color: AUTH.violet,
                         },
-                        "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track":
-                          {
-                            backgroundColor: alpha(
-                              theme.palette.primary.main,
-                              0.55
-                            ),
-                          },
-                      })}
+                        "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track": {
+                          backgroundColor: AUTH.violet,
+                          opacity: 0.5,
+                        },
+                      }}
                     />
                   </Box>
+
                   {values.signup_as_instructor && (
                     <>
                       <Box
-                        sx={(theme) => ({
-                          mt: 1.25,
-                          pl: 1.75,
-                          pr: 1.5,
+                        sx={{
+                          mt: 1.5,
+                          px: 1.75,
                           py: 1.5,
-                          borderRadius: 2,
-                          borderLeft: `3px solid ${theme.palette.primary.main}`,
-                          background: `linear-gradient(90deg, ${alpha(
-                            theme.palette.primary.main,
-                            0.1
-                          )} 0%, ${alpha(theme.palette.primary.main, 0.02)} 100%)`,
-                        })}
+                          borderRadius: `${RADIUS}px`,
+                          backgroundColor: AUTH.canvas,
+                          boxShadow: hairlineRing(),
+                        }}
                       >
                         <Typography
-                          variant="caption"
                           component="p"
                           sx={{
-                            display: "block",
-                            fontWeight: 700,
-                            fontSize: "0.8125rem",
-                            color: "primary.main",
-                            letterSpacing: "0.02em",
-                            textTransform: "uppercase",
+                            ...TYPE.eyebrow,
+                            fontFamily: FONT,
+                            color: AUTH.violet,
                             mb: 0.75,
+                            // Uppercase is a no-op in Arabic and tracking breaks its joins.
+                            textTransform: "uppercase",
+                            '[dir="rtl"] &': {
+                              textTransform: "none",
+                              letterSpacing: "normal",
+                            },
                           }}
                         >
                           {t("auth.instructorSignupApprovalTitle")}
                         </Typography>
                         <Typography
-                          variant="body2"
                           sx={{
-                            display: "block",
-                            color: "text.secondary",
-                            fontSize: "0.8125rem",
-                            lineHeight: 1.55,
+                            ...TYPE.body,
+                            fontFamily: FONT,
+                            fontSize: 13,
+                            color: AUTH.inkMuted,
                           }}
                         >
                           {t("auth.instructorSignupApprovalNote")}
@@ -555,43 +565,39 @@ export default function SignupPage() {
                         />
                         {cvFile ? (
                           <Box
-                            sx={(theme) => ({
+                            sx={{
                               display: "flex",
                               alignItems: "center",
                               gap: 1.25,
                               p: 1.25,
-                              borderRadius: 2,
-                              border: `1.5px solid ${theme.palette.primary.main}`,
-                              background: alpha(
-                                theme.palette.primary.main,
-                                0.06
-                              ),
-                            })}
+                              borderRadius: `${RADIUS}px`,
+                              backgroundColor: AUTH.surface,
+                              boxShadow: hairlineRing(AUTH.violet),
+                            }}
                           >
                             <Box
-                              sx={(theme) => ({
+                              sx={{
                                 flexShrink: 0,
                                 width: 36,
                                 height: 36,
-                                borderRadius: 1.5,
+                                borderRadius: `${RADIUS}px`,
                                 display: "flex",
                                 alignItems: "center",
                                 justifyContent: "center",
-                                backgroundColor: alpha(
-                                  theme.palette.primary.main,
-                                  0.16
-                                ),
-                                color: "primary.main",
-                              })}
+                                backgroundColor: AUTH.violetSoft,
+                                color: AUTH.violet,
+                              }}
                             >
-                              <FileText size={18} strokeWidth={2.25} aria-hidden />
+                              <FileText size={18} strokeWidth={2} aria-hidden />
                             </Box>
                             <Box sx={{ flex: 1, minWidth: 0 }}>
                               <Typography
                                 sx={{
-                                  fontWeight: 600,
-                                  fontSize: "0.8125rem",
-                                  color: "text.primary",
+                                  ...TYPE.body,
+                                  fontFamily: FONT,
+                                  fontSize: 13,
+                                  fontWeight: 500,
+                                  color: AUTH.ink,
                                   overflow: "hidden",
                                   textOverflow: "ellipsis",
                                   whiteSpace: "nowrap",
@@ -601,18 +607,29 @@ export default function SignupPage() {
                               </Typography>
                               <Typography
                                 sx={{
-                                  fontSize: "0.75rem",
-                                  color: "text.secondary",
+                                  ...TYPE.eyebrow,
+                                  fontFamily: FONT,
+                                  letterSpacing: 0,
+                                  color: AUTH.inkFaint,
                                 }}
                               >
                                 {(cvFile.size / 1024 / 1024).toFixed(2)} MB · PDF
                               </Typography>
                             </Box>
                             <IconButton
-                              size="small"
                               onClick={clearCv}
-                              aria-label="Remove CV"
-                              sx={{ color: "text.secondary" }}
+                              aria-label={t("auth.removeCv", {
+                                defaultValue: "Remove CV",
+                              })}
+                              sx={{
+                                width: 44,
+                                height: 44,
+                                color: AUTH.inkFaint,
+                                "&:focus-visible": {
+                                  outline: "none",
+                                  boxShadow: focusRing(AUTH.surface),
+                                },
+                              }}
                             >
                               <X size={16} />
                             </IconButton>
@@ -621,47 +638,47 @@ export default function SignupPage() {
                           <Button
                             type="button"
                             fullWidth
-                            variant="outlined"
                             onClick={() => cvInputRef.current?.click()}
                             startIcon={<Upload size={18} />}
-                            sx={(theme) => ({
-                              py: 1.25,
+                            sx={{
+                              minHeight: CONTROL_HEIGHT,
+                              borderRadius: `${RADIUS}px`,
                               textTransform: "none",
-                              fontWeight: 600,
+                              fontFamily: FONT,
+                              fontWeight: 500,
                               fontSize: "0.875rem",
-                              borderStyle: "dashed",
-                              borderWidth: 2,
-                              borderColor: cvError
-                                ? theme.palette.error.main
-                                : alpha(theme.palette.primary.main, 0.55),
-                              color: cvError
-                                ? "error.main"
-                                : "primary.main",
-                              backgroundColor: alpha(
-                                theme.palette.primary.main,
-                                0.04
+                              color: cvError ? AUTH.error : AUTH.violet,
+                              backgroundColor: AUTH.surface,
+                              boxShadow: hairlineRing(
+                                cvError ? AUTH.error : AUTH.hairline
                               ),
                               "&:hover": {
-                                borderColor: cvError
-                                  ? theme.palette.error.main
-                                  : theme.palette.primary.main,
-                                backgroundColor: alpha(
-                                  theme.palette.primary.main,
-                                  0.08
+                                backgroundColor: AUTH.violetSoft,
+                                boxShadow: hairlineRing(
+                                  cvError ? AUTH.error : AUTH.violet
                                 ),
                               },
-                            })}
+                              "&:focus-visible": {
+                                outline: "none",
+                                boxShadow: focusRing(),
+                              },
+                            }}
                           >
-                            Upload CV (PDF, max {CV_MAX_SIZE_MB}MB)
+                            {t("auth.uploadCv", {
+                              defaultValue: `Upload CV (PDF, max ${CV_MAX_SIZE_MB}MB)`,
+                              max: CV_MAX_SIZE_MB,
+                            })}
                           </Button>
                         )}
                         {cvError && (
                           <Typography
+                            role="alert"
                             sx={{
+                              ...TYPE.eyebrow,
+                              fontFamily: FONT,
+                              letterSpacing: 0,
                               mt: 0.75,
-                              color: "error.main",
-                              fontSize: "0.75rem",
-                              lineHeight: 1.4,
+                              color: AUTH.error,
                             }}
                           >
                             {cvError}
@@ -670,14 +687,17 @@ export default function SignupPage() {
                         {!cvError && !cvFile && (
                           <Typography
                             sx={{
+                              ...TYPE.eyebrow,
+                              fontFamily: FONT,
+                              letterSpacing: 0,
                               mt: 0.75,
-                              color: "text.secondary",
-                              fontSize: "0.75rem",
-                              lineHeight: 1.4,
+                              color: AUTH.inkFaint,
                             }}
                           >
-                            Your CV is required so admins can review your
-                            application.
+                            {t("auth.cvWhy", {
+                              defaultValue:
+                                "Your CV is required so admins can review your application.",
+                            })}
                           </Typography>
                         )}
                       </Box>
@@ -686,73 +706,36 @@ export default function SignupPage() {
                 </Box>
               )}
 
-              {/* Sign Up Button */}
               <LoadingButton
                 type="submit"
                 fullWidth
                 variant="contained"
                 loading={loading}
                 loadingText={t("common.submitting")}
-                disabled={
-                  loading ||
-                  (values.signup_as_instructor && !cvFile)
-                }
+                disabled={loading || (values.signup_as_instructor && !cvFile)}
                 sx={{
-                  py: 1.25,
-                  mb: 2,
-                  background:
-                    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-                  color: "var(--font-light)",
-                  fontWeight: 600,
-                  fontSize: "0.9375rem",
-                  textTransform: "none",
-                  boxShadow: "none",
-                  "&:hover": {
-                    background:
-                      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
-                    boxShadow:
-                      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
-                  },
+                  ...authPrimaryButtonSx,
                   "&:disabled": {
-                    background:
-                      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-                    opacity: 0.6,
-                    color: "var(--font-light)",
+                    background: AUTH.violet,
+                    color: "#ffffff",
+                    opacity: 0.45,
                   },
                 }}
               >
                 {t("auth.signUp")}
               </LoadingButton>
 
-              {/* Sign in link */}
-              <Box sx={{ textAlign: "center", mt: 1 }}>
+              <Box sx={{ textAlign: "center", mt: 3 }}>
                 <Typography
-                  variant="body2"
                   component="span"
-                  sx={{ color: "text.secondary", fontSize: "0.875rem" }}
+                  sx={{ ...TYPE.body, fontFamily: FONT, color: AUTH.inkFaint }}
                 >
-                  Already have an account?{" "}
+                  {t("auth.haveAccount", {
+                    defaultValue: "Already have an account?",
+                  })}{" "}
                 </Typography>
-                <Link
-                  href="/login"
-                  style={{
-                    color: "inherit",
-                    textDecoration: "none",
-                  }}
-                >
-                  <Typography
-                    variant="body2"
-                    component="span"
-                    sx={{
-                      color: "primary.main",
-                      textDecoration: "none",
-                      fontWeight: 500,
-                      fontSize: "0.875rem",
-                      "&:hover": {
-                        textDecoration: "underline",
-                      },
-                    }}
-                  >
+                <Link href="/login" style={{ textDecoration: "none" }}>
+                  <Typography component="span" sx={{ ...TYPE.body, ...authLinkSx }}>
                     {t("auth.signIn")}
                   </Typography>
                 </Link>

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -3,8 +3,17 @@
 import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
-import { TextField, Typography, Box } from "@mui/material";
+import { Typography, Box } from "@mui/material";
 import { LoadingButton } from "@/components/common/LoadingButton";
+import { AuthTextField } from "@/components/auth/fields/AuthTextField";
+import {
+  AUTH,
+  FONT,
+  TYPE,
+  authLinkSx,
+  authPrimaryButtonSx,
+  authSecondaryButtonSx,
+} from "@/components/auth/layout/authTokens";
 import Link from "next/link";
 import { Formik, Form, Field } from "formik";
 import type { FieldInputProps } from "formik";
@@ -77,7 +86,6 @@ export default function VerifyEmailPage() {
       <Box
         sx={{
           width: "100%",
-          maxWidth: 440,
           display: "flex",
           flexDirection: "column",
         }}
@@ -85,12 +93,12 @@ export default function VerifyEmailPage() {
         {/* Title */}
         <Typography
           component="h1"
-          variant="h4"
           sx={{
-            mb: 2,
-            fontWeight: 700,
-            color: "text.primary",
-            fontSize: { xs: "1.75rem", sm: "2rem" },
+            ...TYPE.title,
+            fontFamily: FONT,
+            color: AUTH.ink,
+            mb: 1.5,
+            '[dir="rtl"] &': { letterSpacing: "normal" },
           }}
         >
           {t("auth.verifyEmail")}
@@ -98,12 +106,11 @@ export default function VerifyEmailPage() {
 
         {/* Description */}
         <Typography
-          variant="body1"
           sx={{
-            mb: 3,
-            color: "text.secondary",
-            fontSize: "0.875rem",
-            lineHeight: 1.5,
+            ...TYPE.body,
+            fontFamily: FONT,
+            mb: 4,
+            color: AUTH.inkFaint,
           }}
         >
           {t("auth.verifyDescription")}
@@ -128,24 +135,16 @@ export default function VerifyEmailPage() {
             <Form>
               <Field name="email">
                 {({ field }: { field: FieldInputProps<string> }) => (
-                  <TextField
+                  <AuthTextField
                     {...field}
-                    fullWidth
-                    required
                     id="email"
                     label={t("auth.email")}
-                    placeholder={t("auth.email")}
+                    type="email"
                     autoComplete="username"
-                    size="small"
-                    error={touched.email && !!errors.email}
+                    required
+                    dir="ltr"
+                    error={Boolean(touched.email && errors.email)}
                     helperText={touched.email && errors.email}
-                    sx={{
-                      mb: 1.5,
-                      "& .MuiFormHelperText-root": {
-                        marginTop: 0.5,
-                        fontSize: "0.75rem",
-                      },
-                    }}
                   />
                 )}
               </Field>
@@ -160,29 +159,16 @@ export default function VerifyEmailPage() {
                 loading={loading}
                 loadingText={t("auth.verifying")}
                 sx={{
-                  py: 1.25,
+                  ...authPrimaryButtonSx,
                   mb: 1.5,
-                  background:
-                    "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-                  color: "var(--font-light)",
-                  fontWeight: 600,
-                  fontSize: "0.9375rem",
-                  textTransform: "none",
-                  boxShadow: "none",
-                  "&:hover": {
-                    background:
-                      "linear-gradient(135deg, var(--primary-500) 0%, var(--primary-600) 100%)",
-                    boxShadow:
-                      "0 4px 12px color-mix(in srgb, var(--primary-500) 40%, transparent)",
-                  },
                   "&:disabled": {
-                    background:
-                      "linear-gradient(135deg, var(--primary-400) 0%, var(--primary-600) 100%)",
-                    opacity: 0.6,
+                    background: AUTH.violet,
+                    color: "#ffffff",
+                    opacity: 0.45,
                   },
                 }}
               >
-                Verify Email
+                {t("auth.verifyEmail")}
               </LoadingButton>
 
               {/* Resend OTP Button */}
@@ -195,27 +181,7 @@ export default function VerifyEmailPage() {
                 loadingText={t("common.loading")}
                 disabled={resending || !values.email}
                 size="small"
-                sx={{
-                  py: 1.25,
-                  mb: 2,
-                  borderColor: "var(--border-default)",
-                  borderWidth: 1.5,
-                  color: "var(--font-primary)",
-                  textTransform: "none",
-                  fontWeight: 500,
-                  fontSize: "0.875rem",
-                  "&:hover": {
-                    borderColor:
-                      "color-mix(in srgb, var(--border-default) 70%, var(--font-primary))",
-                    backgroundColor:
-                      "color-mix(in srgb, var(--surface) 70%, var(--background))",
-                    borderWidth: 1.5,
-                  },
-                  "&:disabled": {
-                    borderColor: "var(--border-default)",
-                    opacity: 0.5,
-                  },
-                }}
+                sx={{ ...authSecondaryButtonSx, mb: 3 }}
               >
                 {t("auth.resendOtp")}
               </LoadingButton>
@@ -223,31 +189,13 @@ export default function VerifyEmailPage() {
               {/* Back to login link */}
               <Box sx={{ textAlign: "center" }}>
                 <Typography
-                  variant="body2"
                   component="span"
-                  sx={{ color: "text.secondary" }}
+                  sx={{ ...TYPE.body, fontFamily: FONT, color: AUTH.inkFaint }}
                 >
                   {t("auth.alreadyVerified")}{" "}
                 </Typography>
-                <Link
-                  href="/login"
-                  style={{
-                    color: "inherit",
-                    textDecoration: "none",
-                  }}
-                >
-                  <Typography
-                    variant="body2"
-                    component="span"
-                    sx={{
-                      color: "primary.main",
-                      textDecoration: "none",
-                      fontSize: "0.875rem",
-                      "&:hover": {
-                        textDecoration: "underline",
-                      },
-                    }}
-                  >
+                <Link href="/login" style={{ textDecoration: "none" }}>
+                  <Typography component="span" sx={{ ...TYPE.body, ...authLinkSx }}>
                     {t("auth.login")}
                   </Typography>
                 </Link>

--- a/components/auth/AuthLayout.tsx
+++ b/components/auth/AuthLayout.tsx
@@ -10,11 +10,11 @@ import {
   type LoginHeroBrandingUi,
 } from "@/lib/theme/authHeroBranding";
 import { AuthLayoutShell } from "./layout/AuthLayoutShell";
+import { AuthLeftPanel } from "./layout/AuthLeftPanel";
 import {
-  AuthLeftPanel,
-  type AuthLeftPanelVariant,
-} from "./layout/AuthLeftPanel";
-import { AuthRightPanelDefault } from "./layout/AuthRightPanelDefault";
+  AuthMobileBrandBar,
+  AuthRightPanelDefault,
+} from "./layout/AuthRightPanelDefault";
 import { resolveClientLogoUrl } from "@/lib/utils/resolveClientLogoUrl";
 
 interface AuthLayoutProps {
@@ -41,12 +41,10 @@ export function AuthLayout({ children, slogan }: AuthLayoutProps) {
   const useCustomSlogan = Boolean(sloganOverride);
 
   const loginImgUrl = clientInfo?.login_img_url?.trim() ?? "";
-  const leftVariant: AuthLeftPanelVariant = loginImgUrl ? "glass" : "plain";
-
   const brandName = clientInfo?.name?.trim() || "";
   const logoUrl = resolveClientLogoUrl(clientInfo);
 
-  const rightPanelProps = {
+  const brandProps = {
     clientInfoLoading,
     sloganText,
     logoUrl,
@@ -54,12 +52,23 @@ export function AuthLayout({ children, slogan }: AuthLayoutProps) {
     loginImgUrl: loginImgUrl || null,
     heroBranding,
     useCustomSlogan,
+    supportingText: t("auth.supporting", {
+      defaultValue:
+        "Start from scratch, or from where you left off. Your path adapts as you go.",
+    }),
   };
 
   return (
     <AuthLayoutShell
-      left={<AuthLeftPanel variant={leftVariant}>{children}</AuthLeftPanel>}
-      right={<AuthRightPanelDefault {...rightPanelProps} />}
+      mobileBrand={
+        <AuthMobileBrandBar
+          logoUrl={logoUrl}
+          brandName={brandName}
+          clientInfoLoading={clientInfoLoading}
+        />
+      }
+      left={<AuthLeftPanel>{children}</AuthLeftPanel>}
+      right={<AuthRightPanelDefault {...brandProps} />}
     />
   );
 }

--- a/components/auth/GoogleSignIn.tsx
+++ b/components/auth/GoogleSignIn.tsx
@@ -70,10 +70,16 @@ function makeNonce(): string {
 
 interface GoogleSignInProps {
   disabled?: boolean;
+  /**
+   * Overrides the button copy. Signup passes "Sign up with Google": the shared default
+   * read "Sign in with Google" directly above a divider reading "Or sign up with email".
+   */
+  label?: string;
 }
 
 export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
   disabled = false,
+  label,
 }) => {
   const { t } = useTranslation("common");
   const { googleLogin, celebrate } = useAuth();
@@ -387,16 +393,19 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
         size="small"
         sx={{
           py: 1.25,
-          borderColor: "#e2e8f0",
-          borderWidth: 1.5,
+          minHeight: 44,
+          borderRadius: "8px",
+          border: "none",
+          boxShadow: "0 0 0 1px #e6e8ef",
           color: "#0f172a",
           textTransform: "none",
-          backgroundColor: "white",
+          backgroundColor: "#ffffff",
           fontWeight: 500,
           fontSize: "0.875rem",
           WebkitTapHighlightColor: "transparent",
           touchAction: "manipulation",
-          "&:hover": { borderColor: "#cbd5e1", backgroundColor: "#f8fafc", borderWidth: 1.5 },
+          "&:hover": { border: "none", boxShadow: "0 0 0 1px #d5d8e3", backgroundColor: "#ffffff" },
+          "&:focus-visible": { outline: "none", boxShadow: "0 0 0 2px #fbfbfd, 0 0 0 4px #7c3aed" },
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
@@ -409,7 +418,7 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
             </g>
           </svg>
           <Typography variant="body2" sx={{ fontWeight: 500, fontSize: "0.9375rem", color: "#0f172a" }}>
-            {t("auth.signInWithGoogle")}
+            {label ?? t("auth.signInWithGoogle")}
           </Typography>
         </Box>
       </Button>
@@ -441,11 +450,13 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
         aria-busy={interactive ? true : undefined}
         sx={{
           py: 1.25,
-          borderColor: "#e2e8f0",
-          borderWidth: 1.5,
+          minHeight: 44,
+          borderRadius: "8px",
+          border: "none",
+          boxShadow: "0 0 0 1px #e6e8ef",
           color: "#0f172a",
           textTransform: "none",
-          backgroundColor: "white",
+          backgroundColor: "#ffffff",
           fontWeight: 500,
           fontSize: "0.875rem",
           // Receive clicks only when we ARE the click target. When the GSI
@@ -453,7 +464,8 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
           pointerEvents: interactive ? "auto" : "none",
           WebkitTapHighlightColor: "transparent",
           touchAction: "manipulation",
-          "&:hover": { borderColor: "#cbd5e1", backgroundColor: "#f8fafc", borderWidth: 1.5 },
+          "&:hover": { border: "none", boxShadow: "0 0 0 1px #d5d8e3", backgroundColor: "#ffffff" },
+          "&:focus-visible": { outline: "none", boxShadow: "0 0 0 2px #fbfbfd, 0 0 0 4px #7c3aed" },
           "&.Mui-disabled": { opacity: 0.5, borderColor: "#e2e8f0", backgroundColor: "white" },
         }}
       >
@@ -467,7 +479,7 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
             </g>
           </svg>
           <Typography variant="body2" sx={{ fontWeight: 500, fontSize: "0.9375rem", color: "#0f172a" }}>
-            {t("auth.signInWithGoogle")}
+            {label ?? t("auth.signInWithGoogle")}
           </Typography>
         </Box>
       </Button>

--- a/components/auth/OtpDigitInput.tsx
+++ b/components/auth/OtpDigitInput.tsx
@@ -3,6 +3,15 @@
 import { useRef, useCallback, type KeyboardEvent, type ClipboardEvent } from "react";
 import { Box, InputBase, Typography, FormHelperText } from "@mui/material";
 import { useField } from "formik";
+import {
+  AUTH,
+  CONTROL_HEIGHT,
+  EASE,
+  FONT,
+  RADIUS,
+  focusRing,
+  hairlineRing,
+} from "./layout/authTokens";
 
 const SLOT_COUNT = 6;
 
@@ -152,25 +161,27 @@ export function OtpDigitInput({ name, label }: OtpDigitInputProps) {
               maxWidth: 52,
               "& .MuiInputBase-input": {
                 textAlign: "center",
+                fontFamily: FONT,
                 fontSize: { xs: "1.25rem", sm: "1.375rem" },
-                fontWeight: 600,
+                fontWeight: 500,
                 fontVariantNumeric: "tabular-nums",
+                color: AUTH.ink,
+                height: CONTROL_HEIGHT,
+                boxSizing: "border-box",
                 py: 1.25,
                 px: 0.5,
-                borderRadius: 1.5,
-                border: "1.5px solid",
-                borderColor: showError ? "error.main" : "divider",
-                bgcolor: "background.paper",
-                transition: "border-color 0.15s, box-shadow 0.15s",
+                borderRadius: `${RADIUS}px`,
+                // Border as a shadow, so focus never nudges the row of slots.
+                border: "none",
+                backgroundColor: AUTH.surface,
+                boxShadow: hairlineRing(showError ? AUTH.error : AUTH.hairline),
+                transition: `box-shadow 160ms ${EASE}`,
                 "&:hover": {
-                  borderColor: showError ? "error.main" : "primary.light",
+                  boxShadow: hairlineRing(showError ? AUTH.error : "#d5d8e3"),
                 },
                 "&:focus": {
-                  borderColor: showError ? "error.main" : "primary.main",
-                  boxShadow: (theme) =>
-                    showError
-                      ? `0 0 0 2px ${theme.palette.error.main}33`
-                      : `0 0 0 2px ${theme.palette.primary.main}33`,
+                  outline: "none",
+                  boxShadow: focusRing(),
                 },
               },
             }}

--- a/components/auth/fields/AuthTextField.tsx
+++ b/components/auth/fields/AuthTextField.tsx
@@ -69,7 +69,7 @@ export function AuthTextField({
   const describedBy = helperText ? `${id}-helper` : undefined;
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mb: 2 }}>
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mb: 1.5 }}>
       <Typography
         component="label"
         htmlFor={id}
@@ -119,6 +119,13 @@ export function AuthTextField({
               boxShadow: hairlineRing(),
             },
           },
+          // MUI ships `padding: 16.5px 14px` on the input, which alone is taller than the
+          // 44px control height DESIGN.md specifies, so `minHeight` above never bound and
+          // fields rendered at 54.6px. Setting the padding explicitly is what actually
+          // controls the height.
+          "& .MuiOutlinedInput-input": {
+            padding: "11px 14px",
+          },
           "& .MuiOutlinedInput-input::placeholder": {
             color: AUTH.inkFaint,
             opacity: 1,
@@ -126,20 +133,32 @@ export function AuthTextField({
         }}
       />
 
-      {helperText ? (
-        <Typography
-          id={describedBy}
-          role={error ? "alert" : undefined}
-          sx={{
-            ...TYPE.eyebrow,
-            fontFamily: FONT,
-            letterSpacing: 0,
-            color: error ? AUTH.error : AUTH.inkFaint,
-          }}
-        >
-          {helperText}
-        </Typography>
-      ) : null}
+      {/* The helper row is always present, even when empty.
+          Rendering it conditionally meant the submit button dropped 22.8px the moment
+          validation failed, so it moved out from under the cursor that had just clicked it.
+          Reserving the row costs 17px per field and the shorter control height pays for it. */}
+      <Box
+        id={describedBy}
+        role={error ? "alert" : undefined}
+        // The line box has to be pinned, not just the min-height. Left to inherit, the
+        // empty row measured 17px while the filled row inherited the parent's larger
+        // strut and measured 24px, which put 7px of the shift back.
+        sx={{ minHeight: 17, mt: 0.25, fontSize: 12, lineHeight: "17px" }}
+      >
+        {helperText ? (
+          <Typography
+            component="span"
+            sx={{
+              ...TYPE.eyebrow,
+              fontFamily: FONT,
+              letterSpacing: 0,
+              color: error ? AUTH.error : AUTH.inkFaint,
+            }}
+          >
+            {helperText}
+          </Typography>
+        ) : null}
+      </Box>
     </Box>
   );
 }

--- a/components/auth/fields/AuthTextField.tsx
+++ b/components/auth/fields/AuthTextField.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { ReactNode } from "react";
+import { Box, TextField, Typography } from "@mui/material";
+import {
+  AUTH,
+  CONTROL_HEIGHT,
+  EASE,
+  FONT,
+  RADIUS,
+  TYPE,
+  focusRing,
+  hairlineRing,
+} from "../layout/authTokens";
+
+interface AuthTextFieldProps {
+  id: string;
+  label: string;
+  type?: string;
+  placeholder?: string;
+  autoComplete?: string;
+  required?: boolean;
+  error?: boolean;
+  /** Rendered under the field and wired via aria-describedby. Never a toast. */
+  helperText?: ReactNode;
+  endAdornment?: ReactNode;
+  /** One-time codes, emails and phone numbers stay LTR inside an RTL page. */
+  dir?: "ltr" | "rtl";
+  disabled?: boolean;
+  autoFocus?: boolean;
+  name?: string;
+  value?: unknown;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  inputProps?: Record<string, unknown>;
+}
+
+/**
+ * The one input in the auth surface.
+ *
+ * Replaces the per-page TextField blocks that duplicated the same sx object and the same
+ * MuiFormHelperText override on four pages. Three things it does that the old fields did not:
+ *
+ * 1. A persistent visible label above the field. Placeholder-as-label loses the question the
+ *    moment a user starts typing, and fails WCAG 2.2 Accessible Authentication.
+ * 2. The border is a box-shadow, not a CSS border, so the focus ring costs zero layout and
+ *    the field never nudges its neighbours on focus.
+ * 3. 16px text on mobile. Below 16px, iOS Safari zooms the viewport on focus.
+ */
+export function AuthTextField({
+  id,
+  label,
+  type = "text",
+  placeholder,
+  autoComplete,
+  required,
+  error,
+  helperText,
+  endAdornment,
+  dir,
+  disabled,
+  autoFocus,
+  name,
+  value,
+  onChange,
+  onBlur,
+  inputProps,
+}: AuthTextFieldProps) {
+  const describedBy = helperText ? `${id}-helper` : undefined;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mb: 2 }}>
+      <Typography
+        component="label"
+        htmlFor={id}
+        sx={{ ...TYPE.label, fontFamily: FONT, color: AUTH.inkMuted }}
+      >
+        {label}
+      </Typography>
+
+      <TextField
+        id={id}
+        name={name}
+        type={type}
+        value={value ?? ""}
+        onChange={onChange}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        required={required}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        fullWidth
+        error={error}
+        dir={dir}
+        aria-describedby={describedBy}
+        aria-invalid={error || undefined}
+        InputProps={{ endAdornment }}
+        inputProps={inputProps}
+        sx={{
+          "& .MuiOutlinedInput-root": {
+            minHeight: CONTROL_HEIGHT,
+            borderRadius: `${RADIUS}px`,
+            backgroundColor: AUTH.surface,
+            fontFamily: FONT,
+            fontSize: { xs: 16, sm: 15 },
+            color: AUTH.ink,
+            boxShadow: hairlineRing(error ? AUTH.error : AUTH.hairline),
+            transition: `box-shadow 160ms ${EASE}`,
+            "& fieldset": { border: "none" },
+            "&:hover": {
+              boxShadow: hairlineRing(error ? AUTH.error : "#d5d8e3"),
+            },
+            "&.Mui-focused": {
+              boxShadow: focusRing(),
+            },
+            "&.Mui-disabled": {
+              backgroundColor: AUTH.canvas,
+              boxShadow: hairlineRing(),
+            },
+          },
+          "& .MuiOutlinedInput-input::placeholder": {
+            color: AUTH.inkFaint,
+            opacity: 1,
+          },
+        }}
+      />
+
+      {helperText ? (
+        <Typography
+          id={describedBy}
+          role={error ? "alert" : undefined}
+          sx={{
+            ...TYPE.eyebrow,
+            fontFamily: FONT,
+            letterSpacing: 0,
+            color: error ? AUTH.error : AUTH.inkFaint,
+          }}
+        >
+          {helperText}
+        </Typography>
+      ) : null}
+    </Box>
+  );
+}

--- a/components/auth/layout/AuthLayoutShell.tsx
+++ b/components/auth/layout/AuthLayoutShell.tsx
@@ -2,23 +2,41 @@
 
 import { Box } from "@mui/material";
 import { ReactNode } from "react";
+import { AUTH } from "./authTokens";
 
 interface AuthLayoutShellProps {
   left: ReactNode;
   right: ReactNode;
+  /** Compact dark brand bar shown only below md, where `right` is not rendered. */
+  mobileBrand?: ReactNode;
 }
 
-export function AuthLayoutShell({ left, right }: AuthLayoutShellProps) {
+/**
+ * Two panels on desktop, stacked on mobile.
+ *
+ * The split favours the form (52/48) rather than 50/50 so the form column reads as the
+ * subject of the page instead of one of two equal halves.
+ *
+ * This used to be `height: 100vh; maxHeight: 100vh; overflow: hidden`, which caused two
+ * bugs at once: the brand panel was unreachable on phones (it is display:none below md, and
+ * the shell could not scroll to reveal anything anyway), and `100vh` is larger than the
+ * visible viewport on iOS Safari while the address bar is showing, so the bottom of a tall
+ * form was cut off with no way to scroll to it. `min-height: 100dvh` plus normal document
+ * flow fixes both.
+ */
+export function AuthLayoutShell({ left, right, mobileBrand }: AuthLayoutShellProps) {
   return (
     <Box
       sx={{
-        height: "100vh",
-        maxHeight: "100vh",
-        overflow: "hidden",
+        minHeight: "100dvh",
         display: "flex",
         flexDirection: { xs: "column", md: "row" },
+        backgroundColor: AUTH.canvas,
       }}
     >
+      {mobileBrand ? (
+        <Box sx={{ display: { xs: "block", md: "none" } }}>{mobileBrand}</Box>
+      ) : null}
       {left}
       {right}
     </Box>

--- a/components/auth/layout/AuthLeftPanel.tsx
+++ b/components/auth/layout/AuthLeftPanel.tsx
@@ -2,87 +2,58 @@
 
 import { Box } from "@mui/material";
 import { ReactNode } from "react";
+import { AUTH } from "./authTokens";
 
 export type AuthLeftPanelVariant = "plain" | "glass";
 
 interface AuthLeftPanelProps {
-  variant: AuthLeftPanelVariant;
+  /** Kept for call-site compatibility. Both variants now render the same borderless column. */
+  variant?: AuthLeftPanelVariant;
+  /** Small tenant logo, top-left. Present on every breakpoint. */
+  brandMark?: ReactNode;
   children: ReactNode;
 }
 
-export function AuthLeftPanel({ variant, children }: AuthLeftPanelProps) {
-  // A brand-accented card the form sits in. The thin top gradient gives the auth pages a consistent
-  // identity; the layered shadow reads as depth without heaviness. Theme-aware via CSS vars.
-  const cardSx = {
-    position: "relative" as const,
-    width: "100%",
-    maxWidth: 440,
-    borderRadius: "20px",
-    px: { xs: 2.75, sm: 4 },
-    py: { xs: 3.25, sm: 4 },
-    // NOTE: intentionally NO `overflow: hidden`. The card wraps the Google Sign-In button, which is a
-    // cross-origin GSI <iframe>; a clipping + rounded ancestor breaks that iframe's click hit-testing
-    // (the button renders but stops receiving clicks). The accent strip below rounds its own top
-    // corners so it still tucks into the card's radius without needing to clip the card.
-    border: "1px solid var(--border-default)",
-    boxShadow:
-      "0 1px 2px color-mix(in srgb, var(--font-primary) 6%, transparent), 0 24px 48px -28px color-mix(in srgb, var(--font-primary) 30%, transparent)",
-    "&::before": {
-      content: '""',
-      position: "absolute",
-      top: 0,
-      left: 0,
-      right: 0,
-      height: 4,
-      borderRadius: "20px 20px 0 0",
-      background: "linear-gradient(90deg, var(--primary-500) 0%, var(--accent-pink) 100%)",
-    },
-  } as const;
-
-  if (variant === "glass") {
-    return (
-      <Box
-        sx={{
-          flex: { xs: 1, md: "0 0 50%" },
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          px: { xs: 3, sm: 4, md: 6 },
-          py: { xs: 4, md: 0 },
-          overflow: "auto",
-          background:
-            "linear-gradient(180deg, var(--background) 0%, color-mix(in srgb, var(--surface) 92%, var(--background)) 45%, color-mix(in srgb, var(--card-bg) 88%, var(--background)) 100%)",
-        }}
-      >
-        <Box
-          sx={{
-            ...cardSx,
-            backgroundColor: "color-mix(in srgb, var(--surface) 82%, var(--background))",
-            backdropFilter: "blur(12px)",
-          }}
-        >
-          {children}
-        </Box>
-      </Box>
-    );
-  }
-
+/**
+ * The form column.
+ *
+ * Deliberately has no card. The previous version wrapped the form in a bordered, shadowed,
+ * 20px-radius card with a 4px colored gradient strip across the top: three decorations doing
+ * the job that hierarchy and whitespace should do, and the colored top strip in particular is
+ * one of the most recognisable generated-design tells. Separation now comes from the canvas
+ * to surface lightness shift and spacing alone.
+ *
+ * INVARIANT: no `overflow: hidden` anywhere on this subtree. The column contains the
+ * cross-origin Google Sign-In iframe, and a clipping + rounded ancestor breaks its click
+ * hit-testing: the button renders and silently stops receiving clicks.
+ */
+export function AuthLeftPanel({ brandMark, children }: AuthLeftPanelProps) {
   return (
     <Box
+      component="main"
       sx={{
-        flex: { xs: 1, md: "0 0 50%" },
+        flex: { xs: "1 1 auto", md: "0 0 52%" },
         display: "flex",
+        flexDirection: "column",
         alignItems: "center",
-        justifyContent: "center",
-        px: { xs: 2.5, sm: 4, md: 6 },
-        py: { xs: 4, md: 0 },
-        overflow: "auto",
-        // A soft, brand-tinted ground so the white card reads as elevated rather than floating on flat white.
-        background:
-          "radial-gradient(120% 120% at 0% 0%, color-mix(in srgb, var(--primary-500) 7%, var(--background)) 0%, var(--background) 55%)",
+        // Optically above true center: a form pinned to dead center reads as slightly low.
+        justifyContent: { xs: "flex-start", md: "center" },
+        px: { xs: 3, sm: 5, md: 8 },
+        py: { xs: 4, md: 6 },
+        backgroundColor: AUTH.canvas,
       }}
     >
-      <Box sx={{ ...cardSx, backgroundColor: "var(--card-bg)" }}>{children}</Box>
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: 400,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {brandMark ? <Box sx={{ mb: 4 }}>{brandMark}</Box> : null}
+        {children}
+      </Box>
     </Box>
   );
 }

--- a/components/auth/layout/AuthRightPanelDefault.tsx
+++ b/components/auth/layout/AuthRightPanelDefault.tsx
@@ -1,14 +1,8 @@
 "use client";
 
-import { Box, Typography, Skeleton } from "@mui/material";
-import Image from "next/image";
+import { Box, Skeleton, Typography } from "@mui/material";
 import type { LoginHeroBrandingUi } from "@/lib/theme/authHeroBranding";
-import {
-  brandNameTypographySx,
-  logoContainerSx,
-  sloganTypographySx,
-} from "@/lib/theme/authHeroBranding";
-import { brandWordHighlightSx } from "./authBrandStyles";
+import { AUTH, FONT, RADIUS, TYPE } from "./authTokens";
 
 interface AuthRightPanelDefaultProps {
   clientInfoLoading: boolean;
@@ -18,381 +12,264 @@ interface AuthRightPanelDefaultProps {
   loginImgUrl?: string | null;
   heroBranding?: LoginHeroBrandingUi;
   useCustomSlogan?: boolean;
+  supportingText?: string;
 }
 
+/**
+ * The dark brand surface.
+ *
+ * Three things drive this design:
+ *
+ * 1. It matches the product you land in. ModulePageHeader and the student dashboard already
+ *    define a dark violet identity; auth previously shared none of it, so signing in felt
+ *    like a different product.
+ *
+ * 2. A tenant's uploaded image can never carry the quality of the screen. The old hero branch
+ *    rendered `login_img_url` full-bleed and sharp at 50vw, so a small upload was scaled to
+ *    ~720px wide and rendered visibly pixelated, with dark text laid straight over it and no
+ *    scrim. Here the image sits behind the composition at low opacity, blurred, under a scrim.
+ *    The panel is already finished without it; the image only adds texture.
+ *
+ * 3. No blurred floating blobs, no glassmorphism, no gradient text highlight keyed on the
+ *    literal English words "the" and "world" (which did nothing in Arabic and nothing for any
+ *    tenant-authored slogan).
+ */
 export function AuthRightPanelDefault({
   clientInfoLoading,
   sloganText,
   logoUrl,
   brandName,
   loginImgUrl,
-  heroBranding = {},
-  useCustomSlogan = false,
+  supportingText,
 }: AuthRightPanelDefaultProps) {
-  const hero = Boolean(loginImgUrl?.trim());
-
-  if (hero) {
-    const src = loginImgUrl!.trim();
-    return (
-      <Box
-        sx={{
-          flex: { xs: 0, md: "0 0 50%" },
-          display: { xs: "none", md: "flex" },
-          flexDirection: "column",
-          alignItems: "center",
-          position: "relative",
-          overflow: "hidden",
-          height: "100vh",
-          backgroundColor: "var(--background)",
-        }}
-      >
-        <Box
-          aria-hidden
-          sx={{
-            position: "absolute",
-            inset: 0,
-            zIndex: 0,
-            width: "100%",
-            height: "100%",
-            backgroundColor: "var(--background)",
-          }}
-        >
-          <Image
-            src={src}
-            alt=""
-            fill
-            priority
-            sizes="50vw"
-            style={{ objectFit: "cover", objectPosition: "center" }}
-          />
-        </Box>
-
-        <Box
-          sx={{
-            position: "relative",
-            zIndex: 2,
-            flex: 1,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            width: "100%",
-            maxWidth: 840,
-            px: 4,
-            pt: { md: 2 },
-            gap: 2,
-            textAlign: "center",
-            minHeight: 0,
-            transform: "translateY(clamp(28px, 4vh, 72px))",
-          }}
-        >
-          {clientInfoLoading ? (
-            <Box
-              sx={{
-                width: "100%",
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                gap: 2,
-              }}
-            >
-              <Skeleton
-                variant="rounded"
-                sx={{
-                  bgcolor:
-                    "color-mix(in srgb, var(--font-primary) 12%, transparent)",
-                  width: 320,
-                  height: 120,
-                  borderRadius: 2,
-                }}
-              />
-              <Skeleton
-                variant="text"
-                sx={{
-                  bgcolor:
-                    "color-mix(in srgb, var(--font-primary) 12%, transparent)",
-                  width: "85%",
-                  height: 48,
-                }}
-              />
-              <Skeleton
-                variant="text"
-                sx={{
-                  bgcolor:
-                    "color-mix(in srgb, var(--font-primary) 9%, transparent)",
-                  width: "70%",
-                  height: 22,
-                }}
-              />
-            </Box>
-          ) : (
-            (logoUrl || brandName) && (
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  alignItems: "center",
-                  gap: 2,
-                  width: "100%",
-                }}
-              >
-                {logoUrl ? (
-                  <Box sx={logoContainerSx(true, heroBranding)}>
-                    {/* Plain <img>, NOT next/image: branding logos are arbitrary admin URLs — often
-                        SVG, or on hosts/protocols the next/image optimizer 400s on — which it silently
-                        dropped for many clients. A plain tag renders any valid image URL. */}
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={logoUrl}
-                      alt={brandName || "Logo"}
-                      style={{ width: "100%", height: "100%", objectFit: "contain" }}
-                    />
-                  </Box>
-                ) : null}
-                {brandName ? (
-                  <Typography
-                    component="p"
-                    sx={brandNameTypographySx(true, heroBranding)}
-                  >
-                    {brandName}
-                  </Typography>
-                ) : null}
-              </Box>
-            )
-          )}
-
-          <Typography
-            variant="h2"
-            component="div"
-            sx={sloganTypographySx(true, heroBranding)}
-          >
-            {sloganText.split(" ").map((word, index) => (
-              <span key={index}>{word} </span>
-            ))}
-          </Typography>
-        </Box>
-      </Box>
-    );
-  }
+  const heroSrc = loginImgUrl?.trim() || "";
 
   return (
     <Box
       sx={{
-        flex: { xs: 0, md: "0 0 50%" },
+        flex: { xs: 0, md: "0 0 48%" },
         display: { xs: "none", md: "flex" },
-        alignItems: "center",
-        justifyContent: "center",
+        flexDirection: "column",
+        justifyContent: "space-between",
         position: "relative",
-        backgroundColor: "var(--background)",
         overflow: "hidden",
-        height: "100vh",
+        px: 7,
+        py: 7,
+        backgroundColor: AUTH.night,
+        backgroundImage: `radial-gradient(120% 120% at 8% 108%, ${AUTH.violet}59 0%, ${AUTH.violetDeep}33 38%, transparent 68%), linear-gradient(160deg, ${AUTH.night2} 0%, ${AUTH.night} 62%)`,
       }}
     >
-      <Box
-        sx={{
-          position: "absolute",
-          width: "100%",
-          height: "100%",
-          zIndex: 0,
-        }}
-      >
-        <Box
-          sx={{
-            position: "absolute",
-            top: -100,
-            right: "20%",
-            width: 400,
-            height: 400,
-            borderRadius: "50%",
-            background:
-              "linear-gradient(135deg, var(--primary-300) 0%, var(--primary-500) 100%)",
-            opacity: 0.3,
-            filter: "blur(80px)",
-          }}
-        />
-        <Box
-          sx={{
-            position: "absolute",
-            top: -50,
-            right: -50,
-            width: 350,
-            height: 350,
-            borderRadius: "50%",
-            background:
-              "linear-gradient(135deg, var(--accent-orange) 0%, color-mix(in srgb, var(--accent-orange) 65%, var(--font-light)) 100%)",
-            opacity: 0.25,
-            filter: "blur(70px)",
-          }}
-        />
-        <Box
-          sx={{
-            position: "absolute",
-            bottom: -100,
-            left: -100,
-            width: 500,
-            height: 500,
-            borderRadius: "50%",
-            background:
-              "linear-gradient(135deg, var(--accent-pink) 0%, var(--accent-red) 100%)",
-            opacity: 0.2,
-            filter: "blur(100px)",
-          }}
-        />
-        <Box
-          sx={{
-            position: "absolute",
-            bottom: 100,
-            left: "30%",
-            width: 300,
-            height: 300,
-            borderRadius: "50%",
-            background:
-              "linear-gradient(135deg, var(--accent-blue-light) 0%, color-mix(in srgb, var(--accent-blue-light) 62%, var(--font-light)) 100%)",
-            opacity: 0.25,
-            filter: "blur(60px)",
-          }}
-        />
-        <Box
-          sx={{
-            position: "absolute",
-            bottom: 50,
-            right: 50,
-            width: 200,
-            height: 200,
-            borderRadius: "30%",
-            background:
-              "linear-gradient(135deg, var(--accent-purple) 0%, color-mix(in srgb, var(--accent-purple) 62%, var(--font-light)) 100%)",
-            opacity: 0.3,
-            filter: "blur(50px)",
-          }}
-        />
+      {heroSrc ? (
+        <Box aria-hidden sx={{ position: "absolute", inset: 0, zIndex: 0 }}>
+          {/* Plain <img>, NOT next/image: tenant assets are arbitrary admin-supplied URLs,
+              often SVG or on hosts the optimizer 400s on, and it silently dropped them for
+              many clients. Blur + low opacity is deliberate, not decoration: it makes a
+              low-resolution upload physically incapable of looking broken. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={heroSrc}
+            alt=""
+            style={{
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+              objectPosition: "center",
+              opacity: 0.22,
+              filter: "blur(2px) saturate(0.85)",
+              transform: "scale(1.06)",
+            }}
+          />
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              background: `linear-gradient(160deg, ${AUTH.night2}d9 0%, ${AUTH.night}f2 70%)`,
+            }}
+          />
+        </Box>
+      ) : null}
+
+      <Box sx={{ position: "relative", zIndex: 1 }}>
+        {clientInfoLoading ? (
+          <Skeleton
+            variant="rounded"
+            width={150}
+            height={36}
+            sx={{ bgcolor: "rgba(255,255,255,0.10)", borderRadius: `${RADIUS}px` }}
+          />
+        ) : logoUrl ? (
+          /* A light chip, not a bare image. Tenant logos are arbitrary uploads: transparent
+             SVGs sit fine on dark, but a raster with a baked-in white background reads as a
+             sticker floating on the panel. The chip makes both look deliberate. */
+          <Box
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              px: 1.75,
+              py: 1.25,
+              borderRadius: `${RADIUS}px`,
+              backgroundColor: "rgba(255,255,255,0.94)",
+              maxWidth: 220,
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={logoUrl}
+              alt={brandName || "Logo"}
+              style={{ maxHeight: 28, maxWidth: 180, objectFit: "contain", display: "block" }}
+            />
+          </Box>
+        ) : brandName ? (
+          <Typography
+            sx={{ ...TYPE.section, fontFamily: FONT, color: "#ffffff" }}
+          >
+            {brandName}
+          </Typography>
+        ) : null}
+      </Box>
+
+      <Box sx={{ position: "relative", zIndex: 1, maxWidth: 460 }}>
+        {clientInfoLoading ? (
+          <>
+            <Skeleton
+              variant="text"
+              width="90%"
+              height={52}
+              sx={{ bgcolor: "rgba(255,255,255,0.10)" }}
+            />
+            <Skeleton
+              variant="text"
+              width="70%"
+              height={52}
+              sx={{ bgcolor: "rgba(255,255,255,0.10)" }}
+            />
+          </>
+        ) : (
+          <Typography
+            component="p"
+            sx={{
+              ...TYPE.display,
+              fontFamily: FONT,
+              color: "#ffffff",
+              // Arabic joins cursively; negative tracking breaks the joins.
+              '[dir="rtl"] &': { letterSpacing: "normal" },
+            }}
+          >
+            {sloganText}
+          </Typography>
+        )}
+
+        {supportingText ? (
+          <Typography
+            component="p"
+            sx={{
+              ...TYPE.body,
+              fontFamily: FONT,
+              color: "rgba(255,255,255,0.68)",
+              mt: 2.5,
+              maxWidth: 400,
+            }}
+          >
+            {supportingText}
+          </Typography>
+        ) : null}
       </Box>
 
       <Box
         sx={{
           position: "relative",
           zIndex: 1,
-          px: 6,
-          textAlign: "center",
           display: "flex",
-          flexDirection: "column",
           alignItems: "center",
-          gap: 3,
+          gap: 1.25,
         }}
       >
-        {clientInfoLoading ? (
-          <Box
-            sx={{
-              width: "100%",
-              maxWidth: 320,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              textAlign: "center",
-              gap: 1.5,
-              mx: "auto",
-            }}
-          >
-            <Skeleton variant="rounded" width={200} height={56} sx={{ borderRadius: 1 }} />
-            <Skeleton variant="text" width={280} height={52} />
-          </Box>
-        ) : (
-          (logoUrl || brandName) && (
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                textAlign: "center",
-                width: "100%",
-                gap: 1.5,
-                maxWidth: 600,
-                mx: "auto",
-              }}
-            >
-              {logoUrl ? (
-                <Box sx={logoContainerSx(false, heroBranding)}>
-                  {/* Plain <img>, NOT next/image — see the note above. */}
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={logoUrl}
-                    alt={brandName || "Logo"}
-                    style={{ width: "100%", height: "100%", objectFit: "contain" }}
-                  />
-                </Box>
-              ) : null}
-              {brandName ? (
-                <Typography
-                  component="p"
-                  sx={{
-                    ...brandNameTypographySx(false, heroBranding),
-                    mt: logoUrl ? 0.5 : 0,
-                  }}
-                >
-                  {brandName
-                    .split(/\s+/)
-                    .filter(Boolean)
-                    .map((word, index, words) => (
-                      <Box
-                        key={`${word}-${index}`}
-                        component="span"
-                        sx={{
-                          ...brandWordHighlightSx,
-                          marginRight: index < words.length - 1 ? "0.35em" : 0,
-                        }}
-                      >
-                        {word}
-                      </Box>
-                    ))}
-                </Typography>
-              ) : null}
-            </Box>
-          )
-        )}
-
+        <Box
+          sx={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            backgroundColor: AUTH.pink,
+          }}
+        />
         <Typography
-          variant="h2"
-          component="div"
-          sx={sloganTypographySx(false, heroBranding)}
+          sx={{
+            ...TYPE.eyebrow,
+            fontFamily: FONT,
+            color: "rgba(255,255,255,0.55)",
+            '[dir="rtl"] &': { letterSpacing: "normal" },
+          }}
         >
-          {useCustomSlogan
-            ? sloganText.split(" ").map((word, index) => (
-                <span key={index}>{word} </span>
-              ))
-            : sloganText.split(" ").map((word, index) => {
-                if (word === "the" || word === "world") {
-                  return (
-                    <Box
-                      key={index}
-                      component="span"
-                      sx={{
-                        position: "relative",
-                        display: "inline-block",
-                        "&::after": {
-                          content: '""',
-                          position: "absolute",
-                          top: "50%",
-                          left: 0,
-                          right: 0,
-                          height: "40%",
-                          background:
-                            "linear-gradient(135deg, var(--accent-orange) 0%, var(--accent-pink) 100%)",
-                          borderRadius: "20px",
-                          opacity: 0.3,
-                          zIndex: -1,
-                        },
-                      }}
-                    >
-                      {word}{" "}
-                    </Box>
-                  );
-                }
-                return <span key={index}>{word} </span>;
-              })}
+          {brandName || "AI Linc"}
         </Typography>
       </Box>
+    </Box>
+  );
+}
+
+/**
+ * Compact dark bar for phones, where the panel above is not rendered.
+ *
+ * Without this a tenant's users saw zero branding on mobile: the brand panel is display:none
+ * below md, and the old shell could not scroll to reveal anything anyway.
+ */
+export function AuthMobileBrandBar({
+  logoUrl,
+  brandName,
+  clientInfoLoading,
+}: {
+  logoUrl: string;
+  brandName: string;
+  clientInfoLoading: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        px: 3,
+        py: 2.5,
+        minHeight: 76,
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        backgroundColor: AUTH.night,
+        backgroundImage: `radial-gradient(120% 200% at 4% 120%, ${AUTH.violet}4d 0%, transparent 62%), linear-gradient(160deg, ${AUTH.night2} 0%, ${AUTH.night} 70%)`,
+      }}
+    >
+      {clientInfoLoading ? (
+        <Skeleton
+          variant="rounded"
+          width={120}
+          height={28}
+          sx={{ bgcolor: "rgba(255,255,255,0.10)" }}
+        />
+      ) : logoUrl ? (
+        // Same light chip as the desktop panel, for the same reason: a tenant logo with a
+        // baked-in white background reads as a sticker when placed bare on dark.
+        <Box
+          sx={{
+            display: "inline-flex",
+            alignItems: "center",
+            px: 1.25,
+            py: 0.75,
+            borderRadius: `${RADIUS}px`,
+            backgroundColor: "rgba(255,255,255,0.94)",
+          }}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={logoUrl}
+            alt={brandName || "Logo"}
+            style={{ maxHeight: 24, maxWidth: 150, objectFit: "contain", display: "block" }}
+          />
+        </Box>
+      ) : (
+        <Typography
+          sx={{ ...TYPE.section, fontFamily: FONT, color: "#ffffff" }}
+        >
+          {brandName || "AI Linc"}
+        </Typography>
+      )}
     </Box>
   );
 }

--- a/components/auth/layout/authTokens.ts
+++ b/components/auth/layout/authTokens.ts
@@ -1,0 +1,134 @@
+/**
+ * Auth surface design tokens.
+ *
+ * Deliberately literal constants, NOT CSS custom properties. A new `--var` has to be
+ * registered in CAMEL_TO_CSS (lib/theme/applyDocumentTheme.ts), DEFAULT_THEME_FLAT,
+ * ALLOWED_THEME_KEYS (lib/services/admin/branding.service.ts) and the Python serializer,
+ * or it is silently dropped. These values never vary per tenant, so a constant is honest.
+ *
+ * Values are taken from the shipped student dashboard (components/dashboard/v2/*) and
+ * ModulePageHeader rather than from the token file, because the two disagree:
+ * --primary-500 is #a855f7 while the dashboard's violet is #7c3aed. Signing in should
+ * look like the product you land in, so the dashboard wins.
+ *
+ * See DESIGN.md for the reasoning behind each value.
+ */
+
+export const AUTH = {
+  ink: "#0f172a",
+  inkMuted: "#475569",
+  inkFaint: "#64748b",
+
+  canvas: "#fbfbfd",
+  surface: "#ffffff",
+  hairline: "#e6e8ef",
+
+  violet: "#7c3aed",
+  violetDeep: "#5b21b6",
+  violetSoft: "#f5f0ff",
+  pink: "#ec4899",
+
+  night: "#140b2b",
+  night2: "#1e1040",
+
+  error: "#dc2626",
+  errorSoft: "#fef2f2",
+} as const;
+
+/** 4px base rhythm. */
+export const SPACE = { xs: 8, sm: 12, md: 16, lg: 24, xl: 32, xxl: 48 } as const;
+
+export const RADIUS = 8;
+
+/** Everything except toggles. Pills are a 2021 tell. */
+export const CONTROL_HEIGHT = 44;
+
+export const EASE = "cubic-bezier(.175,.885,.32,1.1)";
+
+/**
+ * The focus ring. The inner canvas-colored buffer is the whole trick: it guarantees the
+ * ring separates from whatever sits behind the control, on any surface.
+ */
+export const focusRing = (buffer: string = AUTH.canvas) =>
+  `0 0 0 2px ${buffer}, 0 0 0 4px ${AUTH.violet}`;
+
+/** Drawn as a shadow, not a border, so focus causes zero layout shift. */
+export const hairlineRing = (color: string = AUTH.hairline) => `0 0 0 1px ${color}`;
+
+export const FONT = `var(--font-family-primary, 'Satoshi'), system-ui, sans-serif`;
+
+/**
+ * Type scale. Tracking tightens as size grows; the eyebrow tier moves the other way.
+ * Those opposing directions do the hierarchy work a second typeface would be hired for.
+ */
+export const TYPE = {
+  display: { fontSize: 44, lineHeight: 1.06, fontWeight: 500, letterSpacing: "-1.4px" },
+  title: { fontSize: 30, lineHeight: 1.15, fontWeight: 600, letterSpacing: "-0.6px" },
+  section: { fontSize: 20, lineHeight: 1.3, fontWeight: 600, letterSpacing: "-0.3px" },
+  body: { fontSize: 15, lineHeight: 1.5, fontWeight: 400, letterSpacing: 0 },
+  label: { fontSize: 13, lineHeight: 1.4, fontWeight: 500, letterSpacing: 0 },
+  eyebrow: { fontSize: 12, lineHeight: 1.4, fontWeight: 500, letterSpacing: "0.4px" },
+} as const;
+
+/**
+ * Arabic script joins cursively, so letter-spacing breaks it and uppercase is a no-op.
+ * Any tier carrying positive tracking must drop it under RTL.
+ */
+export const rtlSafeTracking = {
+  '[dir="rtl"] &': { letterSpacing: "normal", textTransform: "none" },
+} as const;
+
+/** Primary action. Solid, never a gradient: the gradient CTA failed AA on its light half. */
+export const authPrimaryButtonSx = {
+  minHeight: CONTROL_HEIGHT,
+  py: 1.25,
+  borderRadius: `${RADIUS}px`,
+  background: AUTH.violet,
+  color: "#ffffff",
+  fontFamily: FONT,
+  fontWeight: 500,
+  fontSize: "0.9375rem",
+  letterSpacing: 0,
+  textTransform: "none" as const,
+  boxShadow: "none",
+  transition: `background 160ms ${EASE}`,
+  "&:hover": { background: AUTH.violetDeep, boxShadow: "none" },
+  "&:active": { background: AUTH.violetDeep },
+  "&.Mui-focusVisible, &:focus-visible": {
+    outline: "none",
+    boxShadow: focusRing(),
+  },
+} as const;
+
+export const authSecondaryButtonSx = {
+  minHeight: CONTROL_HEIGHT,
+  borderRadius: `${RADIUS}px`,
+  border: "none",
+  boxShadow: hairlineRing(),
+  background: AUTH.surface,
+  color: AUTH.ink,
+  fontFamily: FONT,
+  fontWeight: 500,
+  fontSize: "0.9375rem",
+  textTransform: "none" as const,
+  transition: `box-shadow 160ms ${EASE}`,
+  "&:hover": {
+    background: AUTH.surface,
+    border: "none",
+    boxShadow: hairlineRing("#d5d8e3"),
+  },
+  "&.Mui-focusVisible, &:focus-visible": {
+    outline: "none",
+    boxShadow: focusRing(),
+  },
+} as const;
+
+export const authLinkSx = {
+  color: AUTH.violet,
+  fontFamily: FONT,
+  fontWeight: 500,
+  textDecoration: "none",
+  borderRadius: "4px",
+  "&:hover": { textDecoration: "underline" },
+  "&:focus-visible": { outline: "none", boxShadow: focusRing() },
+} as const;

--- a/components/auth/layout/authTokens.ts
+++ b/components/auth/layout/authTokens.ts
@@ -81,7 +81,9 @@ export const rtlSafeTracking = {
 /** Primary action. Solid, never a gradient: the gradient CTA failed AA on its light half. */
 export const authPrimaryButtonSx = {
   minHeight: CONTROL_HEIGHT,
-  py: 1.25,
+  // py:1.25 made content taller than CONTROL_HEIGHT, so the button rendered at 46.3px
+  // while the Google button sat at 44px. Let minHeight bind instead.
+  py: 1,
   borderRadius: `${RADIUS}px`,
   background: AUTH.violet,
   color: "#ffffff",
@@ -102,6 +104,7 @@ export const authPrimaryButtonSx = {
 
 export const authSecondaryButtonSx = {
   minHeight: CONTROL_HEIGHT,
+  py: 1,
   borderRadius: `${RADIUS}px`,
   border: "none",
   boxShadow: hairlineRing(),

--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -7,19 +7,19 @@ test.describe("Login", () => {
 
   test("renders login form", async ({ page }) => {
     await expect(page.getByLabel(/email/i)).toBeVisible();
-    await expect(page.getByLabel(/password/i)).toBeVisible();
-    await expect(page.getByRole("button", { name: /login|sign in/i })).toBeVisible();
+    await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^login$/i })).toBeVisible();
   });
 
   test("shows validation errors on empty submit", async ({ page }) => {
-    await page.getByRole("button", { name: /login|sign in/i }).click();
+    await page.getByRole("button", { name: /^login$/i }).click();
     await expect(page.getByText(/required|email is required/i).first()).toBeVisible();
   });
 
   test("shows error on bad credentials", async ({ page }) => {
     await page.getByLabel(/email/i).fill("bad@example.com");
-    await page.getByLabel(/password/i).fill("wrongpassword");
-    await page.getByRole("button", { name: /login|sign in/i }).click();
+    await page.getByLabel("Password", { exact: true }).fill("wrongpassword");
+    await page.getByRole("button", { name: /^login$/i }).click();
     await expect(page.getByText(/invalid|incorrect|failed/i).first()).toBeVisible({ timeout: 10_000 });
   });
 

--- a/e2e/auth/signup.spec.ts
+++ b/e2e/auth/signup.spec.ts
@@ -6,7 +6,7 @@ test.describe("Signup", () => {
   });
 
   test("renders signup form", async ({ page }) => {
-    await expect(page.getByRole("heading", { name: /sign up|register|create account/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /sign up|register|create (your )?account/i })).toBeVisible();
   });
 
   test("shows validation error for invalid email", async ({ page }) => {
@@ -17,7 +17,7 @@ test.describe("Signup", () => {
   });
 
   test("link back to login works", async ({ page }) => {
-    await page.getByRole("link", { name: /login|sign in/i }).click();
+    await page.getByRole("link", { name: /^sign in$|^login$/i }).click();
     await expect(page).toHaveURL(/login/);
   });
 });

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -316,7 +316,10 @@
     "instructorSignupApprovalNote": "تحقّق من بريدك، ثم انتظر موافقة أحد المسؤولين على حسابك. يمكنك تسجيل الدخول بعد الموافقة.",
     "passwordResetOtpResent": "تم إرسال رمز تحقق جديد.",
     "passwordResetResendHint": "يُعتمد الرمز الأحدث فقط.",
-    "resendFailed": "تعذر إعادة إرسال الرمز الآن. يُرجى المحاولة بعد لحظة."
+    "resendFailed": "تعذر إعادة إرسال الرمز الآن. يُرجى المحاولة بعد لحظة.",
+    "welcomeBack": "مرحباً بعودتك",
+    "createAccount": "أنشئ حسابك",
+    "supporting": "ابدأ من الصفر، أو من حيث توقفت. مسارك يتكيّف معك."
   },
   "dashboard": {
     "welcomeHello": "مرحباً {{name}}!",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -289,7 +289,7 @@
     "forgotPassword": "Forgot Password",
     "email": "Email",
     "password": "Password",
-    "slogan": "Changing the  way  the  world  learns",
+    "slogan": "Changing the way the world learns",
     "orSignInWithEmail": "Or sign in with email",
     "keepMeLoggedIn": "Keep me logged in",
     "forgotPasswordLink": "Forgot password?",
@@ -366,7 +366,10 @@
     "resendFailed": "We couldn’t resend the code just now. Please try again in a moment.",
     "logoutSuccess": "Signed out",
     "takingYouIn": "Taking you in…",
-    "seeYouSoon": "See you soon"
+    "seeYouSoon": "See you soon",
+    "welcomeBack": "Welcome back",
+    "createAccount": "Create your account",
+    "supporting": "Start from scratch, or from where you left off. Your path adapts as you go."
   },
   "dashboard": {
     "welcomeHello": "Hello {{name}}!",


### PR DESCRIPTION
Promotes the auth surface redesign from `stagging` to prod. Verified live on staging.ailinc.com.

**This changes the login screen for every client at once.** `stagging` contains only this work: 8 commits, 17 files, all auth-related. Nothing else is riding along.

## What ships

A from-scratch redesign of login, signup, forgot-password and verify-email on a shared borderless shell, plus the defects the audit found along the way.

| Bug fixed | Was |
|---|---|
| Mobile showed zero tenant branding | shell was `100vh` + `overflow:hidden` with the brand panel `display:none` below md, and could not scroll |
| `100vh` cut off tall forms behind the iOS Safari address bar | same |
| Gradient CTA failed WCAG AA, disabled state 2.13:1 | all four pages, same sx copy-pasted 8 times |
| `focus-visible` defined exactly once on the whole surface | everywhere |
| Password toggle had no accessible name, under 44px | three instances |
| Signup email was `autocomplete="off"`, a WCAG 2.2 SC 3.3.8 failure | signup |
| Signup Google button read "Sign in with Google" above "Or sign up with email" | shared component |
| Controls at three different heights (54.6 / 46.3 / 44px) | MUI padding beat `minHeight` |
| Form shifted 22.8px when validation failed | helper text rendered only on error |
| Slogan highlight keyed on the English words "the" and "world" | did nothing in Arabic or for tenant slogans |

## Verified on staging.ailinc.com

- CTA contrast **5.70:1** (passes AA), labels 7.33:1
- Focus ring live: `0 0 0 2px #fbfbfd, 0 0 0 4px #7c3aed`
- All controls **44.0px**; validation shift **0.8px**
- Google Sign-In loads and takes clicks (fallback button correctly `aria-hidden`)
- Zero new console errors
- Three tenant states checked: hero tenant with a low-res logo, clean-logo tenant, and backend-down fallback
- `next build`, `tsc --noEmit`, 22/22 vitest, 8/8 auth e2e

## Known, out of scope

Arabic is unreachable for a logged-out visitor (no language switcher on the auth pages, stored language never restored), `stylis-plugin-rtl` is absent so MUI physical properties never mirror, `OtpDigitInput` strips Arabic-Indic digits, and the signup name regex rejects Arabic names. All documented in DESIGN.md §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)