### PR TITLE
The composer fills the form; requests stop piling up

### DIFF
--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -29,6 +29,7 @@ import {
   type CsvCoursePlan,
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+import { parseCourseBrief } from "@/lib/utils/course-brief";
 
 function GenerateAdaptiveCourseInner() {
   const { push } = useInstantNavigation();
@@ -43,10 +44,19 @@ function GenerateAdaptiveCourseInner() {
     params.get("mode") === "csv" ? "csv" : "describe",
   );
 
+  // The composer promises "Describe it. We'll build the whole thing." Handing the sentence over
+  // as the description alone broke that promise: the title stayed empty (and is required, so
+  // Generate was disabled), the duration ignored the "1 week" you typed, and "no coding" was
+  // dropped while the estimate still promised 54 coding problems.
+  const parsedBrief = useMemo(() => {
+    const raw = params.get("brief");
+    return raw ? parseCourseBrief(raw) : null;
+  }, [params]);
+
   // --- Describe mode ---
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState(() => params.get("brief") ?? "");
-  const [durationWeeks, setDurationWeeks] = useState(4);
+  const [title, setTitle] = useState(() => parsedBrief?.title ?? "");
+  const [description, setDescription] = useState(() => parsedBrief?.description ?? "");
+  const [durationWeeks, setDurationWeeks] = useState(() => parsedBrief?.durationWeeks ?? 4);
 
   // --- CSV mode ---
   const [csvTitle, setCsvTitle] = useState("");
@@ -66,7 +76,11 @@ function GenerateAdaptiveCourseInner() {
   const [confidence, setConfidence] = useState(true);
   // All four content types auto-selected by default (quiz + article + AI Coding
   // Mentor + Video Companion); admins can deselect in Advanced options.
-  const [contentTypes, setContentTypes] = useState<ContentType[]>(["quiz", "article", "coding", "video"]);
+  // A brief that mentions no content types leaves all four on — the form's own default. Only an
+  // explicit "no coding" / "heavy on practice problems" narrows it.
+  const [contentTypes, setContentTypes] = useState<ContentType[]>(
+    () => parsedBrief?.contentTypes ?? ["quiz", "article", "coding", "video"],
+  );
   const [codingClipboard, setCodingClipboard] = useState(false);
 
   const [submitting, setSubmitting] = useState(false);
@@ -251,6 +265,30 @@ function GenerateAdaptiveCourseInner() {
             {/* Form */}
             <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
               <GenerateModeToggle mode={mode} onChange={setMode} />
+
+              {/* What was read out of the brief, in the admin's own words. The composer's
+                  pitch is "one review, then generate" — that is only true if there is
+                  something to review against, and silent prefill is worse than none. */}
+              {parsedBrief && parsedBrief.understood.length > 0 && mode === "describe" && (
+                <Box
+                  sx={{
+                    mt: 2, mb: 1, p: 1.75, borderRadius: 3,
+                    display: "flex", alignItems: "flex-start", gap: 1.25,
+                    bgcolor: "color-mix(in srgb, #6366f1 7%, var(--card-bg))",
+                    border: "1px solid color-mix(in srgb, #6366f1 28%, transparent)",
+                  }}
+                >
+                  <Icon icon="mdi:auto-fix" width={18} style={{ color: "#6366f1", flexShrink: 0, marginTop: 2 }} />
+                  <Box sx={{ minWidth: 0 }}>
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.88rem" }}>
+                      Filled in from your brief — {parsedBrief.understood.join(" · ")}
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", lineHeight: 1.5 }}>
+                      Check it below and change anything that is not right, then generate.
+                    </Typography>
+                  </Box>
+                </Box>
+              )}
 
               {mode === "describe" ? (
                 <DescribeModePanel

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -26,6 +26,7 @@ import {
   type AdaptiveCourseJob,
   type AdminAdaptiveCourseListItem,
 } from "@/lib/services/admin/admin-adaptive-course.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const POLL_INTERVAL_MS = 10000;
 const ACTIVE_STATUSES = new Set(["pending", "generating_outline", "creating_structure", "generating_content"]);
@@ -111,6 +112,22 @@ export default function AdminAdaptiveCoursesPage() {
     }
     return { total: courses.length, published, drafts: courses.length - published, quizzes, coding };
   }, [courses]);
+
+  /** Withdraw a waiting request, or dismiss a rejected one. */
+  async function handleWithdraw(job: AdaptiveCourseJob) {
+    try {
+      await adminAdaptiveCourseService.withdrawJob(job.job_id);
+      // Dropped locally rather than refetching the world: the row is gone, and a full reload
+      // makes a one-row change look like a page change.
+      setJobs((prev) => prev.filter((j) => j.job_id !== job.job_id));
+      showToast(
+        job.status === "rejected" ? "Dismissed." : "Request withdrawn.",
+        "success",
+      );
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, "Couldn't withdraw that request."), "error");
+    }
+  }
 
   async function handleConfirmDelete() {
     if (!pendingDelete) return;
@@ -285,49 +302,12 @@ export default function AdminAdaptiveCoursesPage() {
       )}
 
           {(awaitingJobs.length > 0 || rejectedJobs.length > 0) && (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mb: 3 }}>
-              {awaitingJobs.map((job) => (
-                <Box
-                  key={job.job_id}
-                  sx={{
-                    borderRadius: 4, p: 2.25,
-                    bgcolor: "color-mix(in srgb, #f59e0b 8%, var(--card-bg))",
-                    border: "1px solid color-mix(in srgb, #f59e0b 35%, transparent)",
-                    display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap",
-                  }}
-                >
-                  <Icon icon="mdi:clock-outline" width={20} style={{ color: "#f59e0b" }} />
-                  <Box sx={{ minWidth: 0, flex: 1 }}>
-                    <Typography sx={{ fontWeight: 800 }}>{job.title}</Typography>
-                    <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
-                      Waiting for approval. A full course is a large amount of AI generation, so
-                      one of our super admins reviews the brief before it is built. Nothing is
-                      generated — and nothing is charged — until then.
-                    </Typography>
-                  </Box>
-                </Box>
-              ))}
-              {rejectedJobs.map((job) => (
-                <Box
-                  key={job.job_id}
-                  sx={{
-                    borderRadius: 4, p: 2.25,
-                    bgcolor: "color-mix(in srgb, #ef4444 7%, var(--card-bg))",
-                    border: "1px solid color-mix(in srgb, #ef4444 32%, transparent)",
-                    display: "flex", alignItems: "flex-start", gap: 1.5,
-                  }}
-                >
-                  <Icon icon="mdi:close-circle-outline" width={20} style={{ color: "#ef4444" }} />
-                  <Box sx={{ minWidth: 0 }}>
-                    <Typography sx={{ fontWeight: 800 }}>{job.title} — not approved</Typography>
-                    {/* The reviewer's reason, verbatim. A bare "rejected" just gets resubmitted. */}
-                    <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
-                      {job.review_note || "No reason was given."}
-                    </Typography>
-                  </Box>
-                </Box>
-              ))}
-            </Box>
+            <RequestTray
+              awaiting={awaitingJobs}
+              rejected={rejectedJobs}
+              onOpen={(jobId) => push(`/admin/adaptive-courses/jobs/${jobId}`)}
+              onWithdraw={handleWithdraw}
+            />
           )}
 
           {/* Active generation jobs */}
@@ -750,3 +730,119 @@ export function statusLabel(status: string): string {
 
 /** Tabs mirror the assessment hub: the whole set, then the two states that matter. */
 type CourseTab = "all" | "published" | "drafts";
+
+
+/**
+ * Pending and rejected generation requests, as ONE row that expands.
+ *
+ * They used to render as a full-width banner each. Two is already noisy; a tenant that submits
+ * a few a week ends up scrolling past a wall of them to reach their actual courses — and the
+ * rejected ones never go away on their own, so the pile only grows.
+ *
+ * Collapsed by default because the honest summary ("2 waiting") is all most visits need, and
+ * every row carries the way out: withdraw a request nobody has looked at yet, or dismiss a
+ * rejection once it has been read.
+ */
+function RequestTray({
+  awaiting,
+  rejected,
+  onOpen,
+  onWithdraw,
+}: {
+  awaiting: AdaptiveCourseJob[];
+  rejected: AdaptiveCourseJob[];
+  onOpen: (jobId: string) => void;
+  onWithdraw: (job: AdaptiveCourseJob) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const all = [...awaiting, ...rejected];
+
+  const summary = [
+    awaiting.length ? `${awaiting.length} waiting for approval` : "",
+    rejected.length ? `${rejected.length} not approved` : "",
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <Box
+      sx={{
+        mb: 3, borderRadius: 4, overflow: "hidden",
+        bgcolor: "color-mix(in srgb, #f59e0b 6%, var(--card-bg))",
+        border: "1px solid color-mix(in srgb, #f59e0b 30%, transparent)",
+      }}
+    >
+      <ButtonBase
+        onClick={() => setOpen((v) => !v)}
+        sx={{ width: "100%", justifyContent: "flex-start", gap: 1.25, px: 2.25, py: 1.6, textAlign: "left" }}
+      >
+        <Icon icon="mdi:tray-full" width={19} style={{ color: "#f59e0b", flexShrink: 0 }} />
+        <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }}>
+          Generation requests
+        </Typography>
+        <Typography sx={{ fontSize: "0.82rem", color: "text.secondary" }}>{summary}</Typography>
+        <Box sx={{ flex: 1 }} />
+        <Icon icon={open ? "mdi:chevron-up" : "mdi:chevron-down"} width={18} style={{ color: "#f59e0b" }} />
+      </ButtonBase>
+
+      {open && (
+        <Box sx={{ px: 1.25, pb: 1.25, display: "flex", flexDirection: "column", gap: 0.75 }}>
+          {all.map((job) => {
+            const isRejected = job.status === "rejected";
+            return (
+              <Box
+                key={job.job_id}
+                sx={{
+                  display: "flex", alignItems: "center", gap: 1.25, px: 1.75, py: 1.4,
+                  borderRadius: 3, bgcolor: "var(--card-bg)",
+                  border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+                }}
+              >
+                <Icon
+                  icon={isRejected ? "mdi:close-circle-outline" : "mdi:clock-outline"}
+                  width={17}
+                  style={{ color: isRejected ? "#ef4444" : "#f59e0b", flexShrink: 0 }}
+                />
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography sx={{ fontWeight: 800, fontSize: "0.86rem" }} noWrap>
+                    {job.title}
+                  </Typography>
+                  <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }} noWrap>
+                    {/* The reviewer's reason, verbatim — it is the only thing that stops the
+                        same request being submitted again unchanged. */}
+                    {isRejected
+                      ? job.review_note || "No reason was given."
+                      : "Nothing is generated, and nothing is charged, until it is reviewed."}
+                  </Typography>
+                </Box>
+                <ButtonBase
+                  onClick={() => onOpen(job.job_id)}
+                  sx={{ px: 1.4, py: 0.5, borderRadius: 999, fontWeight: 800, fontSize: "0.75rem", color: "#6366f1" }}
+                >
+                  Details
+                </ButtonBase>
+                <ButtonBase
+                  disabled={busy === job.job_id}
+                  onClick={async () => {
+                    setBusy(job.job_id);
+                    try {
+                      await onWithdraw(job);
+                    } finally {
+                      setBusy(null);
+                    }
+                  }}
+                  sx={{
+                    px: 1.4, py: 0.5, borderRadius: 999, fontWeight: 800, fontSize: "0.75rem",
+                    color: "text.secondary", "&:hover": { color: "#ef4444" },
+                    "&:disabled": { opacity: 0.5 },
+                  }}
+                >
+                  {isRejected ? "Dismiss" : "Withdraw"}
+                </ButtonBase>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -1042,4 +1042,15 @@ export const adminAdaptiveCourseService = {
     const { data } = await apiClient.delete(`${CODING_ADMIN}/configs/${configId}/`);
     return data;
   },
+
+  /**
+   * Withdraw a generation request that is still waiting, or dismiss a rejected one.
+   *
+   * Only those two states — the backend refuses once a build is running, because cancelling
+   * then would leave a half-written course with no owner.
+   */
+  async withdrawJob(jobId: string): Promise<void> {
+    await apiClient.delete(`${BASE}/courses/jobs/${jobId}/`);
+  },
+
 };

--- a/lib/utils/course-brief.test.ts
+++ b/lib/utils/course-brief.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCourseBrief } from "./course-brief";
+
+describe("parseCourseBrief", () => {
+  it("reads the exact brief that was reported broken", () => {
+    // "1 week, no coding" landed on a form with duration 4 and 54 coding problems promised.
+    const p = parseCourseBrief("1-week System Design refresher · short articles, no coding");
+    expect(p.durationWeeks).toBe(1);
+    expect(p.title).toBe("System Design");
+    expect(p.contentTypes).not.toContain("coding");
+    expect(p.understood).toContain("no coding");
+  });
+
+  it("fills the title, which is required and was left empty", () => {
+    // An empty title left Generate disabled — the composer handed you a form you could not submit.
+    expect(parseCourseBrief("8-week Python for absolute beginners").title).toBe("Python");
+  });
+
+  it("keeps the writer's own capitalisation", () => {
+    // The point is that "SQL" survives as "SQL" and does not become "Sql For Analysts".
+    // Keeping the audience ("for analysts") is deliberate — it makes a better course title
+    // than the bare subject, and audiences are not something worth trying to enumerate.
+    const title = parseCourseBrief("6-week SQL for analysts").title;
+    expect(title).toBe("SQL for analysts");
+    expect(title).not.toBe("Sql For Analysts");
+  });
+
+  it("title-cases a brief written entirely in lower case", () => {
+    expect(parseCourseBrief("8-week python basics").title).toBe("Python Basics");
+  });
+
+  it("turns each composer example chip into a usable form", () => {
+    const chips = [
+      "8-week Python for absolute beginners · article + quiz per topic",
+      "6-week SQL for analysts · heavy on practice problems",
+      "4-week Excel refresher · short articles, no coding",
+    ];
+    for (const chip of chips) {
+      const p = parseCourseBrief(chip);
+      expect(p.title).toBeTruthy();
+      expect(p.durationWeeks).toBeGreaterThan(0);
+    }
+  });
+
+  it("adds coding when the brief asks for practice", () => {
+    expect(parseCourseBrief("6-week SQL · heavy on practice problems").contentTypes)
+      .toContain("coding");
+  });
+
+  it("leaves the defaults alone when the brief says nothing about content", () => {
+    // Silently narrowing what an admin gets, because they did not mention videos, would be
+    // worse than not parsing at all.
+    expect(parseCourseBrief("8-week Python").contentTypes).toBeNull();
+  });
+
+  it("never invents a duration", () => {
+    expect(parseCourseBrief("a course about Python").durationWeeks).toBeNull();
+  });
+
+  it("ignores an absurd duration rather than passing it to the form", () => {
+    expect(parseCourseBrief("400-week Python").durationWeeks).toBeNull();
+  });
+
+  it("keeps the whole brief as the description", () => {
+    const brief = "4-week Excel refresher · short articles, no coding";
+    expect(parseCourseBrief(brief).description).toBe(brief);
+  });
+
+  it("survives an empty or junk brief", () => {
+    for (const junk of ["", "   ", "!!!"]) {
+      const p = parseCourseBrief(junk);
+      expect(p.durationWeeks).toBeNull();
+      expect(() => p.understood.join()).not.toThrow();
+    }
+  });
+});

--- a/lib/utils/course-brief.ts
+++ b/lib/utils/course-brief.ts
@@ -1,0 +1,119 @@
+import type { ContentType } from "@/components/adaptive-quiz/generate/types";
+
+/**
+ * Turn a one-line brief from the composer into a filled-in generate form.
+ *
+ * The composer says "Describe it. We'll build the whole thing." It was handing the sentence
+ * over as the description and nothing else — so the title was empty (and required, so Generate
+ * stayed disabled), the duration stayed at its default of 4 regardless of what you typed, and
+ * "no coding" was ignored while the estimate cheerfully promised 54 coding problems. You were
+ * dropped into the form you thought you had just skipped, with the wrong numbers in it.
+ *
+ * Deliberately deterministic rather than an LLM call: the whole point of the approval gate is
+ * that model spend is rationed, and spending a request to parse "1 week, no coding" would be
+ * absurd. This handles the shapes the composer's own example chips teach people to type, and
+ * anything it cannot read is simply left at its default — never guessed at.
+ */
+export interface ParsedBrief {
+  title: string;
+  description: string;
+  durationWeeks: number | null;
+  contentTypes: ContentType[] | null;
+  /** What was understood, in the user's terms, so the one review is a real check. */
+  understood: string[];
+}
+
+const WEEK_RE = /(\d{1,2})\s*[-–—]?\s*week/i;
+const LEADING_DURATION_RE = /^\s*\d{1,2}\s*[-–—]?\s*week[s]?\s*/i;
+
+/**
+ * Strip the qualifier tail — everything the chips put after a separator.
+ *
+ * A plain hyphen is deliberately NOT a separator here: "1-week System Design" would split on it
+ * and leave the title as "1". En/em dashes only count when spaced, for the same reason.
+ */
+const TAIL_SEPARATORS = /\s*(?:·|,|:|\||\s[–—-]\s)\s*/;
+
+const SUBJECT_STOPWORDS = [
+  "course", "for absolute beginners", "for beginners", "refresher",
+  "practice test", "diagnostic", "bootcamp",
+];
+
+function toTitle(raw: string): string {
+  const cleaned = raw.trim().replace(/^["'“”]+|["'“”]+$/g, "");
+  if (!cleaned) return "";
+  // Preserve the writer's capitalisation when they used any — "SQL for analysts" must not
+  // become "Sql For Analysts".
+  if (/[A-Z]/.test(cleaned)) return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+  return cleaned.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function parseCourseBrief(brief: string): ParsedBrief {
+  const text = (brief || "").trim();
+  const lower = text.toLowerCase();
+  const understood: string[] = [];
+
+  // --- duration -------------------------------------------------------------
+  const weekMatch = text.match(WEEK_RE);
+  let durationWeeks: number | null = null;
+  if (weekMatch) {
+    const n = Number(weekMatch[1]);
+    if (n >= 1 && n <= 52) {
+      durationWeeks = n;
+      understood.push(`${n} week${n === 1 ? "" : "s"}`);
+    }
+  }
+
+  // --- content types --------------------------------------------------------
+  // Quiz and article are always on: a course with neither has nothing to assess or read, and
+  // nobody types a brief asking for that.
+  const types = new Set<ContentType>(["quiz", "article"]);
+  const saysNo = (thing: string) =>
+    new RegExp(`\\b(no|without|skip|exclude)\\s+\\w*\\s*${thing}`, "i").test(lower);
+
+  const wantsCoding =
+    /\b(coding|practice problems?|programming|dsa|leetcode|hands[- ]on)\b/i.test(lower);
+  const wantsVideo = /\b(video|lecture|screencast)\b/i.test(lower);
+
+  if (saysNo("coding") || saysNo("programming") || saysNo("practice")) {
+    understood.push("no coding");
+  } else if (wantsCoding) {
+    types.add("coding");
+    understood.push("coding problems");
+  }
+
+  if (saysNo("video")) {
+    understood.push("no video");
+  } else if (wantsVideo) {
+    types.add("video");
+    understood.push("videos");
+  }
+
+  // A brief that mentions neither leaves the form's own defaults alone rather than silently
+  // narrowing what the admin gets.
+  const mentionedTypes =
+    wantsCoding || wantsVideo || saysNo("coding") || saysNo("video") || saysNo("practice");
+
+  // --- title ----------------------------------------------------------------
+  // The subject is what is left once the duration prefix and the qualifier tail are removed:
+  //   "8-week Python for absolute beginners · article + quiz per topic" -> "Python"
+  // Duration first, THEN the tail split: "1-week System Design" must lose the "1-week" before
+  // anything looks for separators, or the hyphen inside it becomes the split point.
+  let subject = text.replace(LEADING_DURATION_RE, "");
+  subject = subject.split(TAIL_SEPARATORS)[0] ?? subject;
+  for (const stop of SUBJECT_STOPWORDS) {
+    subject = subject.replace(new RegExp(`\\b${stop}\\b`, "ig"), " ");
+  }
+  subject = subject.replace(/\s{2,}/g, " ").trim();
+
+  const title = toTitle(subject).slice(0, 120);
+  if (title) understood.unshift(title);
+
+  return {
+    title,
+    description: text,
+    durationWeeks,
+    contentTypes: mentionedTypes ? Array.from(types) : null,
+    understood,
+  };
+}


### PR DESCRIPTION
Pairs with backend #537 (the withdraw endpoint).

## The composer was a promise the destination didn't keep

*"Describe it. We'll build the whole thing."* Typing **"1-week System Design refresher · short articles, no coding"** dropped you into the form with:

| | expected | actual |
|---|---|---|
| title | System Design | **empty** — and it's required, so Generate was disabled |
| duration | 1 week | **4** |
| coding | off | **on**, estimate promising 54 coding problems |

The brief was handed over as the *description* and nothing else. You were dumped into the form you thought you'd just skipped, with the wrong numbers in it.

`parseCourseBrief` now reads the duration, subject and content types out of the sentence and fills the form, so "one review, then generate" is actually true. A banner says **what was understood, in your own words** — silent prefill is worse than none, because "one review" only means something if there's something to review against.

**Deterministic, not an LLM call.** The whole point of the approval gate is that model spend is rationed; spending a request to parse "1 week, no coding" would be absurd. Anything it can't read is left at the form's default rather than guessed at — a brief that never mentions video does *not* get video silently switched off.

Two parsing details worth keeping:
- Duration is stripped **before** the qualifier tail is split off. Splitting first made the hyphen in `1-week` the split point, and the title came out as `"1"`.
- A plain hyphen isn't a tail separator, for the same reason. En/em dashes only count when spaced.

## Requests stop piling up

They rendered as a full-width banner each. Two is already noisy — and rejected ones never go away on their own, so the pile only grows until you're scrolling past a wall of them to reach your courses.

One collapsed row now: `Generation requests · 1 waiting for approval · 1 not approved`. Expand for the detail, the reviewer's reason verbatim, and the way out — **Withdraw** a request nobody's looked at yet, **Dismiss** a rejection once it's been read.

## Tests

11 unit tests on the parser (42 across the FE suite), including the exact brief that was reported. Browser-verified: one tray row, correct counts, Withdraw/Dismiss present, reason verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)