### PR TITLE
feat(branding): upload buttons for app logo, email logo and favicon

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -21,12 +21,17 @@ import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import {
   fetchClientBranding,
   patchClientBranding,
+  uploadBrandingImage,
   uploadFavicon,
 } from "@/lib/services/admin/branding.service";
+import { MediaField } from "@/components/admin/branding/MediaField";
 
 const FAVICON_ACCEPT =
-  "image/png,image/x-icon,image/vnd.microsoft.icon,image/svg+xml";
-const LOGO_URL_MAX = 200;
+  "image/png,image/webp,image/x-icon,image/vnd.microsoft.icon";
+const BRANDING_ACCEPT = "image/png,image/jpeg,image/webp";
+// Matches Client.URLField(max_length=2048). This was 200, which is what produced
+// "Logo URL is too long (max 200 characters)" on any real CDN or storage URL.
+const LOGO_URL_MAX = 2048;
 
 function SettingCard({
   icon,
@@ -291,7 +296,10 @@ export default function AdminSettingsPage() {
   const [saving, setSaving] = useState(false);
   const [uploadingFavicon, setUploadingFavicon] = useState(false);
   const [logoUrl, setLogoUrl] = useState("");
+  const [appLogoUrl, setAppLogoUrl] = useState("");
   const [faviconUrl, setFaviconUrl] = useState("");
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [uploadingAppLogo, setUploadingAppLogo] = useState(false);
   const [loginSlogan, setLoginSlogan] = useState("");
   const faviconInputRef = useRef<HTMLInputElement>(null);
 
@@ -302,6 +310,7 @@ export default function AdminSettingsPage() {
         const b = await fetchClientBranding();
         if (!alive) return;
         setLogoUrl(b.login_logo_url || "");
+        setAppLogoUrl(b.app_logo_url || "");
         setFaviconUrl(b.app_icon_url || "");
         const ts = (b.theme_settings || {}) as Record<string, unknown>;
         setLoginSlogan(typeof ts.loginHeroSlogan === "string" ? ts.loginHeroSlogan : "");
@@ -315,6 +324,33 @@ export default function AdminSettingsPage() {
       alive = false;
     };
   }, [showToast]);
+
+  /**
+   * Uploads go to our own S3 and come back as a stable asset URL, never an S3 URL. A
+   * persisted S3 URL is either de-signed (403 straight away) or signed and expiring in 7 days.
+   */
+  const makeUploadHandler = (
+    setUrl: (v: string) => void,
+    setBusy: (v: boolean) => void,
+    what: string
+  ) => async (file: File) => {
+    setBusy(true);
+    try {
+      const res = await uploadBrandingImage(file);
+      setUrl(res.url || "");
+      showToast(`${what} uploaded. Click Save to apply.`, "success");
+    } catch (e) {
+      showToast(
+        e instanceof Error && e.message ? e.message : `${what} upload failed.`,
+        "error"
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleLogoUpload = makeUploadHandler(setLogoUrl, setUploadingLogo, "Logo");
+  const handleAppLogoUpload = makeUploadHandler(setAppLogoUrl, setUploadingAppLogo, "Logo");
 
   const handleFaviconFile = async (file: File | undefined) => {
     if (!file) return;
@@ -385,6 +421,7 @@ export default function AdminSettingsPage() {
     try {
       await patchClientBranding({
         login_logo_url: logo || null,
+        app_logo_url: appLogoUrl.trim() || null,
         app_icon_url: faviconUrl.trim() || null,
         theme_settings: { loginHeroSlogan: loginSlogan },
       });
@@ -435,38 +472,41 @@ export default function AdminSettingsPage() {
             tourId="settings-logo"
             icon="mdi:image-outline"
             title="App logo"
-            description="The logo shown in the sidebar and on the login page. Paste a hosted image URL (PNG, SVG, JPG)."
+            description="Shown in the sidebar and on the login page. Upload an image, or paste a permanent image URL."
           >
-            <TextField
-              fullWidth
-              size="small"
+            <MediaField
+              label="Logo"
               value={logoUrl}
-              onChange={(e) => setLogoUrl(e.target.value)}
-              placeholder="https://…/logo.png"
-              helperText="Paste the whole URL — including any “?…” at the end. SVG works."
-              sx={{ "& .MuiOutlinedInput-root": { borderRadius: 2 } }}
+              onChange={setLogoUrl}
+              onUpload={handleLogoUpload}
+              uploading={uploadingLogo}
+              accept={BRANDING_ACCEPT}
+              aspect="landscape"
+              brandText={clientInfo?.name || undefined}
+              helperText="PNG, JPEG or WEBP, up to 2MB. Uploads are hosted by us, so the link never expires."
             />
-            {logoUrl.trim() && (
-              <Box
-                sx={{
-                  mt: 1.5,
-                  p: 1.5,
-                  borderRadius: 2,
-                  border: "1px dashed var(--border-default)",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 1,
-                  bgcolor: "#0f0518",
-                }}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={logoUrl}
-                  alt="Logo preview"
-                  style={{ maxHeight: 40, maxWidth: 200, objectFit: "contain" }}
-                />
-              </Box>
-            )}
+          </SettingCard>
+
+          {/* Email & certificate logo — Client.app_logo_url.
+              Separate column from the login logo above, and until now it had no tenant-admin
+              write path at all: only a superadmin or the setup wizard could change it, so every
+              transactional email and certificate kept whatever was set at provisioning time. */}
+          <SettingCard
+            icon="mdi:email-outline"
+            title="Email & certificate logo"
+            description="Used on transactional emails and issued certificates. Often the same as your app logo."
+          >
+            <MediaField
+              label="Logo"
+              value={appLogoUrl}
+              onChange={setAppLogoUrl}
+              onUpload={handleAppLogoUpload}
+              uploading={uploadingAppLogo}
+              accept={BRANDING_ACCEPT}
+              aspect="landscape"
+              brandText={clientInfo?.name || undefined}
+              helperText="Emails render on a light background, so a logo with a transparent or white background works best."
+            />
           </SettingCard>
 
           {/* Favicon */}
@@ -474,37 +514,23 @@ export default function AdminSettingsPage() {
             tourId="settings-favicon"
             icon="mdi:star-circle-outline"
             title="Favicon"
-            description="The small icon shown in the browser tab. Paste a hosted image URL or upload a square PNG, ICO, or SVG (32×32 or larger)."
+            description="The small icon in the browser tab. Upload a square image, or paste a permanent image URL."
           >
-            <input
-              ref={faviconInputRef}
-              type="file"
-              accept={FAVICON_ACCEPT}
-              hidden
-              onChange={(e) => handleFaviconFile(e.target.files?.[0])}
-            />
-            <TextField
-              label="Favicon URL"
-              placeholder="https://…/favicon.png"
-              fullWidth
-              size="small"
+            <MediaField
+              label="Favicon"
               value={faviconUrl}
-              onChange={(e) => setFaviconUrl(e.target.value)}
-              helperText="Keep the whole URL — including any “?…” at the end. Then Save to apply."
+              onChange={setFaviconUrl}
+              onUpload={(file) => handleFaviconFile(file)}
+              uploading={uploadingFavicon}
+              accept={FAVICON_ACCEPT}
+              aspect="square"
+              helperText="PNG, WEBP or ICO, square, 32×32 or larger."
             />
-            <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", mt: 1.5 }}>
-              <HeaderActionButton
-                icon={uploadingFavicon ? "mdi:loading" : "mdi:upload"}
-                variant="ghost"
-                onClick={() => faviconInputRef.current?.click()}
-                disabled={uploadingFavicon}
-              >
-                {uploadingFavicon ? "Uploading…" : "Upload instead"}
-              </HeaderActionButton>
-              {faviconUrl.trim() && (
+            {faviconUrl.trim() && (
+              <Box sx={{ mt: 1.5 }}>
                 <FaviconTabPreview url={faviconUrl.trim()} appName={clientInfo?.name || "Your app"} />
-              )}
-            </Box>
+              </Box>
+            )}
           </SettingCard>
 
           {/* Login page text */}

--- a/lib/services/admin/branding.service.ts
+++ b/lib/services/admin/branding.service.ts
@@ -27,6 +27,8 @@ export interface BrandingGetResponse {
   login_img_url: string | null;
   login_logo_url: string | null;
   app_icon_url: string | null;
+  /** The wordmark used by transactional emails and issued certificates. */
+  app_logo_url: string | null;
   theme_preset_id: string | null;
 }
 
@@ -36,10 +38,14 @@ export interface BrandingPatchBody {
   login_img_url?: string | null;
   login_logo_url?: string | null;
   app_icon_url?: string | null;
+  app_logo_url?: string | null;
 }
 
 const clientId = () => Number(config.clientId);
-const BRANDING_URL_MAX_LEN = 200;
+// Matches Client.URLField(max_length=2048) and the backend's _CLIENT_URL_MAX_LEN. This sat at
+// 200 long after the columns were widened, and it threw before the request was even sent, which
+// surfaced as the generic "Couldn't save settings" toast with no clue what was wrong.
+const BRANDING_URL_MAX_LEN = 2048;
 const ALLOWED_THEME_KEYS = new Set([
   "primary50",
   "primary100",
@@ -201,6 +207,7 @@ export async function patchClientBranding(
   normalizedBody.login_img_url = normalizeBrandingUrl(body.login_img_url);
   normalizedBody.login_logo_url = normalizeBrandingUrl(body.login_logo_url);
   normalizedBody.app_icon_url = normalizeBrandingUrl(body.app_icon_url);
+  normalizedBody.app_logo_url = normalizeBrandingUrl(body.app_logo_url);
   normalizedBody.theme_settings = sanitizeThemeSettings(body.theme_settings);
 
   if (
@@ -225,6 +232,14 @@ export async function patchClientBranding(
   ) {
     throw new Error(
       `app_icon_url is too long after normalization (max ${BRANDING_URL_MAX_LEN} chars).`
+    );
+  }
+  if (
+    typeof normalizedBody.app_logo_url === "string" &&
+    normalizedBody.app_logo_url.length > BRANDING_URL_MAX_LEN
+  ) {
+    throw new Error(
+      `app_logo_url is too long after normalization (max ${BRANDING_URL_MAX_LEN} chars).`
     );
   }
 
@@ -256,5 +271,9 @@ export async function uploadLoginBackground(file: File) {
  * returns a URL - the field name on Client decides how it's used).
  */
 export async function uploadFavicon(file: File) {
+  return uploadLoginBackground(file);
+}
+
+export async function uploadBrandingImage(file: File) {
   return uploadLoginBackground(file);
 }


### PR DESCRIPTION
Frontend half of the tenant image upload feature. Backend is already merged and live on prod (ai-linc-backend#514), so this depends on nothing outstanding.

## What changes

Wires `MediaField` (228 lines, previously imported nowhere) into the branding cards, so every image field offers **Upload** alongside paste-a-URL. Uploads go to our own S3 and come back as a stable asset URL that never expires.

Adds an **"Email & certificate logo"** card for `Client.app_logo_url`. That column drives every transactional email and issued certificate and had no tenant-admin write path at all, so admins could not correct their own outbound branding.

## The reported "max character limit" error

Two stale constants, both predating the columns being widened to 2048:

| Where | Was | Now |
|---|---|---|
| `app/admin/settings/page.tsx` `LOGO_URL_MAX` | 200 | 2048 |
| `lib/services/admin/branding.service.ts` `BRANDING_URL_MAX_LEN` | 200 | 2048 |

The service one threw *before* the request was sent, which surfaced as the generic "Couldn't save settings. Please try again." with no clue what was wrong.

## Copy and accept strings now match reality

They advertised SVG, which the upload endpoint rejects, and the favicon card promised ICO, which it also rejected. SVG stays out deliberately: it is XML that can carry script and there is no CSP in front of these files. ICO now works end to end.

Upload errors surface the server's message, so "File size must not exceed 2MB" reaches the admin instead of "upload failed".

## Verification

`tsc --noEmit` clean, `next build` passes. Backend verified live on prod: the new asset route returns DRF JSON while a missing route returns Django HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)