### PR TITLE
feat(auth): the tenant name leads the brand panel, the logo signs it

### DIFF
--- a/components/auth/layout/AuthRightPanelDefault.tsx
+++ b/components/auth/layout/AuthRightPanelDefault.tsx
@@ -16,23 +16,58 @@ interface AuthRightPanelDefaultProps {
 }
 
 /**
+ * Owned atmosphere: a dot lattice fading from the top-left, plus a violet bloom with a pink
+ * counterweight.
+ *
+ * These exist because the panel used to rely on the tenant's hero image for all of its texture,
+ * which fails in both directions: a low-resolution upload turns into visible compression blocks
+ * at low opacity, and a tenant with no hero at all gets a flat gradient. Neither layer depends
+ * on tenant content, so the panel is finished before any asset arrives.
+ */
+function PanelTexture() {
+  return (
+    <>
+      <Box
+        aria-hidden
+        sx={{
+          position: "absolute",
+          inset: 0,
+          zIndex: 1,
+          pointerEvents: "none",
+          backgroundImage:
+            "radial-gradient(circle at center, rgba(255,255,255,0.15) 0.8px, transparent 0.9px)",
+          backgroundSize: "14px 14px",
+          maskImage: "radial-gradient(120% 95% at 12% 8%, #000 0%, transparent 72%)",
+          WebkitMaskImage: "radial-gradient(120% 95% at 12% 8%, #000 0%, transparent 72%)",
+        }}
+      />
+      <Box
+        aria-hidden
+        sx={{
+          position: "absolute",
+          inset: 0,
+          zIndex: 1,
+          pointerEvents: "none",
+          background:
+            "radial-gradient(60% 44% at 82% 16%, rgba(168,85,247,0.24) 0%, transparent 70%), radial-gradient(52% 40% at 6% 62%, rgba(236,72,153,0.15) 0%, transparent 72%)",
+        }}
+      />
+    </>
+  );
+}
+
+/**
  * The dark brand surface.
  *
- * Three things drive this design:
+ * The tenant's NAME is the mark, set in the panel's own type. The uploaded logo sits in the
+ * footer at a size it can survive.
  *
- * 1. It matches the product you land in. ModulePageHeader and the student dashboard already
- *    define a dark violet identity; auth previously shared none of it, so signing in felt
- *    like a different product.
- *
- * 2. A tenant's uploaded image can never carry the quality of the screen. The old hero branch
- *    rendered `login_img_url` full-bleed and sharp at 50vw, so a small upload was scaled to
- *    ~720px wide and rendered visibly pixelated, with dark text laid straight over it and no
- *    scrim. Here the image sits behind the composition at low opacity, blurred, under a scrim.
- *    The panel is already finished without it; the image only adds texture.
- *
- * 3. No blurred floating blobs, no glassmorphism, no gradient text highlight keyed on the
- *    literal English words "the" and "world" (which did nothing in Arabic and nothing for any
- *    tenant-authored slogan).
+ * This inverts what was here before, where the logo led inside an opaque white chip. That chip
+ * existed purely to rescue logos with a baked-in white background, so it penalised every good
+ * logo to protect against the bad ones, and it read as a sticker on the dark field either way.
+ * Type always looks intentional, so this is the only arrangement whose quality does not depend
+ * on what a tenant happened to upload. It also connects the top of the panel to the headline,
+ * which are now both type rather than two unrelated fragments.
  */
 export function AuthRightPanelDefault({
   clientInfoLoading,
@@ -43,6 +78,7 @@ export function AuthRightPanelDefault({
   supportingText,
 }: AuthRightPanelDefaultProps) {
   const heroSrc = loginImgUrl?.trim() || "";
+  const displayName = brandName || "AI Linc";
 
   return (
     <Box
@@ -61,10 +97,10 @@ export function AuthRightPanelDefault({
     >
       {heroSrc ? (
         <Box aria-hidden sx={{ position: "absolute", inset: 0, zIndex: 0 }}>
-          {/* Plain <img>, NOT next/image: tenant assets are arbitrary admin-supplied URLs,
-              often SVG or on hosts the optimizer 400s on, and it silently dropped them for
-              many clients. Blur + low opacity is deliberate, not decoration: it makes a
-              low-resolution upload physically incapable of looking broken. */}
+          {/* Plain <img>, NOT next/image: tenant assets are arbitrary admin-supplied URLs, often
+              SVG or on hosts the optimizer 400s on, and it silently dropped them for many
+              clients. The hero now sits UNDER the owned texture rather than instead of it, so a
+              low-resolution upload can no longer be the only thing carrying the panel. */}
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={heroSrc}
@@ -74,7 +110,7 @@ export function AuthRightPanelDefault({
               height: "100%",
               objectFit: "cover",
               objectPosition: "center",
-              opacity: 0.22,
+              opacity: 0.18,
               filter: "blur(2px) saturate(0.85)",
               transform: "scale(1.06)",
             }}
@@ -89,47 +125,46 @@ export function AuthRightPanelDefault({
         </Box>
       ) : null}
 
-      <Box sx={{ position: "relative", zIndex: 1 }}>
+      <PanelTexture />
+
+      {/* Wordmark. The tenant name is already in clientInfo, so this is correct on day one for
+          every tenant with no admin work and nothing to upload. */}
+      <Box sx={{ position: "relative", zIndex: 2 }}>
         {clientInfoLoading ? (
           <Skeleton
-            variant="rounded"
-            width={150}
-            height={36}
-            sx={{ bgcolor: "rgba(255,255,255,0.10)", borderRadius: `${RADIUS}px` }}
+            variant="text"
+            width={190}
+            height={30}
+            sx={{ bgcolor: "rgba(255,255,255,0.10)" }}
           />
-        ) : logoUrl ? (
-          /* A light chip, not a bare image. Tenant logos are arbitrary uploads: transparent
-             SVGs sit fine on dark, but a raster with a baked-in white background reads as a
-             sticker floating on the panel. The chip makes both look deliberate. */
-          <Box
-            sx={{
-              display: "inline-flex",
-              alignItems: "center",
-              justifyContent: "center",
-              px: 1.75,
-              py: 1.25,
-              borderRadius: `${RADIUS}px`,
-              backgroundColor: "rgba(255,255,255,0.94)",
-              maxWidth: 220,
-            }}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={logoUrl}
-              alt={brandName || "Logo"}
-              style={{ maxHeight: 28, maxWidth: 180, objectFit: "contain", display: "block" }}
+        ) : (
+          <>
+            <Typography
+              component="p"
+              sx={{
+                ...TYPE.section,
+                fontFamily: FONT,
+                color: "#ffffff",
+                '[dir="rtl"] &': { letterSpacing: "normal" },
+              }}
+            >
+              {displayName}
+            </Typography>
+            <Box
+              aria-hidden
+              sx={{
+                width: 34,
+                height: 2,
+                mt: 1.25,
+                borderRadius: "2px",
+                background: `linear-gradient(90deg, ${AUTH.violet}, ${AUTH.pink})`,
+              }}
             />
-          </Box>
-        ) : brandName ? (
-          <Typography
-            sx={{ ...TYPE.section, fontFamily: FONT, color: "#ffffff" }}
-          >
-            {brandName}
-          </Typography>
-        ) : null}
+          </>
+        )}
       </Box>
 
-      <Box sx={{ position: "relative", zIndex: 1, maxWidth: 460 }}>
+      <Box sx={{ position: "relative", zIndex: 2, maxWidth: 460 }}>
         {clientInfoLoading ? (
           <>
             <Skeleton
@@ -176,33 +211,20 @@ export function AuthRightPanelDefault({
         ) : null}
       </Box>
 
-      <Box
-        sx={{
-          position: "relative",
-          zIndex: 1,
-          display: "flex",
-          alignItems: "center",
-          gap: 1.25,
-        }}
-      >
-        <Box
-          sx={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            backgroundColor: AUTH.pink,
-          }}
-        />
-        <Typography
-          sx={{
-            ...TYPE.eyebrow,
-            fontFamily: FONT,
-            color: "rgba(255,255,255,0.55)",
-            '[dir="rtl"] &': { letterSpacing: "normal" },
-          }}
-        >
-          {brandName || "AI Linc"}
-        </Typography>
+      {/* The uploaded logo, demoted to the footer where 28px is the right size rather than an
+          accident. No chip: at this scale a mark reads as a signature, and a tenant who never
+          uploaded one simply has a cleaner panel instead of a hole. */}
+      <Box sx={{ position: "relative", zIndex: 2, minHeight: 28, display: "flex", alignItems: "center" }}>
+        {clientInfoLoading ? (
+          <Skeleton variant="rounded" width={110} height={22} sx={{ bgcolor: "rgba(255,255,255,0.08)" }} />
+        ) : logoUrl ? (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={logoUrl}
+            alt={brandName || "Logo"}
+            style={{ maxHeight: 28, maxWidth: 170, objectFit: "contain", opacity: 0.8 }}
+          />
+        ) : null}
       </Box>
     </Box>
   );
@@ -211,8 +233,9 @@ export function AuthRightPanelDefault({
 /**
  * Compact dark bar for phones, where the panel above is not rendered.
  *
- * Without this a tenant's users saw zero branding on mobile: the brand panel is display:none
- * below md, and the old shell could not scroll to reveal anything anyway.
+ * Same inversion as the desktop panel: the name leads as type, and the uploaded logo trails it
+ * small. Without this a tenant's users saw zero branding on mobile, because the brand panel is
+ * display:none below md.
  */
 export function AuthMobileBrandBar({
   logoUrl,
@@ -223,6 +246,8 @@ export function AuthMobileBrandBar({
   brandName: string;
   clientInfoLoading: boolean;
 }) {
+  const displayName = brandName || "AI Linc";
+
   return (
     <Box
       sx={{
@@ -231,45 +256,51 @@ export function AuthMobileBrandBar({
         minHeight: 76,
         display: "flex",
         alignItems: "center",
-        gap: 1.5,
+        justifyContent: "space-between",
+        gap: 2,
         backgroundColor: AUTH.night,
         backgroundImage: `radial-gradient(120% 200% at 4% 120%, ${AUTH.violet}4d 0%, transparent 62%), linear-gradient(160deg, ${AUTH.night2} 0%, ${AUTH.night} 70%)`,
       }}
     >
       {clientInfoLoading ? (
-        <Skeleton
-          variant="rounded"
-          width={120}
-          height={28}
-          sx={{ bgcolor: "rgba(255,255,255,0.10)" }}
-        />
-      ) : logoUrl ? (
-        // Same light chip as the desktop panel, for the same reason: a tenant logo with a
-        // baked-in white background reads as a sticker when placed bare on dark.
-        <Box
-          sx={{
-            display: "inline-flex",
-            alignItems: "center",
-            px: 1.25,
-            py: 0.75,
-            borderRadius: `${RADIUS}px`,
-            backgroundColor: "rgba(255,255,255,0.94)",
-          }}
-        >
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={logoUrl}
-            alt={brandName || "Logo"}
-            style={{ maxHeight: 24, maxWidth: 150, objectFit: "contain", display: "block" }}
+        <Skeleton variant="text" width={140} height={24} sx={{ bgcolor: "rgba(255,255,255,0.10)" }} />
+      ) : (
+        <Box sx={{ minWidth: 0 }}>
+          <Typography
+            component="p"
+            sx={{
+              ...TYPE.body,
+              fontFamily: FONT,
+              fontWeight: 600,
+              color: "#ffffff",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {displayName}
+          </Typography>
+          <Box
+            aria-hidden
+            sx={{
+              width: 26,
+              height: 2,
+              mt: 0.75,
+              borderRadius: `${RADIUS}px`,
+              background: `linear-gradient(90deg, ${AUTH.violet}, ${AUTH.pink})`,
+            }}
           />
         </Box>
-      ) : (
-        <Typography
-          sx={{ ...TYPE.section, fontFamily: FONT, color: "#ffffff" }}
-        >
-          {brandName || "AI Linc"}
-        </Typography>
       )}
+
+      {!clientInfoLoading && logoUrl ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={logoUrl}
+          alt={brandName || "Logo"}
+          style={{ maxHeight: 22, maxWidth: 96, objectFit: "contain", opacity: 0.8, flex: "none" }}
+        />
+      ) : null}
     </Box>
   );
 }


### PR DESCRIPTION
Fixes the two complaints from the live screenshots: the logo looks bad, and on demo the texture is not even visible.

They are the same root cause. The panel was leaning on tenant-uploaded assets for both its mark and its atmosphere, so its quality was capped by whatever the tenant happened to upload.

## Before

- **The chip is a sticker.** An opaque white rectangle on a dark field. It existed purely to rescue logos with a baked-in white background, so it penalised every good logo to protect against the bad ones.
- **28px in a 900px column.** Too small to register as branding, too big for a footnote, and unrelated to the headline 500px below.
- **The texture was the tenant's hero at 22% opacity.** A low-res upload became visible compression blocks (CodePaathshala); no upload at all left a flat gradient (Demo Client).

## After

The tenant **name** is the mark, set in the panel's own type with a short violet-to-pink rule. The uploaded logo moves to the footer at 28px, where that size is a deliberate signature rather than an accident.

Type always looks intentional, so this is the only arrangement whose result does not depend on the tenant's asset. `clientInfo.name` is already in the payload, so every tenant looks right immediately with nothing to upload and no admin work.

The texture is now owned: a dot lattice masked to fade from the top-left, plus a violet bloom with a pink counterweight. A tenant hero, when present, sits **under** those rather than instead of them.

Same inversion on the mobile bar.

## Verified

Three tenants at 1440x900 and 390x844: CodePaathshala (low-res raster logo and hero), Demo Client (clean logo, no hero), plus the loading skeleton. `tsc --noEmit` clean, `next build` passes, 22/22 vitest.

Direction picked from a comparison board where each option was rendered against both a clean mark and the worst real tenant asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)