### PR TITLE
feat(admin): course settings in one place, module index + paging, shimmer loaders

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { MainLayout } from "@/components/layout/MainLayout";
+import { AdminAdaptiveCourseDetailSkeleton } from "@/components/courses/CourseSkeletons";
 import { useToast } from "@/components/common/Toast";
 import { Reveal } from "@/components/scorecard/shared";
 import { InstructorAssignPanel } from "@/components/instructor/InstructorAssignPanel";
@@ -386,11 +387,7 @@ export default function AdminAdaptiveCourseDetailPage() {
         </ButtonBase>
 
         <AdaptiveSectionShell>
-          {loading && (
-            <Typography sx={{ color: "text.secondary", textAlign: "center", py: 6 }}>
-              Loading course…
-            </Typography>
-          )}
+          {loading && <AdminAdaptiveCourseDetailSkeleton />}
           {error && (
             <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>
               {error}

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -45,6 +45,7 @@ import { CourseCoverArtPanel } from "@/components/admin/adaptive-course/CourseCo
 import { CourseSettingsPanel } from "@/components/admin/adaptive-course/CourseSettingsPanel";
 import { CalibrationAdminSection } from "@/components/admin/adaptive-course/CalibrationAdminSection";
 import { CohortScheduleSection } from "@/components/admin/adaptive-course/CohortScheduleSection";
+import { ModuleNavigator, MODULES_PER_PAGE } from "@/components/admin/adaptive-course/ModuleNavigator";
 import { CalibrationResultsSection } from "@/components/admin/adaptive-course/CalibrationResultsSection";
 import { AssignToCohortsDialog } from "@/components/admin/adaptive-course/AssignToCohortsDialog";
 import { MockInterviewAdminSection } from "@/components/admin/adaptive-course/MockInterviewAdminSection";
@@ -77,6 +78,9 @@ export default function AdminAdaptiveCourseDetailPage() {
   const [course, setCourse] = useState<AdminAdaptiveCourseDetail | null>(null);
   /** Which setting is mid-flight, so its own control disables rather than firing twice. */
   const [pendingSetting, setPendingSetting] = useState<string | null>(null);
+  /** Content tab paging. A finished course is thousands of pixels of scroll unpaged. */
+  const [modulePage, setModulePage] = useState(0);
+  const [activeModuleId, setActiveModuleId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dialog, setDialog] = useState<DialogState>(null);
@@ -88,7 +92,7 @@ export default function AdminAdaptiveCourseDetailPage() {
   const [expandedArticle, setExpandedArticle] = useState<number | null>(null);
   const [expandedCoding, setExpandedCoding] = useState<number | null>(null);
   const [tab, setTab] = useState<
-    "content" | "calibration" | "mock" | "certificate" | "students" | "cover" | "settings"
+    "content" | "calibration" | "mock" | "certificate" | "students" | "settings"
   >("content");
   // Recovery: regenerate ONLY the submodules still missing content (the banner
   // surfaces the gap; this kicks off a fresh fill-in job).
@@ -241,6 +245,18 @@ export default function AdminAdaptiveCourseDetailPage() {
       setPendingSetting(null);
     }
   }
+
+  /** Jump to a module, changing page first so the target is mounted before we scroll to it. */
+  const jumpToModule = useCallback((moduleId: number, targetPage: number) => {
+    setModulePage(targetPage);
+    setActiveModuleId(moduleId);
+    // Two frames: one for the page state to commit, one for the newly mounted rows to lay out.
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        document.getElementById(`module-${moduleId}`)?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }),
+    );
+  }, []);
 
   async function handleToggleContentLock() {
     if (!course) return;
@@ -404,9 +420,10 @@ export default function AdminAdaptiveCourseDetailPage() {
                 accent="indigo"
               />
 
-              {/* Action toolbar — full-width so it wraps onto its own rows instead of crushing the
-                  hero title (the old rightSlot crammed 7 pills beside a 2.5rem title, which collapsed
-                  the title column when zoomed / on narrow screens). */}
+              {/* One content action. Everything else — edit details, cover art, publish,
+                  content health, and every setting — lives in the Settings tab, so there is
+                  exactly one place to look for "configure this course" and the header stops
+                  being a bag of unrelated pills. */}
               <Box
                 sx={{
                   display: "flex",
@@ -417,36 +434,13 @@ export default function AdminAdaptiveCourseDetailPage() {
                   mb: 2.5,
                 }}
               >
-                    {showHealthBanner && health && (
-                      <ContentHealthPill
-                        health={health}
-                        regenerating={regenerating}
-                        onRegenerate={() => setRegenConfirmOpen(true)}
-                      />
-                    )}
-                    <ButtonBase onClick={openEditDetails} sx={pillBtnSx("outline")}>
-                      <Icon icon="mdi:pencil-outline" width={16} />
-                      Edit details
-                    </ButtonBase>
-                    <ButtonBase
-                      onClick={() => openDialog({ kind: "module" })}
-                      sx={pillBtnSx("outline")}
-                    >
-                      <Icon icon="mdi:plus" width={16} />
-                      Add module (AI)
-                    </ButtonBase>
-                    {/* Content lock, auto-enroll, self-enroll, pricing and cohort assignment
-                        moved into the Settings tab. They were state toggles and dialog-openers
-                        rendered identically to the content actions beside them, so nothing told
-                        an admin what a click would do. */}
-                    <ButtonBase onClick={() => setTab("settings")} sx={pillBtnSx("outline")}>
-                      <Icon icon="mdi:cog-outline" width={16} />
-                      Settings
-                    </ButtonBase>
-                    <ButtonBase onClick={() => void handlePublish()} sx={pillBtnSx(course.is_published ? "outline" : "solid")}>
-                      <Icon icon={course.is_published ? "mdi:eye-off-outline" : "mdi:earth"} width={16} />
-                      {course.is_published ? "Unpublish" : "Publish"}
-                    </ButtonBase>
+                <ButtonBase
+                  onClick={() => openDialog({ kind: "module" })}
+                  sx={pillBtnSx("outline")}
+                >
+                  <Icon icon="mdi:plus" width={16} />
+                  Add module (AI)
+                </ButtonBase>
               </Box>
 
               <Box sx={{ display: "flex", gap: 1, mb: 2.5, flexWrap: "wrap" }}>
@@ -456,7 +450,6 @@ export default function AdminAdaptiveCourseDetailPage() {
                   ["mock", "Mock interviews", "mdi:account-voice"],
                   ["certificate", "Certificate", "mdi:certificate"],
                   ["students", "Students", "mdi:account-school-outline"],
-                  ["cover", "Cover art", "mdi:image-outline"],
                   ["settings", "Settings", "mdi:cog-outline"],
                 ] as const).map(([key, label, icon]) => {
                   const active = tab === key;
@@ -492,19 +485,31 @@ export default function AdminAdaptiveCourseDetailPage() {
                   onToggleContentLock={() => void handleToggleContentLock()}
                   onOpenPricing={() => setPricingOpen(true)}
                   onAssignCohorts={() => setAssignCohortsOpen(true)}
+                  onEditDetails={openEditDetails}
+                  onPublish={() => void handlePublish()}
+                  healthSlot={
+                    health ? (
+                      <ContentHealthPill
+                        health={health}
+                        regenerating={regenerating}
+                        onRegenerate={() => setRegenConfirmOpen(true)}
+                      />
+                    ) : undefined
+                  }
+                  scheduleSlot={<CohortScheduleSection courseId={course.id} />}
+                  coverSlot={
+                    <CourseCoverArtPanel
+                      courseId={course.id}
+                      headerUrl={course.header_image_url}
+                      headerHidden={course.header_image_hidden}
+                      cardUrl={course.card_image_url}
+                      cardHidden={course.card_image_hidden}
+                      onChange={handleCoverChange}
+                    />
+                  }
                 />
               )}
 
-              {tab === "cover" && (
-                <CourseCoverArtPanel
-                  courseId={course.id}
-                  headerUrl={course.header_image_url}
-                  headerHidden={course.header_image_hidden}
-                  cardUrl={course.card_image_url}
-                  cardHidden={course.card_image_hidden}
-                  onChange={handleCoverChange}
-                />
-              )}
 
               {tab === "students" && (
                 <Stack spacing={2}>
@@ -524,7 +529,6 @@ export default function AdminAdaptiveCourseDetailPage() {
 
               {tab === "certificate" && <CertificateAdminSection courseId={course.id} />}
 
-              {tab === "content" && <CohortScheduleSection courseId={course.id} />}
 
               {tab === "content" && course.skills.length > 0 && (
                 <Box sx={{
@@ -566,21 +570,40 @@ export default function AdminAdaptiveCourseDetailPage() {
               )}
 
               {tab === "content" && (
+              <ModuleNavigator
+                modules={course.modules}
+                page={modulePage}
+                onPageChange={(p) => {
+                  setModulePage(p);
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                }}
+                onJumpToModule={jumpToModule}
+                activeModuleId={activeModuleId}
+              />
+              )}
+
+              {tab === "content" && (
               <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
                 {course.modules.length === 0 && (
                   <Typography sx={{ color: "text.secondary", textAlign: "center", py: 4 }}>
                     No modules yet. Use <strong>Add module (AI)</strong> to generate one.
                   </Typography>
                 )}
-                {course.modules.map((mod, mIdx) => (
+                {course.modules
+                  .slice(modulePage * MODULES_PER_PAGE, (modulePage + 1) * MODULES_PER_PAGE)
+                  .map((mod, mIdx) => (
                   <Reveal key={mod.id} delay={Math.min(mIdx, 8) * 0.05}>
                     <Box
+                      id={`module-${mod.id}`}
                       sx={{
                         borderRadius: 4,
                         p: { xs: 2, md: 2.5 },
                         bgcolor: "var(--card-bg, #fff)",
                         border: "1px solid var(--border-default, #ececf1)",
                         boxShadow: "0 1px 2px rgba(16,24,40,0.04), 0 10px 26px -22px rgba(16,24,40,0.18)",
+                        // Clears the sticky app header AND the sticky module index above it,
+                        // or a jumped-to module lands underneath both.
+                        scrollMarginTop: 150,
                       }}
                     >
                       <Box

--- a/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
@@ -44,6 +44,7 @@ import {
   isNeverActive,
 } from "@/components/admin/adaptive-course/analytics/studentInsights";
 import { useVizPalette } from "@/components/admin/adaptive-course/analytics/vizPalette";
+import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
 
 const SEVERITY_RANK: Record<string, number> = { critical: 0, serious: 1, warning: 2 };
 
@@ -106,7 +107,7 @@ export default function StudentPerformancePage() {
     return (
       <MainLayout fullWidthContent>
         <Box sx={{ display: "grid", placeItems: "center", minHeight: "60vh" }}>
-          {loading ? <CircularProgress /> : <Typography color="text.secondary">Report unavailable.</Typography>}
+          {loading ? <AdminSectionSkeleton rows={5} /> : <Typography color="text.secondary">Report unavailable.</Typography>}
         </Box>
       </MainLayout>
     );

--- a/components/adaptive-quiz/AdaptiveQuizLayout.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizLayout.tsx
@@ -17,6 +17,7 @@ import { QuizMetaStrip } from "./mid/QuizMetaStrip";
 import { LiveTimerRing } from "./mid/LiveTimerRing";
 import { LiveQuizPoints } from "./mid/LiveQuizPoints";
 import { PointsRewardBurst } from "./mid/PointsRewardBurst";
+import { AdaptiveSessionSkeleton } from "@/components/courses/CourseSkeletons";
 
 interface AdaptiveQuizLayoutProps {
   sessionId: string;
@@ -50,8 +51,8 @@ export function AdaptiveQuizLayout({ sessionId }: AdaptiveQuizLayoutProps) {
 
   if (ctx.loading) {
     return (
-      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "60vh" }}>
-        <Typography sx={{ color: "text.secondary" }}>Loading your adaptive session…</Typography>
+      <Box sx={{ display: "flex", justifyContent: "center", py: 4, px: 2 }}>
+        <AdaptiveSessionSkeleton />
       </Box>
     );
   }

--- a/components/admin/adaptive-course/AdminArticleViewer.tsx
+++ b/components/admin/adaptive-course/AdminArticleViewer.tsx
@@ -11,6 +11,7 @@ import {
   type ReadingTier,
 } from "@/lib/services/adaptive-course.service";
 import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
+import { ArticleBodySkeleton } from "@/components/courses/CourseSkeletons";
 
 /**
  * Read-only admin preview of an adaptive article: renders the content at a tier
@@ -58,7 +59,7 @@ export function AdminArticleViewer({ courseId, articleId }: { courseId: number; 
     }
   }
 
-  if (loading) return <Typography sx={{ color: "text.secondary", fontSize: "0.82rem", py: 2 }}>Loading article…</Typography>;
+  if (loading) return <ArticleBodySkeleton />;
   if (error) return <Typography sx={{ color: "#ef4444", fontSize: "0.82rem", fontWeight: 700, py: 2 }}>{error}</Typography>;
   if (!article) return null;
 

--- a/components/admin/adaptive-course/AdminCodingViewer.tsx
+++ b/components/admin/adaptive-course/AdminCodingViewer.tsx
@@ -9,6 +9,7 @@ import {
   adminAdaptiveCourseService,
   type AdminCodingProblemDetail,
 } from "@/lib/services/admin/admin-adaptive-course.service";
+import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
 
 /**
  * Admin review + edit surface for one generated coding problem - the coding
@@ -119,7 +120,7 @@ export function AdminCodingViewer({ problemId, onChanged, onDeleted }: AdminCodi
   if (loading) {
     return (
       <Box sx={{ display: "grid", placeItems: "center", py: 4 }}>
-        <CircularProgress size={22} />
+        <AdminSectionSkeleton rows={4} showHeader={false} />
       </Box>
     );
   }

--- a/components/admin/adaptive-course/AssignToCohortsDialog.tsx
+++ b/components/admin/adaptive-course/AssignToCohortsDialog.tsx
@@ -18,6 +18,7 @@ import {
   adminCohortsService,
   type CohortListItem,
 } from "@/lib/services/admin/admin-cohorts.service";
+import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
 
 interface Props {
   open: boolean;
@@ -120,7 +121,7 @@ export function AssignToCohortsDialog({ open, onClose, courseId, courseTitle }: 
       <DialogContent sx={{ pt: 1 }}>
         {loading ? (
           <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-            <CircularProgress size={26} />
+            <AdminSectionSkeleton rows={4} showHeader={false} />
           </Box>
         ) : error ? (
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, py: 3, color: "text.secondary" }}>

--- a/components/admin/adaptive-course/CalibrationResultsSection.tsx
+++ b/components/admin/adaptive-course/CalibrationResultsSection.tsx
@@ -22,6 +22,7 @@ import type {
   CalibrationSubmissionRow,
   CalibrationSubmissionsResponse,
 } from "@/lib/types/adaptive-journey";
+import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
 
 const TIER_COLOR: Record<string, string> = {
   beginner: "#f59e0b",
@@ -94,7 +95,7 @@ export function CalibrationResultsSection({ courseId }: { courseId: number }) {
 
       {loading ? (
         <Box sx={{ display: "grid", placeItems: "center", py: 5 }}>
-          <CircularProgress sx={{ color: "#6366f1" }} />
+          <AdminSectionSkeleton rows={4} />
         </Box>
       ) : !data || data.submissions.length === 0 ? (
         <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default, #ececf1)" }}>

--- a/components/admin/adaptive-course/CohortScheduleSection.tsx
+++ b/components/admin/adaptive-course/CohortScheduleSection.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Box, Button, CircularProgress, Stack, TextField, Typography } from "@mui/material";
+import { Box, Button, Stack, TextField, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { useToast } from "@/components/common/Toast";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
+import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
 
 /**
  * Cohort start date - drives the weekly windows (stagger + window) and late
@@ -63,7 +64,7 @@ export function CohortScheduleSection({ courseId }: { courseId: number }) {
 
       {loading ? (
         <Box sx={{ display: "grid", placeItems: "center", py: 2 }}>
-          <CircularProgress size={22} sx={{ color: "#6366f1" }} />
+          <AdminSectionSkeleton rows={2} showHeader={false} />
         </Box>
       ) : (
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, alignItems: "flex-end", justifyContent: "space-between" }}>

--- a/components/admin/adaptive-course/CourseSettingsPanel.tsx
+++ b/components/admin/adaptive-course/CourseSettingsPanel.tsx
@@ -137,6 +137,15 @@ export interface CourseSettingsPanelProps {
   onToggleContentLock: () => void;
   onOpenPricing: () => void;
   onAssignCohorts: () => void;
+  onEditDetails: () => void;
+  onPublish: () => void;
+  publishing?: boolean;
+  /** Content health ("N items still missing") + its regenerate action. */
+  healthSlot?: ReactNode;
+  /** Cover art panel, moved out of its own tab. */
+  coverSlot?: ReactNode;
+  /** Cohort start date, moved out of the Content tab so all pacing sits together. */
+  scheduleSlot?: ReactNode;
 }
 
 export function CourseSettingsPanel({
@@ -149,6 +158,12 @@ export function CourseSettingsPanel({
   onToggleContentLock,
   onOpenPricing,
   onAssignCohorts,
+  onEditDetails,
+  onPublish,
+  publishing = false,
+  healthSlot,
+  coverSlot,
+  scheduleSlot,
 }: CourseSettingsPanelProps) {
   const summary = course.enrollment_summary;
   const cohorts = course.assigned_cohorts ?? [];
@@ -183,12 +198,74 @@ export function CourseSettingsPanel({
   const pacingLines = course.content_locked
     ? [
         "Weeks unlock on the cohort schedule rather than all at once.",
-        "Set a start date on the Content tab, or there are no deadlines and no late penalties yet.",
+        "Without a start date below, there are no deadlines and no late penalties yet.",
       ]
     : ["Every week is open from the start, and all work earns full points whenever it is done."];
 
   return (
     <Stack spacing={2.5}>
+      <SettingsCard
+        icon="mdi:card-text-outline"
+        title="Course details"
+        subtitle={course.is_published ? "Published — students can see this" : "Draft — not visible to students"}
+      >
+        <Stack spacing={1.5}>
+          <Box>
+            <Typography sx={{ fontWeight: 700, fontSize: "0.95rem", color: "#0f172a" }}>{course.title}</Typography>
+            {course.description && (
+              <Typography sx={{ fontSize: "0.8rem", color: "#64748b", mt: 0.5, lineHeight: 1.55 }}>
+                {course.description}
+              </Typography>
+            )}
+          </Box>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            <Box
+              component="button"
+              onClick={onEditDetails}
+              sx={{
+                px: 2, py: 0.85, borderRadius: 999, cursor: "pointer", fontFamily: "inherit",
+                fontWeight: 800, fontSize: "0.78rem", color: "#7c3aed",
+                bgcolor: "#f5f3ff", border: "1px solid #ede9fe",
+              }}
+            >
+              Edit title &amp; description
+            </Box>
+            <Box
+              component="button"
+              onClick={onPublish}
+              disabled={publishing}
+              sx={{
+                px: 2, py: 0.85, borderRadius: 999, cursor: publishing ? "default" : "pointer",
+                fontFamily: "inherit", fontWeight: 800, fontSize: "0.78rem",
+                color: course.is_published ? "#475569" : "#fff",
+                bgcolor: course.is_published ? "#f8fafc" : "#7c3aed",
+                border: course.is_published ? "1px solid #e4e7f0" : "1px solid transparent",
+                opacity: publishing ? 0.6 : 1,
+              }}
+            >
+              {course.is_published ? "Unpublish" : "Publish course"}
+            </Box>
+          </Stack>
+          <ResolvedState
+            lines={[
+              course.is_published
+                ? "Students who have access can open this course now."
+                : "Nobody can open this yet. Publishing is what makes every setting below take effect.",
+            ]}
+          />
+        </Stack>
+      </SettingsCard>
+
+      {healthSlot && (
+        <SettingsCard
+          icon="mdi:clipboard-alert-outline"
+          title="Content health"
+          subtitle="Anything still missing from this course"
+        >
+          {healthSlot}
+        </SettingsCard>
+      )}
+
       {/* Roster first. The question an admin actually has is not "what is auto_enroll set to",
           it is "who is in this course and how did they get here". */}
       <SettingsCard
@@ -282,6 +359,9 @@ export function CourseSettingsPanel({
           onChange={onToggleContentLock}
         />
         <ResolvedState lines={pacingLines} />
+        {scheduleSlot && (
+          <Box sx={{ mt: 2, pt: 2, borderTop: "1px solid #eef2f7" }}>{scheduleSlot}</Box>
+        )}
       </SettingsCard>
 
       {canSetPricing && (
@@ -311,6 +391,12 @@ export function CourseSettingsPanel({
               Auto-enroll is on, so this course can&apos;t carry a price until you turn that off.
             </Typography>
           )}
+        </SettingsCard>
+      )}
+
+      {coverSlot && (
+        <SettingsCard icon="mdi:image-outline" title="Cover art" subtitle="How this course looks in listings">
+          {coverSlot}
         </SettingsCard>
       )}
     </Stack>

--- a/components/admin/adaptive-course/ModuleNavigator.tsx
+++ b/components/admin/adaptive-course/ModuleNavigator.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { Box, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { AdminAdaptiveCourseModule } from "@/lib/services/admin/admin-adaptive-course.service";
+
+/**
+ * Index + pager for the course content tree.
+ *
+ * A finished course is 8-12 modules of 3-5 submodules, each carrying a quiz, an article, a coding
+ * problem and a video. Rendered flat that is several thousand pixels of scroll to reach the last
+ * module, and every one of those rows mounts whether you look at it or not — so the page is both
+ * slow to reach the bottom of and slow to render at all.
+ *
+ * Two fixes, one component. The index makes any module one click away, and the pager means only a
+ * slice is mounted at a time. Paging is skipped entirely below the threshold, because a pager over
+ * four modules is worse than no pager.
+ */
+
+export const MODULES_PER_PAGE = 4;
+
+export function ModuleNavigator({
+  modules,
+  page,
+  onPageChange,
+  onJumpToModule,
+  activeModuleId,
+}: {
+  modules: AdminAdaptiveCourseModule[];
+  page: number;
+  onPageChange: (page: number) => void;
+  onJumpToModule: (moduleId: number, page: number) => void;
+  activeModuleId?: number | null;
+}) {
+  const pageCount = Math.max(1, Math.ceil(modules.length / MODULES_PER_PAGE));
+  const paged = pageCount > 1;
+
+  if (modules.length === 0) return null;
+
+  return (
+    <Box
+      sx={{
+        mb: 2.5,
+        p: { xs: 1.75, md: 2 },
+        borderRadius: 4,
+        border: "1px solid #e4e7f0",
+        bgcolor: "#fff",
+        boxShadow: "0 1px 2px rgba(16,24,40,0.04)",
+        // Sticky so the index stays reachable while reading a long module. Offset clears the
+        // app header; without it the first chip row hides underneath it.
+        position: { md: "sticky" },
+        top: { md: 76 },
+        zIndex: 3,
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.25, flexWrap: "wrap" }}>
+        <Icon icon="mdi:format-list-numbered" width={16} style={{ color: "#7c3aed" }} />
+        <Typography
+          sx={{
+            fontSize: "0.62rem", fontWeight: 800, letterSpacing: 0.5,
+            textTransform: "uppercase", color: "#64748b",
+            '[dir="rtl"] &': { letterSpacing: "normal", textTransform: "none" },
+          }}
+        >
+          Jump to module
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        {paged && (
+          <Typography sx={{ fontSize: "0.72rem", color: "#94a3b8", fontWeight: 700 }}>
+            {modules.length} modules
+          </Typography>
+        )}
+      </Stack>
+
+      <Stack direction="row" spacing={0.75} sx={{ flexWrap: "wrap", gap: 0.75 }}>
+        {modules.map((m, i) => {
+          const targetPage = Math.floor(i / MODULES_PER_PAGE);
+          const active = activeModuleId === m.id;
+          return (
+            <Box
+              key={m.id}
+              component="button"
+              onClick={() => onJumpToModule(m.id, targetPage)}
+              // Title carries the full name; the chip itself is truncated so one long module
+              // title cannot push the rest of the index off the row.
+              title={m.title}
+              sx={{
+                display: "inline-flex", alignItems: "center", gap: 0.6,
+                maxWidth: 240, px: 1.25, py: 0.6, borderRadius: 999,
+                cursor: "pointer", fontFamily: "inherit", fontWeight: 700, fontSize: "0.75rem",
+                border: active ? "1px solid transparent" : "1px solid #e4e7f0",
+                bgcolor: active ? "#7c3aed" : "transparent",
+                color: active ? "#fff" : "#475569",
+                transition: "background .12s, color .12s",
+                "&:hover": { bgcolor: active ? "#7c3aed" : "#f8fafc" },
+                "&:focus-visible": { outline: "none", boxShadow: "0 0 0 2px #fff, 0 0 0 4px #7c3aed" },
+              }}
+            >
+              <Box
+                component="span"
+                sx={{
+                  flexShrink: 0, width: 18, height: 18, borderRadius: "50%",
+                  display: "grid", placeItems: "center", fontSize: "0.62rem", fontWeight: 800,
+                  bgcolor: active ? "rgba(255,255,255,0.22)" : "#f1f5f9",
+                  color: active ? "#fff" : "#64748b",
+                }}
+              >
+                {i + 1}
+              </Box>
+              <Box
+                component="span"
+                sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+              >
+                {m.title}
+              </Box>
+            </Box>
+          );
+        })}
+      </Stack>
+
+      {paged && (
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={1}
+          sx={{ mt: 1.5, pt: 1.5, borderTop: "1px solid #eef2f7" }}
+        >
+          <PagerButton
+            icon="mdi:chevron-left"
+            label="Previous"
+            disabled={page === 0}
+            onClick={() => onPageChange(page - 1)}
+          />
+          <Box sx={{ flex: 1, textAlign: "center" }}>
+            <Typography sx={{ fontSize: "0.75rem", fontWeight: 700, color: "#475569" }}>
+              Page {page + 1} of {pageCount}
+            </Typography>
+          </Box>
+          <PagerButton
+            icon="mdi:chevron-right"
+            label="Next"
+            disabled={page >= pageCount - 1}
+            onClick={() => onPageChange(page + 1)}
+            trailingIcon
+          />
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+function PagerButton({
+  icon, label, disabled, onClick, trailingIcon = false,
+}: {
+  icon: string; label: string; disabled: boolean; onClick: () => void; trailingIcon?: boolean;
+}) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      disabled={disabled}
+      sx={{
+        display: "inline-flex", alignItems: "center", gap: 0.5,
+        px: 1.5, py: 0.7, borderRadius: 999, fontFamily: "inherit",
+        fontWeight: 800, fontSize: "0.75rem",
+        border: "1px solid #e4e7f0", bgcolor: "#fff",
+        color: disabled ? "#cbd5e1" : "#475569",
+        cursor: disabled ? "default" : "pointer",
+        "&:hover": { bgcolor: disabled ? "#fff" : "#f8fafc" },
+        "&:focus-visible": { outline: "none", boxShadow: "0 0 0 2px #fff, 0 0 0 4px #7c3aed" },
+      }}
+    >
+      {!trailingIcon && <Icon icon={icon} width={15} />}
+      {label}
+      {trailingIcon && <Icon icon={icon} width={15} />}
+    </Box>
+  );
+}

--- a/components/courses/CourseSkeletons.tsx
+++ b/components/courses/CourseSkeletons.tsx
@@ -169,3 +169,124 @@ export function AdaptiveSubmoduleSkeleton() {
     </Box>
   );
 }
+
+/**
+ * Admin adaptive course detail — hero, action pills, tab row, then the content tree.
+ *
+ * Replaces a centred "Loading course…" string. A line of text in the middle of an empty card
+ * tells you nothing about what is coming and makes the page appear to jump when the real layout
+ * finally lands; a skeleton shaped like the destination holds the space instead.
+ */
+export function AdminAdaptiveCourseDetailSkeleton() {
+  return (
+    <Box role="status" aria-busy="true" aria-label="Loading course">
+      {/* Hero */}
+      <Box sx={{ ...CARD, borderRadius: 5, p: { xs: 2.5, md: 3.5 }, mb: 2.5 }}>
+        <Shimmer h={12} w={150} sx={{ mb: 1.5 }} />
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Shimmer h={56} w={56} r={3} />
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Shimmer h={30} w="55%" sx={{ mb: 1 }} />
+            <Shimmer h={12} w="80%" />
+          </Box>
+        </Stack>
+      </Box>
+
+      {/* Action pills */}
+      <Stack direction="row" spacing={1} sx={{ mb: 2.5, flexWrap: "wrap", gap: 1 }}>
+        {[120, 140, 96, 104].map((w, i) => (
+          <Shimmer key={i} h={36} w={w} r={999} />
+        ))}
+      </Stack>
+
+      {/* Tabs */}
+      <Stack direction="row" spacing={1} sx={{ mb: 2.5, flexWrap: "wrap", gap: 1 }}>
+        {[92, 108, 132, 108, 96, 96, 92].map((w, i) => (
+          <Shimmer key={i} h={38} w={w} r={999} />
+        ))}
+      </Stack>
+
+      {/* Module tree */}
+      <Stack spacing={2}>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Box key={i} sx={{ ...CARD, borderRadius: 4, p: 2.5 }}>
+            <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1.75 }}>
+              <Shimmer h={30} w={30} r={2} />
+              <Shimmer h={16} w="35%" />
+              <Box sx={{ flex: 1 }} />
+              <Shimmer h={22} w={72} r={999} />
+            </Stack>
+            {Array.from({ length: 2 }).map((__, j) => (
+              <Stack key={j} direction="row" spacing={1.25} alignItems="center" sx={{ py: 1 }}>
+                <Shimmer h={12} w={12} r={999} />
+                <Shimmer h={12} w={`${50 + j * 12}%`} />
+                <Box sx={{ flex: 1 }} />
+                <Shimmer h={18} w={56} r={999} />
+              </Stack>
+            ))}
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+/** A section inside a card: header row + a few lines. For panels that load after their parent. */
+export function AdminSectionSkeleton({ rows = 3, showHeader = true }: { rows?: number; showHeader?: boolean }) {
+  return (
+    <Box role="status" aria-busy="true">
+      {showHeader && (
+        <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 2 }}>
+          <Shimmer h={30} w={30} r={2} />
+          <Shimmer h={14} w={160} />
+        </Stack>
+      )}
+      <Stack spacing={1.25}>
+        {Array.from({ length: rows }).map((_, i) => (
+          <Shimmer key={i} h={14} w={`${92 - i * 9}%`} />
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+/** Prose placeholder — article bodies, where ragged line lengths read as text rather than bars. */
+export function ArticleBodySkeleton({ lines = 7 }: { lines?: number }) {
+  const widths = ["96%", "88%", "93%", "72%", "90%", "85%", "60%", "94%", "78%"];
+  return (
+    <Box role="status" aria-busy="true" sx={{ py: 1 }}>
+      <Shimmer h={20} w="45%" sx={{ mb: 2 }} />
+      <Stack spacing={1.1}>
+        {Array.from({ length: lines }).map((_, i) => (
+          <Shimmer key={i} h={11} w={widths[i % widths.length]} />
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+/** The student adaptive session shell: title, progress bar, question card, answer options. */
+export function AdaptiveSessionSkeleton() {
+  return (
+    <Box role="status" aria-busy="true" aria-label="Loading your session" sx={{ maxWidth: 820, mx: "auto", width: "100%" }}>
+      <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 2 }}>
+        <Shimmer h={38} w={38} r={2.5} />
+        <Box sx={{ flex: 1 }}>
+          <Shimmer h={16} w="45%" sx={{ mb: 0.75 }} />
+          <Shimmer h={10} w="25%" />
+        </Box>
+      </Stack>
+      <Shimmer h={8} w="100%" r={999} sx={{ mb: 3 }} />
+      <Box sx={{ ...CARD, borderRadius: 4, p: 3 }}>
+        <Shimmer h={12} w={90} sx={{ mb: 2 }} />
+        <Shimmer h={16} w="92%" sx={{ mb: 1 }} />
+        <Shimmer h={16} w="70%" sx={{ mb: 3 }} />
+        <Stack spacing={1.25}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Shimmer key={i} h={50} r={2.5} />
+          ))}
+        </Stack>
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
Three things.

## 1. Settings has one home now

Settings had **two** entry points (a toolbar pill and a tab), and the consolidation had stopped half way — edit details, publish, cover art and content health were still header pills, while the cohort start date sat on the Content tab. "Configure this course" meant looking in four places.

Toolbar now keeps a single content action: **Add module (AI)**. Everything else moved into Settings: course details with publish/unpublish, content health, cover art (its own tab is gone), and the cohort start date — which now sits under **Pacing**, next to the content lock it actually interacts with. Previously the pacing copy told you to go to a different tab to set the thing that makes it mean anything.

This reverses my own earlier argument that publish should stay in the toolbar as a lifecycle verb. One obvious home beat proximity.

## 2. Module index + paging for long courses

A finished course is 8–12 modules × 3–5 submodules, each carrying a quiz, article, coding problem and video. Flat, that's thousands of pixels of scroll to reach the last module, and every row mounts whether or not you look at it — so it's slow to reach the bottom of *and* slow to render.

`ModuleNavigator` adds a sticky index (every module one click away) and pages the tree 4 at a time. Jumping across pages switches page first, then scrolls after two frames so the target exists before we scroll to it. Paging is skipped below the threshold — a pager over four modules is worse than none.

Verified with a 9-module course: index lists all 9, only 4 cards mount, "Page 1 of 3", jumping to module 9 lands on the last page.

## 3. Shimmer instead of "Loading course…"

The admin page showed a centred string in an empty card; the student session showed "Loading your adaptive session…". Four skeletons shaped like their destinations (admin course detail, generic section, prose/article, student session shell), all reusing the `Shimmer` already exported from `CourseSkeletons` rather than adding a third copy of the sweep animation.

In-button spinners deliberately left alone — a spinner is right for "I pressed save", a shimmer is for content arriving into a known layout.

`tsc` clean, `next build` green, lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)