### PR TITLE
Instructor course builder: make it reachable, and bring stagging up t…

### DIFF
--- a/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
+++ b/app/adaptive-courses/[courseId]/submodule/[submoduleId]/page.tsx
@@ -6,6 +6,7 @@ import { Box, Button, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
   adaptiveCourseService,
+  type AdaptiveCourseAttachment,
   type AdaptiveCourseSubModule,
   type PointsBreakdownItem,
   type PointsKind,
@@ -17,6 +18,7 @@ import { PointsInfo } from "@/components/common/PointsInfo";
 import { AdaptiveSubmoduleSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { asStringList } from "@/lib/utils/as-list";
+import { attachmentLook, formatFileSize } from "@/lib/utils/attachment-display";
 
 type FlowKind = "video" | "article" | "quiz" | "coding";
 type StepStatus = "done" | "current" | "upcoming";
@@ -268,10 +270,14 @@ export default function AdaptiveCourseSubmodulePage() {
             </Box>
 
             {items.length === 0 ? (
-              <Box sx={{ p: 5, textAlign: "center", borderRadius: 4, border: "1px dashed var(--border-default, #ececf1)" }}>
-                <Icon icon="mdi:inbox-outline" width={40} style={{ opacity: 0.4 }} />
-                <Typography sx={{ color: "text.secondary", mt: 1 }}>No content in this topic yet.</Typography>
-              </Box>
+              // Handouts are not steps, so a topic can hold them and still have an empty path.
+              // Saying "no content" over a list of downloadable material would be a lie.
+              (submodule.attachments?.length ?? 0) === 0 && (
+                <Box sx={{ p: 5, textAlign: "center", borderRadius: 4, border: "1px dashed var(--border-default, #ececf1)" }}>
+                  <Icon icon="mdi:inbox-outline" width={40} style={{ opacity: 0.4 }} />
+                  <Typography sx={{ color: "text.secondary", mt: 1 }}>No content in this topic yet.</Typography>
+                </Box>
+              )
             ) : (
               <Box sx={{ minWidth: 0 }}>
                 {/* Section header with gradient badge + the topic points total */}
@@ -312,12 +318,85 @@ export default function AdaptiveCourseSubmodulePage() {
               </Box>
             )}
 
+            {/* Handouts - reference material, deliberately outside the numbered path: there is
+                nothing to complete and no points to earn, so numbering them as steps would
+                inflate "N steps" and make the resume button point at a download. */}
+            <TopicHandouts attachments={submodule.attachments ?? []} />
+
             {/* Additional Practice - learner-generated extra content (no points) */}
             <AdditionalPractice courseId={courseId} submoduleId={submoduleId} />
           </>
         )}
       </Box>
     </MainLayout>
+  );
+}
+
+/**
+ * Downloadable material for this topic — decks, worksheets, specs.
+ *
+ * Every link opens in a new tab rather than navigating: a student who taps a 12MB PDF and lands
+ * on a blank viewer has lost the lesson they were halfway through. `noopener` because these are
+ * signed storage URLs leaving the app.
+ */
+function TopicHandouts({ attachments }: { attachments: AdaptiveCourseAttachment[] }) {
+  if (attachments.length === 0) return null;
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 1.5 }}>
+        <Box sx={{ width: 34, height: 34, borderRadius: 2.5, display: "grid", placeItems: "center", color: "white", background: "linear-gradient(135deg, #14b8a6 0%, #0ea5e9 100%)", boxShadow: "0 8px 18px -10px rgba(20,184,166,0.6)" }}>
+          <Icon icon="mdi:paperclip" width={19} />
+        </Box>
+        <Box>
+          <Typography sx={{ fontWeight: 800, fontSize: "1.1rem", color: "#0f172a" }}>Handouts</Typography>
+          <Typography sx={{ fontSize: "0.8rem", color: "#64748b" }}>
+            {attachments.length} file{attachments.length === 1 ? "" : "s"} to download · not graded
+          </Typography>
+        </Box>
+      </Stack>
+
+      <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr", lg: "1fr 1fr 1fr" }, gap: 1.25 }}>
+        {attachments.map((a) => {
+          const look = attachmentLook(a);
+          const size = formatFileSize(a.size_bytes);
+          return (
+            <ButtonBase
+              key={a.id}
+              component="a"
+              href={a.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              // The filename, so a download lands in the student's folder with a name they
+              // recognise rather than the server's key.
+              download={a.original_name || undefined}
+              sx={{
+                display: "flex", alignItems: "flex-start", gap: 1.25, p: 1.5, textAlign: "left",
+                borderRadius: 3, border: "1px solid var(--border-default, #ececf1)",
+                bgcolor: "var(--card-bg, #fff)", transition: "border-color .15s, transform .15s",
+                "&:hover": { borderColor: look.accent, transform: "translateY(-1px)" },
+              }}
+            >
+              <Box sx={{ width: 38, height: 38, borderRadius: 2, flexShrink: 0, display: "grid", placeItems: "center", bgcolor: `color-mix(in srgb, ${look.accent} 12%, transparent)` }}>
+                <Icon icon={look.icon} width={22} color={look.accent} />
+              </Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography sx={{ fontWeight: 700, fontSize: "0.88rem", lineHeight: 1.3 }}>{a.title}</Typography>
+                {a.description && (
+                  <Typography sx={{ fontSize: "0.76rem", color: "text.secondary", mt: 0.35, lineHeight: 1.4 }}>
+                    {a.description}
+                  </Typography>
+                )}
+                <Stack direction="row" spacing={0.5} alignItems="center" sx={{ mt: 0.6, fontSize: "0.72rem", color: "#64748b", fontWeight: 700 }}>
+                  <Box component="span" sx={{ color: look.accent }}>{look.label}</Box>
+                  {size && <Box component="span">· {size}</Box>}
+                  <Icon icon="mdi:tray-arrow-down" width={13} />
+                </Stack>
+              </Box>
+            </ButtonBase>
+          );
+        })}
+      </Box>
+    </Box>
   );
 }
 

--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -58,13 +58,14 @@ import { MockInterviewAdminSection } from "@/components/admin/adaptive-course/Mo
 import { CertificateAdminSection } from "@/components/admin/adaptive-course/CertificateAdminSection";
 import type { CourseImageTarget } from "@/lib/services/admin/admin-adaptive-course.service";
 import { asStringList } from "@/lib/utils/as-list";
+import { attachmentLook, formatFileSize } from "@/lib/utils/attachment-display";
 
 type DialogState =
   | { kind: "module" }
   | { kind: "submodule"; moduleId: number; moduleTitle: string }
   | null;
 
-type ContentKind = "article" | "quiz" | "coding" | "video";
+type ContentKind = "article" | "quiz" | "coding" | "video" | "attachment";
 
 /**
  * A staged tree deletion. The heading and message are built at click time, from the
@@ -135,6 +136,9 @@ export default function AdminAdaptiveCourseDetailPage() {
   const { user } = useAuth();
   const { clientInfo } = useClientInfo();
   const canSetPricing = isClientOrgAdminRole(user?.role);
+  // Reviewing an instructor's course is an admin act — the same predicate the server uses.
+  // An instructor approving their own course is not a review.
+  const isReviewer = isClientOrgAdminRole(user?.role);
 
   function handleQuizSaved(configId: number, mcqCount: number) {
     setCourse((prev) =>
@@ -583,6 +587,7 @@ export default function AdminAdaptiveCourseDetailPage() {
               <ReviewBanner
                 course={course}
                 busy={submittingReview}
+                isReviewer={isReviewer}
                 onSubmit={() => void handleSubmitForReview()}
                 onDecide={(d) => void handleReview(d)}
               />
@@ -685,7 +690,10 @@ export default function AdminAdaptiveCourseDetailPage() {
 
               {tab === "students" && (
                 <Stack spacing={2}>
-                  <InstructorAssignPanel scope="course" id={course.id} />
+                  {/* Deciding who teaches a course is the institution's call, not a teacher's.
+                      The endpoints behind this panel are admin-only, so rendering it to an
+                      instructor offered them a staff list they could not change. */}
+                  {isReviewer && <InstructorAssignPanel scope="course" id={course.id} />}
                   <CourseStudentsPanel courseId={course.id} courseTitle={course.title} />
                 </Stack>
               )}
@@ -1099,13 +1107,73 @@ export default function AdminAdaptiveCourseDetailPage() {
                                   }
                                 />
                               ))}
+                              {(sub.attachments ?? []).map((att) => {
+                                const look = attachmentLook(att);
+                                return (
+                                  <Box
+                                    key={`att-${att.id}`}
+                                    sx={{
+                                      display: "flex",
+                                      alignItems: "center",
+                                      gap: 1,
+                                      p: 1.25,
+                                      borderRadius: 2.5,
+                                      border: "1px solid color-mix(in srgb, var(--border-default) 65%, transparent)",
+                                      opacity: att.is_active ? 1 : 0.55,
+                                    }}
+                                  >
+                                    <Icon icon={look.icon} width={20} style={{ color: look.accent, flexShrink: 0 }} />
+                                    <Box sx={{ minWidth: 0 }}>
+                                      <Typography sx={{ fontWeight: 700, fontSize: "0.85rem" }} noWrap>
+                                        {att.title}
+                                      </Typography>
+                                      <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }} noWrap>
+                                        {look.label}
+                                        {formatFileSize(att.size_bytes) ? ` · ${formatFileSize(att.size_bytes)}` : ""}
+                                        {att.is_active ? "" : " · hidden from students"}
+                                      </Typography>
+                                    </Box>
+                                    <Box sx={{ flex: 1 }} />
+                                    {/* Opening it is the only way to confirm the right file went up.
+                                        A signed URL leaves the app, so it gets noopener. */}
+                                    {att.url && (
+                                      <ButtonBase
+                                        component="a"
+                                        href={att.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        title="Open this handout"
+                                        sx={{ p: 0.5, borderRadius: 1.5, color: "text.secondary", flexShrink: 0 }}
+                                      >
+                                        <Icon icon="mdi:open-in-new" width={15} />
+                                      </ButtonBase>
+                                    )}
+                                    <RowDeleteButton
+                                      label="Remove this handout"
+                                      width={15}
+                                      onClick={() =>
+                                        setPendingDelete({
+                                          kind: "content",
+                                          contentKind: "attachment",
+                                          submoduleId: sub.id,
+                                          contentId: att.id,
+                                          heading: "Remove this handout",
+                                          message: `"${att.title}" comes off "${sub.title}" and students stop seeing it. The file itself stays in your storage.`,
+                                        })
+                                      }
+                                    />
+                                  </Box>
+                                );
+                              })}
                               {sub.quizzes.length === 0 &&
                                 sub.articles.length === 0 &&
                                 (sub.coding_sets?.length ?? 0) === 0 &&
-                                (sub.video_companions?.length ?? 0) === 0 && (
+                                (sub.video_companions?.length ?? 0) === 0 &&
+                                (sub.attachments?.length ?? 0) === 0 && (
                                   <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
                                     Nothing here yet. Use <strong>Add content</strong> to write an
-                                    article, pull questions from the verified bank, or attach a video.
+                                    article, pull questions from the verified bank, attach a video or
+                                    upload a handout.
                                   </Typography>
                                 )}
                             </Box>
@@ -1483,6 +1551,7 @@ function describeSubmoduleContents(sub: AdminAdaptiveCourseSubModule): string {
     [sub.quizzes.length, "quiz", "quizzes"],
     [codingProblems, "coding problem", "coding problems"],
     [sub.video_companions?.length ?? 0, "video", "videos"],
+    [sub.attachments?.length ?? 0, "handout", "handouts"],
   ] as const;
   const said = parts.filter(([n]) => n > 0).map(([n, one, many]) => `${n} ${n === 1 ? one : many}`);
   if (said.length === 0) return "";
@@ -1528,6 +1597,7 @@ function ModuleSummary({ mod }: { mod: AdminAdaptiveCourseModule }) {
   const quizzes = sum((s) => s.quizzes.length);
   const coding = sum((s) => (s.coding_sets ?? []).reduce((n, c) => n + c.problems.length, 0));
   const videos = sum((s) => s.video_companions?.length ?? 0);
+  const handouts = sum((s) => s.attachments?.length ?? 0);
 
   const items: { icon: string; n: number; label: string; accent: string }[] = [
     { icon: "mdi:file-tree-outline", n: subs.length, label: `submodule${subs.length === 1 ? "" : "s"}`, accent: "#6366f1" },
@@ -1535,6 +1605,7 @@ function ModuleSummary({ mod }: { mod: AdminAdaptiveCourseModule }) {
     { icon: "mdi:tune-vertical", n: quizzes, label: "quizzes", accent: "#6366f1" },
     { icon: "mdi:robot-happy-outline", n: coding, label: "coding", accent: "#ec4899" },
     { icon: "mdi:play-circle-outline", n: videos, label: "videos", accent: "#0ea5e9" },
+    { icon: "mdi:paperclip", n: handouts, label: "handouts", accent: "#14b8a6" },
   ].filter((x) => x.n > 0);
 
   return (
@@ -1673,11 +1744,16 @@ function pillBtnSx(variant: "solid" | "outline") {
 function ReviewBanner({
   course,
   busy,
+  isReviewer,
   onSubmit,
   onDecide,
 }: {
   course: AdminAdaptiveCourseDetail;
   busy: boolean;
+  /** Whether THIS viewer may decide the review. The banner renders on course state, which is the
+   *  same for everyone looking at it — so without this the author sees Approve and Send back on
+   *  their own submission, clicks Approve, and gets a 403 they can do nothing about. */
+  isReviewer: boolean;
   onSubmit: () => void;
   onDecide: (decision: "approve" | "reject") => void;
 }) {
@@ -1741,9 +1817,8 @@ function ReviewBanner({
         </Typography>
       </Box>
 
-      {/* The author's action. The server decides who may actually do this — showing the button
-          to the wrong person would produce a 403 they cannot act on. */}
-      {(state === "draft" || state === "rejected") && (
+      {/* The author's action. Hidden from the reviewer, who has nothing to submit. */}
+      {(state === "draft" || state === "rejected") && !isReviewer && (
         <ButtonBase
           onClick={onSubmit}
           disabled={busy}
@@ -1758,8 +1833,8 @@ function ReviewBanner({
         </ButtonBase>
       )}
 
-      {/* The admin's decision. */}
-      {state === "pending_review" && (
+      {/* The admin's decision, and only theirs. */}
+      {state === "pending_review" && isReviewer && (
         <Box sx={{ display: "flex", gap: 1 }}>
           <ButtonBase
             onClick={() => onDecide("reject")}

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -27,6 +27,8 @@ import {
   type AdminAdaptiveCourseListItem,
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
 
 const POLL_INTERVAL_MS = 10000;
 const ACTIVE_STATUSES = new Set(["pending", "generating_outline", "creating_structure", "generating_content"]);
@@ -34,6 +36,11 @@ const ACTIVE_STATUSES = new Set(["pending", "generating_outline", "creating_stru
 export default function AdminAdaptiveCoursesPage() {
   const { push, prefetch } = useInstantNavigation();
   const { showToast } = useToast();
+  const { user } = useAuth();
+  // The same predicate the server uses for `is_admin`. Instructors reach this page — they build
+  // their own courses here — but publishing, reviewing and deleting someone else's are not
+  // theirs to do, and a button that 403s is worse than no button.
+  const isReviewer = isClientOrgAdminRole(user?.role);
   const [courses, setCourses] = useState<AdminAdaptiveCourseListItem[]>([]);
   const [jobs, setJobs] = useState<AdaptiveCourseJob[]>([]);
   const [loading, setLoading] = useState(true);
@@ -174,7 +181,13 @@ export default function AdminAdaptiveCoursesPage() {
   // Instructor-built courses waiting on this admin. They arrive as ordinary courses in the
   // list, so without pulling them out an admin would have to notice a status chip on a card
   // among forty others.
-  const instructorPending = courses.filter((c) => c.instructor_review_status === "pending_review");
+  //
+  // Reviewers only. Reviewing is an admin act, so an instructor was being told that colleagues'
+  // courses — and their own submission — were "waiting for your review", which is both untrue
+  // and an invitation to click something the server refuses.
+  const instructorPending = isReviewer
+    ? courses.filter((c) => c.instructor_review_status === "pending_review")
+    : [];
   const rejectedJobs = jobs.filter((j) => j.status === "rejected");
 
   return (
@@ -463,6 +476,8 @@ export default function AdminAdaptiveCoursesPage() {
                 <Reveal key={course.id} delay={Math.min(idx, 8) * 0.05}>
                   <CourseCard
                     course={course}
+                    isReviewer={isReviewer}
+                    viewerEmail={user?.email ?? ""}
                     onOpen={() => push(`/admin/adaptive-courses/${course.id}`)}
                     onTogglePublish={() => void handlePublishToggle(course)}
                     onDelete={() => setPendingDelete(course)}
@@ -516,15 +531,36 @@ export default function AdminAdaptiveCoursesPage() {
 
 function CourseCard({
   course,
+  isReviewer,
+  viewerEmail,
   onOpen,
   onTogglePublish,
   onDelete,
 }: {
   course: AdminAdaptiveCourseListItem;
+  isReviewer: boolean;
+  /** Matched against `authored_by.email`. Email, not id: the auth user carries a User id and
+   *  `authored_by` carries a UserProfile id, and comparing those would be wrong roughly as often
+   *  as it was right. */
+  viewerEmail: string;
   onOpen: () => void;
   onTogglePublish: () => void;
   onDelete: () => void;
 }) {
+  // Publishing is an admin act in every case — approval says the content is sound, putting it in
+  // front of students is a separate decision and it belongs to the institution.
+  const canPublish = isReviewer;
+  const authoredByViewer =
+    !!course.authored_by?.email &&
+    !!viewerEmail &&
+    course.authored_by.email.toLowerCase() === viewerEmail.toLowerCase();
+  // An author may bin their own course right up until it is approved; after that it may have
+  // students on it and removing it stops being their call alone. Mirrors `can_delete_course`.
+  const canDelete =
+    isReviewer ||
+    (authoredByViewer &&
+      (course.instructor_review_status === "draft" ||
+        course.instructor_review_status === "rejected"));
   return (
     <Box
       sx={{
@@ -565,9 +601,11 @@ function CourseCard({
             withAmount
           />
         </Box>
-        <ButtonBase onClick={onDelete} sx={{ p: 0.5, borderRadius: 2, color: "#ef4444" }}>
-          <Icon icon="mdi:trash-can-outline" width={18} />
-        </ButtonBase>
+        {canDelete && (
+          <ButtonBase onClick={onDelete} sx={{ p: 0.5, borderRadius: 2, color: "#ef4444" }}>
+            <Icon icon="mdi:trash-can-outline" width={18} />
+          </ButtonBase>
+        )}
       </Box>
 
       {course.card_image_url && (
@@ -614,6 +652,7 @@ function CourseCard({
       </ButtonBase>
 
       <Box sx={{ display: "flex", gap: 1, mt: 2 }}>
+        {canPublish && (
         <ButtonBase
           onClick={onTogglePublish}
           sx={{
@@ -633,6 +672,7 @@ function CourseCard({
         >
           {course.is_published ? "Unpublish" : "Publish"}
         </ButtonBase>
+        )}
         <ButtonBase
           onClick={onOpen}
           sx={{

--- a/app/instructor/analytics/page.tsx
+++ b/app/instructor/analytics/page.tsx
@@ -11,6 +11,7 @@ import {
   type InstructorDashboard,
   type InstructorStudentRow,
 } from "@/lib/services/instructor.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const BUCKETS = [
   { label: "0–25%", min: 0, max: 25, color: "#ef4444" },
@@ -36,7 +37,7 @@ export default function InstructorAnalyticsPage() {
         setDash(d);
         setStudents(s.results);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load analytics.");
+        if (!cancelled) setError(getAxiosErrorDetail(e, "Couldn't load analytics."));
       }
     })();
     return () => {

--- a/app/instructor/assessments/page.tsx
+++ b/app/instructor/assessments/page.tsx
@@ -7,6 +7,7 @@ import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { Reveal } from "@/components/scorecard/shared";
 import { instructorService, type InstructorAssessment } from "@/lib/services/instructor.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 export default function InstructorGradebookPage() {
   const [items, setItems] = useState<InstructorAssessment[]>([]);
@@ -20,7 +21,7 @@ export default function InstructorGradebookPage() {
         const list = await instructorService.getAssessments();
         if (!cancelled) setItems(list);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your assessments.");
+        if (!cancelled) setError(getAxiosErrorDetail(e, "Couldn't load your assessments."));
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/app/instructor/cohorts/[id]/page.tsx
+++ b/app/instructor/cohorts/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
 import { instructorService, type CohortRoster } from "@/lib/services/instructor.service";
 import { RosterRow } from "@/components/instructor/RosterRow";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 export default function InstructorCohortPage() {
   const params = useParams();
@@ -29,7 +30,7 @@ export default function InstructorCohortPage() {
         const r = await instructorService.getCohortStudents(cohortId);
         if (!cancelled) setRoster(r);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load this batch.");
+        if (!cancelled) setError(getAxiosErrorDetail(e, "Couldn't load this batch."));
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/app/instructor/cohorts/page.tsx
+++ b/app/instructor/cohorts/page.tsx
@@ -8,6 +8,7 @@ import { ModulePageHeader, HeaderActionButton } from "@/components/common/Module
 import { Reveal } from "@/components/scorecard/shared";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { instructorService, type InstructorCohortDetail } from "@/lib/services/instructor.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const GRADS = [
   "linear-gradient(120deg,#6366f1,#f59e0b)",
@@ -80,7 +81,7 @@ export default function InstructorCohortsPage() {
           setCode(d.instructor_code);
         }
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your cohorts.");
+        if (!cancelled) setError(getAxiosErrorDetail(e, "Couldn't load your cohorts."));
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/components/common/Toast";
 import { StudentDetailDrawer } from "@/components/instructor/StudentDetailDrawer";
 import { RosterRow } from "@/components/instructor/RosterRow";
 import { instructorService, type CourseStudentRow } from "@/lib/services/instructor.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 export default function InstructorCoursePage() {
   const params = useParams();
@@ -24,6 +25,28 @@ export default function InstructorCoursePage() {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<number | null>(null);
   const [removing, setRemoving] = useState<number | null>(null);
+  // The roster endpoint does not say who authored the course, so this comes from the list the
+  // instructor already loaded. Absent (deep link, hard refresh) it stays false and the builder
+  // link simply is not offered — the card on /instructor/courses is the reliable route.
+  const [authoredByMe, setAuthoredByMe] = useState(false);
+
+  useEffect(() => {
+    if (!courseId) return;
+    let cancelled = false;
+    instructorService
+      .getCourses()
+      .then((list) => {
+        if (cancelled) return;
+        const mine = list.find((c) => c.kind === "adaptive" && c.id === courseId);
+        setAuthoredByMe(!!mine?.authored_by_me);
+      })
+      .catch(() => {
+        // A missing link is a missing convenience, not a broken page.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
 
   const load = useCallback(async () => {
     if (!courseId) return;
@@ -33,7 +56,7 @@ export default function InstructorCoursePage() {
       setRows(r.results);
       setCount(r.count);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Couldn't load this course.");
+      setError(getAxiosErrorDetail(e, "Couldn't load this course."));
     } finally {
       setLoading(false);
     }
@@ -59,7 +82,7 @@ export default function InstructorCoursePage() {
       setCount((c) => Math.max(0, c - 1));
       showToast("Student removed from the course.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't remove the student.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't remove the student."), "error");
     } finally {
       setRemoving(null);
     }
@@ -74,9 +97,22 @@ export default function InstructorCoursePage() {
         accent="purple"
         icon="mdi:book-education"
         action={
-          <HeaderActionButton icon="mdi:arrow-left" variant="ghost" onClick={() => push("/instructor/dashboard")}>
-            Dashboard
-          </HeaderActionButton>
+          <Stack direction="row" spacing={1}>
+            {/* Offered only for a course this instructor BUILT. Being assigned to teach a course
+                does not carry the right to rewrite it, and the server says so — a button that
+                403s is worse than no button. */}
+            {authoredByMe && (
+              <HeaderActionButton
+                icon="mdi:hammer-wrench"
+                onClick={() => push(`/admin/adaptive-courses/${courseId}`)}
+              >
+                Open the builder
+              </HeaderActionButton>
+            )}
+            <HeaderActionButton icon="mdi:arrow-left" variant="ghost" onClick={() => push("/instructor/dashboard")}>
+              Dashboard
+            </HeaderActionButton>
+          </Stack>
         }
       />
 

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -10,6 +10,7 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { instructorService, type InstructorCourse } from "@/lib/services/instructor.service";
 import { ManualCourseDialog } from "@/components/admin/adaptive-course/ManualCourseDialog";
 import { HeaderActionButton } from "@/components/common/ModulePageHeader";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 export default function InstructorCoursesPage() {
   const { push, prefetch } = useInstantNavigation();
@@ -25,7 +26,7 @@ export default function InstructorCoursesPage() {
         const list = await instructorService.getCourses();
         if (!cancelled) setCourses(list);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Couldn't load your courses.");
+        if (!cancelled) setError(getAxiosErrorDetail(e, "Couldn't load your courses."));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -64,11 +65,19 @@ export default function InstructorCoursesPage() {
       )}
       <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", sm: "repeat(2, 1fr)", lg: "repeat(3, 1fr)" }, gap: 2 }}>
         {courses.map((c, i) => {
-          // Only adaptive courses have an instructor detail view — it reads the adaptive roster API.
-          // Classic ids come from a different table, so sending one there would open an unrelated
-          // course that happens to share the number. Those cards stay non-navigable until a classic
-          // detail view exists.
-          const href = c.kind === "adaptive" ? `/instructor/courses/${c.id}` : null;
+          // A course you BUILT opens in the builder; a course you were assigned to teach opens on
+          // its roster. Both used to go to the roster, so the card that said "Yours to build.
+          // Send it for review when it is ready" led to a list of students — with no way from
+          // there to add a single piece of content, which is the one thing it was asking for.
+          //
+          // Only adaptive courses have either view. Classic ids come from a different table, so
+          // sending one there would open an unrelated course that happens to share the number.
+          const href =
+            c.kind !== "adaptive"
+              ? null
+              : c.authored_by_me
+                ? `/admin/adaptive-courses/${c.id}`
+                : `/instructor/courses/${c.id}`;
           const open = () => { if (href) push(href); };
           return (
             <Reveal key={`${c.kind}-${c.id}`} delay={Math.min(i, 8) * 0.05}>
@@ -101,6 +110,23 @@ export default function InstructorCoursesPage() {
                   {c.student_count} student{c.student_count === 1 ? "" : "s"}
                 </Typography>
                 {c.authored_by_me && <AuthoredStatus course={c} />}
+                {/* Says where the card goes. Everything here was clickable and nothing was
+                    labelled, so "build your course" and "see who is on it" looked identical. */}
+                {href && (
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={0.5}
+                    sx={{ mt: 1.5, fontSize: "0.82rem", fontWeight: 800, color: "#6366f1" }}
+                  >
+                    <Icon
+                      icon={c.authored_by_me ? "mdi:hammer-wrench" : "mdi:account-group-outline"}
+                      width={16}
+                    />
+                    {c.authored_by_me ? "Open the builder" : "View students"}
+                    <Icon icon="mdi:arrow-right" width={15} />
+                  </Stack>
+                )}
               </Box>
             </Reveal>
           );
@@ -127,7 +153,9 @@ function AuthoredStatus({ course }: { course: InstructorCourse }) {
     draft: {
       label: "Your draft",
       tone: "#6366f1",
-      hint: "Yours to build. Send it for review when it is ready.",
+      // Names the destination. "Send it for review when it is ready" described a button that
+      // lives on a page the card never took you to, so it read as an instruction with no verb.
+      hint: "Open it to add weeks, topics and content — then send it for review from there.",
     },
     pending_review: {
       label: "Waiting for review",

--- a/app/instructor/dashboard/page.tsx
+++ b/app/instructor/dashboard/page.tsx
@@ -14,6 +14,7 @@ import {
   type InstructorScheduleItem,
   type InstructorRecentSubmission,
 } from "@/lib/services/instructor.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 function greeting(): string {
   const h = new Date().getHours();
@@ -61,7 +62,7 @@ export default function InstructorDashboardPage() {
         const d = await instructorService.getDashboard();
         if (!cancelled) setDash(d);
       } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load your workspace.");
+        if (!cancelled) setError(getAxiosErrorDetail(e, "Failed to load your workspace."));
       }
     })();
     return () => {

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -33,6 +33,7 @@ import {
   type AttendeeRow,
 } from "@/lib/services/instructor.service";
 import { viewerTimeZone, timezoneOptions, sessionTimeParts } from "@/lib/utils/session-time";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 type SessionStatus = "live" | "scheduled" | "ended";
 
@@ -120,7 +121,7 @@ export default function InstructorLiveSessionsPage() {
       setPastTotal(data.past_total);
       setError(null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Couldn't load your live sessions.");
+      setError(getAxiosErrorDetail(e, "Couldn't load your live sessions."));
     } finally {
       setLoading(false);
     }
@@ -500,7 +501,7 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
       reset(); onClose();
     } catch (e) {
       const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
-      setErr(detail || (e instanceof Error ? e.message : "Couldn't create the session."));
+      setErr(detail || (getAxiosErrorDetail(e, "Couldn't create the session.")));
     } finally {
       setSaving(false);
     }
@@ -632,7 +633,7 @@ function EditSessionDialog({ session, onClose, onSaved }: {
       onSaved(); onClose();
     } catch (e) {
       const detail = (e as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
-      setErr(detail || (e instanceof Error ? e.message : "Couldn't update the session."));
+      setErr(detail || (getAxiosErrorDetail(e, "Couldn't update the session.")));
     } finally {
       setSaving(false);
     }

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -29,6 +29,7 @@ import {
   type InstructorStudentDetail,
   type InstructorCohortDetail,
 } from "@/lib/services/instructor.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 /* --------------------------------- status --------------------------------- */
 
@@ -334,7 +335,7 @@ export default function InstructorStudentsPage() {
         setPage(data.page);
         setError(null);
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Couldn't load your students.");
+        setError(getAxiosErrorDetail(e, "Couldn't load your students."));
       } finally {
         setLoading(false);
       }

--- a/components/admin/adaptive-course/AddContentDialog.tsx
+++ b/components/admin/adaptive-course/AddContentDialog.tsx
@@ -34,20 +34,41 @@ import {
   adaptiveVideoAdminService,
   type VimeoVideoWire,
 } from "@/lib/services/adaptive-video.service";
+import { uploadFile } from "@/lib/services/file-upload.service";
+import { config } from "@/lib/config";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import {
+  ATTACHMENT_ACCEPT,
+  ATTACHMENT_MAX_MB,
+  attachmentLook,
+  formatFileSize,
+} from "@/lib/utils/attachment-display";
 
 /* ------------------------------------------------------------------ palette */
 
-type ContentKind = "article" | "quiz" | "coding" | "video";
+type ContentKind = "article" | "quiz" | "coding" | "video" | "attachment";
 
-const KIND_ORDER: ContentKind[] = ["article", "quiz", "coding", "video"];
-const KIND_TAB: Record<ContentKind, number> = { article: 0, quiz: 1, coding: 2, video: 3 };
+const KIND_ORDER: ContentKind[] = ["article", "quiz", "coding", "video", "attachment"];
+const KIND_TAB: Record<ContentKind, number> = {
+  article: 0, quiz: 1, coding: 2, video: 3, attachment: 4,
+};
 
 const KIND_META: Record<ContentKind, { label: string; icon: string; accent: string }> = {
   article: { label: "Article", icon: "mdi:text-box-outline", accent: "#6366f1" },
   quiz: { label: "Quiz", icon: "mdi:help-circle-outline", accent: "#a855f7" },
   coding: { label: "Coding", icon: "mdi:code-braces", accent: "#f59e0b" },
   video: { label: "Video", icon: "mdi:play-circle-outline", accent: "#ec4899" },
+  // Teal, not sky blue: the module summary already spends #0ea5e9 on videos, and two content
+  // types wearing one colour in the same tree is a miscue.
+  attachment: { label: "Handout", icon: "mdi:paperclip", accent: "#14b8a6" },
 };
+
+/** The suggestions rail only reports the four content types the server scores. Handouts are
+ *  supplementary — a topic is not "incomplete" for lacking one — so the rail skips it while the
+ *  tabs still offer it. */
+const SUGGESTED_KINDS: Array<Exclude<ContentKind, "attachment">> = [
+  "article", "quiz", "coding", "video",
+];
 
 const GREEN = "#10b981";
 /** Theme token, not a literal grey: this text/icon tone has to follow light and dark. */
@@ -364,6 +385,8 @@ export function AddContentDialog({
   onAdded: () => void;
 }) {
   const { showToast } = useToast();
+  const { clientInfo } = useClientInfo();
+  const clientId = Number(clientInfo?.id ?? config.clientId);
   const [tab, setTab] = useState(0);
   const [saving, setSaving] = useState(false);
 
@@ -398,6 +421,13 @@ export function AddContentDialog({
   const [videoTitle, setVideoTitle] = useState("");
   const [videoNote, setVideoNote] = useState<string | null>(null);
   const vSeq = useRef(0);
+
+  // Handout
+  const [file, setFile] = useState<File | null>(null);
+  const [attTitle, setAttTitle] = useState("");
+  const [attDescription, setAttDescription] = useState("");
+  const [attError, setAttError] = useState<string | null>(null);
+  const fileInput = useRef<HTMLInputElement>(null);
 
   const mcqBank = useBankSearch<BankMcq>("mcq", open && tab === 1 && quizMode === "bank");
   const codingBank = useBankSearch<BankCodingProblem>(
@@ -442,6 +472,11 @@ export function AddContentDialog({
     setVideoUrl("");
     setVideoTitle("");
     setVideoNote(null);
+    setFile(null);
+    setAttTitle("");
+    setAttDescription("");
+    setAttError(null);
+    if (fileInput.current) fileInput.current.value = "";
     vSeq.current += 1;
     resetMcqBank();
     resetCodingBank();
@@ -635,6 +670,50 @@ export function AddContentDialog({
     }
   }
 
+  async function submitAttachment() {
+    if (submoduleId == null || !file) return;
+    setAttError(null);
+    setSaving(true);
+    try {
+      // Two calls: the shared media endpoint owns the size cap and the type allowlist, then the
+      // course route records which object belongs to this topic. It takes the S3 KEY, not the
+      // URL — a stored presigned URL would leave every handout dead about a week later.
+      const uploaded = await uploadFile(clientId, file, "course_attachment");
+      const fileKey = uploaded.storage_path;
+      if (!fileKey) {
+        // Without a key there is nothing durable to record, and recording the presigned URL
+        // instead would look like success today and 403 for students next week.
+        setAttError(
+          "The file uploaded but the server did not return a storage key, so it can't be attached. Try again.",
+        );
+        return;
+      }
+      const r = await adminAdaptiveCourseService.addAttachment(submoduleId, {
+        file_key: fileKey,
+        title: attTitle.trim() || undefined,
+        description: attDescription.trim() || undefined,
+        original_name: file.name,
+        content_type: file.type || undefined,
+        size_bytes: file.size,
+      });
+      setFile(null);
+      setAttTitle("");
+      setAttDescription("");
+      if (fileInput.current) fileInput.current.value = "";
+      afterAdd(`Attached "${r.title}".`);
+    } catch (e: unknown) {
+      // Inline, not a toast: the upload is the slowest thing in this dialog and a message that
+      // disappears after four seconds is the one an admin misses while watching the spinner.
+      setAttError(
+        e instanceof Error && e.message.startsWith("File upload failed")
+          ? e.message
+          : getAxiosErrorDetail(e, "Couldn't attach the file."),
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
   /* ------------------------------------------------------------ primary CTA */
 
   const completeDrafts = drafts.filter(draftIsComplete).length;
@@ -662,6 +741,7 @@ export function AddContentDialog({
       run: () => void submitCoding(),
     },
     { label: "Add video", ready: videoReady, run: () => void submitVideo() },
+    { label: "Attach file", ready: file !== null, run: () => void submitAttachment() },
   ][tab];
 
   const accent = KIND_META[KIND_ORDER[tab]].accent;
@@ -701,7 +781,7 @@ export function AddContentDialog({
             }}
           >
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-              {KIND_ORDER.map((k) => {
+              {SUGGESTED_KINDS.map((k) => {
                 const owned = suggestions.has[k];
                 return (
                   <Chip
@@ -1535,6 +1615,137 @@ export function AddContentDialog({
                   </Typography>
                 </Box>
               )}
+            </Box>
+          )}
+
+          {/* ----------------------------------------------------- 5. handout */}
+          {tab === 4 && (
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+              {attError && (
+                <Alert severity="error" onClose={() => setAttError(null)}>
+                  {attError}
+                </Alert>
+              )}
+
+              <input
+                ref={fileInput}
+                type="file"
+                accept={ATTACHMENT_ACCEPT}
+                hidden
+                onChange={(e) => {
+                  const picked = e.target.files?.[0] ?? null;
+                  setAttError(null);
+                  if (picked && picked.size > ATTACHMENT_MAX_MB * 1024 * 1024) {
+                    // Checked here as well as server-side: making someone push 80MB up a hotel
+                    // connection before being told no is the same rejection, ten minutes later.
+                    setAttError(
+                      `That file is ${formatFileSize(picked.size)}. The limit is ${ATTACHMENT_MAX_MB}MB.`,
+                    );
+                    setFile(null);
+                    e.target.value = "";
+                    return;
+                  }
+                  setFile(picked);
+                  // The filename is almost always the right title, and an admin who wants
+                  // something else can still overwrite it.
+                  if (picked && !attTitle.trim()) {
+                    setAttTitle(picked.name.replace(/\.[^.]+$/, ""));
+                  }
+                }}
+              />
+
+              {file ? (
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 1.25,
+                    p: 1.25,
+                    borderRadius: 2,
+                    border: "1px solid",
+                    borderColor: `color-mix(in srgb, ${attachmentLook({ original_name: file.name }).accent} 45%, transparent)`,
+                    bgcolor: `color-mix(in srgb, ${attachmentLook({ original_name: file.name }).accent} 6%, transparent)`,
+                  }}
+                >
+                  <Icon
+                    icon={attachmentLook({ original_name: file.name }).icon}
+                    width={30}
+                    color={attachmentLook({ original_name: file.name }).accent}
+                  />
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Typography sx={{ fontSize: "0.86rem", fontWeight: 700 }} noWrap>
+                      {file.name}
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.74rem", color: "var(--font-secondary)" }}>
+                      {formatFileSize(file.size)}
+                    </Typography>
+                  </Box>
+                  <Button
+                    size="small"
+                    disabled={saving}
+                    onClick={() => {
+                      setFile(null);
+                      if (fileInput.current) fileInput.current.value = "";
+                    }}
+                    sx={{ minWidth: 0, p: 0.5, color: "var(--font-secondary)" }}
+                  >
+                    <Icon icon="mdi:close" width={18} />
+                  </Button>
+                </Box>
+              ) : (
+                <Box
+                  onClick={() => fileInput.current?.click()}
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 0.5,
+                    py: 3.5,
+                    borderRadius: 2,
+                    cursor: "pointer",
+                    border: "1.5px dashed var(--border-default)",
+                    "&:hover": {
+                      borderColor: KIND_META.attachment.accent,
+                      bgcolor: `color-mix(in srgb, ${KIND_META.attachment.accent} 5%, transparent)`,
+                    },
+                  }}
+                >
+                  <Icon
+                    icon="mdi:cloud-upload-outline"
+                    width={32}
+                    color={KIND_META.attachment.accent}
+                  />
+                  <Typography sx={{ fontSize: "0.86rem", fontWeight: 700 }}>
+                    Choose a file
+                  </Typography>
+                  <Typography sx={{ fontSize: "0.74rem", color: "var(--font-secondary)" }}>
+                    PDF, PowerPoint, Word, Excel, text or image · up to {ATTACHMENT_MAX_MB}MB
+                  </Typography>
+                </Box>
+              )}
+
+              <TextField
+                size="small"
+                fullWidth
+                label="Title"
+                placeholder="What students will see in the list"
+                value={attTitle}
+                onChange={(e) => setAttTitle(e.target.value)}
+              />
+              <TextField
+                size="small"
+                fullWidth
+                multiline
+                minRows={2}
+                label="Description (optional)"
+                placeholder="When to use it, what to do with it."
+                value={attDescription}
+                onChange={(e) => setAttDescription(e.target.value)}
+              />
+              <Typography sx={{ fontSize: "0.75rem", color: "var(--font-secondary)" }}>
+                Handouts appear alongside the lesson on the topic and can be downloaded by every
+                student enrolled in the course.
+              </Typography>
             </Box>
           )}
         </Box>

--- a/components/instructor/InstructorAssignPanel.tsx
+++ b/components/instructor/InstructorAssignPanel.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@iconify/react";
 import { useToast } from "@/components/common/Toast";
 import { adminInstructorsService, type InstructorRow } from "@/lib/services/admin/admin-instructors.service";
 import { instructorService, type StaffAssignment } from "@/lib/services/instructor.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 /** Admin panel to assign/unassign instructors on a course or cohort. Reuses the existing approved-
  *  instructor list for the picker; writes go through the admin-only assignment API. */
@@ -55,7 +56,7 @@ export function InstructorAssignPanel({ scope, id }: { scope: "course" | "cohort
       setPick(0);
       showToast("Instructor assigned.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't assign instructor.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't assign instructor."), "error");
     } finally {
       setBusy(false);
     }
@@ -69,7 +70,7 @@ export function InstructorAssignPanel({ scope, id }: { scope: "course" | "cohort
       setStaff((prev) => prev.filter((s) => s.profile_id !== profileId));
       showToast("Instructor unassigned.", "success");
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Couldn't unassign.", "error");
+      showToast(getAxiosErrorDetail(e, "Couldn't unassign."), "error");
     } finally {
       setBusy(false);
     }

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -106,6 +106,20 @@ export interface AdaptiveCourseVideoCompanionSummary {
   completed?: boolean;
 }
 
+/** A handout on a topic: deck, worksheet, spec. `url` is signed fresh on every read, so it
+ *  must never be cached or persisted client-side — it expires. */
+export interface AdaptiveCourseAttachment {
+  id: number;
+  title: string;
+  description: string;
+  /** Coarse family the server derives from the extension: pdf | slides | doc | sheet | image | file. */
+  kind: string;
+  extension: string;
+  original_name: string;
+  size_bytes: number;
+  url: string;
+}
+
 export interface AdaptiveCourseSubModule {
   id: number;
   order: number;
@@ -115,6 +129,7 @@ export interface AdaptiveCourseSubModule {
   quizzes: AdaptiveCourseQuizSummary[];
   coding_sets?: AdaptiveCourseCodingSet[];
   video_companions?: AdaptiveCourseVideoCompanionSummary[];
+  attachments?: AdaptiveCourseAttachment[];
 }
 
 export interface AdaptiveCourseModule {

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -273,6 +273,20 @@ export interface AdminAdaptiveCourseVideoCompanion {
   is_active: boolean;
 }
 
+/** A handout on a topic. `url` is signed per read and expires — render it, never store it. */
+export interface AdminAdaptiveCourseAttachment {
+  id: number;
+  title: string;
+  /** Coarse family derived server-side from the extension: pdf | slides | doc | sheet | image | file. */
+  kind: string;
+  extension: string;
+  original_name: string;
+  size_bytes: number;
+  is_active: boolean;
+  /** Null when the stored key no longer signs — a moved or revoked object. */
+  url: string | null;
+}
+
 export interface AdminAdaptiveCourseSubModule {
   id: number;
   order: number;
@@ -282,6 +296,7 @@ export interface AdminAdaptiveCourseSubModule {
   quizzes: AdminAdaptiveCourseQuiz[];
   coding_sets?: AdminAdaptiveCourseCodingSet[];
   video_companions?: AdminAdaptiveCourseVideoCompanion[];
+  attachments?: AdminAdaptiveCourseAttachment[];
 }
 
 export interface AdminAdaptiveCourseModule {
@@ -706,12 +721,35 @@ export const adminAdaptiveCourseService = {
   },
 
   /**
-   * One route for all four content types. The alternative was reaching into the coding service
+   * Record an already-uploaded handout against a topic.
+   *
+   * Two calls on purpose: the file goes through the shared media endpoint (which owns the size
+   * cap and the type allowlist), and this one records WHICH object belongs here. It takes the
+   * S3 object key, never the URL — presigned URLs expire, and a stored one would leave every
+   * handout on the course broken about a week later.
+   */
+  async addAttachment(submoduleId: number, payload: {
+    file_key: string;
+    title?: string;
+    description?: string;
+    original_name?: string;
+    content_type?: string;
+    size_bytes?: number;
+  }) {
+    const { data } = await apiClient.post(`${BASE}/submodules/${submoduleId}/attachment/`, payload);
+    return data as {
+      id: number; title: string; kind: string; original_name: string;
+      size_bytes: number; url: string | null;
+    };
+  },
+
+  /**
+   * One route for all five content types. The alternative was reaching into the coding service
    * for one delete and the quiz service for another, with nothing for articles or videos.
    */
   async updateContent(
     submoduleId: number,
-    kind: "article" | "quiz" | "coding" | "video",
+    kind: "article" | "quiz" | "coding" | "video" | "attachment",
     contentId: number,
     payload: { title?: string; body?: string; summary?: string; instructions?: string; is_active?: boolean; reading_tier?: string }
   ) {
@@ -725,7 +763,7 @@ export const adminAdaptiveCourseService = {
   /** Soft where the model allows it, so a student mid-attempt does not hit a 500. */
   async deleteContent(
     submoduleId: number,
-    kind: "article" | "quiz" | "coding" | "video",
+    kind: "article" | "quiz" | "coding" | "video" | "attachment",
     contentId: number
   ) {
     const { data } = await apiClient.delete(

--- a/lib/services/file-upload.service.ts
+++ b/lib/services/file-upload.service.ts
@@ -7,6 +7,9 @@ export type FileUploadModule =
   | "profile_avatar"
   | "job_application"
   | "certificate"
+  /** Course handouts — slide decks, worksheets, specs. Its own 50MB cap and an Office-file
+   *  allowlist server-side, because the platform's 10MB default rejects an ordinary PowerPoint. */
+  | "course_attachment"
   | "other";
 
 /** Tier folder for assessment certificate assets (backend maps to S3 path). */

--- a/lib/utils/attachment-display.test.ts
+++ b/lib/utils/attachment-display.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  ATTACHMENT_ACCEPT,
+  ATTACHMENT_MAX_MB,
+  attachmentLook,
+  formatFileSize,
+} from "./attachment-display";
+
+describe("attachmentLook", () => {
+  it("uses the kind the server derived", () => {
+    expect(attachmentLook({ kind: "slides" }).label).toBe("Slides");
+    expect(attachmentLook({ kind: "pdf" }).label).toBe("PDF");
+  });
+
+  it("falls back to the extension when the server sent no kind", () => {
+    expect(attachmentLook({ extension: "pptx" }).label).toBe("Slides");
+    expect(attachmentLook({ extension: ".docx" }).label).toBe("Document");
+  });
+
+  it("falls back to the filename when there is neither", () => {
+    expect(attachmentLook({ original_name: "week-3-notes.pdf" }).label).toBe("PDF");
+  });
+
+  it("never returns undefined for an unknown type", () => {
+    // A row that cannot be rendered is worse than a generic icon: the whole handout list
+    // would throw on one odd file.
+    const look = attachmentLook({ kind: "hologram", extension: "zzz" });
+    expect(look.icon).toBeTruthy();
+    expect(look.accent).toBeTruthy();
+    expect(look.label).toBe("File");
+  });
+
+  it("survives an entirely empty row", () => {
+    expect(attachmentLook({}).label).toBe("File");
+  });
+
+  it("is case-insensitive about extensions", () => {
+    expect(attachmentLook({ original_name: "DECK.PPTX" }).label).toBe("Slides");
+  });
+});
+
+describe("formatFileSize", () => {
+  it("says nothing rather than '0 B' when the size is unknown", () => {
+    // Servers omit size_bytes on older rows; "0 B" would read as an empty file.
+    expect(formatFileSize(undefined)).toBe("");
+    expect(formatFileSize(0)).toBe("");
+  });
+
+  it("scales through B, KB and MB", () => {
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(2048)).toBe("2 KB");
+    expect(formatFileSize(1.5 * 1024 * 1024)).toBe("1.5 MB");
+  });
+
+  it("drops the decimal above 10MB", () => {
+    expect(formatFileSize(14.2 * 1024 * 1024)).toBe("14 MB");
+  });
+});
+
+describe("the upload contract", () => {
+  it("advertises exactly the extensions the server allows", () => {
+    // Drifting from the server list means either a picker that offers files it will reject,
+    // or one that hides files it would have taken.
+    expect(ATTACHMENT_ACCEPT.split(",").sort()).toEqual(
+      [
+        ".pdf", ".ppt", ".pptx", ".doc", ".docx", ".xls", ".xlsx",
+        ".txt", ".csv", ".png", ".jpg", ".jpeg",
+      ].sort(),
+    );
+  });
+
+  it("matches the server's course-attachment cap", () => {
+    expect(ATTACHMENT_MAX_MB).toBe(50);
+  });
+});

--- a/lib/utils/attachment-display.ts
+++ b/lib/utils/attachment-display.ts
@@ -1,0 +1,74 @@
+/**
+ * Presentation for course handouts, shared by the admin builder and the learner topic page.
+ *
+ * Shared on purpose: a deck that shows as an orange slide icon to the admin who uploaded it and
+ * a generic grey page to the student reading it is the same file described two ways, and the
+ * mismatch reads as a broken upload.
+ */
+
+export interface AttachmentLike {
+  kind?: string;
+  extension?: string;
+  original_name?: string;
+  size_bytes?: number;
+}
+
+export interface AttachmentLook {
+  icon: string;
+  accent: string;
+  /** What this file IS, in a word a student recognises — not the MIME type. */
+  label: string;
+}
+
+const LOOKS: Record<string, AttachmentLook> = {
+  pdf: { icon: "mdi:file-pdf-box", accent: "#ef4444", label: "PDF" },
+  slides: { icon: "mdi:file-presentation-box", accent: "#f97316", label: "Slides" },
+  doc: { icon: "mdi:file-word-outline", accent: "#3b82f6", label: "Document" },
+  sheet: { icon: "mdi:file-excel-outline", accent: "#10b981", label: "Spreadsheet" },
+  image: { icon: "mdi:file-image-outline", accent: "#a855f7", label: "Image" },
+  file: { icon: "mdi:file-outline", accent: "#64748b", label: "File" },
+};
+
+/** Extension fallback for rows written before the server derived `kind`, or if it ever sends
+ *  one this table does not know. Never returns undefined — an unrenderable row is worse than a
+ *  generic icon. */
+const BY_EXTENSION: Record<string, string> = {
+  pdf: "pdf",
+  ppt: "slides",
+  pptx: "slides",
+  doc: "doc",
+  docx: "doc",
+  txt: "doc",
+  xls: "sheet",
+  xlsx: "sheet",
+  csv: "sheet",
+  png: "image",
+  jpg: "image",
+  jpeg: "image",
+};
+
+export function attachmentLook(a: AttachmentLike): AttachmentLook {
+  const byKind = a.kind ? LOOKS[a.kind] : undefined;
+  if (byKind) return byKind;
+  const ext = (a.extension || a.original_name?.split(".").pop() || "").toLowerCase().replace(".", "");
+  return LOOKS[BY_EXTENSION[ext] ?? "file"];
+}
+
+/** Bytes as something a human reads before deciding to download on mobile data. */
+export function formatFileSize(bytes?: number): string {
+  if (!bytes || bytes <= 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  // One decimal under 10MB, none above: "1.4 MB" is useful, "14.2 MB" is noise.
+  return mb < 10 ? `${mb.toFixed(1)} MB` : `${Math.round(mb)} MB`;
+}
+
+/** Extensions the server accepts, in the one place the file picker and the help text both read. */
+export const ATTACHMENT_ACCEPT =
+  ".pdf,.ppt,.pptx,.doc,.docx,.xls,.xlsx,.txt,.csv,.png,.jpg,.jpeg";
+
+/** Server-side cap for `module=course_attachment`. Checked client-side too so a learner on a
+ *  slow connection is not made to upload 80MB before being told no. */
+export const ATTACHMENT_MAX_MB = 50;

--- a/proxy.test.ts
+++ b/proxy.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Instructor route confinement.
+ *
+ * Mirrors `instructorBlocked` in proxy.ts. Duplicated rather than imported because proxy.ts pulls
+ * in `next/server`, which needs a request context these tests have no reason to build — and the
+ * thing worth protecting is the RULE, which is a string predicate.
+ *
+ * If you change the rule in proxy.ts, change it here. A drift shows up as a test that passes
+ * while the guard does something else, so keep the two literally identical.
+ */
+const INSTRUCTOR_BLOCKED_PREFIXES = [
+  "/dashboard",
+  "/admin",
+  "/adaptive-courses",
+  "/adaptive-quizzes",
+  "/assessments",
+  "/community",
+  "/courses",
+  "/jobs",
+  "/jobs-v2",
+  "/leaderboard-streaks",
+  "/live-sessions",
+  "/mock-interview",
+  "/points-system",
+  "/proctoring-demo",
+  "/resume",
+];
+
+const INSTRUCTOR_ALLOWED_ADMIN_PATH = /^\/admin\/adaptive-courses\/\d+(\/|$)/;
+
+function instructorBlocked(pathname: string): boolean {
+  if (INSTRUCTOR_ALLOWED_ADMIN_PATH.test(pathname)) return false;
+  return (
+    pathname === "/" ||
+    INSTRUCTOR_BLOCKED_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+  );
+}
+
+describe("the builder is reachable", () => {
+  it("lets an instructor open one course's builder", () => {
+    // Without this the feature has no door: "Build a course" creates the course and bounces its
+    // author to the dashboard.
+    expect(instructorBlocked("/admin/adaptive-courses/56")).toBe(false);
+    expect(instructorBlocked("/admin/adaptive-courses/56/")).toBe(false);
+  });
+
+  it("allows sub-paths of one course", () => {
+    expect(instructorBlocked("/admin/adaptive-courses/56/settings")).toBe(false);
+  });
+});
+
+describe("and nothing else opened with it", () => {
+  it("still blocks the course hub", () => {
+    // The hub lists every course in the tenant.
+    expect(instructorBlocked("/admin/adaptive-courses")).toBe(true);
+    expect(instructorBlocked("/admin/adaptive-courses/")).toBe(true);
+  });
+
+  it("still blocks the rest of the admin area", () => {
+    for (const p of [
+      "/admin",
+      "/admin/students",
+      "/admin/tickets",
+      "/admin/instructors",
+      "/admin/assessments",
+      "/admin/adaptive-coursesX/1",
+    ]) {
+      expect(instructorBlocked(p), p).toBe(true);
+    }
+  });
+
+  it("is not fooled by a non-numeric id", () => {
+    // `/admin/adaptive-courses/new` is not one course; it must not open the whole prefix.
+    expect(instructorBlocked("/admin/adaptive-courses/new")).toBe(true);
+    expect(instructorBlocked("/admin/adaptive-courses/generate")).toBe(true);
+  });
+
+  it("is not fooled by a path that merely starts with a digit", () => {
+    expect(instructorBlocked("/admin/adaptive-courses/56abc")).toBe(true);
+  });
+
+  it("still blocks the student learner view", () => {
+    for (const p of ["/", "/dashboard", "/adaptive-courses/12", "/community", "/resume"]) {
+      expect(instructorBlocked(p), p).toBe(true);
+    }
+  });
+
+  it("leaves the instructor's own space alone", () => {
+    for (const p of ["/instructor/dashboard", "/instructor/courses", "/instructor/courses/56"]) {
+      expect(instructorBlocked(p), p).toBe(false);
+    }
+  });
+});

--- a/proxy.ts
+++ b/proxy.ts
@@ -26,7 +26,27 @@ function normalizeRole(role?: string): string {
   return (role || "").trim().toLowerCase().replace(/\s+/g, "_");
 }
 
+/**
+ * The adaptive course BUILDER for one course, e.g. `/admin/adaptive-courses/56`.
+ *
+ * Instructors build their own courses here — it is the only page that can add a week, a topic or
+ * a piece of content, and there is no instructor-side equivalent. Without this hole the feature
+ * has no door: "Build a course" creates the course and then bounces its author to the dashboard,
+ * and the card that says "yours to build" leads nowhere.
+ *
+ * Deliberately NOT `/admin/adaptive-courses` itself — the hub lists every course in the tenant and
+ * stays blocked. One course, by id, and nothing else under /admin.
+ *
+ * Safe to open because the server now answers the question this rule used to stand in for. When
+ * this confinement was written the authoring API had no object-level check at all, so a blunt
+ * path block was the only guard. It now refuses to read or write a course you neither authored
+ * nor were assigned to, per object, with tests. An instructor typing another course's id gets a
+ * 403 from the API and an error state on the page, not somebody else's course.
+ */
+const INSTRUCTOR_ALLOWED_ADMIN_PATH = /^\/admin\/adaptive-courses\/\d+(\/|$)/;
+
 function instructorBlocked(pathname: string): boolean {
+  if (INSTRUCTOR_ALLOWED_ADMIN_PATH.test(pathname)) return false;
   return (
     pathname === "/" ||
     INSTRUCTOR_BLOCKED_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))


### PR DESCRIPTION
…o main (#1281)

* Adaptive builder: handouts, instructor course authoring, and the assessment-style redesign (#1279)

* feat(adaptive): handouts you can actually upload

The backend for course attachments shipped — model, route, tenant-scoped signing, size cap, Office-file allowlist — and none of it was reachable. There was no button. The admin service still only knew article/quiz/coding/video, so the feature existed and could not be used.

Admin: a Handout tab on Add content. Two calls, on purpose — the shared media endpoint owns the size cap and the type allowlist, then the course route records which object belongs to the topic. It sends the S3 key, never the URL: a stored presigned URL would leave every handout on the course dead about a week later. The size is checked client-side too, because making someone push 80MB up a hotel connection before being told no is the same rejection, ten minutes later.

Student: a Handouts section on the topic, deliberately OUTSIDE the numbered learning path. There is nothing to complete and no points to earn, so numbering them as steps would inflate "N steps" and point the resume button at a download. A topic can now hold handouts and no path at all, which is why the empty state had to learn to check for them — "no content in this topic yet" over a list of downloadable material is a lie.

Icon, colour, type label and size formatting are shared between the two surfaces. A deck that shows as an orange slide icon to the admin who uploaded it and a generic grey page to the student reading it is the same file described two ways, and the mismatch reads as a broken upload.

The suggestions rail still scores four content types, not five: a topic is not incomplete for lacking a handout.



* fix(instructor): stop offering buttons the server will refuse

The builder rendered its actions from course STATE, which is identical for everyone looking at it, so the viewer's role never entered into it. The audit found five places where that produced a control the server then 403s.

- The review banner showed **Approve** and **Send back** to the instructor who submitted the course. Reviewing is an admin act — an instructor approving their own work is not a review — so they clicked Approve and got an error they could do nothing about. The banner's own comment said the server decides who may do this; now the button agrees.
- The hub tray told instructors that colleagues' courses, and their own submission, were "waiting for your review".
- A green **Publish** primary on every card, including for people who cannot publish anything.
- A **delete** icon on every card. An author may bin their own course up to approval, after which it may have students on it; anyone else's is not theirs to delete.
- The instructor-assignment panel, whose endpoints are admin-only, rendered to instructors — a staff list they could look at and not change.

Authorship is matched on email, not id: the auth user carries a User id and `authored_by` carries a UserProfile id, and comparing those would be wrong about as often as it was right.

Separately, twelve instructor screens rendered failures as `e.message`, which for an Axios error is the string "Request failed with status code 403". They now read DRF's `detail`, so the server's actual sentence — "This course is not yours to edit." — reaches the person who needs it.



---------



* fix(instructor): the card said "yours to build" and opened a student roster (#1280)

An instructor creates a course, lands back on Course Content, and the card tells them "Yours to build. Send it for review when it is ready." Clicking it opened the STUDENT ROSTER — a list of the zero people enrolled in a course with no content — and there was no route from there to a single Add-content button. The instruction had no verb attached to it.

Both card types went to the same place. A course you BUILT now opens the builder; a course you were assigned to teach still opens its roster, which is the right destination for that one.

The cards were also all clickable and none of them were labelled, so "build your course" and "see who is on it" looked identical. Each now says which it is.

The roster page carries a builder link too, for anyone who arrives by an old link or a deep link — offered only for a course they authored, because being assigned to teach a course does not carry the right to rewrite it and the server says so.

The draft hint names the destination instead of describing a button on a page it never took you to.

The API was never the problem: a new end-to-end test drives create → week → topic → article → submit → approve → publish across both people and passes unchanged. That is the point — every endpoint worked, and nothing could reach them.



* fix(instructor): the builder was behind a door instructors could not open

`/admin` is in the instructor route-confinement list, so `proxy.ts` server-side redirects them to their dashboard. The builder for one course lives at `/admin/adaptive-courses/<id>`, and it is the only page anywhere that can add a week, a topic or a piece of content.

So the feature had no door. "Build a course" created the course and bounced its author to the dashboard; the card that said "yours to build" led to the same place. Every endpoint behind it worked — an end-to-end backend test drives the whole journey and passes — and nothing could reach them.

One course, by id, is now allowed through. Deliberately not `/admin/adaptive-courses` itself: the hub lists every course in the tenant and stays blocked, as does the rest of /admin.

This is safe to open now in a way it was not before. When the confinement was written the authoring API had no object-level check at all, so a blunt path block was the only guard standing between an instructor and the tenant's whole course tree. It now refuses, per object and with tests, to read or write a course you neither authored nor were assigned to. An instructor typing another course's id gets a 403 from the API and an error state, not somebody else's course.

8 tests on the rule itself, including the ones that matter: the hub stays blocked, a non-numeric segment does not open the prefix, and `/admin/adaptive-courses/56abc` is not one course.



---------