### PR TITLE
Finish the manual authoring paths

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -875,7 +875,12 @@ export default function AdminAdaptiveCourseDetailPage() {
                                     </Box>
                                     {open && (
                                       <Box sx={{ px: 1.25, pb: 1.5 }}>
-                                        <AdminArticleViewer courseId={course.id} articleId={a.article_id} />
+                                        <AdminArticleViewer
+                                          courseId={course.id}
+                                          articleId={a.article_id}
+                                          submoduleId={sub.id}
+                                          onSaved={load}
+                                        />
                                       </Box>
                                     )}
                                   </Box>

--- a/components/adaptive-video/admin/MatchedVideoReview.tsx
+++ b/components/adaptive-video/admin/MatchedVideoReview.tsx
@@ -83,7 +83,14 @@ export function MatchedVideoReview({
     }
   };
 
-  const hasVideo = !!companion.video_title;
+  // An externally-pasted video has no vimeo_video, so video_title is empty — and this used to
+  // read that as "no video". The admin saw "No video attached" on a video they had just
+  // successfully attached, concluded the paste had failed, and pasted it again.
+  const externalUrl = (companion as { external_url?: string }).external_url || "";
+  const hasVideo = !!companion.video_title || !!externalUrl;
+  const label =
+    companion.video_title ||
+    (externalUrl ? externalUrl.replace(/^https?:\/\//, "").slice(0, 60) : "");
 
   return (
     <Box
@@ -132,7 +139,7 @@ export function MatchedVideoReview({
           </Box>
           <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
             <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 320 }}>
-              {hasVideo ? companion.video_title : "No video attached"}
+              {hasVideo ? label : "No video attached"}
             </Typography>
             <MetaDot />
             <MetaChip icon="mdi:lightning-bolt" label={`${companion.check_in_count} check-ins`} />

--- a/components/admin/adaptive-course/AdminArticleViewer.tsx
+++ b/components/admin/adaptive-course/AdminArticleViewer.tsx
@@ -15,11 +15,27 @@ import { ArticleBodySkeleton } from "@/components/courses/CourseSkeletons";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 /**
- * Read-only admin preview of an adaptive article: renders the content at a tier
- * (switchable - uncached tiers generate on demand) plus the auto-glossary.
+ * Admin view of an adaptive article: renders the content at a tier (switchable — uncached tiers
+ * generate on demand, at cost, which the pills now say) plus the auto-glossary.
+ *
+ * Editable. It was read-only, so the only way to fix a typo in a 2000-word hand-written article
+ * was to delete it and retype the whole thing — while `updateContent` sat in the service with
+ * zero callers and a live PATCH route behind it.
+ *
  * Works on draft courses (admin endpoint, not publish-gated).
  */
-export function AdminArticleViewer({ courseId, articleId }: { courseId: number; articleId: number }) {
+export function AdminArticleViewer({
+  courseId,
+  articleId,
+  submoduleId,
+  onSaved,
+}: {
+  courseId: number;
+  articleId: number;
+  /** Editing needs the submodule: the content route is scoped through it. */
+  submoduleId?: number;
+  onSaved?: () => void;
+}) {
   const { showToast } = useToast();
   const [article, setArticle] = useState<AdaptiveArticleDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -27,6 +43,32 @@ export function AdminArticleViewer({ courseId, articleId }: { courseId: number; 
   const [tier, setTier] = useState<ReadingTier>("Intermediate");
   const [html, setHtml] = useState("");
   const [tierLoading, setTierLoading] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [savingEdit, setSavingEdit] = useState(false);
+
+  const saveEdit = useCallback(async () => {
+    if (!submoduleId || savingEdit) return;
+    setSavingEdit(true);
+    try {
+      // Saves into the tier currently on screen, not a flattened article — a generated article
+      // carries several, and rewriting all of them would drop the levels the admin was not
+      // looking at.
+      await adminAdaptiveCourseService.updateContent(submoduleId, "article", articleId, {
+        body: draft,
+        reading_tier: tier,
+      });
+      setHtml(draft);
+      setEditing(false);
+      showToast("Article saved.", "success");
+      onSaved?.();
+    } catch (e) {
+      // Stays open holding what was typed: a failed save must not also lose the edit.
+      showToast(getAxiosErrorDetail(e, "Couldn't save the article."), "error");
+    } finally {
+      setSavingEdit(false);
+    }
+  }, [submoduleId, savingEdit, draft, tier, articleId, showToast, onSaved]);
 
   const load = useCallback(async () => {
     try {
@@ -65,6 +107,8 @@ export function AdminArticleViewer({ courseId, articleId }: { courseId: number; 
   if (!article) return null;
 
   const glossary = Object.entries(article.glossary ?? {});
+  // Which reading levels actually exist. Anything not in here costs a model call to produce.
+  const available = article.available_tiers ?? [];
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mt: 1 }}>
@@ -93,13 +137,30 @@ export function AdminArticleViewer({ courseId, articleId }: { courseId: number; 
         </Typography>
         {READING_TIERS.map((t) => {
           const active = t === tier;
+          // A tier that has never been rendered is not a view filter — clicking it calls the
+          // model and writes a new tier onto the article, at cost. These pills looked identical
+          // to the ones that just switch view, so an admin checking their own hand-written
+          // article could spend credits (and overwrite their words) by clicking what they
+          // reasonably read as a tab.
+          const needsGeneration = !available.includes(t);
           return (
-            <ButtonBase key={t} onClick={() => void switchTier(t)} disabled={tierLoading}
-              sx={{ px: 1.5, py: 0.5, borderRadius: 999, fontWeight: 800, fontSize: "0.74rem",
-                color: active ? "white" : "text.primary",
+            <ButtonBase
+              key={t}
+              onClick={() => {
+                if (needsGeneration && !window.confirm(
+                  `"${t}" has not been written yet. Generating it uses AI credits and adds a new ` +
+                  `reading level to this article. Continue?`
+                )) return;
+                void switchTier(t);
+              }}
+              disabled={tierLoading}
+              title={needsGeneration ? "Not written yet — generating this level uses AI credits" : undefined}
+              sx={{ px: 1.5, py: 0.5, borderRadius: 999, fontWeight: 800, fontSize: "0.74rem", gap: 0.4,
+                color: active ? "white" : needsGeneration ? "text.secondary" : "text.primary",
                 background: active ? "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)" : "color-mix(in srgb, var(--card-bg) 60%, transparent)",
-                border: active ? "1px solid transparent" : "1px solid color-mix(in srgb, var(--border-default) 75%, transparent)",
+                border: active ? "1px solid transparent" : `1px ${needsGeneration ? "dashed" : "solid"} color-mix(in srgb, var(--border-default) 75%, transparent)`,
                 "&:disabled": { opacity: 0.6 } }}>
+              {needsGeneration && <Icon icon="mdi:auto-fix" width={12} />}
               {t}
             </ButtonBase>
           );
@@ -114,7 +175,58 @@ export function AdminArticleViewer({ courseId, articleId }: { courseId: number; 
 
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1fr 240px" }, gap: 2, alignItems: "start" }}>
         <Box sx={{ borderRadius: 3, p: 2, bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)" }}>
-          <AdaptiveArticleBody html={html} explainTerms={[]} onExplain={() => {}} />
+          {/* Editing is offered only where the route can be reached — the content PATCH is
+              scoped through the submodule, so without one there is nothing to save into. */}
+          {submoduleId && (
+            <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mb: 1.25 }}>
+              {editing ? (
+                <>
+                  <ButtonBase
+                    onClick={() => setEditing(false)}
+                    disabled={savingEdit}
+                    sx={{ px: 1.6, py: 0.55, borderRadius: 999, fontWeight: 800, fontSize: "0.76rem", color: "text.secondary" }}
+                  >
+                    Cancel
+                  </ButtonBase>
+                  <ButtonBase
+                    onClick={() => void saveEdit()}
+                    disabled={savingEdit || !draft.trim()}
+                    sx={{ px: 1.8, py: 0.55, borderRadius: 999, fontWeight: 800, fontSize: "0.76rem", color: "white", gap: 0.5,
+                      background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)", "&:disabled": { opacity: 0.6 } }}
+                  >
+                    <Icon icon="mdi:content-save-outline" width={14} />
+                    {savingEdit ? "Saving…" : `Save ${tier}`}
+                  </ButtonBase>
+                </>
+              ) : (
+                <ButtonBase
+                  onClick={() => { setDraft(html); setEditing(true); }}
+                  sx={{ px: 1.6, py: 0.55, borderRadius: 999, fontWeight: 800, fontSize: "0.76rem", color: "#6366f1", gap: 0.5 }}
+                >
+                  <Icon icon="mdi:pencil-outline" width={14} />
+                  Edit this reading level
+                </ButtonBase>
+              )}
+            </Box>
+          )}
+          {editing ? (
+            <Box
+              component="textarea"
+              value={draft}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDraft(e.target.value)}
+              disabled={savingEdit}
+              spellCheck
+              sx={{
+                width: "100%", minHeight: 380, resize: "vertical", p: 1.5, borderRadius: 2,
+                fontFamily: "inherit", fontSize: "0.9rem", lineHeight: 1.7,
+                color: "var(--font-primary)", bgcolor: "var(--card-bg)",
+                border: "1px solid color-mix(in srgb, #6366f1 45%, transparent)",
+                "&:focus": { outline: "2px solid color-mix(in srgb, #6366f1 40%, transparent)" },
+              }}
+            />
+          ) : (
+            <AdaptiveArticleBody html={html} explainTerms={[]} onExplain={() => {}} />
+          )}
         </Box>
         {glossary.length > 0 && (
           <Box sx={{ borderRadius: 3, p: 1.75, bgcolor: "color-mix(in srgb, var(--card-bg) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border-default) 70%, transparent)" }}>

--- a/components/admin/adaptive-course/ManualTreeControls.tsx
+++ b/components/admin/adaptive-course/ManualTreeControls.tsx
@@ -18,6 +18,8 @@ type GhostAddRowProps = {
   onCreate: (title: string) => Promise<void>;
   /** Told after each successful create so the parent can refetch the tree. */
   onAdded: () => void;
+  /** Said out loud on success — the row may create something off-screen. */
+  successMessage: string;
   errorFallback: string;
   /** Submodule rows sit one level deeper, so they render tighter than module rows. */
   dense?: boolean;
@@ -32,6 +34,7 @@ function GhostAddRow({
   placeholder,
   onCreate,
   onAdded,
+  successMessage,
   errorFallback,
   dense = false,
 }: GhostAddRowProps) {
@@ -64,6 +67,11 @@ function GhostAddRow({
       // Clear before notifying the parent: onAdded triggers a tree refetch and
       // re-render, and we do not want the just-submitted text flashing back.
       setValue("");
+      // Success is confirmed OUT LOUD. Only the error path toasted, and the backend appends a
+      // new week at the END of the course — so past MODULES_PER_PAGE it lands on a page the
+      // admin is not looking at and the screen does not change at all. Silence there reads as
+      // "nothing happened", and the next move is to type it again.
+      showToast(successMessage, "success");
       onAdded();
       // Stay in input mode and keep the caret so the next topic is type-Enter-type-Enter.
       // The actual focus() fires from the effect above, once the field is enabled again.
@@ -75,7 +83,7 @@ function GhostAddRow({
     } finally {
       setSaving(false);
     }
-  }, [value, saving, onCreate, onAdded, errorFallback, showToast]);
+  }, [value, saving, onCreate, onAdded, errorFallback, successMessage, showToast]);
 
   const cancel = useCallback(() => {
     setValue("");
@@ -230,6 +238,7 @@ export function AddModuleRow({
   return (
     <GhostAddRow
       ghostLabel="Add week"
+      successMessage="Week added — it goes at the end of the course."
       placeholder="Name this week, e.g. Functions and scope"
       onCreate={onCreate}
       onAdded={onAdded}
@@ -258,6 +267,7 @@ export function AddSubmoduleRow({
     <GhostAddRow
       dense
       ghostLabel="Add topic"
+      successMessage="Topic added."
       placeholder="Name this topic"
       onCreate={onCreate}
       onAdded={onAdded}

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -263,6 +263,8 @@ export interface AdminAdaptiveCourseVideoCompanion {
   id: number;
   title: string;
   video_title: string;
+  /** Set when the admin pasted their own link instead of picking from the Vimeo catalog. */
+  external_url?: string;
   thumbnail_url: string;
   duration_seconds: number;
   check_in_count: number;
@@ -704,7 +706,7 @@ export const adminAdaptiveCourseService = {
     submoduleId: number,
     kind: "article" | "quiz" | "coding" | "video",
     contentId: number,
-    payload: { title?: string; body?: string; summary?: string; instructions?: string; is_active?: boolean }
+    payload: { title?: string; body?: string; summary?: string; instructions?: string; is_active?: boolean; reading_tier?: string }
   ) {
     const { data } = await apiClient.patch(
       `${BASE}/submodules/${submoduleId}/content/${kind}/${contentId}/`,


### PR DESCRIPTION
The last four gaps from the builder audit. Each one is a place the product implied something it couldn't do.

## A hand-written article could never be edited

The viewer was read-only, so fixing a typo in a 2000-word article meant **deleting it and retyping the whole thing** — while `updateContent` sat in the service with *zero callers* and a live PATCH route behind it.

It edits the reading level currently on screen, not a flattened article: a generated article carries several tiers, and rewriting all of them would silently drop the levels the admin wasn't looking at. A failed save keeps the editor open holding the text — losing the edit *as well as* the save is the worst possible response.

## The reading-level pills spent money without saying so

Four identical pills. Clicking one that had never been rendered called the model, charged for it, and wrote a new tier onto the article.

On a hand-written article **none** was highlighted (its tier was the literal `"standard"`), so an admin checking their own words could regenerate over them by clicking what reads as a tab. Ungenerated levels are now dashed, carry a wand icon and a tooltip, and confirm before firing.

## An externally-pasted video said "No video attached"

The label came off the Vimeo FK, which a pasted URL doesn't have. So a video that attached *successfully* reported that it hadn't — and the admin's reasonable response is to paste it again. Shows the URL's hostname now (backend #539 exposes the field).

## Adding a week was silent

Only the error path toasted — and the backend appends the new week at the **end**, so past `MODULES_PER_PAGE` it lands on a page the admin isn't on and **nothing on screen changes**. Silence reads as "it didn't work", and the next move is to type it again. Success is said out loud, and says where the week went.

## Verified

`tsc` clean · `next build` ✓ compiled · 42 unit tests · eslint at the pre-existing baseline (the one error is in `AssignToCohortsDialog` and reproduces on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)