### PR TITLE
Release: fix the adaptive course page crash

### DIFF
--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -16,6 +16,7 @@ import { AdditionalPractice } from "@/components/adaptive-journey/AdditionalPrac
 import { PointsInfo } from "@/components/common/PointsInfo";
 import { AdaptiveSubmoduleSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { asStringList } from "@/lib/utils/as-list";
 
 type FlowKind = "video" | "article" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
@@ -89,7 +90,7 @@ function buildItems(
       chips: [
         { icon: "mdi:database-outline", text: `${q.mcq_count}-item bank` },
         { icon: "mdi:arrow-decision-outline", text: `serves ${q.min_questions}–${q.max_questions}` },
-        ...q.target_skills.slice(0, 2).map((s) => ({ icon: "mdi:tag-outline", text: s })),
+        ...asStringList(q.target_skills).slice(0, 2).map((s) => ({ icon: "mdi:tag-outline", text: s })),
       ],
       href, onClick: () => nav(href),
       // Completed → open the last attempt's results instead of restarting.
@@ -103,7 +104,7 @@ function buildItems(
         kind: "coding", key: `c${p.problem_id}`, contentKey: `coding:${p.problem_id}`, title: p.title, completed: !!p.completed,
         chips: [
           { icon: "mdi:speedometer", text: p.difficulty_level },
-          ...p.target_skills.slice(0, 2).map((s) => ({ icon: "mdi:tag-outline", text: s })),
+          ...asStringList(p.target_skills).slice(0, 2).map((s) => ({ icon: "mdi:tag-outline", text: s })),
         ],
         href, onClick: () => nav(href),
       });

--- a/app/adaptive-quizzes/page.tsx
+++ b/app/adaptive-quizzes/page.tsx
@@ -18,6 +18,7 @@ import {
   type AdaptiveQuizCardData,
 } from "@/components/adaptive-quiz/AdaptiveQuizCard";
 import { RecentAttemptsRow } from "@/components/adaptive-quiz/RecentAttemptsRow";
+import { asStringList } from "@/lib/utils/as-list";
 
 type Filter = "all" | "personal" | "public" | "archived";
 
@@ -71,7 +72,7 @@ export default function AdaptiveQuizListPage() {
     const publicItems = items.filter((i) => !i.is_personal);
     const activeItems = [...publicItems, ...activePersonal];
     const skillSet = new Set<string>();
-    for (const it of activeItems) for (const s of it.target_skills) if (s) skillSet.add(s);
+    for (const it of activeItems) for (const s of asStringList(it.target_skills)) skillSet.add(s);
     return {
       active: activeItems.length,
       personal: activePersonal.length,

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -57,6 +57,7 @@ import { AssignToCohortsDialog } from "@/components/admin/adaptive-course/Assign
 import { MockInterviewAdminSection } from "@/components/admin/adaptive-course/MockInterviewAdminSection";
 import { CertificateAdminSection } from "@/components/admin/adaptive-course/CertificateAdminSection";
 import type { CourseImageTarget } from "@/lib/services/admin/admin-adaptive-course.service";
+import { asStringList } from "@/lib/utils/as-list";
 
 type DialogState =
   | { kind: "module" }
@@ -995,7 +996,9 @@ export default function AdminAdaptiveCourseDetailPage() {
                                           <Typography sx={{ fontWeight: 700, fontSize: "0.85rem" }}>{p.title}</Typography>
                                           <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
                                             AI coding mentor · {p.difficulty_level}
-                                            {p.target_skills.length ? ` · ${p.target_skills.slice(0, 2).join(", ")}` : ""}
+                                            {asStringList(p.target_skills).length
+                                              ? ` · ${asStringList(p.target_skills).slice(0, 2).join(", ")}`
+                                              : ""}
                                             {p.is_active === false ? " · inactive" : ""}
                                           </Typography>
                                           <Box sx={{ flex: 1 }} />

--- a/app/admin/adaptive-quizzes/page.tsx
+++ b/app/admin/adaptive-quizzes/page.tsx
@@ -15,6 +15,7 @@ import {
   type AdminAdaptiveQuiz,
 } from "@/lib/services/admin/admin-adaptive-quiz.service";
 import { AdminQuizCard } from "@/components/admin/adaptive-quiz/AdminQuizCard";
+import { asStringList } from "@/lib/utils/as-list";
 
 export default function AdminAdaptiveQuizzesPage() {
   const router = useRouter();
@@ -47,7 +48,7 @@ export default function AdminAdaptiveQuizzesPage() {
     const skillSet = new Set<string>();
     let totalMcqs = 0;
     for (const it of items) {
-      for (const s of it.target_skills) if (s) skillSet.add(s);
+      for (const s of asStringList(it.target_skills)) skillSet.add(s);
       totalMcqs += it.mcq_count;
     }
     return {

--- a/components/adaptive-quiz/AdaptiveQuizCard.tsx
+++ b/components/adaptive-quiz/AdaptiveQuizCard.tsx
@@ -4,6 +4,7 @@ import { Box, ButtonBase, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 import { Icon } from "@iconify/react";
 import { AdaptiveCardBackdrop } from "./shared/AdaptiveCardBackdrop";
+import { asStringList } from "@/lib/utils/as-list";
 
 export interface AdaptiveQuizCardData {
   config_id: number;
@@ -48,6 +49,9 @@ function prettySkill(s: string): string {
  *   - **Personal re-quiz**: pink→purple accent, account-star icon, "Personal · targeted".
  */
 export function AdaptiveQuizCard({ data, onStart }: AdaptiveQuizCardProps) {
+  // Bound once: the server type says string[], but a JSONField can hold a bare string and
+  // `.slice(...).join()` on one crashed the admin course page in production.
+  const skills = asStringList(data.target_skills);
   const isPersonal = Boolean(data.is_personal);
   const isArchived = Boolean(data.is_archived);
   const isActiveResume = isPersonal && !isArchived && data.latest_session_status === "active";
@@ -194,9 +198,9 @@ export function AdaptiveQuizCard({ data, onStart }: AdaptiveQuizCardProps) {
         </Box>
 
         {/* Sub-skill chips - restrained, max 3 + overflow */}
-        {data.target_skills.length > 0 && (
+        {skills.length > 0 && (
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.5 }}>
-            {data.target_skills.slice(0, 3).map((skill) => (
+            {skills.slice(0, 3).map((skill) => (
               <Box
                 key={skill}
                 sx={{
@@ -213,7 +217,7 @@ export function AdaptiveQuizCard({ data, onStart }: AdaptiveQuizCardProps) {
                 {prettySkill(skill)}
               </Box>
             ))}
-            {data.target_skills.length > 3 && (
+            {skills.length > 3 && (
               <Box
                 sx={{
                   px: 0.9,
@@ -226,7 +230,7 @@ export function AdaptiveQuizCard({ data, onStart }: AdaptiveQuizCardProps) {
                   border: "1px solid color-mix(in srgb, currentColor 18%, transparent)",
                 }}
               >
-                +{data.target_skills.length - 3}
+                +{skills.length - 3}
               </Box>
             )}
           </Box>

--- a/components/admin/adaptive-course/AdminCodingViewer.tsx
+++ b/components/admin/adaptive-course/AdminCodingViewer.tsx
@@ -10,6 +10,7 @@ import {
   type AdminCodingProblemDetail,
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
+import { asStringList } from "@/lib/utils/as-list";
 
 /**
  * Admin review + edit surface for one generated coding problem - the coding
@@ -66,7 +67,7 @@ export function AdminCodingViewer({ problemId, onChanged, onDeleted }: AdminCodi
     setDifficulty(p.difficulty_level);
     setStatement(p.problem_statement);
     setConstraints(p.constraints);
-    setSkills((p.target_skills || []).join(", "));
+    setSkills(asStringList(p.target_skills).join(", "));
     setCases(p.test_cases || []);
   }
 
@@ -219,7 +220,7 @@ export function AdminCodingViewer({ problemId, onChanged, onDeleted }: AdminCodi
           {problem.constraints && (
             <Box sx={{ fontSize: "0.8rem", color: "text.secondary" }} dangerouslySetInnerHTML={{ __html: problem.constraints }} />
           )}
-          <Field label="Target skills" value={(problem.target_skills || []).join(", ") || "-"} />
+          <Field label="Target skills" value={asStringList(problem.target_skills).join(", ") || "-"} />
           {problem.misconception_taxonomy?.length > 0 && (
             <Field label="Misconception taxonomy" value={problem.misconception_taxonomy.map((t) => t.label).join(" · ")} />
           )}

--- a/components/admin/adaptive-quiz/AdminQuizCard.tsx
+++ b/components/admin/adaptive-quiz/AdminQuizCard.tsx
@@ -12,6 +12,7 @@ import {
 import { AdaptiveCardBackdrop } from "@/components/adaptive-quiz/shared/AdaptiveCardBackdrop";
 import { AdaptiveInfoTip } from "@/components/adaptive-quiz/shared/AdaptiveInfoTip";
 import { confidenceTier } from "@/lib/utils/adaptive-confidence";
+import { asStringList } from "@/lib/utils/as-list";
 
 interface AdminQuizCardProps {
   quiz: AdminAdaptiveQuiz;
@@ -36,6 +37,9 @@ function prettySkill(s: string): string {
  *     button sits beside it.
  */
 export function AdminQuizCard({ quiz, onAfterToggle, onRequestDelete }: AdminQuizCardProps) {
+  // Bound once: the server type says string[], but a JSONField can hold a bare string and
+  // `.slice(...).join()` on one crashed the admin course page in production.
+  const skills = asStringList(quiz.target_skills);
   const router = useRouter();
   const [isActive, setIsActive] = useState(quiz.is_active);
   const [toggling, setToggling] = useState(false);
@@ -182,13 +186,13 @@ export function AdminQuizCard({ quiz, onAfterToggle, onRequestDelete }: AdminQui
         </Box>
 
         {/* Sub-skill chips */}
-        {quiz.target_skills.length === 0 ? (
+        {skills.length === 0 ? (
           <Typography sx={{ fontSize: "0.74rem", color: "text.secondary", fontStyle: "italic" }}>
             Skills auto-derive from the MCQ bank.
           </Typography>
         ) : (
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.25 }}>
-            {quiz.target_skills.slice(0, 3).map((s) => (
+            {skills.slice(0, 3).map((s) => (
               <Box
                 key={s}
                 sx={{
@@ -205,7 +209,7 @@ export function AdminQuizCard({ quiz, onAfterToggle, onRequestDelete }: AdminQui
                 {prettySkill(s)}
               </Box>
             ))}
-            {quiz.target_skills.length > 3 && (
+            {skills.length > 3 && (
               <Box
                 sx={{
                   px: 0.9,
@@ -218,7 +222,7 @@ export function AdminQuizCard({ quiz, onAfterToggle, onRequestDelete }: AdminQui
                   border: "1px solid color-mix(in srgb, currentColor 18%, transparent)",
                 }}
               >
-                +{quiz.target_skills.length - 3}
+                +{skills.length - 3}
               </Box>
             )}
           </Box>

--- a/components/admin/adaptive-quiz/QuizListRow.tsx
+++ b/components/admin/adaptive-quiz/QuizListRow.tsx
@@ -17,6 +17,7 @@ import {
   adminAdaptiveQuizService,
   type AdminAdaptiveQuiz,
 } from "@/lib/services/admin/admin-adaptive-quiz.service";
+import { asStringList } from "@/lib/utils/as-list";
 
 interface QuizListRowProps {
   quiz: AdminAdaptiveQuiz;
@@ -31,6 +32,9 @@ function prettySkill(s: string): string {
 }
 
 export function QuizListRow({ quiz, onAfterToggle, onRequestDelete }: QuizListRowProps) {
+  // Bound once: the server type says string[], but a JSONField can hold a bare string and
+  // `.slice(...).join()` on one crashed the admin course page in production.
+  const skills = asStringList(quiz.target_skills);
   const router = useRouter();
   const [isActive, setIsActive] = useState(quiz.is_active);
   const [toggling, setToggling] = useState(false);
@@ -57,12 +61,12 @@ export function QuizListRow({ quiz, onAfterToggle, onRequestDelete }: QuizListRo
       <TableCell sx={{ fontWeight: 700 }}>{quiz.title}</TableCell>
       <TableCell>
         <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
-          {quiz.target_skills.length === 0 && (
+          {skills.length === 0 && (
             <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", fontStyle: "italic" }}>
               auto-derived
             </Typography>
           )}
-          {quiz.target_skills.slice(0, 4).map((s) => (
+          {skills.slice(0, 4).map((s) => (
             <Box
               key={s}
               sx={{
@@ -79,9 +83,9 @@ export function QuizListRow({ quiz, onAfterToggle, onRequestDelete }: QuizListRo
               {prettySkill(s)}
             </Box>
           ))}
-          {quiz.target_skills.length > 4 && (
+          {skills.length > 4 && (
             <Typography sx={{ fontSize: "0.66rem", color: "text.secondary", alignSelf: "center" }}>
-              +{quiz.target_skills.length - 4}
+              +{skills.length - 4}
             </Typography>
           )}
         </Box>

--- a/components/coding/AdaptiveCodingProblemPanel.tsx
+++ b/components/coding/AdaptiveCodingProblemPanel.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@iconify/react";
 
 import { AIPill } from "@/components/adaptive-quiz/shared/AIPill";
 import type { CodingProblem } from "@/lib/services/adaptive-coding.service";
+import { asStringList } from "@/lib/utils/as-list";
 
 /**
  * Structured, student-facing problem panel for the AI Coding Mentor.
@@ -21,7 +22,7 @@ export function AdaptiveCodingProblemPanel({ problem }: { problem: CodingProblem
     .split(",")
     .map((t) => t.trim())
     .filter(Boolean);
-  const skills = problem.target_skills ?? [];
+  const skills = asStringList(problem.target_skills);
   // De-dupe tags that merely repeat a skill chip (case-insensitive).
   const skillSet = new Set(skills.map((s) => s.toLowerCase()));
   const extraTags = tags.filter((t) => !skillSet.has(t.toLowerCase())).slice(0, 6);

--- a/lib/utils/as-list.test.ts
+++ b/lib/utils/as-list.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { asArray, asStringList } from "./as-list";
+
+describe("asStringList", () => {
+  it("passes a well-formed list through", () => {
+    expect(asStringList(["python", "loops"])).toEqual(["python", "loops"]);
+  });
+
+  it("splits the comma-separated string that caused the production crash", () => {
+    // target_skills is a Django JSONField fed from a CharField holding "python, loops".
+    // `.slice(0, 2).join(", ")` on that string threw "join is not a function" and took the
+    // whole admin course page down behind an error boundary.
+    expect(asStringList("python, loops")).toEqual(["python", "loops"]);
+  });
+
+  it("does not explode a single skill into one entry per character", () => {
+    expect(asStringList("python")).toEqual(["python"]);
+  });
+
+  it("handles the other delimiters the backend's split_skills accepts", () => {
+    expect(asStringList("a|b;c/d")).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("returns an empty list for every shape that has no skills in it", () => {
+    for (const bad of [null, undefined, {}, 42, true, "", "   ", []]) {
+      expect(asStringList(bad)).toEqual([]);
+    }
+  });
+
+  it("drops non-string members rather than rendering [object Object]", () => {
+    expect(asStringList(["ok", null, { a: 1 }, 7, "fine"])).toEqual(["ok", "fine"]);
+  });
+
+  it("is safe to chain the array methods that crashed", () => {
+    expect(() => asStringList("python, loops").slice(0, 2).join(", ")).not.toThrow();
+    expect(asStringList("python, loops").slice(0, 2).join(", ")).toBe("python, loops");
+  });
+});
+
+describe("asArray", () => {
+  it("returns the array unchanged", () => {
+    expect(asArray([1, 2])).toEqual([1, 2]);
+  });
+
+  it("returns an empty array for anything else, so .map never throws", () => {
+    for (const bad of [null, undefined, "nope", {}, 0]) {
+      expect(asArray(bad)).toEqual([]);
+    }
+  });
+});

--- a/lib/utils/as-list.ts
+++ b/lib/utils/as-list.ts
@@ -1,0 +1,35 @@
+/**
+ * Coerce a value the API *claims* is `string[]` into one that actually is.
+ *
+ * TypeScript types describe a promise, not a guarantee — they are erased at runtime, so a
+ * `string[]` annotation on an API response is documentation and nothing more. `target_skills` is
+ * a Django `JSONField`, which happily accepts a bare string, and the tables it is copied from
+ * (`lms_core.MCQ.skills`, `lms_core.CodingProblem.skills`) are `CharField`s holding
+ * `"python, loops"`. When one leaked through, `target_skills.slice(0, 2).join(", ")` ran on a
+ * string: `.length` passed the truthiness gate, `.slice` returned `"py"`, and `.join` was
+ * undefined — which took the entire admin course page down behind an error boundary.
+ *
+ * The backend write boundaries are fixed and the stored rows are repaired. This exists because a
+ * single malformed row should degrade one chip, not white-screen a page a student or an admin is
+ * in the middle of using. Belt and braces, deliberately.
+ *
+ * A comma/pipe/semicolon-separated string is split rather than discarded, matching the backend's
+ * `split_skills`, so the legacy shape still renders something meaningful.
+ */
+export function asStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === "string" && v.trim() !== "");
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/[,|/;]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+/** Same guarantee for a list of objects: never throws on `.map`, whatever the server sent. */
+export function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}


### PR DESCRIPTION
Promotes stagging to production. Pairs with backend PR #525.

Fixes the reported crash on /admin/adaptive-courses/47 — `target_skills.slice(...).join is not a function`. Also guards three student-facing pages that would have failed on the same payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)