### PR TITLE
Stop discarding server errors, and stop calling failure success

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -192,7 +192,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       setTopic(res.topic);
       setRationale(res.rationale);
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't suggest a topic.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't suggest a topic."), "error");
     } finally {
       setSuggesting(false);
     }
@@ -214,7 +214,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       const data = await adminAdaptiveCourseService.getCourse(courseId);
       setCourse(data);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load course.");
+      setError(getAxiosErrorDetail(e, "Failed to load course."));
     } finally {
       setLoading(false);
     }
@@ -265,7 +265,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       setCourse(updated);
       showToast(describe(updated), "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't save that setting", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't save that setting"), "error");
     } finally {
       setPendingSetting(null);
     }
@@ -326,7 +326,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       setCourse({ ...course, is_published: res.is_published });
       showToast(res.is_published ? "Course published." : "Course unpublished.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't update.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't update."), "error");
     }
   }
 
@@ -345,7 +345,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       if (description) setEditDescription(description);
       showToast("Description drafted - review and save.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't generate a description.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't generate a description."), "error");
     } finally {
       setGenDesc(false);
     }
@@ -368,7 +368,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       setEditOpen(false);
       showToast("Course details saved.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't save.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't save."), "error");
     } finally {
       setSavingDetails(false);
     }
@@ -403,7 +403,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       showToast("Sent for approval — nothing is generated until it's reviewed.", "success");
       push(`/admin/adaptive-courses/jobs/${job.job_id}`);
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't send that for approval.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't send that for approval."), "error");
       setSubmitting(false);
     }
   }
@@ -418,7 +418,7 @@ export default function AdminAdaptiveCourseDetailPage() {
       // Same flow as the generate/add actions: hand off to the live job view.
       push(`/admin/adaptive-courses/jobs/${job.job_id}`);
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't start regeneration.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't start regeneration."), "error");
       setRegenerating(false);
     }
   }

--- a/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/students/[studentId]/page.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/admin/adaptive-course/analytics/studentInsights";
 import { useVizPalette } from "@/components/admin/adaptive-course/analytics/vizPalette";
 import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const SEVERITY_RANK: Record<string, number> = { critical: 0, serious: 1, warning: 2 };
 
@@ -86,7 +87,7 @@ export default function StudentPerformancePage() {
       setLoading(true);
       setData(await adminAdaptiveCourseService.getStudentAnalytics(courseId, studentId));
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't load this student's report.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't load this student's report."), "error");
     } finally {
       setLoading(false);
     }

--- a/app/admin/adaptive-courses/jobs/[jobId]/page.tsx
+++ b/app/admin/adaptive-courses/jobs/[jobId]/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { LiveGenerationBento } from "@/components/admin/adaptive-course/LiveGenerationBento";
 import { statusLabel } from "../../page";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const POLL_INTERVAL_MS = 2000;
 const ORDER = ["pending", "generating_outline", "creating_structure", "generating_content", "completed"];
@@ -42,7 +43,7 @@ export default function AdaptiveCourseJobPage() {
     try {
       setJob(await adminAdaptiveCourseService.getJob(jobId));
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load job.");
+      setError(getAxiosErrorDetail(e, "Failed to load job."));
     }
   }, [jobId]);
 
@@ -53,7 +54,7 @@ export default function AdaptiveCourseJobPage() {
         const data = await adminAdaptiveCourseService.getJob(jobId);
         if (!cancelled) setJob(data);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load job.");
+        if (!cancelled) setError(getAxiosErrorDetail(e, "Failed to load job."));
       }
     })();
     return () => {

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -55,7 +55,7 @@ export default function AdminAdaptiveCoursesPage() {
       setCourses(courseList);
       setJobs(jobList);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Couldn't load adaptive courses.");
+      setError(getAxiosErrorDetail(e, "Couldn't load adaptive courses."));
     } finally {
       setLoading(false);
     }
@@ -137,7 +137,7 @@ export default function AdminAdaptiveCoursesPage() {
       setCourses((prev) => prev.filter((c) => c.id !== pendingDelete.id));
       showToast(`"${pendingDelete.title}" deleted.`, "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't delete.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't delete."), "error");
     } finally {
       setDeleting(false);
       setPendingDelete(null);
@@ -152,7 +152,7 @@ export default function AdminAdaptiveCoursesPage() {
       );
       showToast(res.is_published ? "Course published." : "Course unpublished.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't update.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't update."), "error");
     }
   }
 

--- a/components/admin/adaptive-course/AddContentDialog.tsx
+++ b/components/admin/adaptive-course/AddContentDialog.tsx
@@ -390,6 +390,7 @@ export function AddContentDialog({
   // Video
   const [videoMode, setVideoMode] = useState<"catalog" | "link">("catalog");
   const [vq, setVq] = useState("");
+  const [videoError, setVideoError] = useState(false);
   const [vRows, setVRows] = useState<VimeoVideoWire[]>([]);
   const [vLoading, setVLoading] = useState(false);
   const [pickedVimeo, setPickedVimeo] = useState<string | null>(null);
@@ -461,9 +462,15 @@ export function AddContentDialog({
           if (vSeq.current !== ticket) return;
           // searchCatalog answers with { results: [...] }, not a bare array.
           setVRows(r.results ?? []);
+          setVideoError(false);
         })
         .catch(() => {
-          if (vSeq.current === ticket) setVRows([]);
+          // Recorded, not swallowed: an empty list and a failed request look identical to the
+          // renderer, and only one of them means "nothing matched".
+          if (vSeq.current === ticket) {
+            setVRows([]);
+            setVideoError(true);
+          }
         })
         .finally(() => {
           if (vSeq.current === ticket) setVLoading(false);
@@ -1417,7 +1424,14 @@ export function AddContentDialog({
                     loading={vLoading}
                     error={null}
                     empty={vRows.length === 0}
-                    emptyText="No videos match that search."
+                    // Distinguishes "the catalog answered, and has nothing" from "the catalog
+                    // did not answer" — telling an admin their search found nothing during an
+                    // outage sends them rewording a query that was never run.
+                    emptyText={
+                      videoError
+                        ? "Couldn't reach the video catalog. Try again in a moment."
+                        : "No videos match that search."
+                    }
                   >
                     {vRows.map((v) => {
                       const picked = pickedVimeo === v.vimeo_id;

--- a/components/admin/adaptive-course/AdminArticleViewer.tsx
+++ b/components/admin/adaptive-course/AdminArticleViewer.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/services/adaptive-course.service";
 import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
 import { ArticleBodySkeleton } from "@/components/courses/CourseSkeletons";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 /**
  * Read-only admin preview of an adaptive article: renders the content at a tier
@@ -34,7 +35,7 @@ export function AdminArticleViewer({ courseId, articleId }: { courseId: number; 
       setTier(d.rendered_tier || d.default_tier);
       setHtml(d.content_html);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Couldn't load article.");
+      setError(getAxiosErrorDetail(e, "Couldn't load article."));
     } finally {
       setLoading(false);
     }
@@ -53,7 +54,7 @@ export function AdminArticleViewer({ courseId, articleId }: { courseId: number; 
       setHtml(res.content_html);
       setArticle((a) => (a ? { ...a, available_tiers: Array.from(new Set([...a.available_tiers, res.tier])) } : a));
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't render that level.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't render that level."), "error");
     } finally {
       setTierLoading(false);
     }

--- a/components/admin/adaptive-course/AdminCodingViewer.tsx
+++ b/components/admin/adaptive-course/AdminCodingViewer.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { AdminSectionSkeleton } from "@/components/courses/CourseSkeletons";
 import { asStringList } from "@/lib/utils/as-list";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 /**
  * Admin review + edit surface for one generated coding problem - the coding
@@ -89,7 +90,7 @@ export function AdminCodingViewer({ problemId, onChanged, onDeleted }: AdminCodi
       showToast("Saved.", "success");
       onChanged?.();
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Save failed.", "error");
+      showToast(getAxiosErrorDetail(e, "Save failed."), "error");
     } finally {
       setSaving(false);
     }
@@ -103,7 +104,7 @@ export function AdminCodingViewer({ problemId, onChanged, onDeleted }: AdminCodi
       showToast(res.is_active ? "Problem activated." : "Problem hidden from learners.", "success");
       onChanged?.();
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't update.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't update."), "error");
     }
   }
 
@@ -114,7 +115,7 @@ export function AdminCodingViewer({ problemId, onChanged, onDeleted }: AdminCodi
       showToast("Problem removed.", "success");
       onDeleted?.();
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't remove.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't remove."), "error");
     }
   }
 

--- a/components/admin/adaptive-course/AssignToCohortsDialog.tsx
+++ b/components/admin/adaptive-course/AssignToCohortsDialog.tsx
@@ -100,6 +100,14 @@ export function AssignToCohortsDialog({ open, onClose, courseId, courseTitle }: 
       const parts = [`Assigned to ${assigned} cohort${assigned === 1 ? "" : "s"}`];
       if (enrolled > 0) parts.push(`${enrolled} student${enrolled === 1 ? "" : "s"} enrolled`);
       if (already > 0) parts.push(`${already} already assigned`);
+      // These are N sequential calls, so a partial failure is the normal failure. Reporting
+      // only the successes and closing the dialog told an admin the whole job was done while
+      // some cohorts had silently 500'd — and closing removed the only place to retry them.
+      if (failed > 0) {
+        parts.push(`${failed} failed`);
+        showToast(`${parts.join(" · ")}. The failed ones are still selected — try again.`, "error");
+        return;
+      }
       showToast(`${parts.join(" · ")}.`, "success");
       onClose();
     } else if (already > 0 && failed === 0) {

--- a/components/admin/adaptive-course/CertificateAdminSection.tsx
+++ b/components/admin/adaptive-course/CertificateAdminSection.tsx
@@ -17,6 +17,7 @@ import { AdminCertificateUploadCard } from "@/components/admin/certificates/Admi
 import { useToast } from "@/components/common/Toast";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import type { AdminCertificateConfig } from "@/lib/types/adaptive-journey";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const AMBER_GRADIENT = "linear-gradient(135deg, #f59e0b 0%, #f97316 100%)";
 const INDIGO_GRADIENT = "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)";
@@ -110,7 +111,7 @@ export function CertificateAdminSection({ courseId }: { courseId: number }) {
       setFile(null);
       showToast("Certificate template uploaded.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Failed to upload template.", "error");
+      showToast(getAxiosErrorDetail(e, "Failed to upload template."), "error");
     } finally {
       setUploading(false);
     }
@@ -127,7 +128,7 @@ export function CertificateAdminSection({ courseId }: { courseId: number }) {
       hydrate(c);
       showToast("Certificate settings saved.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Failed to save settings.", "error");
+      showToast(getAxiosErrorDetail(e, "Failed to save settings."), "error");
     } finally {
       setSaving(false);
     }

--- a/components/admin/adaptive-course/CourseCoverArtPanel.tsx
+++ b/components/admin/adaptive-course/CourseCoverArtPanel.tsx
@@ -8,6 +8,7 @@ import {
   adminAdaptiveCourseService,
   type CourseImageTarget,
 } from "@/lib/services/admin/admin-adaptive-course.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 type Device = "desktop" | "mobile";
 
@@ -147,7 +148,7 @@ function CoverSlot({
       onChange(target, { url: res.url, hidden: res.hidden });
       showToast(`New ${cfg.label.toLowerCase()} generated.`, "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't generate the image.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't generate the image."), "error");
     } finally {
       setBusy(null);
     }
@@ -164,7 +165,7 @@ function CoverSlot({
       onChange(target, { url: res.url, hidden: res.hidden });
       showToast(`${cfg.label} updated.`, "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't upload the image.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't upload the image."), "error");
     } finally {
       setBusy(null);
       if (fileRef.current) fileRef.current.value = "";
@@ -177,7 +178,7 @@ function CoverSlot({
       const res = await adminAdaptiveCourseService.setCourseImageVisibility(courseId, target, !hidden);
       onChange(target, { hidden: res.hidden });
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't update visibility.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't update visibility."), "error");
     } finally {
       setBusy(null);
     }

--- a/components/admin/adaptive-course/CourseQuizEditor.tsx
+++ b/components/admin/adaptive-course/CourseQuizEditor.tsx
@@ -9,6 +9,7 @@ import {
   type AdminMcq,
 } from "@/lib/services/admin/admin-adaptive-quiz.service";
 import { MCQReviewTable } from "@/components/admin/adaptive-quiz/MCQReviewTable";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 interface CourseQuizEditorProps {
   configId: number;
@@ -53,7 +54,7 @@ export function CourseQuizEditor({ configId, topic, onSaved }: CourseQuizEditorP
       setInitialIds(new Set(d.mcqs.map((m) => m.id)));
       setTargetSkills(d.target_skills || []);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Couldn't load questions.");
+      setError(getAxiosErrorDetail(e, "Couldn't load questions."));
     } finally {
       setLoading(false);
     }
@@ -76,7 +77,7 @@ export function CourseQuizEditor({ configId, topic, onSaved }: CourseQuizEditorP
       });
       setMcqs((prev) => [...prev, mcq]);
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't generate a question.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't generate a question."), "error");
     } finally {
       setAdding(false);
     }
@@ -105,7 +106,7 @@ export function CourseQuizEditor({ configId, topic, onSaved }: CourseQuizEditorP
         skipped > 0 ? "info" : "success",
       );
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't save.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't save."), "error");
     } finally {
       setSaving(false);
     }

--- a/components/admin/adaptive-course/CourseStudentsPanel.tsx
+++ b/components/admin/adaptive-course/CourseStudentsPanel.tsx
@@ -27,6 +27,7 @@ import { EnrollAdaptiveStudentsDialog } from "./EnrollAdaptiveStudentsDialog";
 import { BulkEnrollmentDialog } from "@/components/admin/manage-students/BulkEnrollmentDialog";
 import { QuickEnrollStudentDialog } from "@/components/admin/manage-students/QuickEnrollStudentDialog";
 import { GradientBar, StudentAvatar, TYPE_COLOR } from "./studentVisuals";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 interface Props {
   courseId: number;
@@ -92,7 +93,7 @@ export function CourseStudentsPanel({ courseId, courseTitle }: Props) {
         setRows(res.results);
         setCount(res.count);
       } catch (e) {
-        showToast(e instanceof Error ? e.message : "Couldn't load students.", "error");
+        showToast(getAxiosErrorDetail(e, "Couldn't load students."), "error");
       } finally {
         setLoading(false);
       }
@@ -149,7 +150,7 @@ export function CourseStudentsPanel({ courseId, courseTitle }: Props) {
       setPage(nextPage);
       void load(search, nextPage);
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't remove student.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't remove student."), "error");
     } finally {
       setBusyId(null);
     }
@@ -428,7 +429,7 @@ function StudentProgressDialog({
       })
       .catch((e) => {
         if (cancelled) return;
-        showToast(e instanceof Error ? e.message : "Couldn't load progress.", "error");
+        showToast(getAxiosErrorDetail(e, "Couldn't load progress."), "error");
         onClose();
       });
     return () => {

--- a/components/admin/adaptive-course/EnrollAdaptiveStudentsDialog.tsx
+++ b/components/admin/adaptive-course/EnrollAdaptiveStudentsDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/services/admin/admin-student.service";
 import { adminAdaptiveCourseService } from "@/lib/services/admin/admin-adaptive-course.service";
 import { StudentAvatar } from "./studentVisuals";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 interface Props {
   open: boolean;
@@ -106,15 +107,25 @@ export function EnrollAdaptiveStudentsDialog({
     setSubmitting(true);
     try {
       const res = await adminAdaptiveCourseService.enrollStudents(courseId, Array.from(selected));
+      const failedCount = (res as { failed?: unknown[] }).failed?.length ?? 0;
       const msg =
         `Enrolled ${res.succeeded}` +
         (res.skipped ? ` · ${res.skipped} already enrolled` : "") +
-        (res.missing && res.missing.length ? ` · ${res.missing.length} not found` : "");
+        (res.missing && res.missing.length ? ` · ${res.missing.length} not found` : "") +
+        (failedCount ? ` · ${failedCount} failed` : "");
+
+      // "Enrolled 0" is not a success. The endpoint reports per-student failures and this
+      // ignored them, so an admin saw a green toast, the dialog closed, and nobody was enrolled.
+      if (failedCount > 0 || res.succeeded === 0) {
+        showToast(msg, failedCount > 0 ? "error" : "info");
+        onEnrolled();
+        return;
+      }
       showToast(msg, "success");
       onEnrolled();
       onClose();
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Enrollment failed.", "error");
+      showToast(getAxiosErrorDetail(e, "Enrollment failed."), "error");
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## The backend writes real error messages; the frontend threw them away

**31 sites** did `e instanceof Error ? e.message : "Couldn't do the thing."`. On an axios error, `e.message` is `"Request failed with status code 409"` — so every carefully-written server message was replaced with boilerplate.

The backend goes to real trouble here:

> "This topic already has a quiz. Delete it first, or add the questions to the existing one."
> "'X' needs at least one test case — without one the editor cannot tell a student whether their answer is right."

None of it ever reached anyone. All 31 now go through `getAxiosErrorDetail`, which 20 other sites in the same folders already used.

## Three places that reported failure as success

**Assigning a course to several cohorts** is N sequential calls, so a partial failure is the *normal* failure. It counted only successes, said "Assigned to 2 cohorts", and **closed the dialog** — the failures invisible, and closing removed the only place to retry them. Now it names them, keeps the selection, and stays open.

**Enrolling students** ignored the per-student `failed[]` the endpoint returns. **"Enrolled 0" was shown as a green success toast** and the dialog closed with nobody enrolled.

**A Vimeo catalog outage rendered as "No videos match that search."** The catch swallowed the error and set an empty list — indistinguishable from a real empty result, and it sends an admin off rewording a query that was never run. The two states are told apart now.

42 unit tests pass; eslint at the pre-existing warning baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)