### PR TITLE
feat(career): component-level profile locks + fix misleading lock toast

### DIFF
--- a/app/jobs-v2/page.tsx
+++ b/app/jobs-v2/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
-import { ProfileLockModal } from "@/components/common/ProfileLockModal";
+import { ProfileLockBanner, ProfileLockCard } from "@/components/common/ProfileLock";
 import { useModuleLocked } from "@/lib/contexts/ProfileGateContext";
 import Link from "next/link";
 import { Box, LinearProgress, Typography, Tabs, Tab, Avatar, Stack } from "@mui/material";
@@ -413,7 +413,6 @@ export default function JobsV2Page() {
 
   return (
     <PageShell>
-      <ProfileLockModal open={showLock} moduleLabel="Jobs" />
       <ModulePageHeader
         eyebrow="Career"
         title="Jobs"
@@ -421,6 +420,8 @@ export default function JobsV2Page() {
         accent="cyan"
         icon="mdi:briefcase-search"
       />
+
+      {showLock && <ProfileLockBanner moduleLabel="Jobs" />}
       <Box
         sx={{
           display: { xs: "none", lg: "flex" },
@@ -499,6 +500,14 @@ export default function JobsV2Page() {
             </Tabs>
             {activeTab === "applied" ? (
               <AppliedJobsSection onBrowseJobs={() => setActiveTab("browse")} />
+            ) : showLock ? (
+              /* The list is what employers gate on, so the list is what locks. Everything
+                 around it stays interactive. */
+              <ProfileLockCard
+                title="Job listings need a complete profile"
+                body="Employers see your profile when you apply, so we ask for a few details before opening the board."
+                compact
+              />
             ) : loading ? (
               <Box
                 sx={{
@@ -659,6 +668,12 @@ export default function JobsV2Page() {
 
           {activeTab === "applied" ? (
             <AppliedJobsSection onBrowseJobs={() => setActiveTab("browse")} />
+          ) : showLock ? (
+            <ProfileLockCard
+              title="Job listings need a complete profile"
+              body="Employers see your profile when you apply, so we ask for a few details before opening the board."
+              compact
+            />
           ) : loading ? (
             <Box
               sx={{

--- a/app/mock-interview/page.tsx
+++ b/app/mock-interview/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { ProfileLockModal } from "@/components/common/ProfileLockModal";
+import { ProfileLockBanner, ProfileLockCard } from "@/components/common/ProfileLock";
 import { useModuleLocked } from "@/lib/contexts/ProfileGateContext";
 import { useTranslation } from "react-i18next";
 import { Box, Typography } from "@mui/material";
@@ -52,6 +52,14 @@ export default function MockInterviewPage() {
         setInterviews(list);
         setPendingCoursesCount(pending.length);
       } catch (error) {
+        // A profile_incomplete 403 is the lock, not a failure. Toasting it told the learner
+        // "Failed to load interviews" — which reads as the product being broken — right next
+        // to a panel explaining the profile is incomplete. Two contradictory explanations for
+        // one expected state. The lock UI is the only message that should appear.
+        if (reportProfileLock(error)) {
+          setInterviews([]);
+          return;
+        }
         showToast(t("mockInterview.failedToLoad"), "error");
         hasLoadedRef.current = false;
       } finally {
@@ -60,7 +68,7 @@ export default function MockInterviewPage() {
     };
 
     loadInterviews();
-  }, [showToast, t]);
+  }, [showToast, t, reportProfileLock]);
 
   // Calculate statistics
   const total = interviews.length;
@@ -87,7 +95,6 @@ export default function MockInterviewPage() {
 
   return (
     <PageShell>
-      <ProfileLockModal open={showLock} moduleLabel="Mock Interview" />
       <ModulePageHeader
         eyebrow="Career"
         title="Interview"
@@ -95,6 +102,8 @@ export default function MockInterviewPage() {
         accent="pink"
         icon="mdi:account-voice"
       />
+
+        {showLock && <ProfileLockBanner moduleLabel="Interview" />}
 
         {/* Statistics */}
         <Box data-tour-id="mock-stats" sx={{ mb: 4 }}>
@@ -266,9 +275,19 @@ export default function MockInterviewPage() {
           </Box>
         </Box>
 
-        {/* Interview Mode Selector */}
+        {/* Only the launcher is locked. The header, stats and tabs above stay readable on
+            purpose: a learner who cannot see what the module does has no reason to spend the
+            minute it takes to unlock it. */}
         <Box data-tour-id="mock-modes">
-          <InterviewModeSelector />
+          {showLock ? (
+            <ProfileLockCard
+              title="Starting an interview needs a complete profile"
+              body="Interviews are generated from your profile, so we need a few more details before the first one can start."
+              preview={<InterviewModeSelector />}
+            />
+          ) : (
+            <InterviewModeSelector />
+          )}
         </Box>
     </PageShell>
   );

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -17,6 +17,7 @@ import { ActivityHeatmap } from "@/components/profile/ActivityHeatmap";
 import { SavedResumesSection } from "@/components/profile/SavedResumesSection";
 import { ResumeBuilder } from "@/components/profile/resume/ResumeBuilder";
 import { ProfileTabs } from "@/components/profile/ProfileTabs";
+import { useModuleLocked } from "@/lib/contexts/ProfileGateContext";
 import { PROFILE } from "@/components/profile/theme/profileTokens";
 import { buildResumeInitialData } from "@/lib/utils/buildResumeInitialData";
 import {
@@ -63,6 +64,8 @@ export default function ProfilePage() {
   const [loading, setLoading] = useState(true);
   const { showToast } = useToast();
   const { clientInfo } = useClientInfo();
+  // Same gate as /resume: the builder stays editable, only Save and PDF lock.
+  const { showLock: resumeLocked } = useModuleLocked("resume");
 
   const loadProfileData = useCallback(async () => {
     try {
@@ -309,7 +312,7 @@ export default function ProfilePage() {
         </Box>
 
         <Box sx={{ display: activeTab === 1 ? "block" : "none", width: "100%" }}>
-          <ResumeBuilder initialData={buildResumeInitialData(profile)} />
+          <ResumeBuilder initialData={buildResumeInitialData(profile)} lockExports={resumeLocked} />
         </Box>
 
         <Box sx={{ display: activeTab === 2 ? "block" : "none", width: "100%" }}>

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ProfileLockModal } from "@/components/common/ProfileLockModal";
+import { ProfileLockBanner } from "@/components/common/ProfileLock";
 import { useModuleLocked } from "@/lib/contexts/ProfileGateContext";
 import { Box, CircularProgress } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
@@ -39,20 +39,16 @@ export default function ResumePage() {
     };
   }, []);
 
-  if (showLock) {
-    // The hero stays so the learner still knows which module they are looking at; the modal sits
-    // over it. Resume had NO backend gate at all until now, so this page previously just opened.
-    return (
-      <MainLayout fullWidthContent>
-        <ResumeHero />
-        <ProfileLockModal open moduleLabel="Resume" />
-      </MainLayout>
-    );
-  }
+  // No early return any more. Building a resume is exactly the work that fills a profile in,
+  // so blocking the builder to demand a complete profile had the dependency backwards. The
+  // builder stays fully usable; only Save and PDF are gated, which is where the profile
+  // actually matters because that is what leaves the product.
 
   return (
     <MainLayout fullWidthContent>
       <ResumeHero />
+
+      {showLock && <ProfileLockBanner moduleLabel="Resume" />}
 
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 10 }}>
@@ -61,6 +57,7 @@ export default function ResumePage() {
       ) : (
         <ResumeBuilder
           initialData={profile ? buildResumeInitialData(profile) : undefined}
+          lockExports={showLock}
         />
       )}
     </MainLayout>

--- a/components/common/ProfileLock.tsx
+++ b/components/common/ProfileLock.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Box, Button, LinearProgress, Stack, Tooltip, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useRouter } from "next/navigation";
+import { useProfileGate } from "@/lib/contexts/ProfileGateContext";
+
+/**
+ * Component-level profile locks.
+ *
+ * Replaces the full-page ProfileLockModal on Resume, Jobs and Interview. That modal made the
+ * whole page unreachable, which answered "you cannot do this" but never "what am I missing
+ * out on" — a learner staring at a blurred page has no reason to spend the minute it takes to
+ * fix their profile. Locking only the action leaves the page browsable: you can read what the
+ * module does, see the layout, and understand the offer before being asked to pay for it.
+ *
+ * Two shapes, one message:
+ *   ProfileLockCard   replaces a whole component (a job list, the interview launcher)
+ *   LockedAction      wraps a single control (Save resume, Download PDF)
+ *
+ * The lock is a product flow, never a security boundary. Every gated endpoint enforces the
+ * real rule server-side, so nothing here is load-bearing for access control.
+ */
+
+/** The outstanding fields, preferring the server's labelled list over raw field names. */
+function useOutstandingFields() {
+  const { completion, missingFields } = useProfileGate();
+  return completion?.required_fields?.length
+    ? completion.required_fields.filter((f) => !f.filled)
+    : missingFields.map((f) => ({
+        field: f,
+        label: f.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+        filled: false,
+      }));
+}
+
+function CompleteProfileButton({ fullWidth = true, size = "md" }: { fullWidth?: boolean; size?: "sm" | "md" }) {
+  const router = useRouter();
+  return (
+    <Button
+      fullWidth={fullWidth}
+      onClick={() => router.push("/profile#profile-strength")}
+      startIcon={<Icon icon="mdi:account-edit-outline" width={size === "sm" ? 16 : 18} />}
+      sx={{
+        py: size === "sm" ? 0.7 : 1.15,
+        px: size === "sm" ? 2 : 2.5,
+        borderRadius: 999,
+        fontWeight: 800,
+        fontSize: size === "sm" ? "0.78rem" : "0.9rem",
+        color: "white",
+        textTransform: "none",
+        background: "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)",
+        boxShadow: "0 14px 30px -12px rgba(192,38,211,0.7)",
+        "&:hover": { filter: "brightness(1.06)", background: "linear-gradient(135deg, #a855f7 0%, #ec4899 100%)" },
+      }}
+    >
+      Complete profile
+    </Button>
+  );
+}
+
+/**
+ * A locked stand-in for one component.
+ *
+ * `preview` is the point of this over a modal: it renders the real component behind the lock,
+ * dimmed and inert, so the learner can see the thing they are unlocking. Pass it whenever
+ * there is something worth seeing; omit it when there would be nothing but an empty state.
+ */
+export function ProfileLockCard({
+  title,
+  body,
+  preview,
+  compact = false,
+}: {
+  title: string;
+  body: string;
+  preview?: ReactNode;
+  compact?: boolean;
+}) {
+  const { percentage } = useProfileGate();
+  const outstanding = useOutstandingFields();
+
+  return (
+    <Box sx={{ position: "relative", borderRadius: 4, overflow: "hidden" }}>
+      {preview && (
+        <Box
+          aria-hidden
+          // inert would be ideal, but React 18's typings do not carry it; pointerEvents plus
+          // aria-hidden keeps the preview out of both the tab order and the pointer path.
+          sx={{
+            pointerEvents: "none",
+            userSelect: "none",
+            filter: "blur(2.5px) saturate(0.65)",
+            opacity: 0.45,
+            maxHeight: compact ? 220 : 380,
+            overflow: "hidden",
+            maskImage: "linear-gradient(to bottom, #000 30%, transparent 100%)",
+            WebkitMaskImage: "linear-gradient(to bottom, #000 30%, transparent 100%)",
+          }}
+        >
+          {preview}
+        </Box>
+      )}
+
+      <Box
+        sx={
+          preview
+            ? { position: "absolute", inset: 0, display: "grid", placeItems: "center", px: 2 }
+            : { position: "static" }
+        }
+      >
+        <Box
+          sx={{
+            width: "100%",
+            maxWidth: 460,
+            textAlign: "center",
+            p: { xs: 2.5, sm: 3 },
+            borderRadius: 4,
+            bgcolor: "#fff",
+            border: "1px solid #e4e7f0",
+            boxShadow: "0 1px 2px rgba(16,24,40,0.04), 0 18px 40px -24px rgba(30,27,75,0.35)",
+            mx: "auto",
+          }}
+        >
+          <Box
+            sx={{
+              width: 46,
+              height: 46,
+              mx: "auto",
+              mb: 1.75,
+              borderRadius: "50%",
+              display: "grid",
+              placeItems: "center",
+              color: "white",
+              background: "linear-gradient(135deg, #7c3aed, #ec4899)",
+            }}
+          >
+            <Icon icon="mdi:lock-outline" width={22} />
+          </Box>
+
+          <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a", letterSpacing: "-0.3px" }}>
+            {title}
+          </Typography>
+          <Typography sx={{ color: "#475569", mt: 0.75, fontSize: "0.85rem", lineHeight: 1.55 }}>
+            {body}
+          </Typography>
+
+          <Box sx={{ mt: 2 }}>
+            <LinearProgress
+              variant="determinate"
+              value={Math.min(100, percentage)}
+              sx={{
+                height: 7,
+                borderRadius: 999,
+                bgcolor: "#eef2f7",
+                "& .MuiLinearProgress-bar": {
+                  borderRadius: 999,
+                  background: "linear-gradient(90deg, #a855f7, #ec4899)",
+                },
+              }}
+            />
+            <Typography sx={{ mt: 0.75, fontSize: "0.72rem", fontWeight: 700, color: "#94a3b8" }}>
+              Profile {percentage}% complete
+            </Typography>
+          </Box>
+
+          {outstanding.length > 0 && !compact && (
+            <Stack
+              direction="row"
+              flexWrap="wrap"
+              justifyContent="center"
+              gap={0.75}
+              sx={{ mt: 2 }}
+            >
+              {outstanding.map((f) => (
+                <Box
+                  key={f.field}
+                  sx={{
+                    px: 1.25,
+                    py: 0.5,
+                    borderRadius: 999,
+                    bgcolor: "#f8fafc",
+                    border: "1px solid #e4e7f0",
+                    fontSize: "0.74rem",
+                    fontWeight: 700,
+                    color: "#475569",
+                  }}
+                >
+                  {f.label}
+                </Box>
+              ))}
+            </Stack>
+          )}
+
+          <Box sx={{ mt: 2.25 }}>
+            <CompleteProfileButton />
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Wraps a single control. The control still renders, so the learner can see the capability
+ * exists, but it cannot be activated and hovering says why.
+ */
+export function LockedAction({
+  locked,
+  label,
+  children,
+}: {
+  locked: boolean;
+  label: string;
+  children: ReactNode;
+}) {
+  const { percentage } = useProfileGate();
+  const router = useRouter();
+
+  if (!locked) return <>{children}</>;
+
+  return (
+    <Tooltip
+      title={
+        <Box sx={{ p: 0.5, textAlign: "center" }}>
+          <Typography sx={{ fontSize: "0.78rem", fontWeight: 800, mb: 0.25 }}>{label}</Typography>
+          <Typography sx={{ fontSize: "0.72rem", opacity: 0.85 }}>
+            Complete your profile to unlock. {percentage}% done.
+          </Typography>
+        </Box>
+      }
+    >
+      {/* The span carries the tooltip: a disabled child fires no pointer events of its own. */}
+      <Box
+        component="span"
+        onClick={() => router.push("/profile#profile-strength")}
+        sx={{ position: "relative", display: "inline-flex", cursor: "pointer" }}
+      >
+        <Box sx={{ pointerEvents: "none", opacity: 0.45, filter: "grayscale(0.7)" }}>{children}</Box>
+        <Box
+          sx={{
+            position: "absolute",
+            top: -4,
+            insetInlineEnd: -4,
+            width: 18,
+            height: 18,
+            borderRadius: "50%",
+            display: "grid",
+            placeItems: "center",
+            color: "#fff",
+            background: "linear-gradient(135deg, #7c3aed, #ec4899)",
+            boxShadow: "0 2px 6px -1px rgba(15,10,44,0.4)",
+          }}
+        >
+          <Icon icon="mdi:lock" width={11} />
+        </Box>
+      </Box>
+    </Tooltip>
+  );
+}
+
+/**
+ * A one-line banner for the top of a gated page. Explains the state once, so the individual
+ * locked components below do not each have to repeat the whole story.
+ */
+export function ProfileLockBanner({ moduleLabel }: { moduleLabel: string }) {
+  const { percentage } = useProfileGate();
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        flexWrap: "wrap",
+        p: 1.75,
+        mb: 2.5,
+        borderRadius: 3,
+        bgcolor: "#fdfcff",
+        border: "1px solid #ede9fe",
+      }}
+    >
+      <Box
+        sx={{
+          width: 32,
+          height: 32,
+          flexShrink: 0,
+          borderRadius: 2,
+          display: "grid",
+          placeItems: "center",
+          color: "#fff",
+          background: "linear-gradient(135deg, #7c3aed, #ec4899)",
+        }}
+      >
+        <Icon icon="mdi:lock-outline" width={17} />
+      </Box>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.88rem", color: "#0f172a" }}>
+          {moduleLabel} is limited until your profile is complete
+        </Typography>
+        <Typography sx={{ fontSize: "0.76rem", color: "#64748b", mt: 0.15 }}>
+          You can look around. Finishing your profile takes about a minute and unlocks Resume,
+          Jobs and Interview together. {percentage}% done.
+        </Typography>
+      </Box>
+      <CompleteProfileButton fullWidth={false} size="sm" />
+    </Box>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -305,24 +305,40 @@ function SidebarNavButton({
         />
       )}
       {locked && !collapsed && (
-        <Box
-          component="span"
-          sx={{
-            display: "inline-flex",
-            alignItems: "center",
-            flexShrink: 0,
-            opacity: 0.75,
-            // The (i) button sits absolutely at right: 4 and is ~18px wide including its
-            // padding. Without this the padlock renders underneath it.
-            ...(hasInfo
-              ? rtl
-                ? { ml: "22px" }
-                : { mr: "22px" }
-              : {}),
-          }}
+        // A violet pill rather than a faint grey glyph. The old padlock read as "disabled",
+        // which is the wrong story: these rows are reachable and the destination explains
+        // exactly what is missing. A branded badge reads as "there is something here for you"
+        // instead of "this is broken".
+        <Tooltip
+          title="Complete your profile to unlock"
+          placement={rtl ? "left" : "right"}
+          arrow
         >
-          <IconWrapper icon="mdi:lock-outline" size={14} />
-        </Box>
+          <Box
+            component="span"
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              color: "#fff",
+              background: "linear-gradient(135deg, #7c3aed, #ec4899)",
+              boxShadow: "0 2px 6px -2px rgba(124,58,237,0.8)",
+              // The (i) button sits absolutely at right: 4 and is ~18px wide including its
+              // padding. Without this the padlock renders underneath it.
+              ...(hasInfo
+                ? rtl
+                  ? { ml: "22px" }
+                  : { mr: "22px" }
+                : {}),
+            }}
+          >
+            <IconWrapper icon="mdi:lock" size={11} />
+          </Box>
+        </Tooltip>
       )}
     </ListItemButton>
   );

--- a/components/profile/resume/ResumeBuilder.tsx
+++ b/components/profile/resume/ResumeBuilder.tsx
@@ -33,12 +33,19 @@ import { toPng } from "html-to-image";
 import { jsPDF } from "jspdf";
 import { resumeService } from "@/lib/services/resume.service";
 import { PANEL_BORDER, PANEL_SHADOW, PROFILE, TILE_GRADIENT, CTA_GRADIENT, CTA_SHADOW } from "../theme/profileTokens";
+import { LockedAction } from "@/components/common/ProfileLock";
 
 /** Where the builder's current content came from. Drives the toolbar's segmented control. */
 type ResumeSource = "sample" | "profile" | "blank";
 
 interface ResumeBuilderProps {
   initialData?: Partial<ResumeData>;
+  /**
+   * Gate the two actions that put the resume in front of someone else. Editing stays open:
+   * building a resume is the work that fills a profile in, so blocking the builder to demand
+   * a complete profile has the dependency backwards.
+   */
+  lockExports?: boolean;
 }
 
 const EMPTY_BASIC_INFO: ResumeData["basicInfo"] = {
@@ -196,7 +203,7 @@ type TemplateName =
   | "rightsidebar"
   | "bubble";
 
-export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
+export function ResumeBuilder({ initialData, lockExports = false }: ResumeBuilderProps) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateName>("modern");
@@ -587,6 +594,7 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
               ATS {atsScoreLive}
             </Box>
           </Tooltip>
+          <LockedAction locked={lockExports} label="Saving is locked">
           <Button
             variant="outlined"
             startIcon={<IconWrapper icon="mdi:content-save-outline" size={17} />}
@@ -606,6 +614,8 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
           >
             {saveResumeLoading ? "\u2026" : t("profile.saveResume", { defaultValue: "Save" })}
           </Button>
+          </LockedAction>
+          <LockedAction locked={lockExports} label="Download is locked">
           <Button
             variant="contained"
             disableElevation
@@ -626,6 +636,7 @@ export function ResumeBuilder({ initialData }: ResumeBuilderProps) {
           >
             PDF
           </Button>
+          </LockedAction>
         </Box>
       </Paper>
 


### PR DESCRIPTION
## The toast bug

A `profile_incomplete` 403 is the lock working, not a failure. The interview page fed it straight to `showToast`, so a learner saw **"Failed to load interviews"** next to a panel explaining their profile was incomplete — two contradictory explanations for one expected state, one of which says the product is broken.

Jobs already routed the 403 to `reportProfileLock`. Interview never did, despite destructuring it.

## Lock the action, not the page

Blocking the whole page answered "you cannot do this" but never "what am I missing out on". Someone staring at a blurred page has no reason to spend the minute it takes to finish their profile. Now the page stays browsable and only the gated part locks:

- **Interview** — the launcher. Header, stats and tabs stay readable; the locked card renders the real mode selector behind it so the offer is visible.
- **Jobs** — the listings. Header, tabs and filters stay live.
- **Resume** — Save and PDF only. The builder stays fully editable: building a resume is the work that fills a profile in, so gating the builder on a complete profile had the dependency backwards. The gate belongs where the resume leaves the product.

New primitives in `components/common/ProfileLock.tsx`: `ProfileLockCard` (replaces a component, optionally rendering the real one blurred behind it), `LockedAction` (wraps a single control), `ProfileLockBanner` (explains the state once per page).

**Sidebar** padlock becomes a violet badge with a reason on hover. A faint grey glyph on a dimmed row read as "disabled", which is the wrong story — those rows are deliberately still clickable and the destination explains what is missing.

`ProfileLockModal` is left in place: no longer imported by these three pages, but still a reasonable primitive for a genuinely unreachable surface.

## Verification

Browser test with a stubbed `profile_incomplete` 403 on all three routes: module content still visible, lock shown, no "failed to load" anywhere. `tsc` clean, `next build` exit 0, zero lint errors in the new file, and the three touched directories sit at 38 errors both before and after (all pre-existing).

Note: strings in the new lock components are hardcoded English, matching the existing `ProfileLockModal`. Worth a follow-up to move both onto i18n keys together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)