### PR TITLE
Say what things are, in the words the product already uses

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -87,8 +87,8 @@ const EST_CONCEPTS_PER_SUBMODULE = 3;
 const CONTENT_TYPE_LABEL: Record<"quiz" | "article" | "coding" | "video", string> = {
   quiz: "Quiz",
   article: "Article",
-  coding: "AI Coding Mentor",
-  video: "Video Companion",
+  coding: "Coding practice",
+  video: "Video",
 };
 
 export default function AdminAdaptiveCourseDetailPage() {
@@ -959,7 +959,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                                       so it now lives once in Settings and applies course-wide. */}
                                   <Box sx={{ display: "flex", alignItems: "center", gap: 1, px: 0.5 }}>
                                     <Typography sx={{ fontSize: "0.68rem", fontWeight: 800, color: "text.secondary", textTransform: "uppercase", letterSpacing: "0.05em" }}>
-                                      AI Coding Mentor set
+                                      Coding practice set
                                     </Typography>
                                     <Box sx={{ flex: 1 }} />
                                     <RowDeleteButton
@@ -1192,7 +1192,7 @@ export default function AdminAdaptiveCourseDetailPage() {
             Describe the topic / focus. The engine designs the {dialog?.kind === "module" ? "module's submodules" : "submodule"} and
             generates the selected content types ({contentTypes.length ? contentTypes.map((t) => CONTENT_TYPE_LABEL[t]).join(" · ") : "none selected"}) for each new submodule.
             {contentTypes.includes("video") && (
-              <> Video Companion AI-matches a transcribed Vimeo video from your catalog (review &amp; swap after).</>
+              <> Video AI-matches a transcribed Vimeo video from your catalog (review &amp; swap after).</>
             )}
           </Typography>
           <TextField
@@ -1228,7 +1228,7 @@ export default function AdminAdaptiveCourseDetailPage() {
           {dialog?.kind === "module" && (
             <TextField
               type="number"
-              label="Submodules to generate"
+              label="Topics to generate"
               value={subCount}
               onChange={(e) => setSubCount(clamp(Number(e.target.value), 1, 8))}
               sx={{ mt: 2, width: 220 }}
@@ -1242,8 +1242,8 @@ export default function AdminAdaptiveCourseDetailPage() {
               {([
                 ["article", "Article", "mdi:book-open-variant"],
                 ["quiz", "Quiz", "mdi:tune-vertical"],
-                ["coding", "AI Coding Mentor", "mdi:robot-happy-outline"],
-                ["video", "Video Companion", "mdi:play-circle-outline"],
+                ["coding", "Coding practice", "mdi:robot-happy-outline"],
+                ["video", "Video", "mdi:play-circle-outline"],
               ] as const).map(([key, label, icon]) => {
                 const active = contentTypes.includes(key);
                 return (
@@ -1319,7 +1319,7 @@ export default function AdminAdaptiveCourseDetailPage() {
             {contentTypes.includes("article") && (
               <TextField
                 type="number"
-                label="Articles per submodule"
+                label="Articles per topic"
                 value={articlesPerSub}
                 onChange={(e) => setArticlesPerSub(clamp(Number(e.target.value), 1, 5))}
                 helperText="Default 1 · up to 5"
@@ -1371,7 +1371,7 @@ export default function AdminAdaptiveCourseDetailPage() {
               {contentTypes.includes("video") && (
                 <>
                   <br />
-                  (Video Companion needs a synced Vimeo catalog with transcribed videos.)
+                  (Video needs a synced Vimeo catalog with transcribed videos.)
                 </>
               )}
             </Typography>

--- a/app/admin/adaptive-courses/generate/page.tsx
+++ b/app/admin/adaptive-courses/generate/page.tsx
@@ -81,7 +81,7 @@ function GenerateAdaptiveCourseInner() {
   const [maxQuestions, setMaxQuestions] = useState(15);
   const [confidence, setConfidence] = useState(true);
   // All four content types auto-selected by default (quiz + article + AI Coding
-  // Mentor + Video Companion); admins can deselect in Advanced options.
+  // Mentor + Video); admins can deselect in Advanced options.
   // A brief that mentions no content types leaves all four on — the form's own default. Only an
   // explicit "no coding" / "heavy on practice problems" narrows it.
   const [contentTypes, setContentTypes] = useState<ContentType[]>(
@@ -273,7 +273,7 @@ function GenerateAdaptiveCourseInner() {
           <AdaptiveSectionHero
             chapter="Generate · Adaptive"
             title="Generate adaptive course"
-            subtitle="Describe a course in prose, or upload a curriculum CSV and let AI map it - either way we generate modules, submodules, and a full adaptive quiz (IRT bank, branching, confidence capture) for every submodule."
+            subtitle="Describe the course, or upload a curriculum CSV. Either way you get weeks, topics, and a quiz on every topic that gets harder or easier as the student answers."
             icon="mdi:auto-fix"
             accent="purple"
           />
@@ -419,11 +419,11 @@ function GenerateAdaptiveCourseInner() {
                   </Box>
                   <Box sx={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 1.5 }}>
                     {/* Exact, not "~": the generator is now told to build EXACTLY this many. */}
-                    <PreviewStat value={String(preview.modules)} label="Modules" />
-                    <PreviewStat value={String(preview.submodules)} label="Submodules" />
+                    <PreviewStat value={String(preview.modules)} label="Weeks" />
+                    <PreviewStat value={String(preview.submodules)} label="Topics" />
                     {preview.hasQuiz && <PreviewStat value={`~${preview.quizzes}`} label="Adaptive quizzes" />}
                     {preview.hasQuiz && (
-                      <PreviewStat value={`up to ${preview.bankItems}`} label="Calibrated quiz items" />
+                      <PreviewStat value={`up to ${preview.bankItems}`} label="Quiz questions" />
                     )}
                     {preview.hasCoding && (
                       // "up to", because this is a ceiling: the engine asks the model how much
@@ -433,7 +433,7 @@ function GenerateAdaptiveCourseInner() {
                     )}
                   </Box>
                   <Typography sx={{ mt: 2.5, fontSize: "0.82rem", opacity: 0.92, lineHeight: 1.5 }}>
-                    Every submodule ships a branching IRT quiz that picks each next question by performance.
+                    Every topic gets a quiz that picks each next question from how the student is doing.
                     {mode === "csv"
                       ? " Estimates reflect your edited plan."
                       : " Estimates update as you change the form."}

--- a/app/admin/adaptive-courses/jobs/[jobId]/page.tsx
+++ b/app/admin/adaptive-courses/jobs/[jobId]/page.tsx
@@ -21,10 +21,10 @@ import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 const POLL_INTERVAL_MS = 2000;
 const ORDER = ["pending", "generating_outline", "creating_structure", "generating_content", "completed"];
 const STEPS: Array<{ key: string; label: string; detail: string }> = [
-  { key: "generating_outline", label: "Planning outline", detail: "Modules & submodules" },
+  { key: "generating_outline", label: "Planning outline", detail: "Weeks & topics" },
   { key: "creating_structure", label: "Building structure", detail: "Course tree" },
-  { key: "generating_content", label: "Generating content", detail: "Quizzes & articles per submodule" },
-  { key: "completed", label: "Done", detail: "Every submodule has an adaptive quiz" },
+  { key: "generating_content", label: "Generating content", detail: "Quizzes & articles per topic" },
+  { key: "completed", label: "Done", detail: "Every topic has an adaptive quiz" },
 ];
 const DIFF_COLOR: Record<string, string> = { Easy: "#10b981", Medium: "#f59e0b", Hard: "#ef4444" };
 type LogFilter = "all" | "Easy" | "Medium" | "Hard";
@@ -330,7 +330,7 @@ function StatsRail({ stats, status, percent, stalled }: { stats: AdaptiveCourseJ
 
       {/* Stat cards */}
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(7, 1fr)" }, gap: 1.5, mt: 2 }}>
-        <StatCard label="Submodules" value={`${stats.submodules_done} / ${stats.submodules_total}`} accent="#6366f1" icon="mdi:file-tree-outline" />
+        <StatCard label="Topics" value={`${stats.submodules_done} / ${stats.submodules_total}`} accent="#6366f1" icon="mdi:file-tree-outline" />
         <StatCard label="Questions" value={qPlanned > 0 ? `${qDone} / ~${qPlanned}` : `${qDone}`} accent="#a855f7" icon="mdi:help-box-multiple-outline" />
         <StatCard label="Articles" value={`${stats.articles_generated ?? 0}`} accent="#10b981" icon="mdi:book-open-variant" />
         <StatCard label="Coding" value={`${stats.coding_generated ?? 0}`} accent="#ec4899" icon="mdi:robot-happy-outline" />

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -88,8 +88,8 @@ export default function AdminAdaptiveCoursesPage() {
       { label: "Published", value: published, icon: "mdi:earth", tone: "#10b981" },
       { label: "Drafts", value: courses.length - published, icon: "mdi:file-document-edit-outline", tone: "#94a3b8" },
       { label: "Articles", value: articles, icon: "mdi:book-open-variant", tone: "#a855f7" },
-      { label: "Adaptive quizzes", value: quizzes, icon: "mdi:tune-vertical", tone: "#ec4899" },
-      { label: "Coding mentors", value: coding, icon: "mdi:robot-happy-outline", tone: "#0ea5e9" },
+      { label: "Quizzes", value: quizzes, icon: "mdi:tune-vertical", tone: "#ec4899" },
+      { label: "Coding problems", value: coding, icon: "mdi:robot-happy-outline", tone: "#0ea5e9" },
     ];
   }, [courses]);
 

--- a/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
+++ b/components/adaptive-quiz/generate/SharedGenerationConfig.tsx
@@ -8,8 +8,8 @@ import { ALL_CONTENT_TYPES, ALL_DIFFICULTIES, type ContentType, type Difficulty 
 const CONTENT_META: Record<ContentType, { label: string; icon: string }> = {
   article: { label: "Adaptive Article", icon: "mdi:book-open-variant" },
   quiz: { label: "Adaptive Quiz", icon: "mdi:tune-vertical" },
-  coding: { label: "AI Coding Mentor", icon: "mdi:robot-happy-outline" },
-  video: { label: "Video Companion", icon: "mdi:play-circle-outline" },
+  coding: { label: "Coding practice", icon: "mdi:robot-happy-outline" },
+  video: { label: "Video", icon: "mdi:play-circle-outline" },
 };
 
 /**
@@ -155,7 +155,7 @@ export function SharedGenerationConfig({
               />
             )}
             <TextField
-              label="Articles per submodule"
+              label="Articles per topic"
               type="number"
               value={articlesPerSubmodule}
               onChange={(e) => onArticlesPerSubmoduleChange(clamp(Number(e.target.value), 1, 5))}

--- a/components/adaptive-video/CompanionCard.tsx
+++ b/components/adaptive-video/CompanionCard.tsx
@@ -18,7 +18,7 @@ interface CompanionCardProps {
 }
 
 /**
- * The card for the Video Companion surface. Deliberately clean: a near-solid
+ * The card for the Video surface. Deliberately clean: a near-solid
  * surface, a hairline neutral border, and a soft shadow - accent colour appears
  * only in the small header icon chip, never as a full-card wash (which read as
  * muddy background tint when stacked). One dark variant for the live takeaways.

--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -29,7 +29,7 @@ const TABS: { label: string; icon: string }[] = [
 ];
 
 /**
- * The Video Companion surface (the screenshot). Self-contained: starts a watch
+ * The Video surface (the screenshot). Self-contained: starts a watch
  * session, drives the Vimeo player via postMessage, fires auto-pause check-ins on
  * the timeline, and wires the AI Companion tab + adaptive rail to the backend.
  */

--- a/components/admin/manage-students/detail/AdaptiveTab.tsx
+++ b/components/admin/manage-students/detail/AdaptiveTab.tsx
@@ -128,7 +128,7 @@ export function AdaptiveTab({ adaptive }: { adaptive: JourneyAdaptive }) {
         )}
       </Panel>
 
-      <Panel icon="mdi:play-circle" title="Video Companion" accent={ADAPTIVE.purple}>
+      <Panel icon="mdi:play-circle" title="Video" accent={ADAPTIVE.purple}>
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5 }}>
           <StatPill label="Sessions" value={video.session_count} accent={ADAPTIVE.purple} />
           <StatPill label="Completed" value={video.completed_count} accent={ADAPTIVE.green} />


### PR DESCRIPTION
> "796 Coding mentors"

Not a sentence anyone can act on. It counts coding **problems** — and the number was the giveaway: nobody has 796 mentors.

## The builder was speaking two languages on one screen

Its own tree says **WEEK 1** and offers **Add week** / **Add topic**. The stats rail and estimates right next to them said *Modules* and *Submodules* — the schema's names, leaking into the UI.

| was | now |
|---|---|
| Coding mentors | Coding problems |
| Submodules | Topics |
| Modules | Weeks |
| Calibrated quiz items | Quiz questions |
| Video Companion | Video *(admin builder)* |
| AI Coding Mentor | Coding practice *(admin builder)* |

## The worst of it was the sentence selling the feature

**Before:** "…a full adaptive quiz (IRT bank, branching, confidence capture) for every submodule."

**After:** "…a quiz on every topic that gets harder or easier as the student answers."

Three terms an admin has no way to evaluate, in the one sentence meant to explain what they're buying.

## Deliberately not renamed

- **The API and model names** (`module`, `submodule`, `AdaptiveCodingConfig`) — that's a contract, and renaming it is large, risky, and worth nothing to a user.
- **"AI Coding Mentor" on the student solver** — there it's the feature's own name and does describe what it is. Counting 796 of them in a builder was the nonsense, not the name.

## Verified

Browser QA on the generate page: every jargon term confirmed gone (`Coding mentors`, `Submodules`, `Calibrated quiz items`, `IRT bank`, `confidence capture`), every plain-English replacement present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)