### PR TITLE
fix(profile): section removal persistence, LinkedIn header, resume defaults

### DIFF
--- a/components/profile/CoverPhoto.tsx
+++ b/components/profile/CoverPhoto.tsx
@@ -29,10 +29,10 @@ export function CoverPhoto({ coverPhotoUrl, onEditCoverUrl, onUploadCover }: Cov
         sx={{
           position: "relative",
           width: "100%",
-          // Was 220-400px. A 400px photo banner was the single loudest thing making this
-          // page read as a different product from the dashboard, and on a laptop it pushed
-          // every actual fact below the fold. LinkedIn's own banner is ~200px.
-          height: { xs: 132, sm: 172, md: 212 },
+          // Was 220-400px, then 132-212px. Trimmed again now that the name sits below the
+          // avatar rather than beside it: with a stacked header the banner and the identity
+          // block add up, so a tall cover pushes the first real fact off the first screen.
+          height: { xs: 104, sm: 132, md: 164 },
           overflow: "hidden",
           borderRadius: `${HERO_RADIUS * 8}px ${HERO_RADIUS * 8}px 0 0`,
           backgroundColor: coverPhotoUrl ? "transparent" : "transparent",

--- a/components/profile/ProfileHeader.tsx
+++ b/components/profile/ProfileHeader.tsx
@@ -64,25 +64,17 @@ export function ProfileHeader({
         pb: 2.75,
       }}
     >
-      {/* Avatar and identity sit on ONE row, bottoms aligned.
-          Previously the avatar was absolutely positioned and the name was pushed underneath
-          it by top padding, which stacked name, headline and location into a narrow column
-          hard against the left edge while the entire right half of the card sat empty. Here
-          the avatar is a normal flex item pulled up by a negative margin so it still overlaps
-          the cover, and the identity text sits beside it in the space that was going unused. */}
+      {/* LinkedIn's arrangement: avatar overlapping the cover on the left, identity stacked
+          directly beneath it, everything on one left edge.
+          An earlier pass put the identity beside the avatar to fix crowding, but the crowding
+          came from a 212px cover plus a 128px avatar, not from the stacking. With the cover
+          trimmed and real spacing under the avatar, stacked is both roomier and the layout
+          people already know. */}
       <Box
         sx={{
-          display: "flex",
-          flexDirection: { xs: "column", sm: "row" },
-          alignItems: { xs: "flex-start", sm: "flex-end" },
-          gap: { xs: 1.5, sm: 2.5 },
-        }}
-      >
-      <Box
-        sx={{
-          flexShrink: 0,
+          width: "fit-content",
           zIndex: 1,
-          mt: { xs: "-56px", sm: "-64px", md: "-74px" },
+          mt: { xs: "-52px", sm: "-62px", md: "-72px" },
         }}
         onMouseEnter={() => setProfilePicHovered(true)}
         onMouseLeave={() => setProfilePicHovered(false)}
@@ -134,17 +126,17 @@ export function ProfileHeader({
         </Box>
       </Box>
 
-      {/* Identity, beside the avatar rather than stacked beneath it. */}
+      {/* Identity, stacked under the avatar and sharing its left edge. Any actions sit to
+          the right of it, which is where LinkedIn puts them too. */}
       <Box
         sx={{
-          flex: 1,
+          mt: 1.75,
           minWidth: 0,
           display: "flex",
           flexDirection: { xs: "column", md: "row" },
           justifyContent: "space-between",
           alignItems: { xs: "flex-start", md: "flex-end" },
           gap: 2,
-          pb: { xs: 0, sm: 0.5 },
         }}
       >
         {/* Left: Name and Info */}
@@ -275,7 +267,6 @@ export function ProfileHeader({
             </Button>
           </Box>
         )}
-        </Box>
       </Box>
 
       {/* Headline Edit Dialog */}

--- a/components/profile/ProfileSectionsContainer.tsx
+++ b/components/profile/ProfileSectionsContainer.tsx
@@ -19,6 +19,7 @@ import { UserProfile } from "@/lib/services/profile.service";
 import { config } from "@/lib/config";
 
 const PROFILE_SECTIONS_KEY = `profile_visible_sections_${config.clientId}`;
+const PROFILE_HIDDEN_KEY = `profile_hidden_sections_${config.clientId}`;
 const SECTION_ORDER: ProfileSectionId[] = [
   "skills",
   "experience",
@@ -126,6 +127,40 @@ function saveVisibleSections(sections: ProfileSectionId[]) {
   }
 }
 
+/**
+ * Sections the student explicitly removed.
+ *
+ * This list has to exist separately. Visibility used to be
+ * `union(savedList, sectionsThatHaveData)`, and a union cannot express a removal: dropping
+ * "education" from the saved list did nothing, because the education entries still existed
+ * on the server, so getSectionsWithData put it straight back on the next mount. Removing a
+ * section appeared to work and silently undid itself on refresh, for every section that had
+ * any content — which is every section worth removing.
+ *
+ * Hiding is a layout preference, not a delete: the entries are untouched and re-adding the
+ * section brings them back intact.
+ */
+function loadHiddenSections(): ProfileSectionId[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(PROFILE_HIDDEN_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHiddenSections(sections: ProfileSectionId[]) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(PROFILE_HIDDEN_KEY, JSON.stringify(sections));
+  } catch {
+    // ignore
+  }
+}
+
 interface ProfileSectionsContainerProps {
   profile: UserProfile;
   onSave: (updatedProfile: Partial<UserProfile>) => Promise<void>;
@@ -143,17 +178,14 @@ export function ProfileSectionsContainer({
   const initializeSections = useCallback((profileData: UserProfile) => {
     const saved = loadVisibleSections();
     const withData = getSectionsWithData(profileData);
-    const merged = Array.from(
-      new Set([...(saved || []), ...withData])
-    ).sort(
-      (a, b) => SECTION_ORDER.indexOf(a) - SECTION_ORDER.indexOf(b)
-    );
-    if (merged.length > 0) {
-      setVisibleSections(merged);
-      if (!saved || saved.length === 0) saveVisibleSections(merged);
-    } else {
-      setVisibleSections([]);
-    }
+    const hidden = new Set(loadHiddenSections());
+    // Union of "saved" and "has data", MINUS whatever was explicitly removed. The subtraction
+    // is the whole fix: without it, any section holding data is re-added on every mount.
+    const merged = Array.from(new Set([...(saved || []), ...withData]))
+      .filter((id) => !hidden.has(id))
+      .sort((a, b) => SECTION_ORDER.indexOf(a) - SECTION_ORDER.indexOf(b));
+    setVisibleSections(merged);
+    if (!saved || saved.length === 0) saveVisibleSections(merged);
     setInitialized(true);
   }, []);
 
@@ -164,6 +196,8 @@ export function ProfileSectionsContainer({
   }, [profile, initializeSections]);
 
   const handleAddSection = (id: ProfileSectionId) => {
+    // Clear the removal first, or the section would vanish again on the next mount.
+    saveHiddenSections(loadHiddenSections().filter((s) => s !== id));
     if (visibleSections.includes(id)) return;
     const next = [...visibleSections, id].sort(
       (a, b) =>
@@ -177,6 +211,10 @@ export function ProfileSectionsContainer({
     const next = visibleSections.filter((s) => s !== id);
     setVisibleSections(next);
     saveVisibleSections(next);
+    // Record the removal. Dropping it from the visible list alone is not enough: the section
+    // still has data, so the next mount would union it straight back in.
+    const hidden = loadHiddenSections();
+    if (!hidden.includes(id)) saveHiddenSections([...hidden, id]);
   };
 
   if (!initialized) return null;

--- a/components/profile/resume/ResumeBuilder.tsx
+++ b/components/profile/resume/ResumeBuilder.tsx
@@ -32,6 +32,10 @@ import { useToast } from "@/components/common/Toast";
 import { toPng } from "html-to-image";
 import { jsPDF } from "jspdf";
 import { resumeService } from "@/lib/services/resume.service";
+import { PANEL_BORDER, PANEL_SHADOW, PROFILE, TILE_GRADIENT, CTA_GRADIENT, CTA_SHADOW } from "../theme/profileTokens";
+
+/** Where the builder's current content came from. Drives the toolbar's segmented control. */
+type ResumeSource = "sample" | "profile" | "blank";
 
 interface ResumeBuilderProps {
   initialData?: Partial<ResumeData>;
@@ -200,19 +204,32 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
   const [atsDialogOpen, setAtsDialogOpen] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
 
-  // Profile data populates the form by default; sample data is opt-in via the toggle below.
-  const [isSampleMode, setIsSampleMode] = useState(false);
-  const [resumeData, setResumeData] = useState<ResumeData>(() => buildResumeData(initialData));
+  /**
+   * The sample resume is the default; the student's own data is an explicit import.
+   *
+   * It used to be the other way round, which meant opening the Resume tab silently poured a
+   * half-finished profile into the builder: a student with three filled fields saw a nearly
+   * empty document and no sense of what a finished resume looks like. Starting from a
+   * complete sample shows the shape of the thing, and "Use my profile" is then a deliberate
+   * act rather than something that already happened.
+   */
+  const [source, setSource] = useState<ResumeSource>("sample");
+  const [resumeData, setResumeData] = useState<ResumeData>(() => SAMPLE_RESUME_DATA);
 
-  // If the parent fetches profile data after mount (initialData arrives later), hydrate once.
-  const hydratedRef = useRef(false);
+  /**
+   * Only set when the student asks for their profile BEFORE the fetch has landed. Without
+   * it, clicking "Use my profile" early would import an empty object and look broken.
+   * Deliberately not a general "hydrate when data arrives" effect: that is what used to
+   * overwrite the form behind the student's back.
+   */
+  const awaitingProfileRef = useRef(false);
   useEffect(() => {
-    if (hydratedRef.current || isSampleMode) return;
+    if (!awaitingProfileRef.current) return;
     if (initialData && Object.keys(initialData).length > 0) {
       setResumeData(buildResumeData(initialData));
-      hydratedRef.current = true;
+      awaitingProfileRef.current = false;
     }
-  }, [initialData, isSampleMode]);
+  }, [initialData]);
 
   // Rule-based score (deterministic). Shown on the toolbar until the AI analysis runs.
   const ruleBasedAtsScore = useMemo(
@@ -233,22 +250,29 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
 
   const handleClearData = () => {
     setResumeData(buildResumeData());
-    setIsSampleMode(false);
-    hydratedRef.current = true;
+    setSource("blank");
+    awaitingProfileRef.current = false;
     showToast(t("profile.resumeDataCleared"), "success");
   };
 
-  /** Toggle between user's profile data (default) and a sample resume (for preview/demo). */
-  const handleToggleSource = () => {
-    if (isSampleMode) {
-      setResumeData(buildResumeData(initialData));
-      setIsSampleMode(false);
-      showToast(t("profile.switchedToProfileData"), "info");
-    } else {
-      setResumeData(SAMPLE_RESUME_DATA);
-      setIsSampleMode(true);
-      showToast(t("profile.sampleDataLoaded"), "success");
-    }
+  const handleUseSample = () => {
+    if (source === "sample") return;
+    setResumeData(SAMPLE_RESUME_DATA);
+    setSource("sample");
+    awaitingProfileRef.current = false;
+    showToast(t("profile.sampleDataLoaded"), "success");
+  };
+
+  /** Import the student's profile into the builder. Explicit, never automatic. */
+  const handleUseProfile = () => {
+    if (source === "profile") return;
+    const hasProfile = Boolean(initialData && Object.keys(initialData).length > 0);
+    setResumeData(buildResumeData(initialData));
+    setSource("profile");
+    // The profile fetch may still be in flight; fill in when it lands rather than importing
+    // an empty object now and looking broken.
+    awaitingProfileRef.current = !hasProfile;
+    showToast(t("profile.switchedToProfileData"), "info");
   };
 
   /** Convert img elements to data URLs so they can be embedded in the PDF (avoids CORS issues). */
@@ -481,14 +505,16 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
 
   return (
     <Box>
-      {/* Row 1 - My Resume + ATS + Save + PDF */}
+      {/* Toolbar. Two panels on the profile surface's card language: 32px radius, hairline
+          border, the same soft depth ladder as every other card on the page. */}
       <Paper
         elevation={0}
         sx={{
-          p: 1.5,
+          p: { xs: 1.75, sm: 2 },
           mb: 1.5,
-          border: "1px solid var(--border-default)",
-          borderRadius: 3,
+          border: PANEL_BORDER,
+          borderRadius: 4,
+          boxShadow: PANEL_SHADOW,
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
@@ -497,10 +523,37 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
         }}
       >
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, minWidth: 0 }}>
-          <IconWrapper icon="mdi:file-document-outline" size={22} color="var(--font-secondary)" />
-          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "var(--font-primary)" }}>
-            My Resume
-          </Typography>
+          <Box
+            sx={{
+              width: 30,
+              height: 30,
+              borderRadius: 2,
+              flexShrink: 0,
+              display: "grid",
+              placeItems: "center",
+              color: "#fff",
+              background: TILE_GRADIENT,
+            }}
+          >
+            <IconWrapper icon="mdi:file-document-outline" size={17} />
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              component="h3"
+              sx={{ fontWeight: 800, fontSize: "0.95rem", color: PROFILE.ink, lineHeight: 1.2, letterSpacing: "-0.2px" }}
+            >
+              {t("profile.myResume", { defaultValue: "My resume" })}
+            </Typography>
+            <Typography sx={{ fontSize: "0.72rem", color: PROFILE.inkFaint, mt: "1px" }}>
+              {t(`profile.${TEMPLATE_KEYS[selectedTemplate]}`)}
+              {" · "}
+              {source === "sample"
+                ? t("profile.sourceSample", { defaultValue: "Sample content" })
+                : source === "profile"
+                  ? t("profile.sourceProfile", { defaultValue: "Your profile" })
+                  : t("profile.sourceBlank", { defaultValue: "Blank" })}
+            </Typography>
+          </Box>
         </Box>
         <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
           <Tooltip title={t("profile.atsScoreButtonTooltip")}>
@@ -519,14 +572,15 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
                 cursor: "pointer",
                 fontWeight: 800,
                 fontSize: "0.85rem",
-                border: "1px solid var(--border-default)",
+                border: `1px solid ${PROFILE.hairline}`,
                 color:
                   atsScoreLive >= 80
-                    ? "var(--success-500)"
+                    ? "#15803d"
                     : atsScoreLive >= 50
-                      ? "var(--warning-500)"
-                      : "var(--error-500)",
-                "&:hover": { backgroundColor: "var(--surface)" },
+                      ? "#b45309"
+                      : "#b91c1c",
+                "&:hover": { backgroundColor: "#f8fafc" },
+                "&:focus-visible": { outline: "none", boxShadow: `0 0 0 2px #fff, 0 0 0 4px ${PROFILE.violet}` },
               }}
             >
               <IconWrapper icon="mdi:speedometer" size={16} />
@@ -535,38 +589,39 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
           </Tooltip>
           <Button
             variant="outlined"
-            startIcon={<IconWrapper icon="mdi:content-save-outline" />}
+            startIcon={<IconWrapper icon="mdi:content-save-outline" size={17} />}
             onClick={handleSaveResume}
             disabled={saveResumeLoading}
             sx={{
               textTransform: "none",
               fontWeight: 700,
+              fontSize: "0.8125rem",
               borderRadius: 999,
               px: 2,
               py: 0.85,
-              borderColor: "var(--border-default)",
-              color: "var(--font-primary)",
-              "&:hover": { borderColor: "var(--accent-purple)", backgroundColor: "var(--surface)" },
+              borderColor: PROFILE.hairline,
+              color: PROFILE.ink,
+              "&:hover": { borderColor: PROFILE.violet, backgroundColor: PROFILE.violetSoft },
             }}
           >
-            {saveResumeLoading ? "…" : t("profile.saveResume", { defaultValue: "Save" })}
+            {saveResumeLoading ? "\u2026" : t("profile.saveResume", { defaultValue: "Save" })}
           </Button>
           <Button
             variant="contained"
             disableElevation
-            startIcon={<IconWrapper icon="mdi:download" />}
+            startIcon={<IconWrapper icon="mdi:download" size={17} />}
             onClick={handleDownloadPDF}
             sx={{
               textTransform: "none",
               fontWeight: 800,
+              fontSize: "0.8125rem",
               borderRadius: 999,
               px: 2.5,
               py: 0.85,
-              // Platform primary action (violet -> pink), matching HeaderActionButton.
-              background: "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)",
+              background: CTA_GRADIENT,
               color: "#fff",
-              boxShadow: "0 14px 30px -12px rgba(192,38,211,0.7)",
-              "&:hover": { filter: "brightness(1.06)", background: "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)" },
+              boxShadow: CTA_SHADOW,
+              "&:hover": { filter: "brightness(1.06)", background: CTA_GRADIENT },
             }}
           >
             PDF
@@ -574,14 +629,15 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
         </Box>
       </Paper>
 
-      {/* Row 2 - visible template chips + From profile / Sample / Clear */}
+      {/* Template chips + where the content comes from. */}
       <Paper
         elevation={0}
         sx={{
-          p: 1.5,
+          p: { xs: 1.75, sm: 2 },
           mb: 3,
-          border: "1px solid var(--border-default)",
-          borderRadius: 3,
+          border: PANEL_BORDER,
+          borderRadius: 4,
+          boxShadow: PANEL_SHADOW,
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
@@ -593,23 +649,18 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
           <Typography
             sx={{
               fontWeight: 800,
-              fontSize: "0.72rem",
-              letterSpacing: "0.08em",
-              color: "var(--font-tertiary)",
+              fontSize: "0.6rem",
+              letterSpacing: 0.5,
+              textTransform: "uppercase",
+              color: PROFILE.inkFaint,
               flexShrink: 0,
               display: { xs: "none", sm: "block" },
+              '[dir="rtl"] &': { letterSpacing: "normal", textTransform: "none" },
             }}
           >
-            TEMPLATE
+            {t("profile.templateEyebrow", { defaultValue: "Template" })}
           </Typography>
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: 0.6,
-              py: 0.5,
-            }}
-          >
+          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.6, py: 0.5 }}>
             {(Object.keys(TEMPLATE_KEYS) as TemplateName[]).map((template) => {
               const active = selectedTemplate === template;
               return (
@@ -630,11 +681,14 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
                     whiteSpace: "nowrap",
                     fontWeight: 700,
                     fontSize: "0.76rem",
-                    border: active ? "1px solid transparent" : "1px solid var(--border-default)",
-                    bgcolor: active ? "var(--font-primary-dark, #1f2937)" : "transparent",
-                    color: active ? "#fff" : "var(--font-primary)",
+                    // Active was near-black #1f2937, the only near-black chip on a surface
+                    // whose entire selected-state language is violet.
+                    border: active ? "1px solid transparent" : `1px solid ${PROFILE.hairline}`,
+                    bgcolor: active ? PROFILE.violet : "transparent",
+                    color: active ? "#fff" : PROFILE.inkMuted,
                     transition: "all .12s",
-                    "&:hover": { bgcolor: active ? "var(--font-primary-dark, #1f2937)" : "var(--surface)" },
+                    "&:hover": { bgcolor: active ? PROFILE.violet : "#f8fafc" },
+                    "&:focus-visible": { outline: "none", boxShadow: `0 0 0 2px #fff, 0 0 0 4px ${PROFILE.violet}` },
                   }}
                 >
                   <Box
@@ -643,7 +697,7 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
                       height: 7,
                       borderRadius: "50%",
                       flexShrink: 0,
-                      bgcolor: TEMPLATE_DOTS[template] || "var(--accent-purple)",
+                      bgcolor: active ? "rgba(255,255,255,0.9)" : TEMPLATE_DOTS[template] || PROFILE.violetLight,
                     }}
                   />
                   {t(`profile.${TEMPLATE_KEYS[template]}`)}
@@ -652,55 +706,61 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
             })}
           </Box>
         </Box>
-        <Box sx={{ display: "flex", gap: 0.75, flexShrink: 0, flexWrap: "wrap", alignItems: "center" }}>
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<IconWrapper icon="mdi:account-outline" size={16} />}
-            onClick={() => {
-              if (isSampleMode) handleToggleSource();
-            }}
+
+        {/* Segmented control rather than three equal outlined buttons. Sample and profile are
+            two states of one setting, so they belong in one control that shows which is on;
+            Clear is a separate destructive action and sits outside it. */}
+        <Box sx={{ display: "flex", gap: 1, flexShrink: 0, alignItems: "center" }}>
+          <Box
             sx={{
-              textTransform: "none",
-              fontWeight: 700,
-              fontSize: "0.78rem",
-              borderRadius: 2,
-              px: 1.25,
-              py: 0.5,
-              color: "var(--accent-purple)",
-              borderColor: !isSampleMode ? "var(--accent-purple)" : "var(--border-default)",
-              backgroundColor: !isSampleMode
-                ? "color-mix(in srgb, var(--accent-purple) 10%, transparent)"
-                : "transparent",
+              display: "flex",
+              p: 0.4,
+              gap: 0.4,
+              borderRadius: 999,
+              bgcolor: "#f1f5f9",
+              border: `1px solid ${PROFILE.hairline}`,
             }}
           >
-            {t("profile.useProfileData", { defaultValue: "Profile" })}
-          </Button>
+            {([
+              { key: "sample", label: t("profile.sample", { defaultValue: "Sample" }), icon: "mdi:auto-fix", onClick: handleUseSample },
+              { key: "profile", label: t("profile.useMyProfile", { defaultValue: "Use my profile" }), icon: "mdi:account-outline", onClick: handleUseProfile },
+            ] as const).map((opt) => {
+              const active = source === opt.key;
+              return (
+                <Box
+                  key={opt.key}
+                  component="button"
+                  onClick={opt.onClick}
+                  aria-pressed={active}
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 0.6,
+                    px: 1.5,
+                    py: 0.7,
+                    border: 0,
+                    borderRadius: 999,
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    fontWeight: 700,
+                    fontSize: "0.78rem",
+                    whiteSpace: "nowrap",
+                    transition: "background .15s, color .15s",
+                    bgcolor: active ? "#fff" : "transparent",
+                    color: active ? PROFILE.violet : PROFILE.inkFaint,
+                    boxShadow: active ? "0 1px 3px rgba(16,24,40,0.10)" : "none",
+                    "&:hover": { color: active ? PROFILE.violet : PROFILE.inkMuted },
+                    "&:focus-visible": { outline: "none", boxShadow: `0 0 0 2px #f1f5f9, 0 0 0 4px ${PROFILE.violet}` },
+                  }}
+                >
+                  <IconWrapper icon={opt.icon} size={15} />
+                  {opt.label}
+                </Box>
+              );
+            })}
+          </Box>
           <Button
-            variant="outlined"
-            size="small"
-            startIcon={<IconWrapper icon="mdi:auto-fix" size={16} />}
-            onClick={() => {
-              if (!isSampleMode) handleToggleSource();
-            }}
-            sx={{
-              textTransform: "none",
-              fontWeight: 700,
-              fontSize: "0.78rem",
-              borderRadius: 2,
-              px: 1.25,
-              py: 0.5,
-              color: "var(--accent-purple)",
-              borderColor: isSampleMode ? "var(--accent-purple)" : "var(--border-default)",
-              backgroundColor: isSampleMode
-                ? "color-mix(in srgb, var(--accent-purple) 10%, transparent)"
-                : "transparent",
-            }}
-          >
-            {t("profile.sample", { defaultValue: "Sample" })}
-          </Button>
-          <Button
-            variant="outlined"
+            variant="text"
             size="small"
             startIcon={<IconWrapper icon="mdi:restore" size={16} />}
             onClick={handleClearData}
@@ -708,15 +768,11 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
               textTransform: "none",
               fontWeight: 700,
               fontSize: "0.78rem",
-              borderRadius: 2,
-              px: 1.25,
-              py: 0.5,
-              color: "var(--error-500)",
-              borderColor: "var(--border-default)",
-              "&:hover": {
-                borderColor: "var(--error-500)",
-                backgroundColor: "color-mix(in srgb, var(--error-500) 8%, var(--surface))",
-              },
+              borderRadius: 999,
+              px: 1.5,
+              py: 0.6,
+              color: PROFILE.inkFaint,
+              "&:hover": { color: "#b91c1c", backgroundColor: "#fef2f2" },
             }}
           >
             {t("profile.clear", { defaultValue: "Clear" })}

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -1098,7 +1098,13 @@
     "publicViewBadge": "العرض العام",
     "previewTitle": "هذا هو ملفك الشخصي العام",
     "previewSubtitle": "تماماً كما يراه المدرّبون وجهات التوظيف. لا يمكن التعديل من هنا.",
-    "backToEditing": "العودة إلى التحرير"
+    "backToEditing": "العودة إلى التحرير",
+    "myResume": "سيرتي الذاتية",
+    "useMyProfile": "استخدم ملفي الشخصي",
+    "sourceSample": "محتوى نموذجي",
+    "sourceProfile": "ملفك الشخصي",
+    "sourceBlank": "فارغ",
+    "templateEyebrow": "القالب"
   },
   "community": {
     "title": "المجتمع",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1255,7 +1255,13 @@
     "publicViewBadge": "Public view",
     "previewTitle": "This is your public profile",
     "previewSubtitle": "Exactly what instructors and recruiters see. Nothing here is editable.",
-    "backToEditing": "Back to editing"
+    "backToEditing": "Back to editing",
+    "myResume": "My resume",
+    "useMyProfile": "Use my profile",
+    "sourceSample": "Sample content",
+    "sourceProfile": "Your profile",
+    "sourceBlank": "Blank",
+    "templateEyebrow": "Template"
   },
   "community": {
     "title": "Community",


### PR DESCRIPTION
Three fixes from staging feedback.

## 1. Removing a section did not persist (bug)

**Root cause.** Visibility was `union(savedList, sectionsThatHaveData)`, and a union cannot express a removal. `handleRemoveSection` dropped the id from the saved list, but the entries still existed on the server, so `getSectionsWithData` put the section straight back on the next mount. Removal was broken for **every section holding content** — it only appeared to work on empty ones, where there was nothing to re-add.

**Fix.** A removal is now its own recorded fact: hidden sections are tracked in a separate list and subtracted after the union. Adding a section clears its removal first, or it would vanish again on the next mount.

Hiding stays a layout preference, not a delete. Verified in a browser against a profile with real education data: remove → reload → still gone → re-add → original entry restored.

**Known limits, unchanged by this fix:** it lives in localStorage, so it does not follow the student to another browser or device, and the read-only view renders from the data rather than this list, so a hidden section is still visible to instructors and recruiters. Both need a server-side field — flagging rather than silently half-solving.

## 2. LinkedIn-style header

Reverts the previous "identity beside the avatar" pass. That solved the crowding, but the crowding came from a 212px cover plus a 128px avatar, not from the stacking. Cover drops to 104–164px and the identity goes back under the photo on one left edge — roomier than before *and* the arrangement people recognise.

## 3. Resume opens on the sample

Opening the Resume tab used to pour the profile into the builder automatically, so a half-finished profile rendered as a nearly empty document. The sample is now the default and "Use my profile" is an explicit import.

This also fixes a quieter bug: the old auto-hydrate effect refilled the form whenever `initialData` arrived, so a slow profile fetch could overwrite what the student had already typed. The replacement only fills in when the student asked for their profile before the fetch landed.

Toolbar moves onto the profile card language; sample/profile become a segmented control that shows which is active instead of three identical buttons.

`tsc` clean, `next build` exit 0, lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)