### PR TITLE
Release: course-size estimate agrees with the build

### DIFF
--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -70,6 +70,9 @@ function GenerateAdaptiveCourseInner() {
   const [difficulties, setDifficulties] = useState<Difficulty[]>(["Easy", "Medium", "Hard"]);
   const [questionsPerCell, setQuestionsPerCell] = useState(3);
   const [articlesPerSubmodule, setArticlesPerSubmodule] = useState(1);
+  // Drives BOTH the estimate the admin sees and the structure the generator is told to build,
+  // so the two cannot drift apart.
+  const [submodulesPerModule, setSubmodulesPerModule] = useState(3);
   // Default to a fixed 15-question quiz (min === max): every quiz asks 15, difficulty adapts.
   const [minQuestions, setMinQuestions] = useState(15);
   const [maxQuestions, setMaxQuestions] = useState(15);
@@ -148,8 +151,14 @@ function GenerateAdaptiveCourseInner() {
         codingProblems: hasCoding ? submodules * difficulties.length * 2 : 0,
       };
     }
-    const modules = Math.max(1, Math.round(durationWeeks * 0.75));
-    const submodules = modules * 3;
+    // One module per week, exactly. The 0.75 factor that used to be here was invented — the
+    // generator's own prompt says "each module represents one week", and the tree labels them
+    // "Week 1", "Week 2". A 4-week course estimated 3 modules and then built 4.
+    //
+    // submodulesPerModule is a real request field now, not the silent 3 this used to assume
+    // while the prompt asked the model for "3-5" and was free to give 5.
+    const modules = Math.max(1, durationWeeks);
+    const submodules = modules * submodulesPerModule;
     const bankPerQuiz = 3 * difficulties.length * questionsPerCell;
     return {
       modules,
@@ -160,7 +169,7 @@ function GenerateAdaptiveCourseInner() {
       bankItems: hasQuiz ? submodules * bankPerQuiz : 0,
       codingProblems: hasCoding ? submodules * difficulties.length * 2 : 0,
     };
-  }, [mode, plan, durationWeeks, difficulties, questionsPerCell, contentTypes]);
+  }, [mode, plan, durationWeeks, submodulesPerModule, difficulties, questionsPerCell, contentTypes]);
 
   function buildConfig(): AdaptiveCourseGenConfig {
     return {
@@ -168,6 +177,9 @@ function GenerateAdaptiveCourseInner() {
       difficulty_level: difficulties.includes("Medium") ? "Medium" : difficulties[0],
       questions_per_cell: questionsPerCell,
       articles_per_submodule: articlesPerSubmodule,
+      // Sent so the generator builds what the estimate promised, and so the super admin's
+      // review queue sizes the request off the same number the admin was shown.
+      submodules_per_module: submodulesPerModule,
       min_questions: minQuestions,
       max_questions: maxQuestions,
       confidence_prompt_enabled: confidence,
@@ -331,7 +343,9 @@ function GenerateAdaptiveCourseInner() {
                 questionsPerCell={questionsPerCell}
                 onQuestionsPerCellChange={setQuestionsPerCell}
                 articlesPerSubmodule={articlesPerSubmodule}
+                submodulesPerModule={submodulesPerModule}
                 onArticlesPerSubmoduleChange={setArticlesPerSubmodule}
+                onSubmodulesPerModuleChange={setSubmodulesPerModule}
                 minQuestions={minQuestions}
                 onMinQuestionsChange={setMinQuestions}
                 maxQuestions={maxQuestions}

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -29,7 +29,9 @@ export function SharedGenerationConfig({
   questionsPerCell,
   onQuestionsPerCellChange,
   articlesPerSubmodule,
+  submodulesPerModule,
   onArticlesPerSubmoduleChange,
+  onSubmodulesPerModuleChange,
   // minQuestions intentionally not read - the single "Questions per quiz" field drives both
   // min and max (fixed-length quizzes) via the change handlers below.
   onMinQuestionsChange,
@@ -48,6 +50,8 @@ export function SharedGenerationConfig({
   onQuestionsPerCellChange: (v: number) => void;
   articlesPerSubmodule: number;
   onArticlesPerSubmoduleChange: (v: number) => void;
+  submodulesPerModule: number;
+  onSubmodulesPerModuleChange: (v: number) => void;
   minQuestions: number;
   onMinQuestionsChange: (v: number) => void;
   maxQuestions: number;
@@ -126,6 +130,14 @@ export function SharedGenerationConfig({
               type="number"
               value={questionsPerCell}
               onChange={(e) => onQuestionsPerCellChange(clamp(Number(e.target.value), 1, 10))}
+              sx={{ width: 220 }}
+            />
+            <TextField
+              label="Topics per week"
+              type="number"
+              value={submodulesPerModule}
+              onChange={(e) => onSubmodulesPerModuleChange(clamp(Number(e.target.value), 1, 8))}
+              helperText="Drives the estimate AND what gets built"
               sx={{ width: 220 }}
             />
             <TextField

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -14,6 +14,8 @@ export interface AdaptiveCourseGenConfig {
   questions_per_cell?: number;
   /** Adaptive articles generated per submodule (default 1). */
   articles_per_submodule?: number;
+  /** Topics per week. Drives the estimate AND the structure the generator is told to build. */
+  submodules_per_module?: number;
   min_questions?: number;
   max_questions?: number;
   se_threshold?: number;


### PR DESCRIPTION
Promotes stagging. Pairs with backend #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)