### PR TITLE
feat(profile): public profile view + declutter the preview card

### DIFF
--- a/app/admin/profile/[id]/page.tsx
+++ b/app/admin/profile/[id]/page.tsx
@@ -3,24 +3,12 @@
 import { useState, useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { useTranslation } from "react-i18next";
-import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { MainLayout } from "@/components/layout/MainLayout";
-import { CoverPhoto } from "@/components/profile/CoverPhoto";
-import { ProfileHeader } from "@/components/profile/ProfileHeader";
-import { ProfileSummary } from "@/components/profile/ProfileSummary";
-import { UserDetailsCard } from "@/components/profile/UserDetailsCard";
-import { AdminProfileSectionsReadOnly } from "@/components/admin/AdminProfileSectionsReadOnly";
-import { ProfilePanel, ProfileSectionHeader, StatTile } from "@/components/profile/theme/surfaces";
-import {
-  PANEL_BORDER,
-  PANEL_RADIUS,
-  PANEL_SHADOW,
-  PROFILE,
-  STAT_ACCENT,
-} from "@/components/profile/theme/profileTokens";
-import { calculateProfileCompletion } from "@/lib/utils/profileCompletion";
+import { PublicProfileView } from "@/components/profile/PublicProfileView";
+import { PROFILE } from "@/components/profile/theme/profileTokens";
 import { adminProfileService } from "@/lib/services/admin/admin-profile.service";
 import { useToast } from "@/components/common/Toast";
 import type { UserProfile } from "@/lib/services/profile.service";
@@ -102,21 +90,6 @@ export default function AdminProfilePage() {
     );
   }
 
-  const location =
-    profile.city && profile.state
-      ? `${profile.city}, ${profile.state}`
-      : profile.city || profile.state || "";
-
-  const completion = calculateProfileCompletion(profile);
-  const sectionsFilled = [
-    profile.skills,
-    profile.experience,
-    profile.education,
-    profile.projects,
-    profile.certifications,
-    profile.achievements,
-  ].filter((s) => Array.isArray(s) && s.length > 0).length;
-
   return (
     <MainLayout fullWidthContent>
       {/* Same palette scope as the student page. This view deliberately keeps the LinkedIn
@@ -151,199 +124,12 @@ export default function AdminProfilePage() {
           {t("common.back")}
         </Button>
 
-        {/* Cover, then avatar. One card so the photo, the name and the read-only badge read
-            as a single object instead of three stacked full-bleed bands. */}
-        <Box
-          sx={{
-            borderRadius: PANEL_RADIUS,
-            border: PANEL_BORDER,
-            bgcolor: PROFILE.surface,
-            boxShadow: PANEL_SHADOW,
-            overflow: "hidden",
-            mb: 2.5,
-          }}
-        >
-          <Box sx={{ position: "relative" }}>
-            <CoverPhoto coverPhotoUrl={profile.cover_photo_url ?? undefined} />
-            <Box
-              sx={{
-                position: "absolute",
-                top: 14,
-                insetInlineEnd: 16,
-                px: 1.25,
-                py: 0.5,
-                borderRadius: 999,
-                bgcolor: "rgba(255,255,255,0.92)",
-                color: PROFILE.ink,
-                fontSize: "0.68rem",
-                fontWeight: 800,
-                letterSpacing: 0.4,
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 0.5,
-              }}
-            >
-              <IconWrapper icon="mdi:eye-outline" size={13} />
-              {t("profile.adminReadOnly", { defaultValue: "Read only" })}
-            </Box>
-          </Box>
-          <ProfileHeader
-            userName={`${profile.first_name} ${profile.last_name}`}
-            profilePicUrl={profile.profile_picture}
-            role={profile.role || t("profile.student")}
-            headline={profile.headline ?? undefined}
-            location={location}
-          />
-        </Box>
-
-        {/* Read-only signal row. The student sees these as things to finish; an admin sees
-            them as facts about the student, so they render as stat tiles, not as a nag. */}
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "repeat(2,1fr)", sm: "repeat(4,1fr)" },
-            gap: 1.5,
-            mb: 2.5,
-          }}
-        >
-          <StatTile
-            label={t("profile.profileStrength")}
-            value={`${completion.percentage}%`}
-            sub={`${completion.completedFields}/${completion.totalFields} ${t("profile.completed").toLowerCase()}`}
-            icon="mdi:account-check-outline"
-            accent={STAT_ACCENT.violet}
-          />
-          <StatTile
-            label={t("profile.sectionsFilled", { defaultValue: "Sections filled" })}
-            value={`${sectionsFilled}`}
-            sub={t("profile.ofSix", { defaultValue: "of 6" })}
-            icon="mdi:view-list-outline"
-            accent={STAT_ACCENT.amber}
-          />
-          <StatTile
-            label={t("profile.skillsListed", { defaultValue: "Skills listed" })}
-            value={`${profile.skills?.length ?? 0}`}
-            icon="mdi:lightning-bolt-outline"
-            accent={STAT_ACCENT.blue}
-          />
-          <StatTile
-            label={t("profile.experienceEntries", { defaultValue: "Experience" })}
-            value={`${profile.experience?.length ?? 0}`}
-            sub={t("profile.entries", { defaultValue: "entries" })}
-            icon="mdi:briefcase-outline"
-            accent={STAT_ACCENT.green}
-          />
-        </Box>
-
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" },
-            gap: 2.5,
-            alignItems: "start",
-          }}
-        >
-          <Stack spacing={2.5} sx={{ minWidth: 0, order: { xs: 2, lg: 1 } }}>
-            <ProfileSummary profile={profile} readOnly />
-            <AdminProfileInfoCard profile={profile} />
-            <AdminProfileSectionsReadOnly profile={profile} />
-          </Stack>
-
-          <Stack spacing={2.5} sx={{ minWidth: 0, order: { xs: 1, lg: 2 } }}>
-            <UserDetailsCard
-              username={profile.username}
-              emailAddress={profile.email}
-              socialLinks={{
-                github: profile.social_links?.github || "",
-                linkedin: profile.social_links?.linkedin || "",
-              }}
-              externalProfiles={{
-                portfolio_website_url: profile.portfolio_website_url ?? undefined,
-                leetcode_url: profile.leetcode_url ?? undefined,
-                hackerrank_url: profile.hackerrank_url ?? undefined,
-                kaggle_url: profile.kaggle_url ?? undefined,
-                medium_url: profile.medium_url ?? undefined,
-              }}
-            />
-            {clientInfo && (
-              <ProfilePanel>
-                <ProfileSectionHeader
-                  icon="mdi:office-building-outline"
-                  title={t("profile.organization", { defaultValue: "Organization" })}
-                />
-                <Typography sx={{ fontWeight: 700, fontSize: "0.9rem", color: PROFILE.ink }}>
-                  {clientInfo.name || "AI-Linc Learning"}
-                </Typography>
-              </ProfilePanel>
-            )}
-          </Stack>
-        </Box>
+        <PublicProfileView
+          profile={profile}
+          variant="admin"
+          organizationName={clientInfo ? clientInfo.name || "AI-Linc Learning" : undefined}
+        />
       </Box>
     </MainLayout>
-  );
-}
-
-function AdminProfileInfoCard({
-  profile,
-}: {
-  profile: UserProfile;
-}) {
-  const { t } = useTranslation("common");
-  const fields = [
-    { label: t("profile.collegeName"), value: profile.college_name },
-    { label: t("profile.degreeType"), value: profile.degree_type },
-    { label: t("profile.branch"), value: profile.branch },
-    { label: t("profile.graduationYear"), value: profile.graduation_year },
-    { label: t("profile.phoneNumber"), value: profile.phone_number },
-    { label: t("profile.dateOfBirth"), value: profile.date_of_birth },
-  ];
-
-  const filled = fields.filter((f) => f.value).length;
-
-  return (
-    <ProfilePanel>
-      <ProfileSectionHeader
-        icon="mdi:account-details-outline"
-        title={t("profile.personalInformation")}
-        subtitle={t("profile.fieldsFilled", {
-          defaultValue: "{{filled}} of {{total}} filled",
-          filled,
-          total: fields.length,
-        })}
-      />
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", md: "repeat(3, 1fr)" },
-          gap: 2.25,
-        }}
-      >
-        {fields.map(({ label, value }) => (
-          <Box key={label}>
-            <Typography
-              sx={{
-                color: PROFILE.inkFaint,
-                fontSize: "0.68rem",
-                fontWeight: 700,
-                letterSpacing: 0.2,
-              }}
-            >
-              {label}
-            </Typography>
-            <Typography
-              sx={{
-                color: value ? PROFILE.ink : "#cbd5e1",
-                fontWeight: value ? 500 : 400,
-                fontSize: "0.875rem",
-                mt: 0.4,
-                display: "block",
-              }}
-            >
-              {value || t("profile.notAddedYet", { defaultValue: "Not added yet" })}
-            </Typography>
-          </Box>
-        ))}
-      </Box>
-    </ProfilePanel>
   );
 }

--- a/app/profile/preview/page.tsx
+++ b/app/profile/preview/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Box, CircularProgress, Stack, Typography } from "@mui/material";
+import { motion } from "framer-motion";
+import { MainLayout } from "@/components/layout/MainLayout";
+import { PublicProfileView } from "@/components/profile/PublicProfileView";
+import { PROFILE, ON_DARK, HERO_BG, HERO_SHADOW } from "@/components/profile/theme/profileTokens";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { profileService, type UserProfile } from "@/lib/services/profile.service";
+import { useToast } from "@/components/common/Toast";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * "See exactly how my public profile looks."
+ *
+ * Renders PublicProfileView, the same component app/admin/profile/[id] uses, against the
+ * student's own data. Sharing the component rather than rebuilding a lookalike is the whole
+ * point: it is what makes "exactly" true, and keeps it true as the read-only view changes.
+ *
+ * Read-only by construction, not by a flag: no save handler is threaded in, and
+ * PublicProfileView passes no edit callbacks down, so nothing here can mutate the profile.
+ */
+export default function ProfilePreviewPage() {
+  const { t } = useTranslation("common");
+  const { push } = useInstantNavigation();
+  const { showToast } = useToast();
+  const { clientInfo } = useClientInfo();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      // Deliberately the raw API profile, with no localStorage merge. The edit page merges
+      // unsaved local drafts back in so you do not lose typing; showing those here would be
+      // a lie, because nobody else can see a draft that never reached the server.
+      setProfile(await profileService.getUserProfile());
+    } catch {
+      showToast(t("profile.failedToLoad"), "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast, t]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <MainLayout fullWidthContent>
+        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "60vh" }}>
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
+            <CircularProgress size={48} sx={{ color: PROFILE.violet }} />
+          </motion.div>
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <MainLayout fullWidthContent>
+        <Box sx={{ py: 12, textAlign: "center", px: 2 }}>
+          <Typography sx={{ color: PROFILE.inkMuted }}>{t("profile.notFound")}</Typography>
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout fullWidthContent>
+      <Box
+        className="profile-surface"
+        sx={{
+          width: "100%",
+          minHeight: "100vh",
+          bgcolor: PROFILE.canvas,
+          pb: 6,
+          px: { xs: 2, sm: 3, md: 4, lg: 6, xl: 8 },
+          pt: 2.5,
+        }}
+      >
+        {/* A dark bar, not a light one: it has to be obvious at a glance that this is a
+            preview and not the editable page, or a student will try to edit here and think
+            the page is broken. */}
+        <Box
+          sx={{
+            borderRadius: 3,
+            background: HERO_BG,
+            boxShadow: HERO_SHADOW,
+            color: "#fff",
+            px: { xs: 2, sm: 2.5 },
+            py: 1.75,
+            mb: 2.5,
+          }}
+        >
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            spacing={1.5}
+          >
+            <Box
+              sx={{
+                width: 34,
+                height: 34,
+                borderRadius: 2,
+                flexShrink: 0,
+                display: "grid",
+                placeItems: "center",
+                bgcolor: ON_DARK.fillStrong,
+                border: `1px solid ${ON_DARK.border}`,
+              }}
+            >
+              <IconWrapper icon="mdi:earth" size={18} />
+            </Box>
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography sx={{ fontWeight: 800, fontSize: "0.95rem", lineHeight: 1.2 }}>
+                {t("profile.previewTitle", { defaultValue: "This is your public profile" })}
+              </Typography>
+              <Typography sx={{ fontSize: "0.78rem", color: ON_DARK.textFaint, mt: 0.25 }}>
+                {t("profile.previewSubtitle", {
+                  defaultValue: "Exactly what instructors and recruiters see. Nothing here is editable.",
+                })}
+              </Typography>
+            </Box>
+            <Box
+              component="button"
+              onClick={() => push("/profile")}
+              sx={{
+                flexShrink: 0,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.75,
+                px: 2,
+                py: 1,
+                borderRadius: 999,
+                border: `1px solid ${ON_DARK.border}`,
+                bgcolor: ON_DARK.fillStrong,
+                color: "#fff",
+                fontFamily: "inherit",
+                fontWeight: 800,
+                fontSize: "0.8125rem",
+                cursor: "pointer",
+                "&:hover": { bgcolor: "rgba(255,255,255,0.24)" },
+                "&:focus-visible": { outline: "none", boxShadow: `0 0 0 2px ${PROFILE.night}, 0 0 0 4px #fff` },
+              }}
+            >
+              <IconWrapper icon="mdi:pencil-outline" size={16} />
+              {t("profile.backToEditing", { defaultValue: "Back to editing" })}
+            </Box>
+          </Stack>
+        </Box>
+
+        <PublicProfileView
+          profile={profile}
+          variant="preview"
+          organizationName={clientInfo ? clientInfo.name || "AI-Linc Learning" : undefined}
+        />
+      </Box>
+    </MainLayout>
+  );
+}

--- a/components/profile/PublicPreviewCard.tsx
+++ b/components/profile/PublicPreviewCard.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { ImageUrlDialog } from "./ImageUrlDialog";
 import { ProfilePanel } from "./theme/surfaces";
 import { PROFILE } from "./theme/profileTokens";
@@ -58,6 +59,7 @@ export function PublicPreviewCard({
   onEditHeadline,
 }: PublicPreviewCardProps) {
   const { t } = useTranslation("common");
+  const { push } = useInstantNavigation();
   const [coverDialogOpen, setCoverDialogOpen] = useState(false);
   const [picDialogOpen, setPicDialogOpen] = useState(false);
   const [headlineDialogOpen, setHeadlineDialogOpen] = useState(false);
@@ -94,28 +96,32 @@ export function PublicPreviewCard({
             }}
           />
           {onEditCoverUrl && (
-            <Button
-              size="small"
+            // Icon only. A labelled "Change" pill was the largest, highest-contrast thing in
+            // the card, which put the loudest emphasis on its least important action.
+            <Box
+              component="button"
+              aria-label={coverPhotoUrl ? t("profile.changeCoverPhoto") : t("profile.addCoverPhoto")}
               onClick={() => setCoverDialogOpen(true)}
-              startIcon={<IconWrapper icon="mdi:image-edit-outline" size={15} />}
               sx={{
                 position: "absolute",
                 top: 10,
                 insetInlineEnd: 10,
-                minWidth: 0,
-                textTransform: "none",
-                fontSize: "0.72rem",
-                fontWeight: 700,
+                width: 30,
+                height: 30,
+                p: 0,
+                border: 0,
+                borderRadius: "50%",
+                display: "grid",
+                placeItems: "center",
+                cursor: "pointer",
                 color: PROFILE.ink,
-                bgcolor: "rgba(255,255,255,0.92)",
-                borderRadius: 999,
-                px: 1.5,
-                py: 0.5,
+                bgcolor: "rgba(255,255,255,0.9)",
                 "&:hover": { bgcolor: "#fff" },
+                "&:focus-visible": { outline: "none", boxShadow: `0 0 0 2px rgba(15,10,44,.6), 0 0 0 4px #fff` },
               }}
             >
-              {coverPhotoUrl ? t("profile.change") : t("profile.add")}
-            </Button>
+              <IconWrapper icon="mdi:image-edit-outline" size={15} />
+            </Box>
           )}
         </Box>
 
@@ -176,19 +182,19 @@ export function PublicPreviewCard({
             </Box>
           </Stack>
 
-          <Stack direction="row" spacing={0.5} alignItems="flex-start" sx={{ mt: 1.5 }}>
-            <Typography
-              sx={{
-                flex: 1,
-                minWidth: 0,
-                fontSize: "0.8rem",
-                lineHeight: 1.45,
-                color: headline ? PROFILE.inkMuted : "#94a3b8",
-                fontStyle: headline ? "normal" : "italic",
-              }}
-            >
-              {headline || t("profile.addHeadline")}
-            </Typography>
+          {/* The headline's edit pencil sits inline right after the text rather than pushed
+              to the far right, so it reads as attached to what it edits instead of opening a
+              gap across the card. */}
+          <Typography
+            sx={{
+              mt: 1.25,
+              fontSize: "0.8rem",
+              lineHeight: 1.45,
+              color: headline ? PROFILE.inkMuted : "#94a3b8",
+              fontStyle: headline ? "normal" : "italic",
+            }}
+          >
+            {headline || t("profile.addHeadline")}
             {onEditHeadline && (
               <Box
                 component="button"
@@ -198,25 +204,26 @@ export function PublicPreviewCard({
                   setHeadlineDialogOpen(true);
                 }}
                 sx={{
-                  flexShrink: 0,
-                  width: 24,
-                  height: 24,
+                  verticalAlign: "middle",
+                  ml: 0.5,
+                  width: 22,
+                  height: 22,
                   borderRadius: 1.5,
                   border: 0,
                   bgcolor: "transparent",
                   color: PROFILE.violet,
                   cursor: "pointer",
-                  display: "grid",
+                  display: "inline-grid",
                   placeItems: "center",
                   p: 0,
                   "&:hover": { bgcolor: PROFILE.violetSoft },
                   "&:focus-visible": { outline: "none", boxShadow: `0 0 0 2px #fff, 0 0 0 4px ${PROFILE.violet}` },
                 }}
               >
-                <IconWrapper icon="mdi:pencil" size={14} />
+                <IconWrapper icon="mdi:pencil" size={13} />
               </Box>
             )}
-          </Stack>
+          </Typography>
 
           {location && (
             <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.75 }}>
@@ -225,20 +232,36 @@ export function PublicPreviewCard({
             </Stack>
           )}
 
-          <Typography
+          {/* Replaces a divider plus a sentence explaining what the card was for. The button
+              says the same thing in fewer words and, unlike the sentence, does something. */}
+          <Box
+            component="button"
+            onClick={() => push("/profile/preview")}
             sx={{
-              mt: 1.75,
-              pt: 1.5,
-              borderTop: `1px solid ${PROFILE.hairline}`,
-              fontSize: "0.7rem",
-              color: PROFILE.inkFaint,
-              lineHeight: 1.5,
+              mt: 2,
+              width: "100%",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 0.75,
+              py: 1,
+              px: 1.5,
+              borderRadius: 999,
+              border: `1px solid ${PROFILE.violetBorder}`,
+              bgcolor: PROFILE.violetSoft,
+              color: PROFILE.violet,
+              fontFamily: "inherit",
+              fontWeight: 800,
+              fontSize: "0.8125rem",
+              cursor: "pointer",
+              transition: "background .15s",
+              "&:hover": { bgcolor: "#ede9fe" },
+              "&:focus-visible": { outline: "none", boxShadow: `0 0 0 2px #fff, 0 0 0 4px ${PROFILE.violet}` },
             }}
           >
-            {t("profile.publicPreviewNote", {
-              defaultValue: "This is how your profile appears to instructors and recruiters.",
-            })}
-          </Typography>
+            <IconWrapper icon="mdi:earth" size={16} />
+            {t("profile.seePublicView", { defaultValue: "See public view" })}
+          </Box>
         </Box>
       </ProfilePanel>
 

--- a/components/profile/PublicProfileView.tsx
+++ b/components/profile/PublicProfileView.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { Box, Stack, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { CoverPhoto } from "./CoverPhoto";
+import { ProfileHeader } from "./ProfileHeader";
+import { ProfileSummary } from "./ProfileSummary";
+import { UserDetailsCard } from "./UserDetailsCard";
+import { AdminProfileSectionsReadOnly } from "@/components/admin/AdminProfileSectionsReadOnly";
+import { ProfilePanel, ProfileSectionHeader, StatTile } from "./theme/surfaces";
+import { PANEL_BORDER, PANEL_RADIUS, PANEL_SHADOW, PROFILE, STAT_ACCENT } from "./theme/profileTokens";
+import { calculateProfileCompletion } from "@/lib/utils/profileCompletion";
+import type { UserProfile } from "@/lib/services/profile.service";
+
+/**
+ * The read-only rendering of a profile: cover, then the avatar overlapping it, then the
+ * facts. LinkedIn's shape, on the dashboard's palette.
+ *
+ * ONE component with two callers, deliberately:
+ *  - app/admin/profile/[id]  — an admin inspecting a student
+ *  - app/profile/preview     — a student checking their own public view
+ *
+ * The student asked to see "exactly" how their profile looks to other people. Two lookalike
+ * components would answer that on the day they were written and then drift; sharing the
+ * render makes the answer true by construction. The only differences are the badge wording
+ * and whether the completion stat row is shown, both of which are chrome around the same
+ * profile, not the profile itself.
+ *
+ * Note this deliberately does NOT use ProfileBriefingHero. That hero coaches you to finish
+ * your profile, which is meaningless when you are looking at someone else's, and misleading
+ * in a preview that is supposed to show what other people see.
+ */
+
+export interface PublicProfileViewProps {
+  profile: UserProfile;
+  /** "admin" adds the completion stat row; "preview" keeps it to what a viewer would see. */
+  variant: "admin" | "preview";
+  /** Organization name, when the caller has client context. */
+  organizationName?: string;
+}
+
+export function PublicProfileView({ profile, variant, organizationName }: PublicProfileViewProps) {
+  const { t } = useTranslation("common");
+
+  const location =
+    profile.city && profile.state
+      ? `${profile.city}, ${profile.state}`
+      : profile.city || profile.state || "";
+
+  const completion = calculateProfileCompletion(profile);
+  const sectionsFilled = [
+    profile.skills,
+    profile.experience,
+    profile.education,
+    profile.projects,
+    profile.certifications,
+    profile.achievements,
+  ].filter((s) => Array.isArray(s) && s.length > 0).length;
+
+  const badge =
+    variant === "admin"
+      ? { icon: "mdi:eye-outline", label: t("profile.adminReadOnly", { defaultValue: "Read only" }) }
+      : {
+          icon: "mdi:earth",
+          label: t("profile.publicViewBadge", { defaultValue: "Public view" }),
+        };
+
+  return (
+    <>
+      {/* Cover, then avatar. One card so the photo, the name and the badge read as a single
+          object instead of three stacked full-bleed bands. */}
+      <Box
+        sx={{
+          borderRadius: PANEL_RADIUS,
+          border: PANEL_BORDER,
+          bgcolor: PROFILE.surface,
+          boxShadow: PANEL_SHADOW,
+          overflow: "hidden",
+          mb: 2.5,
+        }}
+      >
+        <Box sx={{ position: "relative" }}>
+          <CoverPhoto coverPhotoUrl={profile.cover_photo_url ?? undefined} />
+          <Box
+            sx={{
+              position: "absolute",
+              top: 14,
+              insetInlineEnd: 16,
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 999,
+              bgcolor: "rgba(255,255,255,0.92)",
+              color: PROFILE.ink,
+              fontSize: "0.68rem",
+              fontWeight: 800,
+              letterSpacing: 0.4,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+            }}
+          >
+            <IconWrapper icon={badge.icon} size={13} />
+            {badge.label}
+          </Box>
+        </Box>
+        {/* No edit callbacks passed, so ProfileHeader renders without any edit affordance. */}
+        <ProfileHeader
+          userName={`${profile.first_name ?? ""} ${profile.last_name ?? ""}`.trim()}
+          profilePicUrl={profile.profile_picture}
+          role={profile.role || t("profile.student")}
+          headline={profile.headline ?? undefined}
+          location={location}
+        />
+      </Box>
+
+      {variant === "admin" && (
+        // Facts about the student, for an admin. A student looking at their own public view
+        // does not need this: it is internal chrome, not something a viewer sees.
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "repeat(2,1fr)", sm: "repeat(4,1fr)" },
+            gap: 1.5,
+            mb: 2.5,
+          }}
+        >
+          <StatTile
+            label={t("profile.profileStrength")}
+            value={`${completion.percentage}%`}
+            sub={`${completion.completedFields}/${completion.totalFields} ${t("profile.completed").toLowerCase()}`}
+            icon="mdi:account-check-outline"
+            accent={STAT_ACCENT.violet}
+          />
+          <StatTile
+            label={t("profile.sectionsFilled", { defaultValue: "Sections filled" })}
+            value={`${sectionsFilled}`}
+            sub={t("profile.ofSix", { defaultValue: "of 6" })}
+            icon="mdi:view-list-outline"
+            accent={STAT_ACCENT.amber}
+          />
+          <StatTile
+            label={t("profile.skillsListed", { defaultValue: "Skills listed" })}
+            value={`${profile.skills?.length ?? 0}`}
+            icon="mdi:lightning-bolt-outline"
+            accent={STAT_ACCENT.blue}
+          />
+          <StatTile
+            label={t("profile.experienceEntries", { defaultValue: "Experience" })}
+            value={`${profile.experience?.length ?? 0}`}
+            sub={t("profile.entries", { defaultValue: "entries" })}
+            icon="mdi:briefcase-outline"
+            accent={STAT_ACCENT.green}
+          />
+        </Box>
+      )}
+
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", lg: "minmax(0,1fr) 390px" },
+          gap: 2.5,
+          alignItems: "start",
+        }}
+      >
+        <Stack spacing={2.5} sx={{ minWidth: 0, order: { xs: 2, lg: 1 } }}>
+          <ProfileSummary profile={profile} readOnly />
+          <ReadOnlyInfoCard profile={profile} />
+          <AdminProfileSectionsReadOnly profile={profile} />
+        </Stack>
+
+        <Stack spacing={2.5} sx={{ minWidth: 0, order: { xs: 1, lg: 2 } }}>
+          <UserDetailsCard
+            username={profile.username}
+            emailAddress={profile.email}
+            socialLinks={{
+              github: profile.social_links?.github || "",
+              linkedin: profile.social_links?.linkedin || "",
+            }}
+            externalProfiles={{
+              portfolio_website_url: profile.portfolio_website_url ?? undefined,
+              leetcode_url: profile.leetcode_url ?? undefined,
+              hackerrank_url: profile.hackerrank_url ?? undefined,
+              kaggle_url: profile.kaggle_url ?? undefined,
+              medium_url: profile.medium_url ?? undefined,
+            }}
+          />
+          {organizationName && (
+            <ProfilePanel>
+              <ProfileSectionHeader
+                icon="mdi:office-building-outline"
+                title={t("profile.organization", { defaultValue: "Organization" })}
+              />
+              <Typography sx={{ fontWeight: 700, fontSize: "0.9rem", color: PROFILE.ink }}>
+                {organizationName}
+              </Typography>
+            </ProfilePanel>
+          )}
+        </Stack>
+      </Box>
+    </>
+  );
+}
+
+/** The education and contact block, read-only. Empty fields say so rather than showing "-". */
+function ReadOnlyInfoCard({ profile }: { profile: UserProfile }) {
+  const { t } = useTranslation("common");
+  const fields = [
+    { label: t("profile.collegeName"), value: profile.college_name },
+    { label: t("profile.degreeType"), value: profile.degree_type },
+    { label: t("profile.branch"), value: profile.branch },
+    { label: t("profile.graduationYear"), value: profile.graduation_year },
+    { label: t("profile.phoneNumber"), value: profile.phone_number },
+    { label: t("profile.dateOfBirth"), value: profile.date_of_birth },
+  ];
+  const filled = fields.filter((f) => f.value).length;
+
+  return (
+    <ProfilePanel>
+      <ProfileSectionHeader
+        icon="mdi:account-details-outline"
+        title={t("profile.personalInformation")}
+        subtitle={t("profile.fieldsFilled", {
+          defaultValue: "{{filled}} of {{total}} filled",
+          filled,
+          total: fields.length,
+        })}
+      />
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", md: "repeat(3, 1fr)" },
+          gap: 2.25,
+        }}
+      >
+        {fields.map(({ label, value }) => (
+          <Box key={label}>
+            <Typography
+              sx={{ color: PROFILE.inkFaint, fontSize: "0.68rem", fontWeight: 700, letterSpacing: 0.2 }}
+            >
+              {label}
+            </Typography>
+            <Typography
+              sx={{
+                color: value ? PROFILE.ink : "#cbd5e1",
+                fontWeight: value ? 500 : 400,
+                fontSize: "0.875rem",
+                mt: 0.4,
+                display: "block",
+              }}
+            >
+              {value || t("profile.notAddedYet", { defaultValue: "Not added yet" })}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </ProfilePanel>
+  );
+}

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -1085,7 +1085,6 @@
     "sectionsTitle": "أقسام الملف الشخصي",
     "sectionsSubtitle": "تمت إضافة {{shown}} من {{total}}",
     "addSection": "أضف قسماً",
-    "publicPreviewNote": "هكذا يظهر ملفك للمدرّبين وجهات التوظيف.",
     "notAddedYet": "لم يُضف بعد",
     "adminReadOnly": "للاطلاع فقط",
     "sectionsFilled": "الأقسام المكتملة",
@@ -1094,7 +1093,12 @@
     "experienceEntries": "الخبرة",
     "entries": "مدخلات",
     "organization": "المؤسسة",
-    "fieldsFilled": "{{filled}} من {{total}} مكتملة"
+    "fieldsFilled": "{{filled}} من {{total}} مكتملة",
+    "seePublicView": "عرض الملف العام",
+    "publicViewBadge": "العرض العام",
+    "previewTitle": "هذا هو ملفك الشخصي العام",
+    "previewSubtitle": "تماماً كما يراه المدرّبون وجهات التوظيف. لا يمكن التعديل من هنا.",
+    "backToEditing": "العودة إلى التحرير"
   },
   "community": {
     "title": "المجتمع",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1242,7 +1242,6 @@
     "sectionsTitle": "Profile sections",
     "sectionsSubtitle": "{{shown}} of {{total}} added",
     "addSection": "Add section",
-    "publicPreviewNote": "This is how your profile appears to instructors and recruiters.",
     "notAddedYet": "Not added yet",
     "adminReadOnly": "Read only",
     "sectionsFilled": "Sections filled",
@@ -1251,7 +1250,12 @@
     "experienceEntries": "Experience",
     "entries": "entries",
     "organization": "Organization",
-    "fieldsFilled": "{{filled}} of {{total}} filled"
+    "fieldsFilled": "{{filled}} of {{total}} filled",
+    "seePublicView": "See public view",
+    "publicViewBadge": "Public view",
+    "previewTitle": "This is your public profile",
+    "previewSubtitle": "Exactly what instructors and recruiters see. Nothing here is editable.",
+    "backToEditing": "Back to editing"
   },
   "community": {
     "title": "Community",


### PR DESCRIPTION
Follow-up to #1233, on the same branch. Two pieces of feedback from staging.

## 1. A real public profile view

The rail card claimed "this is how your profile appears to instructors and recruiters" while showing only a name, headline and location. Now students can actually see it.

`PublicProfileView` is the read-only rendering of a profile, extracted from the admin page. Both surfaces render it:

- `app/admin/profile/[id]` — an admin inspecting a student
- `app/profile/preview` — a student checking their own public view

Sharing one component rather than writing a second lookalike is the whole point: the ask was to see *exactly* what others see, and two similar components answer that on the day they're written and then drift.

Read-only by construction, not by a flag — no save handler is threaded in and no edit callbacks are passed down, so nothing on that route can mutate the profile. It also reads the raw API profile with no localStorage merge, because showing an unsaved local draft in a "what others see" view would be a lie. The completion stat row stays admin-only.

## 2. Decluttered the preview card

In a 390px rail it carried a labelled "Change" pill, a camera badge, a pencil pushed to the far right, a divider, and a sentence explaining what the card was for — five pieces of chrome around four facts. The pill becomes icon-only, the pencil moves inline next to the headline, and the divider plus sentence are replaced by a "See public view" button that says the same thing and actually does something.

## Verification

`tsc` clean, `next build` exit 0 (route `/profile/preview` present), eslint error count unchanged at 8 (all pre-existing). All three routes rendered in a browser; the preview page shows zero edit affordances, as intended.

Still fixture-driven rather than real data — same caveat as #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)