### PR TITLE
The coding estimate reads the real cap, and admits it's a ceiling

### DIFF
--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -73,6 +73,9 @@ function GenerateAdaptiveCourseInner() {
   // Drives BOTH the estimate the admin sees and the structure the generator is told to build,
   // so the two cannot drift apart.
   const [submodulesPerModule, setSubmodulesPerModule] = useState(3);
+  // Per DIFFICULTY TIER, which is what the generator's cap actually means — the field name
+  // says "per submodule" but coding_per_tier_for_submodule applies it once per tier.
+  const [codingPerTier, setCodingPerTier] = useState(2);
   // Default to a fixed 15-question quiz (min === max): every quiz asks 15, difficulty adapts.
   const [minQuestions, setMinQuestions] = useState(15);
   const [maxQuestions, setMaxQuestions] = useState(15);
@@ -148,7 +151,7 @@ function GenerateAdaptiveCourseInner() {
         hasCoding,
         quizzes: hasQuiz ? submodules : 0,
         bankItems,
-        codingProblems: hasCoding ? submodules * difficulties.length * 2 : 0,
+        codingProblems: hasCoding ? submodules * difficulties.length * codingPerTier : 0,
       };
     }
     // One module per week, exactly. The 0.75 factor that used to be here was invented — the
@@ -167,9 +170,14 @@ function GenerateAdaptiveCourseInner() {
       hasCoding,
       quizzes: hasQuiz ? submodules : 0,
       bankItems: hasQuiz ? submodules * bankPerQuiz : 0,
-      codingProblems: hasCoding ? submodules * difficulties.length * 2 : 0,
+      // The 2 here was hardcoded, so raising the cap in Advanced settings changed what got
+      // built and not what was shown. And this is a CEILING, not a forecast: the generator asks
+      // the model how much a topic warrants, clamps to [1, cap], and returns NOTHING for a
+      // topic it judges non-coding — which is why "System Design, no coding" could still show
+      // dozens of coding problems.
+      codingProblems: hasCoding ? submodules * difficulties.length * codingPerTier : 0,
     };
-  }, [mode, plan, durationWeeks, submodulesPerModule, difficulties, questionsPerCell, contentTypes]);
+  }, [mode, plan, durationWeeks, submodulesPerModule, difficulties, questionsPerCell, codingPerTier, contentTypes]);
 
   function buildConfig(): AdaptiveCourseGenConfig {
     return {
@@ -185,7 +193,11 @@ function GenerateAdaptiveCourseInner() {
       confidence_prompt_enabled: confidence,
       content_types: contentTypes,
       ...(contentTypes.includes("coding")
-        ? { coding_problems_per_submodule: 2, coding_language: "Python", coding_allow_clipboard: codingClipboard }
+        ? {
+            coding_problems_per_submodule: codingPerTier,
+            coding_language: "Python",
+            coding_allow_clipboard: codingClipboard,
+          }
         : {}),
     };
   }
@@ -344,8 +356,10 @@ function GenerateAdaptiveCourseInner() {
                 onQuestionsPerCellChange={setQuestionsPerCell}
                 articlesPerSubmodule={articlesPerSubmodule}
                 submodulesPerModule={submodulesPerModule}
+                codingPerTier={codingPerTier}
                 onArticlesPerSubmoduleChange={setArticlesPerSubmodule}
                 onSubmodulesPerModuleChange={setSubmodulesPerModule}
+                onCodingPerTierChange={setCodingPerTier}
                 minQuestions={minQuestions}
                 onMinQuestionsChange={setMinQuestions}
                 maxQuestions={maxQuestions}
@@ -404,12 +418,18 @@ function GenerateAdaptiveCourseInner() {
                     <Typography sx={{ fontWeight: 800 }}>{"What you'll get"}</Typography>
                   </Box>
                   <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 1.5 }}>
-                    <PreviewStat value={`~${preview.modules}`} label="Modules" />
-                    <PreviewStat value={`~${preview.submodules}`} label="Submodules" />
+                    {/* Exact, not "~": the generator is now told to build EXACTLY this many. */}
+                    <PreviewStat value={String(preview.modules)} label="Modules" />
+                    <PreviewStat value={String(preview.submodules)} label="Submodules" />
                     {preview.hasQuiz && <PreviewStat value={`~${preview.quizzes}`} label="Adaptive quizzes" />}
-                    {preview.hasQuiz && <PreviewStat value={`~${preview.bankItems}`} label="Calibrated quiz items" />}
+                    {preview.hasQuiz && (
+                      <PreviewStat value={`up to ${preview.bankItems}`} label="Calibrated quiz items" />
+                    )}
                     {preview.hasCoding && (
-                      <PreviewStat value={`~${preview.codingProblems}`} label="Coding problems" />
+                      // "up to", because this is a ceiling: the engine asks the model how much
+                      // each topic warrants, clamps to the cap, and generates NOTHING for a
+                      // topic it judges non-coding.
+                      <PreviewStat value={`up to ${preview.codingProblems}`} label="Coding problems" />
                     )}
                   </Box>
                   <Typography sx={{ mt: 2.5, fontSize: "0.82rem", opacity: 0.92, lineHeight: 1.5 }}>

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -30,8 +30,10 @@ export function SharedGenerationConfig({
   onQuestionsPerCellChange,
   articlesPerSubmodule,
   submodulesPerModule,
+  codingPerTier,
   onArticlesPerSubmoduleChange,
   onSubmodulesPerModuleChange,
+  onCodingPerTierChange,
   // minQuestions intentionally not read - the single "Questions per quiz" field drives both
   // min and max (fixed-length quizzes) via the change handlers below.
   onMinQuestionsChange,
@@ -52,6 +54,8 @@ export function SharedGenerationConfig({
   onArticlesPerSubmoduleChange: (v: number) => void;
   submodulesPerModule: number;
   onSubmodulesPerModuleChange: (v: number) => void;
+  codingPerTier: number;
+  onCodingPerTierChange: (v: number) => void;
   minQuestions: number;
   onMinQuestionsChange: (v: number) => void;
   maxQuestions: number;
@@ -140,6 +144,16 @@ export function SharedGenerationConfig({
               helperText="Drives the estimate AND what gets built"
               sx={{ width: 220 }}
             />
+            {contentTypes.includes("coding") && (
+              <TextField
+                label="Coding problems per difficulty tier"
+                type="number"
+                value={codingPerTier}
+                onChange={(e) => onCodingPerTierChange(clamp(Number(e.target.value), 1, 10))}
+                helperText="An upper bound — the engine skips non-coding topics"
+                sx={{ width: 260 }}
+              />
+            )}
             <TextField
               label="Articles per submodule"
               type="number"


### PR DESCRIPTION
Pairs with backend #541.

**`~18 Coding problems`** for a 1-week course was `submodules × tiers × a hardcoded 2` — while the config exposes 1–10, so raising the cap changed what got **built** and not what was **shown**.

It also presented a ceiling as a forecast. The generator asks the model how much each topic warrants, clamps to the cap, and generates **nothing** for a topic it judges non-coding — so the floor is zero. That's how *"System Design refresher · no coding"* could still show dozens of coding problems. Coding and the quiz bank now read **"up to N"**.

Modules and submodules lost their `~` for the opposite reason: the generator is now told to build *exactly* that many, so approximating them understated a promise the backend actually makes.

Adds a **Coding problems per difficulty tier** control, shown only when coding is selected — per *tier*, because that's what the cap does whatever its name says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)