### PR TITLE
Dashboard: readable labels, filled deck, CSV export

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Alert, Box, Button, Typography } from "@mui/material";
 import { PageShell } from "@/components/common/PageShell";
 import { IconWrapper } from "@/components/common/IconWrapper";
@@ -19,7 +19,6 @@ import {
   type RangeKey,
 } from "@/lib/services/admin/admin-insights.service";
 import { DashboardHero, HeroKpi, DeckSection } from "@/components/admin/dashboard/v2/surfaces";
-import { generateDashboardPdf } from "@/lib/utils/pdf-generation.utils";
 import { useToast } from "@/components/common/Toast";
 import { LeaderboardPanel } from "@/components/admin/dashboard/v2/LeaderboardPanel";
 import { AtRiskPanel, PulseTrendPanel } from "@/components/admin/insights/PulseSection";
@@ -65,24 +64,22 @@ export default function AdminDashboardPage() {
   const [learning, setLearning] = useState<LearningPayload | null>(null);
   const [people, setPeople] = useState<PeoplePayload | null>(null);
 
-  // PDF export survives the redesign, and the linear deck is what makes it possible: the helper
-  // walks `.pdf-section` blocks in document order, so a tabbed layout would silently export one
-  // quarter of the page. Kept because admins were using it on the old dashboard.
-  const deckRef = useRef<HTMLDivElement>(null);
   const [exporting, setExporting] = useState(false);
   const { showToast } = useToast();
 
-  const exportPdf = useCallback(async () => {
-    if (!deckRef.current) return;
+  // CSV rather than PDF: an admin exporting a dashboard almost always wants to pivot the
+  // numbers, and a picture of a chart cannot be pivoted. The file is generated server-side
+  // under the filters currently on screen, so it cannot disagree with what is displayed.
+  const exportCsv = useCallback(async () => {
     setExporting(true);
     try {
-      await generateDashboardPdf({ element: deckRef.current, fileName: "admin-dashboard.pdf" });
+      await adminInsightsService.exportCsv(range, courseId);
     } catch {
-      showToast("Could not build the PDF. Try again.", "error");
+      showToast("Could not build the export. Try again.", "error");
     } finally {
       setExporting(false);
     }
-  }, [showToast]);
+  }, [range, courseId, showToast]);
 
   // Loading is derived, not stored: a section is loading exactly when it has no payload and
   // nothing has failed. Changing a filter clears the payloads, so the skeletons appear in the
@@ -175,11 +172,54 @@ export default function AdminDashboardPage() {
 
   const tiles = pulse?.tiles;
 
+  // One sentence an admin can act on without reading a single chart. Built from the numbers
+  // already on screen rather than a new endpoint, and written so the shape of the sentence
+  // changes with the situation — a flat month and a collapsing one should not read alike.
+  const summary = (() => {
+    if (!tiles) return "Loading this tenant's adaptive activity…";
+    const active = tiles.active_students.value;
+    const total = tiles.active_students.denominator ?? 0;
+    const pct = total > 0 ? Math.round((active / total) * 100) : null;
+    const diff = tiles.active_students.diff;
+    const periodLabel = pulse?.range.label ?? "this period";
+
+    const direction =
+      diff > 0 ? `up ${diff.toLocaleString()} on the period before`
+        : diff < 0 ? `down ${Math.abs(diff).toLocaleString()} on the period before`
+        : "level with the period before";
+
+    const head = total
+      ? `${active.toLocaleString()} of ${total.toLocaleString()} students (${pct}%) did something in the ${periodLabel}, ${direction}.`
+      : `${active.toLocaleString()} students were active in the ${periodLabel}.`;
+
+    const risk = atRisk?.results.length ?? 0;
+    const tail = risk > 0
+      ? ` ${risk} ${risk === 1 ? "student needs" : "students need"} attention.`
+      : " Nobody is currently flagged as falling behind.";
+
+    return head + tail;
+  })();
+
+  const facts = [
+    {
+      icon: "mdi:school-outline",
+      label: courseId
+        ? "1 course selected"
+        : `${courses.length} adaptive ${courses.length === 1 ? "course" : "courses"}`,
+    },
+    ...(people?.cohorts?.length
+      ? [{ icon: "mdi:account-group-outline", label: `${people.cohorts.length} cohorts` }]
+      : []),
+    ...(tiles ? [{ icon: "mdi:ticket-outline", label: `${tiles.stale_tickets.value} tickets waiting` }] : []),
+  ];
+
   return (
     <PageShell>
-      <Box className="profile-surface" sx={{ p: { xs: 2, md: 4 } }} ref={deckRef}>
+      <Box className="profile-surface" sx={{ p: { xs: 2, md: 4 } }}>
         <DashboardHero
           tenantName={clientInfo?.name || undefined}
+          summary={summary}
+          facts={facts}
           range={range}
           onRangeChange={changeRange}
           courses={courses}
@@ -188,11 +228,10 @@ export default function AdminDashboardPage() {
           disabled={busy(pulse)}
           action={
             <Button
-              className="exclude-from-pdf"
-              onClick={exportPdf}
+              onClick={exportCsv}
               disabled={exporting || busy(pulse)}
               size="small"
-              startIcon={<IconWrapper icon="mdi:file-pdf-box" size={16} />}
+              startIcon={<IconWrapper icon="mdi:file-delimited-outline" size={16} />}
               sx={{
                 textTransform: "none",
                 fontWeight: 700,
@@ -204,7 +243,7 @@ export default function AdminDashboardPage() {
                 "&:hover": { background: "rgba(255,255,255,0.16)" },
               }}
             >
-              {exporting ? "Building…" : "Export PDF"}
+              {exporting ? "Building…" : "Export CSV"}
             </Button>
           }
         >
@@ -217,7 +256,7 @@ export default function AdminDashboardPage() {
             }}
           >
             <HeroKpi
-              label="Active students"
+              label="Students active"
               value={tiles?.active_students.value ?? 0}
               denominator={tiles?.active_students.denominator}
               definition={
@@ -231,7 +270,7 @@ export default function AdminDashboardPage() {
               }
             />
             <HeroKpi
-              label="Items completed"
+              label="Activities completed"
               value={tiles?.items_completed.value ?? 0}
               definition={
                 tiles?.items_completed.definition ??
@@ -254,13 +293,13 @@ export default function AdminDashboardPage() {
               footnote="per active day"
             />
             <HeroKpi
-              label="Stale tickets"
+              label="Tickets waiting"
               value={tiles?.stale_tickets.value ?? 0}
               definition={
                 tiles?.stale_tickets.definition ??
                 "Unresolved tickets opened more than 48 hours ago."
               }
-              footnote="open over 48h"
+              footnote="unanswered over 48h"
             />
           </Box>
         </DashboardHero>
@@ -271,7 +310,7 @@ export default function AdminDashboardPage() {
           </Alert>
         )}
 
-        <Box className="pdf-section">
+        <Box>
           <DeckSection title="Who is here" />
           <Box
             sx={{
@@ -286,12 +325,12 @@ export default function AdminDashboardPage() {
           </Box>
         </Box>
 
-        <Box className="pdf-section">
+        <Box>
           <DeckSection title="What they are learning" />
           <LearningSection data={learning} loading={busy(learning)} />
         </Box>
 
-        <Box className="pdf-section">
+        <Box>
           <DeckSection
             title="How they are working"
             hint="Activity mix, study times and consistency, from scored adaptive work."
@@ -299,12 +338,12 @@ export default function AdminDashboardPage() {
           <EngagementSection data={engagement} loading={busy(engagement)} />
         </Box>
 
-        <Box className="pdf-section">
+        <Box>
           <DeckSection title="Who needs help" />
           <AtRiskPanel atRisk={atRisk} loading={busy(atRisk)} />
         </Box>
 
-        <Box className="pdf-section">
+        <Box>
           <DeckSection
             title="Cohorts, support and instructors"
             hint="Tenant-wide. None of these have a course dimension, so the course filter does not apply."

--- a/components/admin/dashboard/v2/LeaderboardPanel.tsx
+++ b/components/admin/dashboard/v2/LeaderboardPanel.tsx
@@ -59,7 +59,19 @@ export function LeaderboardPanel({
                 alignItems: "center",
                 gap: 1.25,
                 py: 1,
-                borderBottom: "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
+                px: r.rank <= 3 ? 1 : 0,
+                mb: r.rank <= 3 ? 0.5 : 0,
+                borderRadius: r.rank <= 3 ? 2 : 0,
+                // The podium gets a tint of its own medal. A leaderboard where the top row looks
+                // exactly like the tenth is a list, not a ranking.
+                background:
+                  r.rank <= 3
+                    ? `linear-gradient(110deg, color-mix(in srgb, ${MEDAL[r.rank - 1]} 14%, transparent) 0%, transparent 65%)`
+                    : "transparent",
+                borderBottom:
+                  r.rank <= 3
+                    ? "none"
+                    : "1px solid color-mix(in srgb, var(--border-default) 55%, transparent)",
                 "&:last-of-type": { borderBottom: 0 },
               }}
             >
@@ -74,7 +86,14 @@ export function LeaderboardPanel({
                   fontSize: "0.7rem",
                   fontWeight: 800,
                   color: r.rank <= 3 ? "#fff" : "var(--font-secondary)",
-                  bgcolor: r.rank <= 3 ? MEDAL[r.rank - 1] : "color-mix(in srgb, var(--border-default) 40%, transparent)",
+                  background:
+                    r.rank <= 3
+                      ? `linear-gradient(140deg, ${MEDAL[r.rank - 1]}, color-mix(in srgb, ${MEDAL[r.rank - 1]} 65%, #7c3aed))`
+                      : "color-mix(in srgb, var(--border-default) 40%, transparent)",
+                  boxShadow:
+                    r.rank <= 3
+                      ? `0 6px 14px -8px color-mix(in srgb, ${MEDAL[r.rank - 1]} 90%, transparent)`
+                      : "none",
                 }}
               >
                 {r.rank}

--- a/components/admin/dashboard/v2/surfaces.tsx
+++ b/components/admin/dashboard/v2/surfaces.tsx
@@ -11,6 +11,7 @@ import {
   HERO_SHADOW,
   ON_DARK,
   PROFILE,
+  TILE_GRADIENT,
 } from "@/components/profile/theme/profileTokens";
 import {
   RANGE_OPTIONS,
@@ -33,6 +34,8 @@ import {
 
 export function DashboardHero({
   tenantName,
+  summary,
+  facts,
   range,
   onRangeChange,
   courses,
@@ -43,6 +46,10 @@ export function DashboardHero({
   children,
 }: {
   tenantName?: string;
+  /** One plain sentence synthesising the numbers below. The reason to read the hero at all. */
+  summary?: ReactNode;
+  /** Small context chips: course count, cohort count, freshness. */
+  facts?: Array<{ icon: string; label: string }>;
   range: RangeKey;
   onRangeChange: (r: RangeKey) => void;
   courses: AdaptiveCourseOption[];
@@ -69,26 +76,74 @@ export function DashboardHero({
         mb: 3,
       }}
     >
-      <Typography
-        sx={{
-          fontSize: "0.66rem",
-          fontWeight: 800,
-          letterSpacing: "0.1em",
-          textTransform: "uppercase",
-          color: ON_DARK.textFaint,
-          '[dir="rtl"] &': { letterSpacing: "normal", textTransform: "none" },
-        }}
-      >
-        Analytics
-      </Typography>
-      <Typography sx={{ fontSize: { xs: "1.5rem", md: "1.75rem" }, fontWeight: 800, mt: 0.5 }}>
-        Dashboard
-      </Typography>
-      <Typography sx={{ color: ON_DARK.textSoft, fontSize: "0.88rem" }}>
-        {[tenantName, "adaptive courses", RANGE_OPTIONS.find((r) => r.key === range)?.label]
-          .filter(Boolean)
-          .join(" · ")}
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 2 }}>
+        <Box
+          sx={{
+            width: 52,
+            height: 52,
+            borderRadius: 2.5,
+            display: "grid",
+            placeItems: "center",
+            flexShrink: 0,
+            background: CTA_GRADIENT,
+            boxShadow: "0 14px 30px -14px rgba(192,38,211,0.8)",
+          }}
+        >
+          <IconWrapper icon="mdi:chart-box-outline" size={26} color="#fff" />
+        </Box>
+
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Typography
+            sx={{
+              fontSize: "0.66rem",
+              fontWeight: 800,
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: ON_DARK.textFaint,
+              '[dir="rtl"] &': { letterSpacing: "normal", textTransform: "none" },
+            }}
+          >
+            {tenantName ? `${tenantName} · Analytics` : "Analytics"}
+          </Typography>
+          <Typography sx={{ fontSize: { xs: "1.5rem", md: "1.75rem" }, fontWeight: 800, mt: 0.25 }}>
+            Dashboard
+          </Typography>
+
+          {/* The synthesis, not a restatement. An admin who reads only this line should still
+              know whether anything needs them today. */}
+          <Typography
+            sx={{ color: ON_DARK.textSoft, fontSize: "0.92rem", mt: 0.5, maxWidth: "72ch" }}
+          >
+            {summary ?? "Everything below covers adaptive courses only."}
+          </Typography>
+
+          {facts && facts.length > 0 && (
+            <Box sx={{ display: "flex", gap: 0.75, flexWrap: "wrap", mt: 1.25 }}>
+              {facts.map((f) => (
+                <Box
+                  key={f.label}
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    px: 1.25,
+                    py: 0.4,
+                    borderRadius: 999,
+                    fontSize: "0.74rem",
+                    fontWeight: 700,
+                    color: ON_DARK.textSoft,
+                    background: ON_DARK.fill,
+                    border: `1px solid ${ON_DARK.border}`,
+                  }}
+                >
+                  <IconWrapper icon={f.icon} size={13} />
+                  {f.label}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Box>
+      </Box>
 
       <Box
         sx={{
@@ -331,7 +386,17 @@ export function HeroKpi({
 /** The uppercase rule that separates one question from the next down the deck. */
 export function DeckSection({ title, hint }: { title: string; hint?: string }) {
   return (
-    <Box sx={{ mt: 3.5, mb: 1.5 }}>
+    <Box sx={{ mt: 3.5, mb: 1.5, display: "flex", alignItems: "center", gap: 1.25 }}>
+      <Box
+        sx={{
+          width: 4,
+          height: 26,
+          borderRadius: 999,
+          flexShrink: 0,
+          background: TILE_GRADIENT,
+        }}
+      />
+      <Box sx={{ minWidth: 0 }}>
       <Typography
         sx={{
           fontSize: "0.66rem",
@@ -349,6 +414,7 @@ export function DeckSection({ title, hint }: { title: string; hint?: string }) {
           {hint}
         </Typography>
       )}
+      </Box>
     </Box>
   );
 }

--- a/components/admin/insights/LearningSection.tsx
+++ b/components/admin/insights/LearningSection.tsx
@@ -251,7 +251,7 @@ function CourseHealthHeader({ definitions }: { definitions: Record<string, strin
       <Typography sx={label}>Course</Typography>
       <Typography sx={{ ...label, textAlign: "right" }}>Enrolled</Typography>
       <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-        <Typography sx={label}>Activation</Typography>
+        <Typography sx={label}>Started</Typography>
         <DefinitionMark text={definitions.activation_pct} />
       </Box>
       <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
@@ -264,7 +264,7 @@ function CourseHealthHeader({ definitions }: { definitions: Record<string, strin
 
 function CourseRow({ course }: { course: Course }) {
   /*
-   * Activation and completion are deliberately shown side by side, because the pair is what
+   * Started and completed are deliberately shown side by side, because the pair is what
    * carries the diagnosis. Low activation with respectable completion means the people who
    * open the course finish it fine and the problem is upstream — nobody is being pointed at
    * the course. That is a distribution fix (enrolment emails, cohort assignment, a link on the
@@ -358,7 +358,7 @@ function CourseRow({ course }: { course: Course }) {
         </Box>
       </Typography>
 
-      <MetricBar label="Activation" value={course.activation_pct} color={INSIGHT.blue} />
+      <MetricBar label="Started" value={course.activation_pct} color={INSIGHT.blue} />
       <MetricBar label="Completion" value={course.completion_pct} color={INSIGHT.green} />
     </Box>
   );

--- a/components/admin/insights/PeopleSection.tsx
+++ b/components/admin/insights/PeopleSection.tsx
@@ -30,6 +30,15 @@ const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "
 const EM_DASH = "—";
 
 /**
+ * How many cohorts show before "view all".
+ *
+ * A tenant with thirty cohorts turned this panel into the whole page, pushing support load and
+ * instructor feedback below the fold for a list nobody reads past the top of. The server orders
+ * by size, so the five shown are the five that matter.
+ */
+const COHORT_PREVIEW = 5;
+
+/**
  * Cohort dates arrive as plain calendar dates ("2026-03-12"). `new Date(iso)` parses those as
  * UTC midnight, so any viewer behind UTC sees the day before — a cohort that starts on the 1st
  * renders as starting the previous month. Read the parts off the string instead.
@@ -227,6 +236,7 @@ function PanelSkeleton({ rows }: { rows: number }) {
 
 export function PeopleSection({ data, loading }: { data: PeoplePayload | null; loading: boolean }) {
   const ink = useChartInk();
+  const [allCohorts, setAllCohorts] = useState(false);
 
   const gridSx = {
     display: "grid",
@@ -254,6 +264,7 @@ export function PeopleSection({ data, loading }: { data: PeoplePayload | null; l
   }
 
   const { cohorts, tickets, instructors } = data;
+  const visibleCohorts = allCohorts ? cohorts : cohorts.slice(0, COHORT_PREVIEW);
   const rangeLabel = data.range.label;
 
   const medianDef = tickets.definitions.median_resolution_hours;
@@ -273,7 +284,11 @@ export function PeopleSection({ data, loading }: { data: PeoplePayload | null; l
           title="Cohorts"
           // Membership is a stock. Appending the range would suggest these counts are filtered
           // by it, and an admin comparing them against a range-filtered panel would be misled.
-          subtitle="Membership and fill as of today"
+          subtitle={
+            cohorts.length > COHORT_PREVIEW
+              ? `Largest ${COHORT_PREVIEW} of ${cohorts.length}, as of today`
+              : "Membership as of today"
+          }
           icon="mdi:account-group-outline"
           accent={INSIGHT.indigo}
         >
@@ -287,7 +302,7 @@ export function PeopleSection({ data, loading }: { data: PeoplePayload | null; l
             <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
               {/* Server already ordered these. Re-sorting on the client would silently disagree
                   with the ordering the API documents. */}
-              {cohorts.map((c) => {
+              {visibleCohorts.map((c) => {
                 const dates = formatDateRange(c.start_date, c.end_date);
                 const tone = STATUS_TONE[c.status?.toLowerCase()] ?? INSIGHT.indigo;
                 const over = c.fill_pct !== null && c.fill_pct > 100;
@@ -353,7 +368,7 @@ export function PeopleSection({ data, loading }: { data: PeoplePayload | null; l
                         <Box sx={{ display: "flex", alignItems: "center", gap: 0.4 }}>
                           <IconWrapper icon="mdi:account-check-outline" size={14} />
                           <span>
-                            {c.active.toLocaleString()} active of {c.members.toLocaleString()}
+                            {c.active.toLocaleString()} of {c.members.toLocaleString()} still active
                           </span>
                         </Box>
                         {c.completed > 0 && (
@@ -411,6 +426,36 @@ export function PeopleSection({ data, loading }: { data: PeoplePayload | null; l
                   </Box>
                 );
               })}
+              {cohorts.length > COHORT_PREVIEW && (
+                <Box
+                  component="button"
+                  type="button"
+                  onClick={() => setAllCohorts((v) => !v)}
+                  sx={{
+                    mt: 0.5,
+                    alignSelf: "flex-start",
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 0.5,
+                    px: 1.5,
+                    py: 0.75,
+                    borderRadius: 999,
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    fontWeight: 700,
+                    fontSize: "0.78rem",
+                    color: INSIGHT.indigo,
+                    border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+                    backgroundColor: "transparent",
+                    "&:hover": { backgroundColor: "color-mix(in srgb, var(--border-default) 28%, transparent)" },
+                  }}
+                >
+                  <IconWrapper icon={allCohorts ? "mdi:chevron-up" : "mdi:chevron-down"} size={15} />
+                  {allCohorts
+                    ? "Show the largest 5"
+                    : `View all ${cohorts.length} cohorts`}
+                </Box>
+              )}
             </Box>
           )}
         </Panel>

--- a/components/admin/insights/PulseSection.tsx
+++ b/components/admin/insights/PulseSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Chip, Skeleton, Tooltip, Typography } from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
 import {
   Area,
   CartesianGrid,
@@ -64,6 +65,56 @@ function severityColor(severity: number): string {
 }
 
 const CHART_HEIGHT = 300;
+const EM = "—";
+
+/** A small tinted stat under the trend chart. Fills the column and answers what the curve asks. */
+function TrendStat({
+  icon,
+  accent,
+  label,
+  value,
+  hint,
+}: {
+  icon: string;
+  accent: string;
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <Box
+      sx={{
+        borderRadius: 2.5,
+        px: 1.5,
+        py: 1.25,
+        minWidth: 0,
+        border: `1px solid color-mix(in srgb, ${accent} 22%, transparent)`,
+        background: `linear-gradient(150deg, color-mix(in srgb, ${accent} 10%, transparent) 0%, transparent 70%)`,
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.6, color: accent, mb: 0.35 }}>
+        <IconWrapper icon={icon} size={14} />
+        <Typography
+          sx={{
+            fontSize: "0.62rem",
+            fontWeight: 800,
+            letterSpacing: "0.05em",
+            textTransform: "uppercase",
+            color: "var(--font-secondary)",
+          }}
+        >
+          {label}
+        </Typography>
+      </Box>
+      <Typography sx={{ fontSize: "1.05rem", fontWeight: 800, color: "var(--font-primary)", lineHeight: 1.2 }}>
+        {value}
+      </Typography>
+      {hint && (
+        <Typography sx={{ fontSize: "0.68rem", color: "var(--font-secondary)" }}>{hint}</Typography>
+      )}
+    </Box>
+  );
+}
 
 /**
  * The activity trend, on its own.
@@ -92,6 +143,23 @@ export function PulseTrendPanel({ data, loading }: { data: PulsePayload | null; 
     );
   }
   const { trend, range } = data;
+
+  // The chart alone left a tall column half empty next to the leaderboard. These three read off
+  // the same series, so they cost nothing and answer the questions the curve provokes: when was
+  // the best day, when was the worst, and how much happened overall.
+  const busiest = trend.reduce(
+    (best, p) => (p.items_completed > (best?.items_completed ?? -1) ? p : best),
+    null as (typeof trend)[number] | null
+  );
+  const quietest = trend
+    .filter((p) => p.items_completed > 0)
+    .reduce(
+      (worst, p) => (p.items_completed < (worst?.items_completed ?? Infinity) ? p : worst),
+      null as (typeof trend)[number] | null
+    );
+  const totalDone = trend.reduce((n, p) => n + p.items_completed, 0);
+  const peakStudents = trend.reduce((n, p) => Math.max(n, p.active_students), 0);
+
   return (
     <Panel
       title="Activity trend"
@@ -182,7 +250,7 @@ export function PulseTrendPanel({ data, loading }: { data: PulsePayload | null; 
                 yAxisId="items"
                 type="monotone"
                 dataKey="items_completed"
-                name="Items completed (left)"
+                name="Activities completed"
                 stroke={INSIGHT.indigo}
                 strokeWidth={2}
                 fill="url(#pulseItemsFill)"
@@ -193,7 +261,7 @@ export function PulseTrendPanel({ data, loading }: { data: PulsePayload | null; 
                 yAxisId="students"
                 type="monotone"
                 dataKey="active_students"
-                name="Active students (right)"
+                name="Students active"
                 stroke={INSIGHT.green}
                 strokeWidth={2}
                 dot={false}
@@ -203,9 +271,52 @@ export function PulseTrendPanel({ data, loading }: { data: PulsePayload | null; 
           </ResponsiveContainer>
 
           <Typography sx={{ fontSize: "0.74rem", color: "var(--font-secondary)", mt: 1 }}>
-            Left axis counts completions, right axis counts students. The two scales are
-            independent — where the lines cross means nothing.
+            These two count different things, so each has its own scale. The purple area is how
+            much work was finished; the green line is how many students showed up. Where they
+            cross means nothing.
           </Typography>
+
+          <Box
+            sx={{
+              mt: 2,
+              display: "grid",
+              gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(4, 1fr)" },
+              gap: 1.25,
+            }}
+          >
+            <TrendStat
+              icon="mdi:trophy-outline"
+              accent={INSIGHT.amber}
+              label="Busiest day"
+              value={busiest ? formatBucket(busiest.bucket, range.grain) : EM}
+              hint={busiest ? `${busiest.items_completed.toLocaleString()} activities` : undefined}
+            />
+            <TrendStat
+              icon="mdi:weather-night"
+              accent={INSIGHT.blue}
+              label="Quietest day"
+              value={quietest ? formatBucket(quietest.bucket, range.grain) : EM}
+              hint={
+                quietest
+                  ? `${quietest.items_completed.toLocaleString()} activities`
+                  : "no activity yet"
+              }
+            />
+            <TrendStat
+              icon="mdi:check-all"
+              accent={INSIGHT.indigo}
+              label="Total finished"
+              value={totalDone.toLocaleString()}
+              hint={`over ${range.label}`}
+            />
+            <TrendStat
+              icon="mdi:account-multiple-outline"
+              accent={INSIGHT.green}
+              label="Best turnout"
+              value={peakStudents.toLocaleString()}
+              hint="students in one day"
+            />
+          </Box>
         </>
       )}
     </Panel>

--- a/components/admin/insights/primitives.tsx
+++ b/components/admin/insights/primitives.tsx
@@ -72,6 +72,9 @@ export function Panel({
           px: { xs: 2, md: 2.5 },
           py: 1.75,
           borderBottom: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
+          // A tinted band rather than white-on-white. Every panel reading as one flat sheet is
+          // what made the deck feel empty; the accent also tells the sections apart at a glance.
+          background: `linear-gradient(120deg, color-mix(in srgb, ${accent} 9%, transparent) 0%, transparent 62%)`,
         }}
       >
         <Box
@@ -81,8 +84,9 @@ export function Panel({
             borderRadius: 1.5,
             display: "grid",
             placeItems: "center",
-            backgroundColor: `color-mix(in srgb, ${accent} 14%, transparent)`,
-            color: accent,
+            background: `linear-gradient(135deg, ${accent}, color-mix(in srgb, ${accent} 55%, #a855f7))`,
+            color: "#fff",
+            boxShadow: `0 8px 18px -10px color-mix(in srgb, ${accent} 85%, transparent)`,
             flexShrink: 0,
           }}
         >
@@ -260,6 +264,12 @@ export function MetricTile({
  * at all. Cells are coloured on a square-root scale: a linear ramp against a single spiky peak
  * flattens every other cell to the same near-white and hides the shape of the week.
  */
+/** 0 -> 12am, 13 -> 1pm. Admins read the clock they use, not a 24-hour one. */
+function amPm(hour: number): string {
+  const suffix = hour < 12 ? "am" : "pm";
+  return `${hour % 12 || 12}${suffix}`;
+}
+
 export function HourHeatmap({
   matrix,
   max,
@@ -274,7 +284,7 @@ export function HourHeatmap({
   return (
     <Box>
       <Box sx={{ overflowX: "auto", pb: 1 }}>
-        <Box sx={{ minWidth: 620 }}>
+        <Box sx={{ minWidth: 760 }}>
           <Box sx={{ display: "flex", gap: 0.4, mb: 0.5, pl: 4.5 }}>
             {Array.from({ length: 24 }, (_, h) => (
               <Box
@@ -282,12 +292,12 @@ export function HourHeatmap({
                 sx={{
                   flex: 1,
                   textAlign: "center",
-                  fontSize: "0.58rem",
+                  fontSize: "0.56rem",
                   color: "var(--font-secondary)",
                   fontWeight: 700,
                 }}
               >
-                {h % 3 === 0 ? h : ""}
+                {h % 3 === 0 ? amPm(h) : ""}
               </Box>
             ))}
           </Box>
@@ -310,7 +320,9 @@ export function HourHeatmap({
                   key={h}
                   arrow
                   enterTouchDelay={0}
-                  title={`${row.day} ${String(h).padStart(2, "0")}:00 — ${n.toLocaleString()} activities`}
+                  title={`${row.day} ${amPm(h)} to ${amPm((h + 1) % 24)} — ${n.toLocaleString()} ${
+                    n === 1 ? "activity" : "activities"
+                  }`}
                 >
                   <Box
                     sx={{

--- a/lib/services/admin/admin-insights.service.ts
+++ b/lib/services/admin/admin-insights.service.ts
@@ -235,6 +235,35 @@ export const adminInsightsService = {
     return res.data;
   },
 
+  /**
+   * Downloads the whole dashboard as one CSV, under the filters currently on screen.
+   *
+   * Goes through apiClient rather than `window.open` so the auth header is attached; the
+   * endpoint is admin-only and a bare link would 401. The server names the file, so the
+   * filename says which course and period it was taken under.
+   */
+  exportCsv: async (range: RangeKey, courseId?: number | null): Promise<void> => {
+    const qs = new URLSearchParams({ range });
+    if (courseId != null) qs.set("course_id", String(courseId));
+
+    const res = await apiClient.get(
+      `/admin-dashboard/api/clients/${config.clientId}/insights/export/?${qs.toString()}`,
+      { responseType: "blob" }
+    );
+
+    const disposition = String(res.headers?.["content-disposition"] ?? "");
+    const named = /filename="?([^"]+)"?/.exec(disposition)?.[1];
+    const url = URL.createObjectURL(res.data as Blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = named || "dashboard.csv";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    // Revoking immediately cancels the download in Safari; one tick is enough.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  },
+
   /** Adaptive courses only. The legacy dropdown listed ids that match nothing here. */
   getCourseOptions: async (): Promise<AdaptiveCourseOption[]> => {
     const res = await apiClient.get<{ results: AdaptiveCourseOption[] }>(


### PR DESCRIPTION
Pairs with backend PR #521.

## Say what the numbers mean

The trend tooltip read `Active students (right): 0 / Items completed (left): 2` — axis mechanics in the reader's face. The series are now **Students active** and **Activities completed**, with the two-scale caveat explained once in the caption instead of tagged onto every tooltip.

Same fix elsewhere: *Activation* → **Started**, *Items completed* → **Activities completed**, *Stale tickets* → **Tickets waiting**. Hours are am/pm on the axis, the tooltips and the peak callout.

## The hero says something

It now leads with one synthesised sentence — how many of how many students were active, which way that moved, and whether anyone needs attention — plus a gradient badge and context chips. An admin who reads only that line still knows whether today needs them.

## Export is CSV, not PDF

A picture of a chart cannot be pivoted. One file, every panel a labelled block, generated server-side under the filters on screen (course filter included) so the file and the screen cannot disagree.

## Cohorts stop eating the page

Five largest show, with a **view all** expander. Thirty cohorts previously pushed support load and instructor feedback below the fold.

## Fill and contrast

The trend panel left a tall column half empty beside the leaderboard; it now carries a stat strip read off the same series (busiest day, quietest day, total finished, best turnout), so the space is earned rather than padded.

Panel headers get a tinted band and gradient icon tile, the leaderboard podium is tinted with its own medal, and deck sections get a gradient rule — borrowing the treatment the student dashboard already uses, through the shared profile tokens rather than new hexes.

Verified: `tsc` and `eslint` clean, production build passes, visually QA'd end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)