### PR TITLE
The instructor card said "yours to build" and opened a student roster

### DIFF
--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -25,6 +25,28 @@ export default function InstructorCoursePage() {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<number | null>(null);
   const [removing, setRemoving] = useState<number | null>(null);
+  // The roster endpoint does not say who authored the course, so this comes from the list the
+  // instructor already loaded. Absent (deep link, hard refresh) it stays false and the builder
+  // link simply is not offered — the card on /instructor/courses is the reliable route.
+  const [authoredByMe, setAuthoredByMe] = useState(false);
+
+  useEffect(() => {
+    if (!courseId) return;
+    let cancelled = false;
+    instructorService
+      .getCourses()
+      .then((list) => {
+        if (cancelled) return;
+        const mine = list.find((c) => c.kind === "adaptive" && c.id === courseId);
+        setAuthoredByMe(!!mine?.authored_by_me);
+      })
+      .catch(() => {
+        // A missing link is a missing convenience, not a broken page.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
 
   const load = useCallback(async () => {
     if (!courseId) return;
@@ -75,9 +97,22 @@ export default function InstructorCoursePage() {
         accent="purple"
         icon="mdi:book-education"
         action={
-          <HeaderActionButton icon="mdi:arrow-left" variant="ghost" onClick={() => push("/instructor/dashboard")}>
-            Dashboard
-          </HeaderActionButton>
+          <Stack direction="row" spacing={1}>
+            {/* Offered only for a course this instructor BUILT. Being assigned to teach a course
+                does not carry the right to rewrite it, and the server says so — a button that
+                403s is worse than no button. */}
+            {authoredByMe && (
+              <HeaderActionButton
+                icon="mdi:hammer-wrench"
+                onClick={() => push(`/admin/adaptive-courses/${courseId}`)}
+              >
+                Open the builder
+              </HeaderActionButton>
+            )}
+            <HeaderActionButton icon="mdi:arrow-left" variant="ghost" onClick={() => push("/instructor/dashboard")}>
+              Dashboard
+            </HeaderActionButton>
+          </Stack>
         }
       />
 

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -65,11 +65,19 @@ export default function InstructorCoursesPage() {
       )}
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }, gap: 2 }}>
         {courses.map((c, i) => {
-          // Only adaptive courses have an instructor detail view — it reads the adaptive roster API.
-          // Classic ids come from a different table, so sending one there would open an unrelated
-          // course that happens to share the number. Those cards stay non-navigable until a classic
-          // detail view exists.
-          const href = c.kind === "adaptive" ? `/instructor/courses/${c.id}` : null;
+          // A course you BUILT opens in the builder; a course you were assigned to teach opens on
+          // its roster. Both used to go to the roster, so the card that said "Yours to build.
+          // Send it for review when it is ready" led to a list of students — with no way from
+          // there to add a single piece of content, which is the one thing it was asking for.
+          //
+          // Only adaptive courses have either view. Classic ids come from a different table, so
+          // sending one there would open an unrelated course that happens to share the number.
+          const href =
+            c.kind !== "adaptive"
+              ? null
+              : c.authored_by_me
+                ? `/admin/adaptive-courses/${c.id}`
+                : `/instructor/courses/${c.id}`;
           const open = () => { if (href) push(href); };
           return (
             <Reveal key={`${c.kind}-${c.id}`} delay={Math.min(i, 8) * 0.05}>
@@ -102,6 +110,23 @@ export default function InstructorCoursesPage() {
                   {c.student_count} student{c.student_count === 1 ? "" : "s"}
                 </Typography>
                 {c.authored_by_me && <AuthoredStatus course={c} />}
+                {/* Says where the card goes. Everything here was clickable and nothing was
+                    labelled, so "build your course" and "see who is on it" looked identical. */}
+                {href && (
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={0.5}
+                    sx={{ mt: 1.5, fontSize: "0.82rem", fontWeight: 800, color: "#6366f1" }}
+                  >
+                    <Icon
+                      icon={c.authored_by_me ? "mdi:hammer-wrench" : "mdi:account-group-outline"}
+                      width={16}
+                    />
+                    {c.authored_by_me ? "Open the builder" : "View students"}
+                    <Icon icon="mdi:arrow-right" width={15} />
+                  </Stack>
+                )}
               </Box>
             </Reveal>
           );
@@ -128,7 +153,9 @@ function AuthoredStatus({ course }: { course: InstructorCourse }) {
     draft: {
       label: "Your draft",
       tone: "#6366f1",
-      hint: "Yours to build. Send it for review when it is ready.",
+      // Names the destination. "Send it for review when it is ready" described a button that
+      // lives on a page the card never took you to, so it read as an instruction with no verb.
+      hint: "Open it to add weeks, topics and content — then send it for review from there.",
     },
     pending_review: {
       label: "Waiting for review",


### PR DESCRIPTION
An instructor creates a course, lands back on Course Content, and the card tells them:

> **Your draft** · built by you
> Yours to build. Send it for review when it is ready.

Clicking it opened the **student roster** — a list of the zero people enrolled in a course with no
content — and there was no route from there to a single Add-content button. The instruction had no
verb attached to it.

## What changed

- **A course you built opens the builder.** A course you were assigned to teach still opens its
  roster, which is the right destination for that one. Both went to the roster before.
- **Each card says where it goes.** Everything was clickable and nothing was labelled, so "build
  your course" and "see who is on it" looked identical.
- **The roster page carries a builder link** for anyone arriving by an old or deep link — offered
  only for a course they authored, because being assigned to teach a course does not carry the
  right to rewrite it and the server says so.
- **The draft hint names the destination** instead of describing a button on a page it never took
  you to.

## The API was never the problem

A new end-to-end test drives the whole journey across both people and passes **unchanged**:

create → week → topic → article → submit for review → (author cannot approve or publish: 403) →
admin approves → admin publishes.

That is the point. Every endpoint worked; nothing could reach them. Two more cover an empty course
being refused before it wastes a reviewer's time, and a sent-back course being reworked and
resubmitted with the stale rejection note cleared.

**Tests:** 43 in `tests_authoring_rbac` green (backend, lands with the paired BE change); 53 FE
unit tests green; `tsc --noEmit` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)