### PR TITLE
fix(profile): stop stacking the name underneath the avatar

### DIFF
--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -58,21 +58,31 @@ export function ProfileHeader({
   return (
     <Box
       sx={{
-        position: "relative",
         width: "100%",
         px: { xs: 2.5, sm: 3 },
+        pt: 1.5,
         pb: 2.75,
-        // Clears the avatar, which hangs above this box. Retuned for the shorter cover.
-        pt: { xs: 6, sm: 6.5, md: 7 },
       }}
     >
-      {/* Profile Picture - Positioned over cover photo */}
+      {/* Avatar and identity sit on ONE row, bottoms aligned.
+          Previously the avatar was absolutely positioned and the name was pushed underneath
+          it by top padding, which stacked name, headline and location into a narrow column
+          hard against the left edge while the entire right half of the card sat empty. Here
+          the avatar is a normal flex item pulled up by a negative margin so it still overlaps
+          the cover, and the identity text sits beside it in the space that was going unused. */}
       <Box
         sx={{
-          position: "absolute",
-          top: { xs: -44, sm: -54, md: -66 },
-          insetInlineStart: { xs: 20, sm: 24 },
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          alignItems: { xs: "flex-start", sm: "flex-end" },
+          gap: { xs: 1.5, sm: 2.5 },
+        }}
+      >
+      <Box
+        sx={{
+          flexShrink: 0,
           zIndex: 1,
+          mt: { xs: "-56px", sm: "-64px", md: "-74px" },
         }}
         onMouseEnter={() => setProfilePicHovered(true)}
         onMouseLeave={() => setProfilePicHovered(false)}
@@ -124,20 +134,21 @@ export function ProfileHeader({
         </Box>
       </Box>
 
-      {/* Profile Info Section */}
+      {/* Identity, beside the avatar rather than stacked beneath it. */}
       <Box
         sx={{
+          flex: 1,
+          minWidth: 0,
           display: "flex",
-          flexDirection: { xs: "column", sm: "row" },
+          flexDirection: { xs: "column", md: "row" },
           justifyContent: "space-between",
-          alignItems: { xs: "flex-start", sm: "flex-end" },
+          alignItems: { xs: "flex-start", md: "flex-end" },
           gap: 2,
-          pt: { xs: 0, sm: 0 },
-          mt: { xs: 0, sm: 0 },
+          pb: { xs: 0, sm: 0.5 },
         }}
       >
         {/* Left: Name and Info */}
-        <Box sx={{ flex: 1, minWidth: 0, pl: { xs: 0, sm: 0, md: 0 }, mt: { xs: 0, sm: 0 } }}>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
           <Typography
             variant="h4"
             sx={{
@@ -264,6 +275,7 @@ export function ProfileHeader({
             </Button>
           </Box>
         )}
+        </Box>
       </Box>
 
       {/* Headline Edit Dialog */}

--- a/components/profile/PublicPreviewCard.tsx
+++ b/components/profile/PublicPreviewCard.tsx
@@ -125,8 +125,12 @@ export function PublicPreviewCard({
           )}
         </Box>
 
+        {/* One left edge for everything.
+            The name used to sit beside the avatar while the headline and location started
+            back at the card's left edge, so the eye tracked across three different left
+            margins in a 390px column. Avatar on its own line, all text aligned under it. */}
         <Box sx={{ px: 2.5, pb: 2.5 }}>
-          <Stack direction="row" spacing={1.5} alignItems="flex-end" sx={{ mt: "-28px", position: "relative" }}>
+          <Box sx={{ mt: "-30px", position: "relative", width: "fit-content" }}>
             <Box sx={{ position: "relative", flexShrink: 0 }}>
               <Avatar
                 src={profilePicUrl}
@@ -172,15 +176,16 @@ export function PublicPreviewCard({
               )}
             </Box>
 
-            <Box sx={{ minWidth: 0, pb: 0.25 }}>
-              <Typography
-                sx={{ fontWeight: 800, fontSize: "0.95rem", color: PROFILE.ink, lineHeight: 1.2, letterSpacing: "-0.3px" }}
-              >
-                {userName}
-              </Typography>
-              {role && <Typography sx={{ fontSize: "0.72rem", color: PROFILE.inkFaint }}>{role}</Typography>}
-            </Box>
-          </Stack>
+          </Box>
+
+          <Box sx={{ mt: 1.25, minWidth: 0 }}>
+            <Typography
+              sx={{ fontWeight: 800, fontSize: "1rem", color: PROFILE.ink, lineHeight: 1.2, letterSpacing: "-0.3px" }}
+            >
+              {userName}
+            </Typography>
+            {role && <Typography sx={{ fontSize: "0.72rem", color: PROFILE.inkFaint, mt: 0.25 }}>{role}</Typography>}
+          </Box>
 
           {/* The headline's edit pencil sits inline right after the text rather than pushed
               to the far right, so it reads as attached to what it edits instead of opening a


### PR DESCRIPTION
Third pass on the same branch, from staging screenshots.

Both headers put the identity into a narrow column jammed against the left edge, which read as cluttered at every width.

**Wide header (public view + admin).** The avatar was absolutely positioned and the name pushed below it by top padding, so name, headline and location piled up under a 128px circle while the entire right half of the card sat empty. The avatar is now a normal flex item pulled up by a negative margin — it still overlaps the cover — and the identity sits beside it in the space that was going unused.

**390px rail card.** The name sat beside the avatar while the headline and location started back at the card's left edge, so the eye tracked across three different left margins in one small column. Everything now shares a single left edge, avatar on its own line above the text.

`tsc` clean, `next build` exit 0, lint unchanged. All three routes re-rendered and checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)