### PR TITLE
Instructors can build their own courses

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -102,6 +102,7 @@ export default function AdminAdaptiveCourseDetailPage() {
   /** Content tab paging. A finished course is thousands of pixels of scroll unpaged. */
   const [modulePage, setModulePage] = useState(0);
   const [addContentFor, setAddContentFor] = useState<{ id: number; title: string } | null>(null);
+  const [submittingReview, setSubmittingReview] = useState(false);
   /** Staged delete for any tree row (week / topic / one piece of content). */
   const [pendingDelete, setPendingDelete] = useState<TreeDeleteTarget | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -290,6 +291,51 @@ export default function AdminAdaptiveCourseDetailPage() {
         ? "Content locked: weeks unlock on the cohort schedule and late work loses points."
         : "Content unlocked: students can open any week now and always earn full XP.",
     );
+  }
+
+  /** The instructor says their course is finished and hands it to an admin. */
+  async function handleSubmitForReview() {
+    if (!course || submittingReview) return;
+    setSubmittingReview(true);
+    try {
+      const res = await adminAdaptiveCourseService.submitCourseForReview(course.id);
+      setCourse((c) => (c ? { ...c, instructor_review_status: res.instructor_review_status as never } : c));
+      showToast("Sent for review. An admin will take a look — students can't see it yet.", "success");
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, "Couldn't send that for review."), "error");
+    } finally {
+      setSubmittingReview(false);
+    }
+  }
+
+  /** The admin's decision on an instructor-built course. */
+  async function handleReview(decision: "approve" | "reject") {
+    if (!course || submittingReview) return;
+    let note = "";
+    if (decision === "reject") {
+      // Required, and asked for BEFORE the call so the instructor is never sent a bare "no" —
+      // they built a whole course, and "no" with nothing attached just produces the same one
+      // again tomorrow.
+      note = window.prompt("What needs to change? The instructor sees this.")?.trim() ?? "";
+      if (!note) return;
+    }
+    setSubmittingReview(true);
+    try {
+      const res = await adminAdaptiveCourseService.reviewCourse(course.id, decision, note);
+      setCourse((c) =>
+        c ? { ...c, instructor_review_status: res.instructor_review_status as never,
+              instructor_review_note: res.instructor_review_note } : c);
+      showToast(
+        decision === "approve"
+          ? "Approved. Assign students to make it live."
+          : "Sent back to the instructor with your note.",
+        "success",
+      );
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, "Couldn't record that decision."), "error");
+    } finally {
+      setSubmittingReview(false);
+    }
   }
 
   async function handleToggleClipboard() {
@@ -529,6 +575,16 @@ export default function AdminAdaptiveCourseDetailPage() {
                 subtitle={course.description}
                 icon="mdi:book-cog-outline"
                 accent="indigo"
+              />
+
+              {/* The review banner. Shown only for an instructor-built course, and it is the one
+                  place either side learns where the course stands — the tree below looks
+                  identical whatever the state. */}
+              <ReviewBanner
+                course={course}
+                busy={submittingReview}
+                onSubmit={() => void handleSubmitForReview()}
+                onDecide={(d) => void handleReview(d)}
               />
 
               {/* One content action. Everything else — edit details, cover art, publish,
@@ -1606,4 +1662,130 @@ function pillBtnSx(variant: "solid" | "outline") {
         ? "1px solid transparent"
         : "1px solid color-mix(in srgb, #6366f1 40%, transparent)",
   } as const;
+}
+
+/**
+ * Where an instructor-built course stands, and the one action available on it.
+ *
+ * Renders nothing for an ordinary admin- or AI-built course: `instructor_review_status` is
+ * blank for those, and a banner explaining a workflow they are not in would be noise.
+ */
+function ReviewBanner({
+  course,
+  busy,
+  onSubmit,
+  onDecide,
+}: {
+  course: AdminAdaptiveCourseDetail;
+  busy: boolean;
+  onSubmit: () => void;
+  onDecide: (decision: "approve" | "reject") => void;
+}) {
+  const state = course.instructor_review_status ?? "";
+  if (!state) return null;
+
+  const author = course.authored_by?.name || "an instructor";
+  const tone =
+    state === "approved" ? "#10b981" : state === "rejected" ? "#ef4444" : state === "pending_review" ? "#f59e0b" : "#6366f1";
+
+  const copy: Record<string, { title: string; body: string }> = {
+    draft: {
+      title: `Draft — built by ${author}`,
+      body: "Students can't see this yet. Send it for review when it's ready; an admin checks it before anyone is assigned.",
+    },
+    pending_review: {
+      title: `Waiting for review — built by ${author}`,
+      body: "An admin is checking this. Nothing reaches students until they approve it.",
+    },
+    approved: {
+      title: `Approved — built by ${author}`,
+      body: "It can be published now. Assign students from Settings to make it live.",
+    },
+    rejected: {
+      title: `Sent back — built by ${author}`,
+      body: course.instructor_review_note || "An admin asked for changes.",
+    },
+  };
+  const text = copy[state];
+  if (!text) return null;
+
+  return (
+    <Box
+      sx={{
+        mt: { xs: -1, md: -1.5 },
+        mb: 2.5,
+        p: 2.25,
+        borderRadius: 3.5,
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 1.5,
+        flexWrap: "wrap",
+        bgcolor: `color-mix(in srgb, ${tone} 7%, var(--card-bg))`,
+        border: `1px solid color-mix(in srgb, ${tone} 32%, transparent)`,
+      }}
+    >
+      <Icon
+        icon={
+          state === "approved" ? "mdi:check-circle-outline"
+            : state === "rejected" ? "mdi:close-circle-outline"
+            : state === "pending_review" ? "mdi:clock-outline"
+            : "mdi:pencil-ruler"
+        }
+        width={22}
+        style={{ color: tone, flexShrink: 0, marginTop: 2 }}
+      />
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography sx={{ fontWeight: 800, fontSize: "0.95rem" }}>{text.title}</Typography>
+        <Typography sx={{ fontSize: "0.84rem", color: "text.secondary", lineHeight: 1.5 }}>
+          {text.body}
+        </Typography>
+      </Box>
+
+      {/* The author's action. The server decides who may actually do this — showing the button
+          to the wrong person would produce a 403 they cannot act on. */}
+      {(state === "draft" || state === "rejected") && (
+        <ButtonBase
+          onClick={onSubmit}
+          disabled={busy}
+          sx={{
+            px: 2.4, py: 1, borderRadius: 999, fontWeight: 800, fontSize: "0.84rem", gap: 0.6,
+            color: "white", background: "linear-gradient(135deg, #6366f1 0%, #a855f7 100%)",
+            "&:disabled": { opacity: 0.6 },
+          }}
+        >
+          <Icon icon="mdi:send-outline" width={16} />
+          {state === "rejected" ? "Send again" : "Send for review"}
+        </ButtonBase>
+      )}
+
+      {/* The admin's decision. */}
+      {state === "pending_review" && (
+        <Box sx={{ display: "flex", gap: 1 }}>
+          <ButtonBase
+            onClick={() => onDecide("reject")}
+            disabled={busy}
+            sx={{
+              px: 2, py: 1, borderRadius: 999, fontWeight: 800, fontSize: "0.84rem",
+              color: "text.secondary", bgcolor: "var(--card-bg)",
+              border: "1px solid var(--border-default)", "&:disabled": { opacity: 0.6 },
+            }}
+          >
+            Send back
+          </ButtonBase>
+          <ButtonBase
+            onClick={() => onDecide("approve")}
+            disabled={busy}
+            sx={{
+              px: 2.4, py: 1, borderRadius: 999, fontWeight: 800, fontSize: "0.84rem", gap: 0.6,
+              color: "white", background: "linear-gradient(135deg, #10b981 0%, #059669 100%)",
+              "&:disabled": { opacity: 0.6 },
+            }}
+          >
+            <Icon icon="mdi:check" width={16} />
+            Approve
+          </ButtonBase>
+        </Box>
+      )}
+    </Box>
+  );
 }

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -171,6 +171,10 @@ export default function AdminAdaptiveCoursesPage() {
   // "active" (nothing is running) and there is no course yet, so an admin who just submitted one
   // sees an unchanged page and submits again.
   const awaitingJobs = jobs.filter((j) => j.status === "awaiting_approval");
+  // Instructor-built courses waiting on this admin. They arrive as ordinary courses in the
+  // list, so without pulling them out an admin would have to notice a status chip on a card
+  // among forty others.
+  const instructorPending = courses.filter((c) => c.instructor_review_status === "pending_review");
   const rejectedJobs = jobs.filter((j) => j.status === "rejected");
 
   return (
@@ -308,6 +312,51 @@ export default function AdminAdaptiveCoursesPage() {
               onOpen={(jobId) => push(`/admin/adaptive-courses/jobs/${jobId}`)}
               onWithdraw={handleWithdraw}
             />
+          )}
+
+          {instructorPending.length > 0 && (
+            <Box
+              sx={{
+                mb: 3, borderRadius: 4, p: 2.25,
+                bgcolor: "color-mix(in srgb, #6366f1 6%, var(--card-bg))",
+                border: "1px solid color-mix(in srgb, #6366f1 30%, transparent)",
+              }}
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1.25, mb: 1.25 }}>
+                <Icon icon="mdi:account-school-outline" width={19} style={{ color: "#6366f1" }} />
+                <Typography sx={{ fontWeight: 800, fontSize: "0.9rem" }}>
+                  Courses built by instructors
+                </Typography>
+                <Typography sx={{ fontSize: "0.82rem", color: "text.secondary" }}>
+                  {instructorPending.length} waiting for your review
+                </Typography>
+              </Box>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75 }}>
+                {instructorPending.map((c) => (
+                  <ButtonBase
+                    key={c.id}
+                    onClick={() => push(`/admin/adaptive-courses/${c.id}`)}
+                    sx={{
+                      justifyContent: "flex-start", gap: 1.25, px: 1.75, py: 1.4, borderRadius: 3,
+                      textAlign: "left", bgcolor: "var(--card-bg)",
+                      border: "1px solid color-mix(in srgb, var(--border-default) 80%, transparent)",
+                    }}
+                  >
+                    <Box sx={{ minWidth: 0, flex: 1 }}>
+                      <Typography sx={{ fontWeight: 800, fontSize: "0.86rem" }} noWrap>{c.title}</Typography>
+                      <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }} noWrap>
+                        Built by {c.authored_by?.name || "an instructor"} ·{" "}
+                        {c.module_count} week{c.module_count === 1 ? "" : "s"} ·{" "}
+                        {c.submodule_count} topic{c.submodule_count === 1 ? "" : "s"}
+                      </Typography>
+                    </Box>
+                    <Typography sx={{ fontWeight: 800, fontSize: "0.78rem", color: "#6366f1" }}>
+                      Review
+                    </Typography>
+                  </ButtonBase>
+                ))}
+              </Box>
+            </Box>
           )}
 
           {/* Active generation jobs */}
@@ -542,12 +591,22 @@ function CourseCard({
         <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3 }}>
           {course.title}
         </Typography>
+        {/* Who built it. An admin looking at forty courses has no other way to tell an
+            instructor's work from their own, and it changes how they read everything else
+            on the card. */}
+        {course.authored_by && (
+          <Typography sx={{ fontSize: "0.76rem", color: "text.secondary", mt: 0.4 }} noWrap>
+            Built by {course.authored_by.name}
+            {course.instructor_review_status === "pending_review" && " · waiting for your review"}
+            {course.instructor_review_status === "rejected" && " · sent back"}
+          </Typography>
+        )}
         <Box sx={{ display: "flex", gap: 2, mt: 1.5, flexWrap: "wrap" }}>
-          <Metric icon="mdi:view-module-outline" value={course.module_count} label="modules" />
-          <Metric icon="mdi:file-tree-outline" value={course.submodule_count} label="submodules" />
+          <Metric icon="mdi:view-module-outline" value={course.module_count} label="weeks" />
+          <Metric icon="mdi:file-tree-outline" value={course.submodule_count} label="topics" />
           <Metric icon="mdi:book-open-variant" value={course.article_count} label="articles" />
           <Metric icon="mdi:tune-vertical" value={course.quiz_count} label="quizzes" />
-          <Metric icon="mdi:robot-happy-outline" value={course.coding_count ?? 0} label="coding" />
+          <Metric icon="mdi:robot-happy-outline" value={course.coding_count ?? 0} label="coding problems" />
           {(course.video_count ?? 0) > 0 && (
             <Metric icon="mdi:play-circle-outline" value={course.video_count ?? 0} label="videos" />
           )}

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -8,12 +8,15 @@ import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { Reveal } from "@/components/scorecard/shared";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { instructorService, type InstructorCourse } from "@/lib/services/instructor.service";
+import { ManualCourseDialog } from "@/components/admin/adaptive-course/ManualCourseDialog";
+import { HeaderActionButton } from "@/components/common/ModulePageHeader";
 
 export default function InstructorCoursesPage() {
   const { push, prefetch } = useInstantNavigation();
   const [courses, setCourses] = useState<InstructorCourse[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [buildOpen, setBuildOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -40,11 +43,23 @@ export default function InstructorCoursesPage() {
         description="The course material you teach. A course is the content; a batch is the group of students studying it — open My Batches to work with a specific class."
         accent="purple"
         icon="mdi:book-education"
+        action={
+          // An instructor can build their own course. It stays theirs — full edit rights over
+          // every part of it — and goes to an admin for review before any student sees it.
+          <HeaderActionButton icon="mdi:plus" onClick={() => setBuildOpen(true)}>
+            Build a course
+          </HeaderActionButton>
+        }
       />
       {error && <Typography sx={{ color: "#ef4444", fontWeight: 700, textAlign: "center", py: 4 }}>{error}</Typography>}
       {!error && !loading && courses.length === 0 && (
         <Box sx={{ p: 4, textAlign: "center", borderRadius: 3, border: "1px dashed var(--border-default)" }}>
-          <Typography sx={{ color: "text.secondary" }}>No courses assigned yet.</Typography>
+          <Typography sx={{ fontWeight: 800, mb: 0.5 }}>Nothing here yet</Typography>
+          <Typography sx={{ color: "text.secondary", maxWidth: 520, mx: "auto", lineHeight: 1.6 }}>
+            Courses you are assigned to teach appear here. You can also{" "}
+            <strong>build one of your own</strong> — you keep full control of it, and an admin
+            reviews it before students see it.
+          </Typography>
         </Box>
       )}
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }, gap: 2 }}>
@@ -85,11 +100,81 @@ export default function InstructorCoursesPage() {
                 <Typography sx={{ color: "text.secondary", fontSize: "0.84rem", mt: 0.5 }}>
                   {c.student_count} student{c.student_count === 1 ? "" : "s"}
                 </Typography>
+                {c.authored_by_me && <AuthoredStatus course={c} />}
               </Box>
             </Reveal>
           );
         })}
       </Box>
+
+      <ManualCourseDialog
+        open={buildOpen}
+        onClose={() => setBuildOpen(false)}
+        onCreated={(courseId) => {
+          setBuildOpen(false);
+          // Straight into the builder: an empty course in a list of populated ones is
+          // indistinguishable from a failed create.
+          push(`/admin/adaptive-courses/${courseId}`);
+        }}
+      />
     </PageShell>
+  );
+}
+
+/** Where an instructor's own course stands, and — on a rejection — what to do about it. */
+function AuthoredStatus({ course }: { course: InstructorCourse }) {
+  const map: Record<string, { label: string; tone: string; hint: string }> = {
+    draft: {
+      label: "Your draft",
+      tone: "#6366f1",
+      hint: "Yours to build. Send it for review when it is ready.",
+    },
+    pending_review: {
+      label: "Waiting for review",
+      tone: "#f59e0b",
+      hint: "An admin is reviewing it. Students cannot see it yet.",
+    },
+    approved: {
+      label: "Approved",
+      tone: "#10b981",
+      hint: "An admin approved it. They assign students to make it live.",
+    },
+    rejected: {
+      label: "Sent back",
+      tone: "#ef4444",
+      // The reason itself replaces this — see below. This is only the fallback for a
+      // rejection with no note, which the API refuses but old rows might carry.
+      hint: "An admin sent this back for changes.",
+    },
+  };
+  const state = map[course.review_status];
+  if (!state) return null;
+
+  return (
+    <Box sx={{ mt: 1.25 }}>
+      <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 0.5 }}>
+        <Chip
+          size="small"
+          label={state.label}
+          sx={{
+            fontWeight: 800,
+            color: state.tone,
+            bgcolor: `color-mix(in srgb, ${state.tone} 14%, transparent)`,
+          }}
+        />
+        <Chip
+          size="small"
+          label="built by you"
+          sx={{ fontWeight: 700, color: "text.secondary", bgcolor: "color-mix(in srgb, var(--border-default) 60%, transparent)" }}
+        />
+      </Stack>
+      <Typography sx={{ fontSize: "0.78rem", color: "text.secondary", lineHeight: 1.45 }}>
+        {/* The admin's own words, verbatim: a rejection with no reason attached tells the
+            instructor nothing about what to change, and the same course comes back unchanged. */}
+        {course.review_status === "rejected" && course.review_note
+          ? course.review_note
+          : state.hint}
+      </Typography>
+    </Box>
   );
 }

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -315,6 +315,11 @@ export interface AdminAdaptiveCourseListItem {
   content_locked: boolean;
   /** Course-wide copy/paste policy for the code editor. Was per coding set. */
   allow_clipboard: boolean;
+  /** "" unless an instructor built this course. */
+  instructor_review_status?: "" | "draft" | "pending_review" | "approved" | "rejected";
+  instructor_review_note?: string;
+  /** Who built it, when an instructor did. */
+  authored_by?: { id: number; name: string; email: string } | null;
   module_count: number;
   submodule_count: number;
   quiz_count: number;
@@ -1055,6 +1060,19 @@ export const adminAdaptiveCourseService = {
    */
   async withdrawJob(jobId: string): Promise<void> {
     await apiClient.delete(`${BASE}/courses/jobs/${jobId}/`);
+  },
+
+
+  /** Instructor hands their finished course to a tenant admin. */
+  async submitCourseForReview(courseId: number) {
+    const { data } = await apiClient.post(`${BASE}/courses/${courseId}/submit-review/`, {});
+    return data as { id: number; instructor_review_status: string };
+  },
+
+  /** The admin's decision. A rejection must carry a reason — the server enforces it too. */
+  async reviewCourse(courseId: number, decision: "approve" | "reject", note = "") {
+    const { data } = await apiClient.post(`${BASE}/courses/${courseId}/review/`, { decision, note });
+    return data as { id: number; instructor_review_status: string; instructor_review_note: string };
   },
 
 };

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -95,6 +95,12 @@ export interface InstructorCourse {
   is_published: boolean;
   student_count: number;
   updated_at: string;
+  /** True when THIS instructor built it — which carries full edit rights, unlike being assigned. */
+  authored_by_me: boolean;
+  /** "" for anything not instructor-authored (including every classic course). */
+  review_status: "" | "draft" | "pending_review" | "approved" | "rejected";
+  /** The admin's reason on a rejection, shown verbatim. */
+  review_note: string;
 }
 
 export interface InstructorCohort {


### PR DESCRIPTION
Pairs with backend #543 and #544.

The instructor **Course Content** page listed courses they teach and offered nothing to *do* with any of them. Now it's somewhere they can build.

## What's there

**Build a course** — creates one through the same manual builder an admin uses. No second code path, no second set of bugs. Drops them straight into it, because an empty course in a list of populated ones is indistinguishable from a failed create.

**Their courses carry their state on the card** — Your draft / Waiting for review / Approved / Sent back, plus a *built by you* chip so a course they authored never looks like one an admin assigned them.

On a rejection the card shows the admin's reason **verbatim**, not a generic hint. The reason is the only thing that makes the rework possible; burying it behind a click means the same course comes back unchanged.

**The builder grows a review banner** — the one place either side learns where a course stands, since the module tree below looks identical in every state.

- Author sees **Send for review**
- Admin sees **Approve** / **Send back**, and a rejection asks for the reason *before* the call, so an instructor is never handed a bare "no"

**The admin hub pulls instructor submissions into their own strip.** They arrive as ordinary courses, so without this an admin has to notice a status chip on one card among forty. Every card now also says **who built it** — otherwise there's no way to tell an instructor's work from your own, and it changes how you read everything else on the card.

Card metrics renamed to match the terminology pass: modules/submodules → **weeks/topics**, coding → **coding problems**.

## Verified

Browser QA across all four states — including that a course they merely *teach* is not marked as theirs, and that the rejection reason renders verbatim. `next build` ✓ compiled. eslint: **zero problems in the touched files**; the 7 errors under `app/instructor` are pre-existing and reproduce on master (verified by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)