### PR TITLE
Fix: the hub's CSV card opens the CSV tab

### DIFF
--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Container, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
@@ -29,15 +30,22 @@ import {
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
-export default function GenerateAdaptiveCoursePage() {
+function GenerateAdaptiveCourseInner() {
   const { push } = useInstantNavigation();
   const { showToast } = useToast();
+  const params = useSearchParams();
 
-  const [mode, setMode] = useState<GenerateMode>("describe");
+  // The hub links straight into a mode ("From a CSV plan") and can hand over the brief typed
+  // into its composer. Read once, as the INITIAL state rather than in an effect: seeding from an
+  // effect would flash the Describe tab first, and would fight the user if they then switched
+  // tabs while the param was still in the URL.
+  const [mode, setMode] = useState<GenerateMode>(
+    params.get("mode") === "csv" ? "csv" : "describe",
+  );
 
   // --- Describe mode ---
   const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
+  const [description, setDescription] = useState(() => params.get("brief") ?? "");
   const [durationWeeks, setDurationWeeks] = useState(4);
 
   // --- CSV mode ---
@@ -418,5 +426,19 @@ function CsvHowItWorks() {
         ))}
       </Box>
     </>
+  );
+}
+
+
+/**
+ * `useSearchParams` opts a route into client-side rendering, and Next fails the BUILD — not
+ * typecheck — if it is not inside a Suspense boundary. tsc is happy either way, so this is the
+ * kind of thing only `next build` catches.
+ */
+export default function GenerateAdaptiveCoursePage() {
+  return (
+    <Suspense fallback={null}>
+      <GenerateAdaptiveCourseInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
Reported with a screenshot: clicking **"From a CSV plan"** in the new composer band landed on the **Describe** tab.

My bug from #1258 — I linked the card to `?mode=csv` but never taught the generate page to read the param. Same for the `?brief=` the composer hands over: you type the brief once, then it's thrown away and you type it again.

Both are read as **initial state**, not in an effect. Seeding from an effect would flash Describe before switching, and would fight you if you changed tabs while the param was still in the URL.

## One thing worth flagging

`useSearchParams` opts the route into client rendering, and Next fails the **build** if it isn't inside a Suspense boundary. `tsc` is perfectly happy either way — this is a case only `next build` catches, which is the same shape as the type error I let through to `main` earlier in this session. So I ran a real build rather than trusting the typecheck:

```
✓ Compiled successfully in 35.5s
```

## Verified

| URL | expected | result |
|---|---|---|
| `/generate` | Describe | CSV panel hidden ✓ |
| `/generate?mode=csv` | CSV | drop zone shown ✓ |
| `/generate?brief=8-week%20Python…` | pre-filled | description carries the text ✓ |

No page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)