### PR TITLE
Release: manual adaptive course builder

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -46,6 +46,8 @@ import { CourseSettingsPanel } from "@/components/admin/adaptive-course/CourseSe
 import { CalibrationAdminSection } from "@/components/admin/adaptive-course/CalibrationAdminSection";
 import { CohortScheduleSection } from "@/components/admin/adaptive-course/CohortScheduleSection";
 import { ModuleNavigator, MODULES_PER_PAGE } from "@/components/admin/adaptive-course/ModuleNavigator";
+import { AddModuleRow, AddSubmoduleRow } from "@/components/admin/adaptive-course/ManualTreeControls";
+import { AddContentDialog } from "@/components/admin/adaptive-course/AddContentDialog";
 import { CalibrationResultsSection } from "@/components/admin/adaptive-course/CalibrationResultsSection";
 import { AssignToCohortsDialog } from "@/components/admin/adaptive-course/AssignToCohortsDialog";
 import { MockInterviewAdminSection } from "@/components/admin/adaptive-course/MockInterviewAdminSection";
@@ -80,6 +82,7 @@ export default function AdminAdaptiveCourseDetailPage() {
   const [pendingSetting, setPendingSetting] = useState<string | null>(null);
   /** Content tab paging. A finished course is thousands of pixels of scroll unpaged. */
   const [modulePage, setModulePage] = useState(0);
+  const [addContentFor, setAddContentFor] = useState<{ id: number; title: string } | null>(null);
   const [activeModuleId, setActiveModuleId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -586,7 +589,8 @@ export default function AdminAdaptiveCourseDetailPage() {
               <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
                 {course.modules.length === 0 && (
                   <Typography sx={{ color: "text.secondary", textAlign: "center", py: 4 }}>
-                    No modules yet. Use <strong>Add module (AI)</strong> to generate one.
+                    No modules yet. Add one below and fill it in yourself, or use{" "}
+                    <strong>Add module (AI)</strong> to generate one.
                   </Typography>
                 )}
                 {course.modules
@@ -661,7 +665,18 @@ export default function AdminAdaptiveCourseDetailPage() {
                               border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)",
                             }}
                           >
-                            <Typography sx={{ fontWeight: 700, fontSize: "0.95rem" }}>{sub.title}</Typography>
+                            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                              <Typography sx={{ fontWeight: 700, fontSize: "0.95rem", flex: 1, minWidth: 0 }}>
+                                {sub.title}
+                              </Typography>
+                              <ButtonBase
+                                onClick={() => setAddContentFor({ id: sub.id, title: sub.title })}
+                                sx={{ ...pillBtnSx("outline"), py: 0.5, px: 1.4, fontSize: "0.74rem" }}
+                              >
+                                <Icon icon="mdi:plus" width={13} />
+                                Add content
+                              </ButtonBase>
+                            </Box>
                             <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mt: 1 }}>
                               {sub.articles.map((a) => {
                                 const open = expandedArticle === a.article_id;
@@ -827,6 +842,11 @@ export default function AdminAdaptiveCourseDetailPage() {
                                   })}
                                 </Box>
                               ))}
+                              <AddSubmoduleRow
+                                courseId={course.id}
+                                moduleId={mod.id}
+                                onAdded={() => void load()}
+                              />
                               {(sub.video_companions ?? []).map((vc) => (
                                 <MatchedVideoReview key={vc.id} companion={vc} onChanged={() => void load()} />
                               ))}
@@ -835,7 +855,8 @@ export default function AdminAdaptiveCourseDetailPage() {
                                 (sub.coding_sets?.length ?? 0) === 0 &&
                                 (sub.video_companions?.length ?? 0) === 0 && (
                                   <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
-                                    No content generated for this submodule.
+                                    Nothing here yet. Use <strong>Add content</strong> to write an
+                                    article, pull questions from the verified bank, or attach a video.
                                   </Typography>
                                 )}
                             </Box>
@@ -845,6 +866,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                     </Box>
                   </Reveal>
                 ))}
+                  <AddModuleRow courseId={course.id} onAdded={() => void load()} />
               </Box>
               )}
             </>
@@ -1164,6 +1186,14 @@ export default function AdminAdaptiveCourseDetailPage() {
         @keyframes acb-spin { to { transform: rotate(360deg); } }
         .acb-spin { animation: acb-spin 0.9s linear infinite; display: inline-flex; }
       `}</style>
+    
+      <AddContentDialog
+        open={addContentFor !== null}
+        submoduleId={addContentFor?.id ?? null}
+        submoduleTitle={addContentFor?.title ?? ""}
+        onClose={() => setAddContentFor(null)}
+        onAdded={() => void load()}
+      />
     </MainLayout>
   );
 }

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -6,6 +6,7 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
+import { ManualCourseDialog } from "@/components/admin/adaptive-course/ManualCourseDialog";
 import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useToast } from "@/components/common/Toast";
@@ -29,6 +30,7 @@ export default function AdminAdaptiveCoursesPage() {
   const [error, setError] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<AdminAdaptiveCourseListItem | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ListView>("cards");
 
   const load = useCallback(async () => {
@@ -103,13 +105,26 @@ export default function AdminAdaptiveCoursesPage() {
       <ModulePageHeader
         eyebrow="Content"
         title="Adaptive Course Builder"
-        description="Build adaptive, AI-personalised courses from a prompt."
+        description="Generate a course from a prompt, or build one yourself and fill it from the verified bank."
         accent="purple"
         icon="mdi:robot-excited-outline"
         action={
-          <HeaderActionButton icon="mdi:auto-fix" onClick={() => push("/admin/adaptive-courses/generate")}>
-            Generate adaptive course
-          </HeaderActionButton>
+          // Two ways in, side by side. Generation stays the solid primary because it is the
+          // faster path for most courses; building by hand is the ghost variant rather than
+          // buried in a menu, because an admin who already has their material should not have
+          // to discover that the product supports them.
+          <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+            <HeaderActionButton
+              icon="mdi:pencil-ruler"
+              variant="ghost"
+              onClick={() => setManualOpen(true)}
+            >
+              Build it myself
+            </HeaderActionButton>
+            <HeaderActionButton icon="mdi:auto-fix" onClick={() => push("/admin/adaptive-courses/generate")}>
+              Generate adaptive course
+            </HeaderActionButton>
+          </Box>
         }
       />
 
@@ -187,7 +202,9 @@ export default function AdminAdaptiveCoursesPage() {
                 No adaptive courses yet.
               </Typography>
               <Typography sx={{ color: "text.secondary", mt: 0.75, maxWidth: 560, mx: "auto", lineHeight: 1.5 }}>
-                Click <strong>Generate adaptive course</strong> - describe the course, and the engine builds the
+                Click <strong>Build it myself</strong> to start from an empty course and add each
+                module, topic and item by hand, pulling questions from the verified bank. Or click{" "}
+                <strong>Generate adaptive course</strong> - describe the course, and the engine builds the
                 module tree with an adaptive quiz per submodule.
               </Typography>
             </Box>
@@ -248,6 +265,17 @@ export default function AdminAdaptiveCoursesPage() {
         confirmColor="error"
         onConfirm={() => void handleConfirmDelete()}
         onCancel={() => setPendingDelete(null)}
+      />
+    
+      <ManualCourseDialog
+        open={manualOpen}
+        onClose={() => setManualOpen(false)}
+        onCreated={(courseId) => {
+          setManualOpen(false);
+          // Straight into the new course rather than back to the list: an empty course on a list
+          // of populated ones is indistinguishable from a failed create.
+          push(`/admin/adaptive-courses/${courseId}`);
+        }}
       />
     </PageShell>
   );

--- a/components/admin/adaptive-course/AddContentDialog.tsx
+++ b/components/admin/adaptive-course/AddContentDialog.tsx
@@ -1,0 +1,1261 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  Select,
+  Skeleton,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { useToast } from "@/components/common/Toast";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+import {
+  adminAdaptiveCourseService,
+  type BankMcq,
+  type BankCodingProblem,
+  type SubmoduleSuggestions,
+} from "@/lib/services/admin/admin-adaptive-course.service";
+import {
+  adaptiveVideoAdminService,
+  type VimeoVideoWire,
+} from "@/lib/services/adaptive-video.service";
+
+/* ------------------------------------------------------------------ palette */
+
+type ContentKind = "article" | "quiz" | "coding" | "video";
+
+const KIND_ORDER: ContentKind[] = ["article", "quiz", "coding", "video"];
+const KIND_TAB: Record<ContentKind, number> = { article: 0, quiz: 1, coding: 2, video: 3 };
+
+const KIND_META: Record<ContentKind, { label: string; icon: string; accent: string }> = {
+  article: { label: "Article", icon: "mdi:text-box-outline", accent: "#6366f1" },
+  quiz: { label: "Quiz", icon: "mdi:help-circle-outline", accent: "#a855f7" },
+  coding: { label: "Coding", icon: "mdi:code-braces", accent: "#f59e0b" },
+  video: { label: "Video", icon: "mdi:play-circle-outline", accent: "#ec4899" },
+};
+
+const GREEN = "#10b981";
+/** Theme token, not a literal grey: this text/icon tone has to follow light and dark. */
+const MUTED = "var(--font-secondary)";
+
+const DIFF_TONE: Record<string, string> = { easy: GREEN, medium: "#f59e0b", hard: "#ec4899" };
+
+const DEBOUNCE_MS = 350;
+
+/* ------------------------------------------------------------------ helpers */
+
+function fmtDuration(seconds: number): string {
+  if (!seconds || seconds < 0) return "";
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function DifficultyChip({ value }: { value: string }) {
+  const tone = DIFF_TONE[(value || "").toLowerCase()] ?? MUTED;
+  return (
+    <Box
+      component="span"
+      sx={{
+        px: 0.9,
+        py: 0.15,
+        borderRadius: 999,
+        fontSize: "0.65rem",
+        fontWeight: 800,
+        textTransform: "capitalize",
+        whiteSpace: "nowrap",
+        color: tone,
+        bgcolor: `color-mix(in srgb, ${tone} 14%, transparent)`,
+      }}
+    >
+      {value || "unrated"}
+    </Box>
+  );
+}
+
+/** A hand-written MCQ still being edited. `uid` keeps React row identity stable across
+ *  removals - with index keys, deleting row 1 would leave row 2's text sitting in row 1's inputs. */
+interface DraftMcq {
+  uid: number;
+  question_text: string;
+  option_a: string;
+  option_b: string;
+  option_c: string;
+  option_d: string;
+  correct_option: "a" | "b" | "c" | "d";
+  explanation: string;
+  difficulty_level: "easy" | "medium" | "hard";
+}
+
+let draftUid = 0;
+function blankDraft(): DraftMcq {
+  draftUid += 1;
+  return {
+    uid: draftUid,
+    question_text: "",
+    option_a: "",
+    option_b: "",
+    option_c: "",
+    option_d: "",
+    correct_option: "a",
+    explanation: "",
+    difficulty_level: "medium",
+  };
+}
+
+function draftIsComplete(d: DraftMcq): boolean {
+  return (
+    d.question_text.trim().length > 0 &&
+    d.option_a.trim().length > 0 &&
+    d.option_b.trim().length > 0 &&
+    d.option_c.trim().length > 0 &&
+    d.option_d.trim().length > 0
+  );
+}
+
+/* ------------------------------------------------------- shared bank search */
+
+/**
+ * Debounced verified-bank search shared by the quiz and coding tabs.
+ * `enabled` is false while the tab is off-screen so switching tabs does not fire
+ * requests nobody is looking at.
+ */
+function useBankSearch<T>(kind: "mcq" | "coding", enabled: boolean) {
+  const [q, setQ] = useState("");
+  const [difficulty, setDifficulty] = useState("any");
+  const [rows, setRows] = useState<T[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const seq = useRef(0);
+
+  const reset = useCallback(() => {
+    setQ("");
+    setDifficulty("any");
+    setRows([]);
+    setTotal(0);
+    setError(null);
+    setLoading(false);
+    // Invalidate anything already in flight: its results belong to a dialog state
+    // that no longer exists.
+    seq.current += 1;
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // Each run claims a ticket and only the newest one may write state, so a slow
+    // response for an earlier query cannot clobber the list the admin is reading now.
+    seq.current += 1;
+    const ticket = seq.current;
+    // The spinner is raised inside the timer, not before it: raising it on every
+    // keystroke would strobe the list during the debounce window.
+    const timer = setTimeout(() => {
+      setLoading(true);
+      adminAdaptiveCourseService
+        .searchBank<T>(kind, {
+          q: q.trim() || undefined,
+          difficulty: difficulty === "any" ? undefined : difficulty,
+          limit: 40,
+        })
+        .then((r) => {
+          if (seq.current !== ticket) return;
+          setRows(r.results ?? []);
+          setTotal(r.total ?? 0);
+          setError(null);
+        })
+        .catch((e: unknown) => {
+          if (seq.current !== ticket) return;
+          setRows([]);
+          setError(getAxiosErrorDetail(e, "Couldn't search the verified bank."));
+        })
+        .finally(() => {
+          if (seq.current === ticket) setLoading(false);
+        });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [kind, q, difficulty, enabled]);
+
+  return { q, setQ, difficulty, setDifficulty, rows, total, loading, error, reset };
+}
+
+/* ---------------------------------------------------------------- fragments */
+
+function SearchControls({
+  q,
+  onQ,
+  difficulty,
+  onDifficulty,
+  placeholder,
+}: {
+  q: string;
+  onQ: (v: string) => void;
+  difficulty: string;
+  onDifficulty: (v: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <Box sx={{ display: "flex", gap: 1, mb: 1 }}>
+      <TextField
+        size="small"
+        fullWidth
+        value={q}
+        onChange={(e) => onQ(e.target.value)}
+        placeholder={placeholder}
+        InputProps={{
+          startAdornment: (
+            <Icon icon="mdi:magnify" width={18} style={{ marginRight: 6, opacity: 0.55 }} />
+          ),
+        }}
+      />
+      <Select
+        size="small"
+        value={difficulty}
+        onChange={(e) => onDifficulty(String(e.target.value))}
+        sx={{ minWidth: 118 }}
+      >
+        <MenuItem value="any">Any level</MenuItem>
+        <MenuItem value="easy">Easy</MenuItem>
+        <MenuItem value="medium">Medium</MenuItem>
+        <MenuItem value="hard">Hard</MenuItem>
+      </Select>
+    </Box>
+  );
+}
+
+function ResultShell({
+  loading,
+  error,
+  empty,
+  emptyText,
+  children,
+}: {
+  loading: boolean;
+  error: string | null;
+  empty: boolean;
+  emptyText: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box
+      sx={{
+        maxHeight: 300,
+        overflowY: "auto",
+        border: "1px solid var(--border-default)",
+        borderRadius: 2,
+        p: 0.5,
+      }}
+    >
+      {error ? (
+        <Alert severity="error" sx={{ m: 0.5 }}>
+          {error}
+        </Alert>
+      ) : loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress size={22} />
+        </Box>
+      ) : empty ? (
+        <Typography
+          sx={{ fontSize: "0.85rem", color: "var(--font-secondary)", textAlign: "center", py: 4 }}
+        >
+          {emptyText}
+        </Typography>
+      ) : (
+        children
+      )}
+    </Box>
+  );
+}
+
+function PickRow({
+  checked,
+  onToggle,
+  accent,
+  children,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  accent: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box
+      onClick={onToggle}
+      sx={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 1,
+        px: 1,
+        py: 0.75,
+        borderRadius: 2,
+        cursor: "pointer",
+        border: "1px solid",
+        borderColor: checked ? accent : "transparent",
+        bgcolor: checked ? `color-mix(in srgb, ${accent} 7%, transparent)` : "transparent",
+        "&:hover": { bgcolor: `color-mix(in srgb, ${accent} 5%, transparent)` },
+      }}
+    >
+      <Checkbox checked={checked} size="small" sx={{ p: 0.5, mt: -0.25 }} />
+      <Box sx={{ flex: 1, minWidth: 0 }}>{children}</Box>
+    </Box>
+  );
+}
+
+/* ---------------------------------------------------------------- component */
+
+export function AddContentDialog({
+  open,
+  submoduleId,
+  submoduleTitle,
+  onClose,
+  onAdded,
+}: {
+  open: boolean;
+  submoduleId: number | null;
+  submoduleTitle: string;
+  onClose: () => void;
+  onAdded: () => void;
+}) {
+  const { showToast } = useToast();
+  const [tab, setTab] = useState(0);
+  const [saving, setSaving] = useState(false);
+
+  // Suggestions rail
+  const [suggestions, setSuggestions] = useState<SubmoduleSuggestions | null>(null);
+  const [sugLoading, setSugLoading] = useState(false);
+
+  // Article
+  const [artTitle, setArtTitle] = useState("");
+  const [artBody, setArtBody] = useState("");
+  const [artSummary, setArtSummary] = useState("");
+
+  // Quiz
+  const [quizMode, setQuizMode] = useState<"bank" | "write">("bank");
+  const [pickedMcqs, setPickedMcqs] = useState<Set<number>>(new Set());
+  const [drafts, setDrafts] = useState<DraftMcq[]>([blankDraft()]);
+  const [quizConflict, setQuizConflict] = useState<string | null>(null);
+
+  // Coding
+  const [pickedProblems, setPickedProblems] = useState<Set<number>>(new Set());
+
+  // Video
+  const [videoMode, setVideoMode] = useState<"catalog" | "link">("catalog");
+  const [vq, setVq] = useState("");
+  const [vRows, setVRows] = useState<VimeoVideoWire[]>([]);
+  const [vLoading, setVLoading] = useState(false);
+  const [pickedVimeo, setPickedVimeo] = useState<string | null>(null);
+  const [videoUrl, setVideoUrl] = useState("");
+  const [videoTitle, setVideoTitle] = useState("");
+  const [videoNote, setVideoNote] = useState<string | null>(null);
+  const vSeq = useRef(0);
+
+  const mcqBank = useBankSearch<BankMcq>("mcq", open && tab === 1 && quizMode === "bank");
+  const codingBank = useBankSearch<BankCodingProblem>("coding", open && tab === 2);
+  const resetMcqBank = mcqBank.reset;
+  const resetCodingBank = codingBank.reset;
+
+  const loadSuggestions = useCallback(async (id: number) => {
+    setSugLoading(true);
+    try {
+      setSuggestions(await adminAdaptiveCourseService.getSuggestions(id));
+    } catch {
+      // The rail is a hint, not the job. A failure here must not block authoring.
+      setSuggestions(null);
+    } finally {
+      setSugLoading(false);
+    }
+  }, []);
+
+  // Full reset whenever the dialog opens or is re-pointed at another submodule, so a
+  // half-typed article never lands on the wrong topic.
+  useEffect(() => {
+    if (!open) return;
+    setTab(0);
+    setSaving(false);
+    setArtTitle("");
+    setArtBody("");
+    setArtSummary("");
+    setQuizMode("bank");
+    setPickedMcqs(new Set());
+    setDrafts([blankDraft()]);
+    setQuizConflict(null);
+    setPickedProblems(new Set());
+    setVideoMode("catalog");
+    setVq("");
+    setVRows([]);
+    setPickedVimeo(null);
+    setVideoUrl("");
+    setVideoTitle("");
+    setVideoNote(null);
+    vSeq.current += 1;
+    resetMcqBank();
+    resetCodingBank();
+    setSuggestions(null);
+    if (submoduleId != null) void loadSuggestions(submoduleId);
+  }, [open, submoduleId, resetMcqBank, resetCodingBank, loadSuggestions]);
+
+  // Vimeo catalog lives on its own service, so it gets its own debounce and race guard.
+  useEffect(() => {
+    if (!open || tab !== 3 || videoMode !== "catalog") return;
+    vSeq.current += 1;
+    const ticket = vSeq.current;
+    const timer = setTimeout(() => {
+      setVLoading(true);
+      adaptiveVideoAdminService
+        .searchCatalog(vq.trim(), false)
+        .then((r) => {
+          if (vSeq.current !== ticket) return;
+          // searchCatalog answers with { results: [...] }, not a bare array.
+          setVRows(r.results ?? []);
+        })
+        .catch(() => {
+          if (vSeq.current === ticket) setVRows([]);
+        })
+        .finally(() => {
+          if (vSeq.current === ticket) setVLoading(false);
+        });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [open, tab, videoMode, vq]);
+
+  const afterAdd = useCallback(
+    (message: string | null) => {
+      if (message) showToast(message, "success");
+      onAdded();
+      // Chips in the rail are now stale: the topic just gained a content type.
+      if (submoduleId != null) void loadSuggestions(submoduleId);
+    },
+    [showToast, onAdded, submoduleId, loadSuggestions],
+  );
+
+  const toggleIn = (set: Set<number>, id: number) => {
+    const next = new Set(set);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    return next;
+  };
+
+  const patchDraft = (uid: number, patch: Partial<DraftMcq>) =>
+    setDrafts((prev) => prev.map((d) => (d.uid === uid ? { ...d, ...patch } : d)));
+
+  /* -------------------------------------------------------------- submitters */
+
+  async function submitArticle() {
+    if (submoduleId == null) return;
+    setSaving(true);
+    try {
+      const r = await adminAdaptiveCourseService.addArticle(submoduleId, {
+        title: artTitle.trim(),
+        body: artBody,
+        summary: artSummary.trim() || undefined,
+      });
+      setArtTitle("");
+      setArtBody("");
+      setArtSummary("");
+      afterAdd(`Added "${r.title}".`);
+    } catch (e: unknown) {
+      showToast(getAxiosErrorDetail(e, "Couldn't add the article."), "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function submitQuiz() {
+    if (submoduleId == null) return;
+    setQuizConflict(null);
+    setSaving(true);
+    try {
+      const payload =
+        quizMode === "bank"
+          ? { mcq_ids: Array.from(pickedMcqs) }
+          : {
+              mcqs: drafts.filter(draftIsComplete).map((d) => ({
+                question_text: d.question_text.trim(),
+                option_a: d.option_a.trim(),
+                option_b: d.option_b.trim(),
+                option_c: d.option_c.trim(),
+                option_d: d.option_d.trim(),
+                correct_option: d.correct_option,
+                explanation: d.explanation.trim(),
+                difficulty_level: d.difficulty_level,
+              })),
+            };
+      const r = await adminAdaptiveCourseService.addQuiz(submoduleId, payload);
+      setPickedMcqs(new Set());
+      setDrafts([blankDraft()]);
+      afterAdd(`Quiz added with ${r.questions} question${r.questions === 1 ? "" : "s"}.`);
+    } catch (e: unknown) {
+      const status = (e as { response?: { status?: number } })?.response?.status;
+      if (status === 409) {
+        // A submodule holds only one live quiz. The server's detail names the existing
+        // quiz and what to do about it, which a generic "couldn't add" would throw away.
+        setQuizConflict(
+          getAxiosErrorDetail(e, "This topic already has a quiz. Remove it before adding another."),
+        );
+      } else {
+        showToast(getAxiosErrorDetail(e, "Couldn't add the quiz."), "error");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function submitCoding() {
+    if (submoduleId == null) return;
+    setSaving(true);
+    try {
+      const r = await adminAdaptiveCourseService.addCoding(submoduleId, {
+        problem_ids: Array.from(pickedProblems),
+      });
+      setPickedProblems(new Set());
+      afterAdd(`Added ${r.problems} coding problem${r.problems === 1 ? "" : "s"}.`);
+    } catch (e: unknown) {
+      showToast(getAxiosErrorDetail(e, "Couldn't add the coding problems."), "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function submitVideo() {
+    if (submoduleId == null) return;
+    setSaving(true);
+    setVideoNote(null);
+    try {
+      const r = await adminAdaptiveCourseService.addVideo(
+        submoduleId,
+        videoMode === "catalog"
+          ? { vimeo_id: pickedVimeo ?? undefined }
+          : { url: videoUrl.trim(), title: videoTitle.trim() || undefined },
+      );
+      setPickedVimeo(null);
+      setVideoUrl("");
+      setVideoTitle("");
+      if (r.check_ins_built) {
+        afterAdd(`Added "${r.title}" with check-ins.`);
+      } else {
+        // No transcript means no comprehension check-ins. A toast would vanish and the
+        // admin would learn this from a student instead, so it stays on screen.
+        setVideoNote(r.note || "Added as a plain video: no comprehension check-ins were built.");
+        afterAdd(null);
+      }
+    } catch (e: unknown) {
+      showToast(getAxiosErrorDetail(e, "Couldn't attach the video."), "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  /* ------------------------------------------------------------ primary CTA */
+
+  const completeDrafts = drafts.filter(draftIsComplete).length;
+  const articleReady = artTitle.trim().length > 0 && artBody.trim().length >= 20;
+  const quizReady = quizMode === "bank" ? pickedMcqs.size > 0 : completeDrafts > 0;
+  const codingReady = pickedProblems.size > 0;
+  const videoReady =
+    videoMode === "catalog" ? pickedVimeo !== null : videoUrl.trim().length > 0;
+
+  const primary: { label: string; ready: boolean; run: () => void } = [
+    { label: "Add article", ready: articleReady, run: () => void submitArticle() },
+    {
+      label: quizMode === "bank" ? `Add quiz (${pickedMcqs.size})` : `Add quiz (${completeDrafts})`,
+      ready: quizReady,
+      run: () => void submitQuiz(),
+    },
+    {
+      label: `Add problems (${pickedProblems.size})`,
+      ready: codingReady,
+      run: () => void submitCoding(),
+    },
+    { label: "Add video", ready: videoReady, run: () => void submitVideo() },
+  ][tab];
+
+  const accent = KIND_META[KIND_ORDER[tab]].accent;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: { bgcolor: "var(--card-bg)", color: "var(--font-primary)", borderRadius: 3 },
+      }}
+    >
+      <DialogTitle sx={{ fontWeight: 800, pb: 1 }}>
+        Add content
+        <Typography
+          sx={{ fontSize: "0.82rem", fontWeight: 500, color: "var(--font-secondary)", mt: 0.25 }}
+          noWrap
+        >
+          {submoduleTitle}
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1 }}>
+        {/* ---------------------------------------------------- suggestions rail */}
+        {sugLoading ? (
+          <Skeleton variant="rounded" height={54} sx={{ mb: 1.5, borderRadius: 2 }} />
+        ) : suggestions ? (
+          <Box
+            sx={{
+              mb: 1.5,
+              p: 1,
+              borderRadius: 2,
+              border: "1px solid var(--border-default)",
+              bgcolor: "color-mix(in srgb, #6366f1 4%, transparent)",
+            }}
+          >
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+              {KIND_ORDER.map((k) => {
+                const owned = suggestions.has[k];
+                return (
+                  <Chip
+                    key={k}
+                    size="small"
+                    onClick={() => setTab(KIND_TAB[k])}
+                    icon={
+                      <Icon
+                        icon={owned ? "mdi:check-circle" : "mdi:circle-outline"}
+                        width={13}
+                        color={owned ? GREEN : MUTED}
+                      />
+                    }
+                    label={KIND_META[k].label}
+                    sx={{
+                      height: 24,
+                      fontSize: "0.72rem",
+                      fontWeight: 700,
+                      color: owned ? GREEN : "var(--font-secondary)",
+                      border: "1px solid",
+                      borderColor: owned
+                        ? `color-mix(in srgb, ${GREEN} 35%, transparent)`
+                        : "var(--border-default)",
+                      bgcolor: owned
+                        ? `color-mix(in srgb, ${GREEN} 10%, transparent)`
+                        : "transparent",
+                    }}
+                  />
+                );
+              })}
+            </Box>
+
+            {suggestions.gaps.length > 0 && (
+              <Box sx={{ mt: 0.75, display: "flex", flexDirection: "column", gap: 0.25 }}>
+                {suggestions.gaps.map((g) => (
+                  <Box
+                    key={`${g.kind}-${g.title}`}
+                    onClick={() => setTab(KIND_TAB[g.kind])}
+                    sx={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: 0.75,
+                      px: 0.5,
+                      py: 0.25,
+                      borderRadius: 1.5,
+                      cursor: "pointer",
+                      "&:hover": { bgcolor: "color-mix(in srgb, #6366f1 8%, transparent)" },
+                    }}
+                  >
+                    <Icon
+                      icon="mdi:lightbulb-on-outline"
+                      width={13}
+                      color={KIND_META[g.kind].accent}
+                    />
+                    <Typography sx={{ fontSize: "0.76rem", fontWeight: 700 }}>{g.title}</Typography>
+                    <Typography
+                      sx={{ fontSize: "0.7rem", color: "var(--font-secondary)", flex: 1 }}
+                      noWrap
+                    >
+                      {g.why}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </Box>
+        ) : null}
+
+        {/* ------------------------------------------------------------- tabs */}
+        <Tabs
+          value={tab}
+          onChange={(_, v: number) => setTab(v)}
+          variant="fullWidth"
+          sx={{
+            minHeight: 40,
+            borderBottom: "1px solid var(--border-default)",
+            "& .MuiTab-root": {
+              minHeight: 40,
+              textTransform: "none",
+              fontWeight: 700,
+              fontSize: "0.84rem",
+              color: "var(--font-secondary)",
+            },
+            "& .Mui-selected": { color: `${accent} !important` },
+            "& .MuiTabs-indicator": { backgroundColor: accent },
+          }}
+        >
+          {KIND_ORDER.map((k) => (
+            <Tab
+              key={k}
+              icon={<Icon icon={KIND_META[k].icon} width={16} />}
+              iconPosition="start"
+              label={KIND_META[k].label}
+            />
+          ))}
+        </Tabs>
+
+        <Box sx={{ pt: 2 }}>
+          {/* ------------------------------------------------------- 1. article */}
+          {tab === 0 && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+              <TextField
+                size="small"
+                fullWidth
+                label="Title"
+                value={artTitle}
+                onChange={(e) => setArtTitle(e.target.value)}
+              />
+              <TextField
+                fullWidth
+                multiline
+                minRows={10}
+                label="Body"
+                placeholder="Write the lesson. Markdown is fine."
+                value={artBody}
+                onChange={(e) => setArtBody(e.target.value)}
+                helperText={
+                  artBody.trim().length < 20
+                    ? `${20 - artBody.trim().length} more characters before this can be saved`
+                    : `${artBody.trim().length} characters`
+                }
+              />
+              <TextField
+                size="small"
+                fullWidth
+                label="Summary (optional)"
+                value={artSummary}
+                onChange={(e) => setArtSummary(e.target.value)}
+              />
+            </Box>
+          )}
+
+          {/* ---------------------------------------------------------- 2. quiz */}
+          {tab === 1 && (
+            <Box>
+              {quizConflict && (
+                <Alert severity="warning" sx={{ mb: 1.5 }} onClose={() => setQuizConflict(null)}>
+                  {quizConflict}
+                </Alert>
+              )}
+
+              <Box sx={{ display: "flex", gap: 0.5, mb: 1.5 }}>
+                {(
+                  [
+                    ["bank", "From the verified bank"],
+                    ["write", "Write one"],
+                  ] as const
+                ).map(([mode, label]) => (
+                  <Button
+                    key={mode}
+                    size="small"
+                    onClick={() => setQuizMode(mode)}
+                    sx={{
+                      textTransform: "none",
+                      fontWeight: 700,
+                      fontSize: "0.76rem",
+                      borderRadius: 999,
+                      px: 1.5,
+                      color: quizMode === mode ? "#fff" : "var(--font-secondary)",
+                      bgcolor: quizMode === mode ? KIND_META.quiz.accent : "transparent",
+                      border: "1px solid",
+                      borderColor:
+                        quizMode === mode ? KIND_META.quiz.accent : "var(--border-default)",
+                      "&:hover": {
+                        bgcolor:
+                          quizMode === mode
+                            ? KIND_META.quiz.accent
+                            : "color-mix(in srgb, #a855f7 8%, transparent)",
+                      },
+                    }}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </Box>
+
+              {quizMode === "bank" ? (
+                <>
+                  <SearchControls
+                    q={mcqBank.q}
+                    onQ={mcqBank.setQ}
+                    difficulty={mcqBank.difficulty}
+                    onDifficulty={mcqBank.setDifficulty}
+                    placeholder="Search verified questions"
+                  />
+                  <Box
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      mb: 0.5,
+                      fontSize: "0.73rem",
+                      color: "var(--font-secondary)",
+                    }}
+                  >
+                    <span>
+                      {mcqBank.total} match{mcqBank.total === 1 ? "" : "es"}
+                    </span>
+                    <Box component="span" sx={{ fontWeight: 800, color: KIND_META.quiz.accent }}>
+                      {pickedMcqs.size} selected
+                    </Box>
+                  </Box>
+                  <ResultShell
+                    loading={mcqBank.loading}
+                    error={mcqBank.error}
+                    empty={mcqBank.rows.length === 0}
+                    emptyText="No questions match that search."
+                  >
+                    {mcqBank.rows.map((m) => (
+                      <PickRow
+                        key={m.id}
+                        checked={pickedMcqs.has(m.id)}
+                        accent={KIND_META.quiz.accent}
+                        onToggle={() => setPickedMcqs((p) => toggleIn(p, m.id))}
+                      >
+                        <Typography sx={{ fontSize: "0.85rem", fontWeight: 600 }}>
+                          {m.question_text}
+                        </Typography>
+                        <Box
+                          sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.25 }}
+                        >
+                          <DifficultyChip value={m.difficulty_level} />
+                          <Typography
+                            sx={{ fontSize: "0.72rem", color: "var(--font-secondary)" }}
+                            noWrap
+                          >
+                            {m.topic}
+                          </Typography>
+                        </Box>
+                      </PickRow>
+                    ))}
+                  </ResultShell>
+                </>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                  {drafts.map((d, i) => (
+                    <Box
+                      key={d.uid}
+                      sx={{
+                        p: 1.25,
+                        borderRadius: 2,
+                        border: "1px solid var(--border-default)",
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 1,
+                      }}
+                    >
+                      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                        <Typography
+                          sx={{ fontSize: "0.72rem", fontWeight: 800, color: "var(--font-secondary)" }}
+                        >
+                          Q{i + 1}
+                        </Typography>
+                        <Box sx={{ flex: 1 }} />
+                        <Select
+                          size="small"
+                          value={d.difficulty_level}
+                          onChange={(e) =>
+                            patchDraft(d.uid, {
+                              difficulty_level: e.target.value as DraftMcq["difficulty_level"],
+                            })
+                          }
+                          sx={{ minWidth: 104, "& .MuiSelect-select": { py: 0.5, fontSize: "0.78rem" } }}
+                        >
+                          <MenuItem value="easy">Easy</MenuItem>
+                          <MenuItem value="medium">Medium</MenuItem>
+                          <MenuItem value="hard">Hard</MenuItem>
+                        </Select>
+                        {drafts.length > 1 && (
+                          <Button
+                            size="small"
+                            onClick={() =>
+                              setDrafts((prev) => prev.filter((x) => x.uid !== d.uid))
+                            }
+                            sx={{ minWidth: 0, p: 0.5, color: "var(--font-secondary)" }}
+                          >
+                            <Icon icon="mdi:close" width={16} />
+                          </Button>
+                        )}
+                      </Box>
+
+                      <TextField
+                        size="small"
+                        fullWidth
+                        multiline
+                        minRows={2}
+                        label="Question"
+                        value={d.question_text}
+                        onChange={(e) => patchDraft(d.uid, { question_text: e.target.value })}
+                      />
+
+                      <Box
+                        sx={{
+                          display: "grid",
+                          gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+                          gap: 1,
+                        }}
+                      >
+                        {(["a", "b", "c", "d"] as const).map((k) => (
+                          <TextField
+                            key={k}
+                            size="small"
+                            fullWidth
+                            label={`Option ${k.toUpperCase()}`}
+                            value={d[`option_${k}` as const]}
+                            onChange={(e) => patchDraft(d.uid, { [`option_${k}`]: e.target.value })}
+                            sx={{
+                              "& .MuiOutlinedInput-notchedOutline": {
+                                borderColor:
+                                  d.correct_option === k ? GREEN : "var(--border-default)",
+                              },
+                            }}
+                          />
+                        ))}
+                      </Box>
+
+                      <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+                        <Typography sx={{ fontSize: "0.76rem", color: "var(--font-secondary)" }}>
+                          Correct
+                        </Typography>
+                        <Select
+                          size="small"
+                          value={d.correct_option}
+                          onChange={(e) =>
+                            patchDraft(d.uid, {
+                              correct_option: e.target.value as DraftMcq["correct_option"],
+                            })
+                          }
+                          sx={{
+                            minWidth: 72,
+                            "& .MuiSelect-select": { py: 0.5, fontSize: "0.78rem", fontWeight: 800 },
+                          }}
+                        >
+                          {(["a", "b", "c", "d"] as const).map((k) => (
+                            <MenuItem key={k} value={k}>
+                              {k.toUpperCase()}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                        <TextField
+                          size="small"
+                          fullWidth
+                          label="Explanation (optional)"
+                          value={d.explanation}
+                          onChange={(e) => patchDraft(d.uid, { explanation: e.target.value })}
+                        />
+                      </Box>
+                    </Box>
+                  ))}
+
+                  <Button
+                    size="small"
+                    onClick={() => setDrafts((prev) => [...prev, blankDraft()])}
+                    startIcon={<Icon icon="mdi:plus" width={16} />}
+                    sx={{
+                      alignSelf: "flex-start",
+                      textTransform: "none",
+                      fontWeight: 700,
+                      color: KIND_META.quiz.accent,
+                    }}
+                  >
+                    Add another question
+                  </Button>
+                </Box>
+              )}
+            </Box>
+          )}
+
+          {/* -------------------------------------------------------- 3. coding */}
+          {tab === 2 && (
+            <Box>
+              <SearchControls
+                q={codingBank.q}
+                onQ={codingBank.setQ}
+                difficulty={codingBank.difficulty}
+                onDifficulty={codingBank.setDifficulty}
+                placeholder="Search verified coding problems"
+              />
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  mb: 0.5,
+                  fontSize: "0.73rem",
+                  color: "var(--font-secondary)",
+                }}
+              >
+                <span>
+                  {codingBank.total} match{codingBank.total === 1 ? "" : "es"}
+                </span>
+                <Box component="span" sx={{ fontWeight: 800, color: KIND_META.coding.accent }}>
+                  {pickedProblems.size} selected
+                </Box>
+              </Box>
+              <ResultShell
+                loading={codingBank.loading}
+                error={codingBank.error}
+                empty={codingBank.rows.length === 0}
+                emptyText="No problems match that search."
+              >
+                {codingBank.rows.map((p) => (
+                  <PickRow
+                    key={p.id}
+                    checked={pickedProblems.has(p.id)}
+                    accent={KIND_META.coding.accent}
+                    onToggle={() => setPickedProblems((s) => toggleIn(s, p.id))}
+                  >
+                    <Typography sx={{ fontSize: "0.85rem", fontWeight: 700 }}>{p.title}</Typography>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.25 }}>
+                      <DifficultyChip value={p.difficulty_level} />
+                      <Typography
+                        sx={{ fontSize: "0.72rem", color: "var(--font-secondary)", flex: 1 }}
+                        noWrap
+                      >
+                        {p.topic}
+                      </Typography>
+                      <Typography
+                        sx={{ fontSize: "0.72rem", color: "var(--font-secondary)", whiteSpace: "nowrap" }}
+                      >
+                        {p.test_cases} test{p.test_cases === 1 ? "" : "s"}
+                      </Typography>
+                    </Box>
+                  </PickRow>
+                ))}
+              </ResultShell>
+            </Box>
+          )}
+
+          {/* --------------------------------------------------------- 4. video */}
+          {tab === 3 && (
+            <Box>
+              {videoNote && (
+                <Alert severity="info" sx={{ mb: 1.5 }} onClose={() => setVideoNote(null)}>
+                  {videoNote}
+                </Alert>
+              )}
+
+              <Box sx={{ display: "flex", gap: 0.5, mb: 1.5 }}>
+                {(
+                  [
+                    ["catalog", "From the Vimeo catalog"],
+                    ["link", "Paste a link"],
+                  ] as const
+                ).map(([mode, label]) => (
+                  <Button
+                    key={mode}
+                    size="small"
+                    onClick={() => setVideoMode(mode)}
+                    sx={{
+                      textTransform: "none",
+                      fontWeight: 700,
+                      fontSize: "0.76rem",
+                      borderRadius: 999,
+                      px: 1.5,
+                      color: videoMode === mode ? "#fff" : "var(--font-secondary)",
+                      bgcolor: videoMode === mode ? KIND_META.video.accent : "transparent",
+                      border: "1px solid",
+                      borderColor:
+                        videoMode === mode ? KIND_META.video.accent : "var(--border-default)",
+                      "&:hover": {
+                        bgcolor:
+                          videoMode === mode
+                            ? KIND_META.video.accent
+                            : "color-mix(in srgb, #ec4899 8%, transparent)",
+                      },
+                    }}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </Box>
+
+              {videoMode === "catalog" ? (
+                <>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    value={vq}
+                    onChange={(e) => setVq(e.target.value)}
+                    placeholder="Search the catalog"
+                    sx={{ mb: 1 }}
+                    InputProps={{
+                      startAdornment: (
+                        <Icon
+                          icon="mdi:magnify"
+                          width={18}
+                          style={{ marginRight: 6, opacity: 0.55 }}
+                        />
+                      ),
+                    }}
+                  />
+                  <ResultShell
+                    loading={vLoading}
+                    error={null}
+                    empty={vRows.length === 0}
+                    emptyText="No videos match that search."
+                  >
+                    {vRows.map((v) => {
+                      const picked = pickedVimeo === v.vimeo_id;
+                      return (
+                        <Box
+                          key={v.vimeo_id}
+                          onClick={() => setPickedVimeo(picked ? null : v.vimeo_id)}
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 1,
+                            px: 1,
+                            py: 0.75,
+                            borderRadius: 2,
+                            cursor: "pointer",
+                            border: "1px solid",
+                            borderColor: picked ? KIND_META.video.accent : "transparent",
+                            bgcolor: picked
+                              ? "color-mix(in srgb, #ec4899 7%, transparent)"
+                              : "transparent",
+                            "&:hover": { bgcolor: "color-mix(in srgb, #ec4899 5%, transparent)" },
+                          }}
+                        >
+                          {/* Vimeo thumbnails are arbitrary remote URLs, so a plain img
+                              keeps them off the next/image optimizer allow-list. */}
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={v.thumbnail_url}
+                            alt=""
+                            width={84}
+                            height={48}
+                            style={{
+                              borderRadius: 6,
+                              objectFit: "cover",
+                              flexShrink: 0,
+                              background: "color-mix(in srgb, #ec4899 10%, transparent)",
+                            }}
+                          />
+                          <Box sx={{ flex: 1, minWidth: 0 }}>
+                            <Typography sx={{ fontSize: "0.85rem", fontWeight: 700 }} noWrap>
+                              {v.title}
+                            </Typography>
+                            <Box
+                              sx={{ display: "flex", alignItems: "center", gap: 0.75, mt: 0.25 }}
+                            >
+                              <Typography
+                                sx={{ fontSize: "0.72rem", color: "var(--font-secondary)" }}
+                              >
+                                {fmtDuration(v.duration_seconds)}
+                              </Typography>
+                              {v.has_text_track && (
+                                <Box
+                                  component="span"
+                                  sx={{
+                                    px: 0.9,
+                                    py: 0.15,
+                                    borderRadius: 999,
+                                    fontSize: "0.65rem",
+                                    fontWeight: 800,
+                                    color: GREEN,
+                                    bgcolor: `color-mix(in srgb, ${GREEN} 14%, transparent)`,
+                                  }}
+                                >
+                                  transcript
+                                </Box>
+                              )}
+                            </Box>
+                          </Box>
+                          {picked && (
+                            <Icon
+                              icon="mdi:check-circle"
+                              width={20}
+                              color={KIND_META.video.accent}
+                            />
+                          )}
+                        </Box>
+                      );
+                    })}
+                  </ResultShell>
+                </>
+              ) : (
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                  <TextField
+                    size="small"
+                    fullWidth
+                    label="Video URL"
+                    placeholder="https://"
+                    value={videoUrl}
+                    onChange={(e) => setVideoUrl(e.target.value)}
+                  />
+                  <TextField
+                    size="small"
+                    fullWidth
+                    label="Title (optional)"
+                    value={videoTitle}
+                    onChange={(e) => setVideoTitle(e.target.value)}
+                  />
+                  <Typography sx={{ fontSize: "0.75rem", color: "var(--font-secondary)" }}>
+                    A pasted link has no transcript, so check-ins usually cannot be built. Catalog
+                    videos are the richer option where one exists.
+                  </Typography>
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2, borderTop: "1px solid var(--border-default)", pt: 1.5 }}>
+        <Typography sx={{ flex: 1, fontSize: "0.74rem", color: "var(--font-secondary)" }}>
+          The dialog stays open so you can add several items to this topic.
+        </Typography>
+        <Button
+          onClick={onClose}
+          disabled={saving}
+          sx={{ textTransform: "none", fontWeight: 700, color: "var(--font-secondary)" }}
+        >
+          Done
+        </Button>
+        <LoadingButton
+          variant="contained"
+          onClick={primary.run}
+          loading={saving}
+          loadingText="Adding..."
+          disabled={!primary.ready || submoduleId == null}
+          startIcon={<Icon icon="mdi:plus" width={16} />}
+          sx={{
+            textTransform: "none",
+            fontWeight: 800,
+            color: "#fff",
+            px: 2.5,
+            borderRadius: 2,
+            boxShadow: "none",
+            background: `linear-gradient(135deg, ${accent}, color-mix(in srgb, ${accent} 55%, #6366f1))`,
+            "&.Mui-disabled": { color: "rgba(255,255,255,0.7)", opacity: 0.55 },
+          }}
+        >
+          {primary.label}
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/adaptive-course/ManualCourseDialog.tsx
+++ b/components/admin/adaptive-course/ManualCourseDialog.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { useToast } from "@/components/common/Toast";
+import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+
+const INDIGO = "#6366f1";
+const PURPLE = "#a855f7";
+
+const MIN_TITLE = 2;
+const MIN_WEEKS = 1;
+const MAX_WEEKS = 52;
+const DEFAULT_WEEKS = "8";
+
+/**
+ * Create an empty adaptive course that the admin fills in by hand.
+ *
+ * The sibling of the "Generate adaptive course" flow, and the copy leans on the one distinction
+ * that actually changes what the admin does next: generation returns a course already written,
+ * this one returns a shell whose first module does not exist yet. An admin who picks the wrong
+ * door here loses either a prompt or an afternoon, so the difference is stated on the dialog
+ * rather than left to the button label.
+ */
+export function ManualCourseDialog({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (courseId: number) => void;
+}) {
+  const { showToast } = useToast();
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [audience, setAudience] = useState("");
+  /**
+   * Held as a string, not a number. A numeric state cannot tell "the admin cleared the field"
+   * apart from 0, and the two need different outcomes: cleared means omit `duration_weeks` from
+   * the payload and let the server keep its own default, 0 means a value the server rejects.
+   */
+  const [weeks, setWeeks] = useState(DEFAULT_WEEKS);
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed on every open. Without this a failed attempt's text, and its red Alert, would be
+  // sitting there the next time the admin opens the dialog to create an unrelated course.
+  useEffect(() => {
+    if (!open) return;
+    setTitle("");
+    setDescription("");
+    setAudience("");
+    setWeeks(DEFAULT_WEEKS);
+    setError(null);
+    setSaving(false);
+  }, [open]);
+
+  const titleValid = title.trim().length >= MIN_TITLE;
+
+  const weeksRaw = weeks.trim();
+  const weeksNum = Number(weeksRaw);
+  // Empty is legal (the field is optional). Anything present must be a whole number in range —
+  // checked here so a typo costs a helper line instead of a round trip and a bounced form.
+  const weeksValid =
+    weeksRaw === "" ||
+    (Number.isInteger(weeksNum) && weeksNum >= MIN_WEEKS && weeksNum <= MAX_WEEKS);
+
+  const canCreate = titleValid && weeksValid && !saving;
+
+  const handleCreate = async () => {
+    if (!canCreate) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const course = await adminAdaptiveCourseService.createBlankCourse({
+        title: title.trim(),
+        // Optional fields are omitted rather than sent empty: a blank string is a value the
+        // server would store, overwriting whatever default the course template carries.
+        ...(description.trim() ? { description: description.trim() } : {}),
+        ...(audience.trim() ? { target_audience: audience.trim() } : {}),
+        ...(weeksRaw ? { duration_weeks: weeksNum } : {}),
+      });
+      showToast("Course created. Add your first module.", "success");
+      onCreated(course.id);
+      onClose();
+    } catch (e) {
+      // Deliberately no onClose() and no field reset. The dialog stays exactly as typed so a
+      // 500 or a dropped connection costs a second click, not the whole form.
+      setError(getAxiosErrorDetail(e, "Couldn't create the course. Please try again."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      // Closing mid-save would strand the request: the course would exist but onCreated would
+      // never fire, leaving the admin on a list that does not show it until a refresh.
+      onClose={saving ? undefined : onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          backgroundColor: "var(--card-bg)",
+          border: "1px solid var(--border-default)",
+          backgroundImage: "none",
+        },
+      }}
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.25 }}>
+          <Box
+            sx={{
+              width: 34,
+              height: 34,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              flexShrink: 0,
+              background: `linear-gradient(135deg, ${INDIGO}, ${PURPLE})`,
+              color: "#fff",
+            }}
+          >
+            <Icon icon="mdi:table-column-plus-after" width={18} />
+          </Box>
+          <Typography
+            component="span"
+            sx={{ fontSize: 18, fontWeight: 700, color: "var(--font-primary)" }}
+          >
+            Build a course manually
+          </Typography>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1 }}>
+        <Box
+          sx={{
+            display: "flex",
+            gap: 1.25,
+            p: 1.5,
+            mb: 2.5,
+            mt: 0.5,
+            borderRadius: 2,
+            border: "1px solid var(--border-default)",
+            backgroundColor: `${INDIGO}0d`,
+          }}
+        >
+          <Icon
+            icon="mdi:information-outline"
+            width={18}
+            style={{ color: INDIGO, flexShrink: 0, marginTop: 2 }}
+          />
+          <Typography sx={{ fontSize: 13, lineHeight: 1.6, color: "var(--font-secondary)" }}>
+            Generating a course writes the modules, topics and items for you from a prompt. This
+            creates the shell only — the title and outline below, then you add every module, topic
+            and item yourself. Pick this when you already know the shape of the course.
+          </Typography>
+        </Box>
+
+        {error && (
+          <Alert
+            severity="error"
+            icon={<Icon icon="mdi:alert-circle-outline" width={20} />}
+            sx={{ mb: 2, borderRadius: 2, fontSize: 13 }}
+          >
+            {error}
+          </Alert>
+        )}
+
+        <TextField
+          label="Course title"
+          required
+          autoFocus
+          fullWidth
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="e.g. Programming Fundamentals with Python"
+          disabled={saving}
+          // Only nag once there is something to nag about — a required-field error on an
+          // untouched field is noise the admin has not earned yet.
+          error={title.length > 0 && !titleValid}
+          helperText={
+            title.length > 0 && !titleValid
+              ? `Give it at least ${MIN_TITLE} characters.`
+              : "Students see this name in the catalog. You can rename it later."
+          }
+          sx={{ mb: 2.25 }}
+        />
+
+        <TextField
+          label="Description"
+          fullWidth
+          multiline
+          minRows={3}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What the course covers and what a student walks away able to do."
+          disabled={saving}
+          helperText="Optional."
+          sx={{ mb: 2.25 }}
+        />
+
+        <TextField
+          label="Target audience"
+          fullWidth
+          value={audience}
+          onChange={(e) => setAudience(e.target.value)}
+          placeholder="e.g. Final-year CS students with no prior Python"
+          disabled={saving}
+          helperText="Optional. Used to pitch the difficulty of the course."
+          sx={{ mb: 2.25 }}
+        />
+
+        <TextField
+          label="Duration (weeks)"
+          type="number"
+          value={weeks}
+          onChange={(e) => setWeeks(e.target.value)}
+          disabled={saving}
+          error={!weeksValid}
+          helperText={
+            !weeksValid
+              ? `Enter a whole number between ${MIN_WEEKS} and ${MAX_WEEKS}, or leave it empty.`
+              : "Optional. Sets the default pacing of the weekly plan."
+          }
+          inputProps={{ min: MIN_WEEKS, max: MAX_WEEKS, step: 1 }}
+          sx={{ width: { xs: "100%", sm: 220 } }}
+        />
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2.5, pt: 1 }}>
+        <LoadingButton
+          variant="text"
+          onClick={onClose}
+          disabled={saving}
+          sx={{ color: "var(--font-secondary)", textTransform: "none", fontWeight: 600 }}
+        >
+          Cancel
+        </LoadingButton>
+        <LoadingButton
+          variant="contained"
+          onClick={handleCreate}
+          loading={saving}
+          loadingText="Creating..."
+          disabled={!canCreate}
+          sx={{
+            textTransform: "none",
+            fontWeight: 700,
+            borderRadius: 2,
+            px: 2.5,
+            color: "#fff",
+            background: `linear-gradient(135deg, ${INDIGO}, ${PURPLE})`,
+            boxShadow: `0 6px 16px ${INDIGO}40`,
+            "&:hover": {
+              background: `linear-gradient(135deg, ${INDIGO}, ${PURPLE})`,
+              filter: "brightness(1.06)",
+              boxShadow: `0 8px 20px ${INDIGO}55`,
+            },
+            // The gradient is painted by `background`, which MUI's disabled rule does not clear,
+            // so a disabled button would otherwise still look fully enabled.
+            "&.Mui-disabled": {
+              background: "var(--border-default)",
+              color: "var(--font-secondary)",
+              boxShadow: "none",
+            },
+          }}
+        >
+          Create course
+        </LoadingButton>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/adaptive-course/ManualTreeControls.tsx
+++ b/components/admin/adaptive-course/ManualTreeControls.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Box, TextField, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { LoadingButton } from "@/components/common/LoadingButton";
+import { useToast } from "@/components/common/Toast";
+import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+
+const INDIGO = "#6366f1";
+
+type GhostAddRowProps = {
+  /** Text shown in the collapsed ghost state. */
+  ghostLabel: string;
+  placeholder: string;
+  /** Resolves once the row exists server-side; rejects with the axios error. */
+  onCreate: (title: string) => Promise<void>;
+  /** Told after each successful create so the parent can refetch the tree. */
+  onAdded: () => void;
+  errorFallback: string;
+  /** Submodule rows sit one level deeper, so they render tighter than module rows. */
+  dense?: boolean;
+};
+
+/**
+ * Ghost row -> inline field. Shared by both exports below because the only real
+ * differences are the copy and which service call fires.
+ */
+function GhostAddRow({
+  ghostLabel,
+  placeholder,
+  onCreate,
+  onAdded,
+  errorFallback,
+  dense = false,
+}: GhostAddRowProps) {
+  const { showToast } = useToast();
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const refocusAfterSave = useRef(false);
+
+  // The field is `disabled` for the whole save, and focus() on a disabled input is a
+  // no-op - so the caret has to be restored on the render *after* saving flips back
+  // to false, not inline in submit(), or every successful add drops the caret.
+  useEffect(() => {
+    if (saving || !refocusAfterSave.current) return;
+    refocusAfterSave.current = false;
+    inputRef.current?.focus();
+  }, [saving]);
+
+  const submit = useCallback(async () => {
+    const title = value.trim();
+    // The `saving` half of this guard is load-bearing: holding Enter, or hitting it
+    // twice while the POST is in flight, would otherwise create duplicate rows that
+    // the admin then has to delete one by one.
+    if (!title || saving) return;
+
+    setSaving(true);
+    try {
+      await onCreate(title);
+      // Clear before notifying the parent: onAdded triggers a tree refetch and
+      // re-render, and we do not want the just-submitted text flashing back.
+      setValue("");
+      onAdded();
+      // Stay in input mode and keep the caret so the next topic is type-Enter-type-Enter.
+      // The actual focus() fires from the effect above, once the field is enabled again.
+      refocusAfterSave.current = true;
+    } catch (e) {
+      // Keep `value` untouched on failure - retyping a title the admin already
+      // typed is the most annoying possible response to a server error.
+      showToast(getAxiosErrorDetail(e, errorFallback), "error");
+    } finally {
+      setSaving(false);
+    }
+  }, [value, saving, onCreate, onAdded, errorFallback, showToast]);
+
+  const cancel = useCallback(() => {
+    setValue("");
+    setEditing(false);
+  }, []);
+
+  if (!editing) {
+    return (
+      <Box
+        component="button"
+        type="button"
+        // type="button" matters: these rows render inside course-settings forms in
+        // some layouts, and a bare <button> would default to submitting them.
+        onClick={(e: React.MouseEvent) => {
+          // The tree rows above are click-to-expand; without this the accordion
+          // toggles at the same time the field opens.
+          e.stopPropagation();
+          setEditing(true);
+        }}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          width: "100%",
+          px: dense ? 1.5 : 2,
+          py: dense ? 0.85 : 1.15,
+          border: "1px dashed var(--border-default)",
+          borderRadius: "10px",
+          bgcolor: "transparent",
+          color: "var(--font-secondary)",
+          cursor: "pointer",
+          textAlign: "left",
+          font: "inherit",
+          transition: "border-color 140ms ease, color 140ms ease, background-color 140ms ease",
+          "&:hover": {
+            borderColor: INDIGO,
+            color: INDIGO,
+            bgcolor: "rgba(99, 102, 241, 0.06)",
+          },
+        }}
+      >
+        <Icon icon="mdi:plus" width={16} />
+        <Typography
+          component="span"
+          sx={{ fontSize: dense ? "0.8125rem" : "0.875rem", fontWeight: 500, color: "inherit" }}
+        >
+          {ghostLabel}
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      onClick={(e) => e.stopPropagation()}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        width: "100%",
+        pl: dense ? 1 : 1.5,
+        pr: 1,
+        py: 0.5,
+        border: `1px dashed ${INDIGO}`,
+        borderRadius: "10px",
+        bgcolor: "var(--card-bg)",
+        boxShadow: "0 0 0 3px rgba(99, 102, 241, 0.10)",
+      }}
+    >
+      <Icon icon="mdi:plus" width={16} color={INDIGO} />
+      <TextField
+        inputRef={inputRef}
+        autoFocus
+        fullWidth
+        size="small"
+        value={value}
+        placeholder={placeholder}
+        disabled={saving}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          // The surrounding tree binds Enter/Escape/arrows for navigation, so every
+          // key we handle has to stop here or it fires twice with two meanings.
+          if (e.key === "Enter") {
+            e.preventDefault();
+            e.stopPropagation();
+            void submit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+            cancel();
+          }
+        }}
+        onBlur={() => {
+          // Only an empty field collapses. Typed text survives a stray click, and
+          // clicking Add cannot self-cancel because Add requires non-empty text.
+          if (!saving && !value.trim()) setEditing(false);
+        }}
+        sx={{
+          "& .MuiOutlinedInput-root": {
+            bgcolor: "transparent",
+            color: "var(--font-primary)",
+            fontSize: dense ? "0.8125rem" : "0.875rem",
+            "& fieldset": { border: "none" },
+            "&:hover fieldset": { border: "none" },
+            "&.Mui-focused fieldset": { border: "none" },
+          },
+          "& .MuiOutlinedInput-input::placeholder": {
+            color: "var(--font-secondary)",
+            opacity: 0.75,
+          },
+        }}
+      />
+      <LoadingButton
+        variant="contained"
+        loading={saving}
+        loadingText="Adding"
+        disabled={!value.trim()}
+        onClick={() => void submit()}
+        sx={{
+          flexShrink: 0,
+          textTransform: "none",
+          fontWeight: 600,
+          fontSize: "0.8125rem",
+          px: 2,
+          borderRadius: "8px",
+          bgcolor: INDIGO,
+          "&:hover": { bgcolor: "#4f46e5" },
+        }}
+      >
+        Add
+      </LoadingButton>
+    </Box>
+  );
+}
+
+export function AddModuleRow({
+  courseId,
+  onAdded,
+}: {
+  courseId: number;
+  onAdded: () => void;
+}) {
+  const onCreate = useCallback(
+    async (title: string) => {
+      // weekno is omitted deliberately - the backend appends at the end of the
+      // course, which is what "add a week" means from this position in the tree.
+      await adminAdaptiveCourseService.createModule(courseId, { title });
+    },
+    [courseId]
+  );
+
+  return (
+    <GhostAddRow
+      ghostLabel="Add week"
+      placeholder="Name this week, e.g. Functions and scope"
+      onCreate={onCreate}
+      onAdded={onAdded}
+      errorFallback="Could not add the week. Please try again."
+    />
+  );
+}
+
+export function AddSubmoduleRow({
+  courseId,
+  moduleId,
+  onAdded,
+}: {
+  courseId: number;
+  moduleId: number;
+  onAdded: () => void;
+}) {
+  const onCreate = useCallback(
+    async (title: string) => {
+      await adminAdaptiveCourseService.createSubmodule(courseId, moduleId, { title });
+    },
+    [courseId, moduleId]
+  );
+
+  return (
+    <GhostAddRow
+      dense
+      ghostLabel="Add topic"
+      placeholder="Name this topic"
+      onCreate={onCreate}
+      onAdded={onAdded}
+      errorFallback="Could not add the topic. Please try again."
+    />
+  );
+}

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -526,7 +526,167 @@ export interface StudentAnalytics {
   }[];
 }
 
+
+/* ---------------------------------------------------------------- manual authoring */
+
+/** A verified-library MCQ, as offered by the bank picker. */
+export interface BankMcq {
+  id: number;
+  question_text: string;
+  options: { a: string; b: string; c: string; d: string };
+  correct_option: string;
+  explanation: string;
+  difficulty_level: string;
+  topic: string;
+  skills: string[];
+}
+
+export interface BankCodingProblem {
+  id: number;
+  title: string;
+  problem_statement: string;
+  difficulty_level: string;
+  topic: string;
+  skills: string[];
+  test_cases: number;
+}
+
+export interface BankSearchResult<T> {
+  results: T[];
+  total: number;
+  offset: number;
+  limit: number;
+  note: string;
+}
+
+export interface SubmoduleSuggestions {
+  submodule: { id: number; title: string };
+  has: { article: boolean; quiz: boolean; coding: boolean; video: boolean };
+  gaps: Array<{ kind: "article" | "quiz" | "coding" | "video"; title: string; why: string }>;
+  bank_matches: {
+    mcqs: Array<{ id: number; question_text: string; difficulty_level: string; topic: string }>;
+    coding: Array<{ id: number; title: string; difficulty_level: string; topic: string }>;
+  };
+  matched_on: string;
+}
+
+/** The video endpoints answer with what they could and could not build. */
+export interface AttachVideoResult {
+  id: number;
+  title: string;
+  source: "catalog" | "external";
+  check_ins_built: boolean;
+  note: string;
+}
+
 export const adminAdaptiveCourseService = {
+
+  /* -------------------------------------------------- manual authoring (no AI) */
+
+  /** A blank course. Unlike `generateCourse` this returns the course itself, not a job. */
+  async createBlankCourse(payload: {
+    title: string;
+    description?: string;
+    target_audience?: string;
+    duration_weeks?: number;
+  }): Promise<AdminAdaptiveCourseDetail> {
+    const { data } = await apiClient.post(`${BASE}/courses/create/`, payload);
+    return data;
+  },
+
+  async createModule(courseId: number, payload: { title: string; weekno?: number }) {
+    const { data } = await apiClient.post(`${BASE}/courses/${courseId}/modules/`, payload);
+    return data as AdminAdaptiveCourseModule;
+  },
+
+  async updateModule(courseId: number, moduleId: number, payload: { title?: string; weekno?: number }) {
+    const { data } = await apiClient.patch(`${BASE}/courses/${courseId}/modules/${moduleId}/`, payload);
+    return data as AdminAdaptiveCourseModule;
+  },
+
+  async deleteModule(courseId: number, moduleId: number) {
+    const { data } = await apiClient.delete(`${BASE}/courses/${courseId}/modules/${moduleId}/`);
+    return data as { deleted: boolean; submodules_removed: number };
+  },
+
+  async createSubmodule(courseId: number, moduleId: number, payload: { title: string; description?: string }) {
+    const { data } = await apiClient.post(
+      `${BASE}/courses/${courseId}/modules/${moduleId}/submodules/`,
+      payload
+    );
+    return data;
+  },
+
+  async updateSubmodule(submoduleId: number, payload: { title?: string; description?: string; order?: number }) {
+    const { data } = await apiClient.patch(`${BASE}/submodules/${submoduleId}/`, payload);
+    return data;
+  },
+
+  async deleteSubmodule(submoduleId: number) {
+    const { data } = await apiClient.delete(`${BASE}/submodules/${submoduleId}/`);
+    return data as { deleted: boolean };
+  },
+
+  /** Sends the whole arrangement, not a move-one-step: a lost request cannot half-apply a drag. */
+  async reorderTree(
+    courseId: number,
+    modules: Array<{ id: number; weekno: number; submodules: Array<{ id: number; order: number }> }>
+  ) {
+    const { data } = await apiClient.post(`${BASE}/courses/${courseId}/reorder/`, { modules });
+    return data as { modules_updated: number; submodules_updated: number };
+  },
+
+  async addArticle(submoduleId: number, payload: {
+    title: string; body: string; summary?: string; reading_tier?: string;
+  }) {
+    const { data } = await apiClient.post(`${BASE}/submodules/${submoduleId}/article/`, payload);
+    return data as { id: number; title: string; reading_tier: string };
+  },
+
+  /** `mcq_ids` pulls from the verified bank; `mcqs` are hand-written. Both may be sent. */
+  async addQuiz(submoduleId: number, payload: {
+    title?: string;
+    instructions?: string;
+    mcq_ids?: number[];
+    mcqs?: Array<Record<string, unknown>>;
+  }) {
+    const { data } = await apiClient.post(`${BASE}/submodules/${submoduleId}/quiz/`, payload);
+    return data as { id: number; title: string; questions: number };
+  },
+
+  async addCoding(submoduleId: number, payload: {
+    problem_ids: number[]; title?: string; instructions?: string; default_language?: string;
+  }) {
+    const { data } = await apiClient.post(`${BASE}/submodules/${submoduleId}/coding/`, payload);
+    return data as { id: number; title: string; problems: number };
+  },
+
+  /** Either `vimeo_id` (catalog, brings a transcript) or `url` (plain watch). */
+  async addVideo(submoduleId: number, payload: {
+    vimeo_id?: string; url?: string; title?: string; description?: string;
+  }): Promise<AttachVideoResult> {
+    const { data } = await apiClient.post(`${BASE}/submodules/${submoduleId}/video/`, payload);
+    return data;
+  },
+
+  async getSuggestions(submoduleId: number): Promise<SubmoduleSuggestions> {
+    const { data } = await apiClient.get(`${BASE}/submodules/${submoduleId}/suggestions/`);
+    return data;
+  },
+
+  async searchBank<T = BankMcq | BankCodingProblem>(
+    kind: "mcq" | "coding",
+    params: { q?: string; difficulty?: string; topic?: string; limit?: number; offset?: number } = {}
+  ): Promise<BankSearchResult<T>> {
+    const qs = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+      if (v !== undefined && v !== null && v !== "") qs.set(k, String(v));
+    });
+    const { data } = await apiClient.get(`${BASE}/bank/${kind}/?${qs.toString()}`);
+    return data;
+  },
+
+  // Generation (all return `AdaptiveCourseJobDetail`)
   async generateCourse(payload: GenerateAdaptiveCoursePayload): Promise<AdaptiveCourseJobDetail> {
     const { data } = await apiClient.post<AdaptiveCourseJobDetail>(
       `${BASE}/courses/generate/`,


### PR DESCRIPTION
Promotes stagging to production. Pairs with backend PR #522, merged to master.

Adds a fully manual path to the adaptive course builder alongside AI generation: create an empty course, add weeks and topics as inline ghost rows, and fill each topic with an article you write, questions pulled from the verified bank, coding problems from the bank, or a video from the Vimeo catalog or your own link. A hint rail per topic names what is missing and why.

Backend writes through the same service functions the generator uses, so a hand-built course is the same shape as a generated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)