### PR TITLE
ci: run the unit suite on Node 22, which is what jsdom 30 requires

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # 22, not 20. jsdom 30 pulls undici 8, which calls
+          # `webidl.util.markAsUncloneable` — an API that only exists on Node 22+. On 20 it
+          # is undefined, so jsdom throws while being imported and every test file dies at
+          # load time: "Tests: no tests, Errors: 3 errors". The suite has been red on every
+          # main build since it was introduced, while passing locally on Node 22.
+          node-version: 22
       # --legacy-peer-deps because @tiptap/extension-image pins a @tiptap/core older than the one
       # the starter kit resolves. Pre-existing, unrelated to the tests, and npm refuses to install
       # at all without it.


### PR DESCRIPTION
The `unit` job has failed on **every** build since vitest was introduced in #1217, and the failure has nothing to do with any test.

```
TypeError: webidl.util.markAsUncloneable is not a function
  at new CacheStorage node_modules/undici/lib/web/cache/cachestorage.js:20:17
  at Object.<anonymous> node_modules/jsdom/lib/api.js:12:33

Tests  no tests
Errors  3 errors
```

jsdom 30.0.1 depends on undici 8.9.0, which calls `webidl.util.markAsUncloneable`. That API only exists on **Node 22+**. The workflow pinned Node 20, where it is `undefined`, so jsdom threw while being *imported* and all three test files died before a single test ran.

## Reproduced both ways locally

| Node | Result |
|---|---|
| 20.20.2 | identical `TypeError`, "Tests: no tests", 3 errors |
| 22.22.2 | 3 files, **22/22 pass** |

Node 22 also matches what Next 16 expects, so this aligns CI with local and with the runtime the app is built against.

Leaving the job non-required, per the note at the top of the file.

Held back until now so its deploy previews would not queue behind the auth and branding rollouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)