### PR TITLE
feat(profile): upload a profile picture or cover photo instead of pasting a link

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -199,6 +199,13 @@ export default function ProfilePage() {
               await handleSaveProfile({ cover_photo_url: url || null });
               showToast(url ? t("profile.coverPhotoUpdated") : t("profile.coverPhotoCleared"), "success");
             }}
+            onUploadCover={async (file: File) => {
+              // The endpoint writes the column itself and returns a permanent URL of ours, so
+              // there is no separate save step and nothing that can expire.
+              const { cover_photo_url } = await profileService.uploadCoverPhoto(file);
+              setProfile((prev) => (prev ? { ...prev, cover_photo_url } : prev));
+              showToast(t("profile.coverPhotoUpdated"), "success");
+            }}
           />
           <Box
             sx={{
@@ -219,6 +226,11 @@ export default function ProfilePage() {
               onEditProfilePicUrl={async (url: string) => {
                 await handleSaveProfile({ profile_picture: url || null });
                 showToast(url ? t("profile.profilePictureUpdated") : t("profile.profilePictureCleared"), "success");
+              }}
+              onUploadProfilePic={async (file: File) => {
+                const { profile_picture } = await profileService.uploadProfilePicture(file);
+                setProfile((prev) => (prev ? { ...prev, profile_picture } : prev));
+                showToast(t("profile.profilePictureUpdated"), "success");
               }}
               onEditHeadline={async (newHeadline: string) => {
                 await handleSaveProfile({ headline: newHeadline.trim() || null });

--- a/components/profile/CoverPhoto.tsx
+++ b/components/profile/CoverPhoto.tsx
@@ -9,10 +9,11 @@ import { ImageUrlDialog } from "./ImageUrlDialog";
 
 interface CoverPhotoProps {
   coverPhotoUrl?: string;
+  onUploadCover?: (file: File) => Promise<void>;
   onEditCoverUrl?: (url: string) => Promise<void>;
 }
 
-export function CoverPhoto({ coverPhotoUrl, onEditCoverUrl }: CoverPhotoProps) {
+export function CoverPhoto({ coverPhotoUrl, onEditCoverUrl, onUploadCover }: CoverPhotoProps) {
   const { t } = useTranslation("common");
   const [hovered, setHovered] = useState(false);
   const [urlDialogOpen, setUrlDialogOpen] = useState(false);
@@ -114,6 +115,7 @@ export function CoverPhoto({ coverPhotoUrl, onEditCoverUrl }: CoverPhotoProps) {
           open={urlDialogOpen}
           onClose={() => setUrlDialogOpen(false)}
           onSave={onEditCoverUrl}
+          onUpload={onUploadCover}
           title={t("profile.editCoverPhoto")}
           subtitle="Paste an image URL to use as your cover photo"
           currentImageUrl={coverPhotoUrl}

--- a/components/profile/ImageUrlDialog.tsx
+++ b/components/profile/ImageUrlDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useRef, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog,
@@ -23,7 +23,16 @@ interface ImageUrlDialogProps {
   subtitle?: string;
   currentImageUrl?: string;
   placeholder?: string;
+  /**
+   * When provided, the dialog offers uploading from the device alongside pasting a URL.
+   * Uploads go to our own storage and come back as a permanent URL, which is why this is
+   * the better path: a pasted link can rot, expire, or point at a host that blocks hotlinking.
+   */
+  onUpload?: (file: File) => Promise<void>;
 }
+
+const UPLOAD_ACCEPT = "image/png,image/jpeg,image/webp,image/gif";
+const UPLOAD_MAX_MB = 10;
 
 function isValidUrl(s: string): boolean {
   const trimmed = s.trim();
@@ -44,10 +53,37 @@ export function ImageUrlDialog({
   subtitle,
   currentImageUrl,
   placeholder = "https://example.com/your-image.jpg",
+  onUpload,
 }: ImageUrlDialogProps) {
   const { t } = useTranslation("common");
   const [urlValue, setUrlValue] = useState(currentImageUrl || "");
   const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file || !onUpload) return;
+    setUploadError(null);
+    // Checked here as well as server-side so the user gets the reason instantly rather than
+    // after uploading several megabytes.
+    if (file.size > UPLOAD_MAX_MB * 1024 * 1024) {
+      setUploadError(`That image is ${(file.size / 1024 / 1024).toFixed(1)}MB. The limit is ${UPLOAD_MAX_MB}MB.`);
+      return;
+    }
+    setUploading(true);
+    try {
+      await onUpload(file);
+      onClose();
+    } catch (e) {
+      setUploadError(
+        e instanceof Error && e.message ? e.message : "That upload failed. Please try again."
+      );
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
   const [error, setError] = useState("");
 
   useEffect(() => {
@@ -131,6 +167,69 @@ export function ImageUrlDialog({
         </Box>
       </DialogTitle>
       <DialogContent sx={{ pt: 4.5, px: { xs: 2.5, sm: 3 }, pb: 2, overflow: "auto" }}>
+        {onUpload && (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={UPLOAD_ACCEPT}
+              hidden
+              onChange={(e) => handleFile(e.target.files?.[0])}
+            />
+            <Button
+              fullWidth
+              onClick={() => fileInputRef.current?.click()}
+              disabled={uploading || saving}
+              startIcon={
+                <IconWrapper
+                  icon={uploading ? "mdi:loading" : "mdi:tray-arrow-up"}
+                  size={18}
+                  color="var(--accent-indigo)"
+                />
+              }
+              sx={{
+                mt: 1,
+                py: 1.4,
+                borderRadius: 1.5,
+                textTransform: "none",
+                fontWeight: 600,
+                fontSize: "0.9375rem",
+                color: "var(--accent-indigo)",
+                border: "1px dashed color-mix(in srgb, var(--accent-indigo) 45%, transparent)",
+                backgroundColor: "color-mix(in srgb, var(--accent-indigo) 5%, transparent)",
+                "&:hover": {
+                  backgroundColor: "color-mix(in srgb, var(--accent-indigo) 10%, transparent)",
+                  border: "1px dashed var(--accent-indigo)",
+                },
+              }}
+            >
+              {uploading ? "Uploading…" : "Upload from your device"}
+            </Button>
+            <Typography
+              variant="caption"
+              sx={{ display: "block", mt: 0.75, color: "var(--font-tertiary)", fontSize: "0.75rem" }}
+            >
+              PNG, JPEG, WEBP or GIF, up to {UPLOAD_MAX_MB}MB. Uploaded images are hosted by us,
+              so the link never expires.
+            </Typography>
+            {uploadError && (
+              <Typography
+                role="alert"
+                variant="caption"
+                sx={{ display: "block", mt: 0.75, color: "var(--error-500)", fontSize: "0.75rem" }}
+              >
+                {uploadError}
+              </Typography>
+            )}
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, my: 2.5 }}>
+              <Box sx={{ flex: 1, height: "1px", backgroundColor: "var(--border-default)" }} />
+              <Typography variant="caption" sx={{ color: "var(--font-tertiary)", fontSize: "0.75rem" }}>
+                or paste a link
+              </Typography>
+              <Box sx={{ flex: 1, height: "1px", backgroundColor: "var(--border-default)" }} />
+            </Box>
+          </>
+        )}
         <TextField
           label="Image URL"
           value={urlValue}

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -25,6 +25,7 @@ interface ProfileHeaderProps {
   headline?: string;
   location?: string;
   onEdit?: () => void;
+  onUploadProfilePic?: (file: File) => Promise<void>;
   onEditProfilePicUrl?: (url: string) => Promise<void>;
   onEditHeadline?: (headline: string) => Promise<void>;
 }
@@ -37,6 +38,7 @@ export function ProfileHeader({
   location,
   onEdit,
   onEditProfilePicUrl,
+  onUploadProfilePic,
   onEditHeadline,
 }: ProfileHeaderProps) {
   const { t } = useTranslation("common");
@@ -612,6 +614,7 @@ export function ProfileHeader({
           open={profilePicDialogOpen}
           onClose={() => setProfilePicDialogOpen(false)}
           onSave={onEditProfilePicUrl}
+          onUpload={onUploadProfilePic}
           title={t("profile.editProfilePicture")}
           subtitle="Paste an image URL to use as your profile picture"
           currentImageUrl={profilePicUrl}


### PR DESCRIPTION
Frontend half of profile image upload. Backend is merged and **already live on prod** (ai-linc-backend#516), verified: the upload route now returns 401 for an unauthenticated request instead of the 404 it gave before.

## Why nothing worked before

`profile.service.ts` has shipped `uploadProfilePicture` and `uploadCoverPhoto` for a while, posting to `/user-profile/profile-picture/` and `/user-profile/cover-photo/`. **Neither route existed**, so both would have 404'd. That is why they were called from nowhere and both fields stayed paste-a-URL only.

## What changes

Upload lives inside the dialog both fields already open, rather than as a second dialog: one place, both options, with pasting a link still available under a divider. The upload path leads because an uploaded image is hosted by us and its link never expires, while a pasted link can rot or point at a host that blocks hotlinking.

- Size checked client-side as well as server-side, so the user learns the reason instantly rather than after uploading several megabytes.
- Upload failures surface the server's message rather than a generic error.
- The endpoint writes the column and returns a permanent URL, so there is no separate save step; handlers update local state from the response.

`tsc --noEmit` clean, `next build` passes, 22/22 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)