### PR TITLE
Promote: pasted videos play, and Publish is not offered where the server refuses

### DIFF
--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -549,7 +549,15 @@ function CourseCard({
 }) {
   // Publishing is an admin act in every case — approval says the content is sound, putting it in
   // front of students is a separate decision and it belongs to the institution.
-  const canPublish = isReviewer;
+  // Publishing an instructor-authored course that has not been approved is refused by the server
+  // with a 409 — the review gate holds. The BUTTON was offered anyway, so an admin got a green
+  // Publish on a course with 0 weeks and 0 topics and an error when they pressed it. Unpublishing
+  // stays available in every state: taking something down must never be blocked.
+  const awaitingReview =
+    course.instructor_review_status === "draft" ||
+    course.instructor_review_status === "pending_review" ||
+    course.instructor_review_status === "rejected";
+  const canPublish = isReviewer && (course.is_published || !awaitingReview);
   const authoredByViewer =
     !!course.authored_by?.email &&
     !!viewerEmail &&

--- a/components/adaptive-video/VideoCompanion.tsx
+++ b/components/adaptive-video/VideoCompanion.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Tab, Tabs, Typography, CircularProgress, Tooltip } from "@mui/material";
+import { Box, ButtonBase, Tab, Tabs, Typography, CircularProgress, Tooltip } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -20,6 +20,7 @@ import { ConceptMap } from "./ConceptMap";
 import { TimestampQA } from "./TimestampQA";
 import { CompanionCard } from "./CompanionCard";
 import { WatchModeSelector, AutoChapters, LiveTakeaways } from "./RailPanels";
+import { toEmbedUrl } from "@/lib/utils/video-embed";
 
 const fmt = (s: number) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
 const TABS: { label: string; icon: string }[] = [
@@ -52,6 +53,8 @@ export function VideoCompanion({ configId }: { configId: number }) {
   // timeline markers, so they update the instant an answer lands (a ref wouldn't
   // re-render). shownRef stays a ref: it only gates the auto-pause effect.
   const [answered, setAnswered] = useState<Set<number>>(new Set());
+  // Externally-hosted videos report nothing back, so the student says when they are done.
+  const [markedWatched, setMarkedWatched] = useState(false);
   const shownRef = useRef<Set<number>>(new Set());
 
   // Destructure the controller into stable locals - passing `setIframe` to a ref taints the
@@ -259,16 +262,24 @@ export function VideoCompanion({ configId }: { configId: number }) {
         <Typography sx={{ mt: 2, color: "text.secondary", fontSize: "0.85rem" }}>Warming up your companion…</Typography>
       </Box>
     );
-  if (!companion.video)
+  // `play_url` is the field to gate on, NOT `video`. Only CATALOG videos have a Vimeo record;
+  // a pasted link has `video: null` and its URL in play_url. Checking `video` told every student
+  // who reached an admin's pasted video that no video was attached — while the link sat in the
+  // payload, and in the admin's builder, plainly attached.
+  const playUrl = companion.play_url || companion.video?.embed_url || "";
+  const isExternal = companion.source === "external" || (!companion.video && !!companion.play_url);
+  if (!playUrl)
     return (
       <CompanionCard accent="#6366f1" sx={{ textAlign: "center", py: 5 }}>
         <Typography sx={{ color: "text.secondary" }}>No video is attached to this companion yet.</Typography>
       </CompanionCard>
     );
 
-  const embed = `${companion.video.embed_url}?api=1&title=0&byline=0&portrait=0`;
+  // A watch URL cannot be framed; the id has to be moved into the provider's embed form.
+  const embed = toEmbedUrl(playUrl, companion.source);
   // Video/module names often arrive snake_cased (e.g. "Module_01_Java_Fundamentals…"); show them humanized.
-  const displayTitle = (companion.video.title || companion.title || "").replace(/_/g, " ").trim();
+  // Falls back to the companion's own title, which is all a pasted link has.
+  const displayTitle = (companion.video?.title || companion.title || "").replace(/_/g, " ").trim();
   const watchedConcepts = companion.concept_map?.nodes?.filter((n) => currentTime >= (n.timestamp_seconds ?? 0)).length ?? 0;
 
   return (
@@ -335,6 +346,48 @@ export function VideoCompanion({ configId }: { configId: number }) {
               />
             )}
           </Box>
+
+          {/* An externally-hosted video is a plain iframe: no transcript, so no check-ins, and no
+              player API, so nothing reports back how much was watched. Coverage stays at 0 no
+              matter how long the student sits there, and the watch would score nothing.
+
+              Rather than let that look like a bug, say what is true and give them the one action
+              that matters. The server treats scoring as idempotent and monotonic, so pressing
+              this after some coverage has accrued can only ever raise the award. */}
+          {isExternal && (
+            <Box
+              sx={{
+                mt: 2, mb: 1, p: 1.5, borderRadius: 2.5, display: "flex", alignItems: "center",
+                gap: 1.5, flexWrap: "wrap",
+                border: "1px solid color-mix(in srgb, #6366f1 28%, transparent)",
+                bgcolor: "color-mix(in srgb, #6366f1 5%, transparent)",
+              }}
+            >
+              <Icon icon="mdi:information-outline" width={18} style={{ color: "#6366f1" }} />
+              <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", flex: 1, minWidth: 220 }}>
+                This video is hosted elsewhere, so there are no comprehension check-ins and it
+                can&apos;t track your progress automatically.
+              </Typography>
+              <ButtonBase
+                onClick={() => {
+                  if (markedWatched) return;
+                  coverageRef.current = 100;
+                  setMarkedWatched(true);
+                  endRef.current();
+                }}
+                disabled={markedWatched}
+                sx={{
+                  px: 2, py: 0.9, borderRadius: 999, fontWeight: 800, fontSize: "0.8rem", gap: 0.6,
+                  color: "#fff", background: markedWatched
+                    ? "linear-gradient(135deg, #10b981, #059669)"
+                    : "linear-gradient(135deg, #6366f1, #a855f7)",
+                }}
+              >
+                <Icon icon={markedWatched ? "mdi:check-circle" : "mdi:check"} width={16} />
+                {markedWatched ? "Marked as watched" : "I've finished watching"}
+              </ButtonBase>
+            </Box>
+          )}
 
           {/* Companion timeline strip - check-in markers (spec §3.2b) */}
           <Box sx={{ position: "relative", height: 8, mt: 2, mb: 1, borderRadius: 999,

--- a/components/adaptive-video/admin/MatchedVideoReview.tsx
+++ b/components/adaptive-video/admin/MatchedVideoReview.tsx
@@ -9,6 +9,7 @@ import {
   type VideoCompanion,
 } from "@/lib/services/adaptive-video.service";
 import type { AdminAdaptiveCourseVideoCompanion } from "@/lib/services/admin/admin-adaptive-course.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 const fmt = (s: number) => `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
 
@@ -66,7 +67,11 @@ export function MatchedVideoReview({
       setPreview(null); // scaffolds/video may have changed - refetch on next open
       onChanged?.();
     } catch (e) {
-      setNote(e instanceof Error ? e.message : "Something went wrong.");
+      // DRF's `detail`, not the Axios string. The server distinguishes "this video cannot
+      // work" (400, e.g. no transcript, so no check-ins can be built) from "come back later"
+      // (502) and says which in words — all of which "Request failed with status code 400"
+      // threw away, leaving an admin staring at a number.
+      setNote(getAxiosErrorDetail(e, "Something went wrong."));
     } finally {
       setBusy(null);
     }

--- a/lib/services/adaptive-video.service.ts
+++ b/lib/services/adaptive-video.service.ts
@@ -62,7 +62,13 @@ export interface VideoCompanion {
   instructions: string;
   /** AI-generated learner-facing summary, derived from the transcript (cached server-side). */
   description: string;
+  /** Null for a pasted link — only catalog videos have a Vimeo record behind them. Use
+   *  `play_url` to decide whether there is anything to play; this is metadata, not the source. */
   video: VimeoVideoWire | null;
+  /** The one field the player can always read: a catalog embed URL, or the pasted link. */
+  play_url?: string;
+  /** `catalog` (has a transcript, so check-ins exist) · `external` (pasted) · `none`. */
+  source?: "catalog" | "external" | "none";
   concept_map: ConceptMap;
   chapters: Chapter[];
   takeaways: string[];

--- a/lib/utils/video-embed.test.ts
+++ b/lib/utils/video-embed.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { supportsCheckIns, toEmbedUrl } from "./video-embed";
+
+describe("pasted YouTube links", () => {
+  it("converts a watch URL, which cannot be framed", () => {
+    // This is what a person copies out of the address bar, and what the builder stores.
+    expect(toEmbedUrl("https://www.youtube.com/watch?v=ApSbjuVHAR8", "external")).toContain(
+      "youtube.com/embed/ApSbjuVHAR8",
+    );
+  });
+
+  it("handles a missing scheme", () => {
+    expect(toEmbedUrl("www.youtube.com/watch?v=ApSbjuVHAR8", "external")).toContain(
+      "youtube.com/embed/ApSbjuVHAR8",
+    );
+  });
+
+  it("handles youtu.be short links", () => {
+    expect(toEmbedUrl("https://youtu.be/ApSbjuVHAR8", "external")).toContain(
+      "youtube.com/embed/ApSbjuVHAR8",
+    );
+  });
+
+  it("handles shorts and live", () => {
+    expect(toEmbedUrl("https://www.youtube.com/shorts/abc123", "external")).toContain(
+      "/embed/abc123",
+    );
+    expect(toEmbedUrl("https://www.youtube.com/live/abc123", "external")).toContain(
+      "/embed/abc123",
+    );
+  });
+
+  it("keeps a start timestamp", () => {
+    expect(toEmbedUrl("https://www.youtube.com/watch?v=X&t=90", "external")).toContain("start=90");
+  });
+
+  it("leaves an already-embeddable URL alone", () => {
+    expect(toEmbedUrl("https://www.youtube.com/embed/ApSbjuVHAR8", "external")).toContain(
+      "/embed/ApSbjuVHAR8",
+    );
+  });
+});
+
+describe("pasted Vimeo links", () => {
+  it("converts a plain vimeo.com link", () => {
+    expect(toEmbedUrl("https://vimeo.com/920338266", "external")).toContain(
+      "player.vimeo.com/video/920338266",
+    );
+  });
+
+  it("keeps the unlisted hash", () => {
+    expect(toEmbedUrl("https://vimeo.com/920338266/abc123", "external")).toContain("h=abc123");
+  });
+
+  it("leaves a player.vimeo.com URL alone", () => {
+    const out = toEmbedUrl("https://player.vimeo.com/video/920338266", "external");
+    expect(out).toContain("player.vimeo.com/video/920338266");
+  });
+});
+
+describe("everything else", () => {
+  it("passes an unrecognised URL through", () => {
+    // A direct file, or a provider we do not know. Guessing would break the case that worked.
+    const mp4 = "https://cdn.example.com/lesson.mp4";
+    expect(toEmbedUrl(mp4, "external")).toBe(mp4);
+  });
+
+  it("returns empty for nothing", () => {
+    expect(toEmbedUrl("", "external")).toBe("");
+    expect(toEmbedUrl("   ", "none")).toBe("");
+  });
+
+  it("does not throw on junk", () => {
+    expect(() => toEmbedUrl("not a url at all", "external")).not.toThrow();
+  });
+
+  it("adds the Vimeo player options to a catalog URL", () => {
+    expect(toEmbedUrl("https://player.vimeo.com/video/1", "catalog")).toContain("title=0");
+  });
+});
+
+describe("check-ins", () => {
+  it("are only possible for catalog videos", () => {
+    // They are built from a transcript, and a pasted link has none.
+    expect(supportsCheckIns("catalog")).toBe(true);
+    expect(supportsCheckIns("external")).toBe(false);
+    expect(supportsCheckIns(undefined)).toBe(false);
+  });
+});

--- a/lib/utils/video-embed.ts
+++ b/lib/utils/video-embed.ts
@@ -1,0 +1,76 @@
+/**
+ * Turn whatever an admin pasted into something an `<iframe>` can actually play.
+ *
+ * The builder stores the pasted URL verbatim, which is right — it is what they typed and what
+ * they will recognise later. But the URL a person copies out of their address bar is almost never
+ * embeddable: `youtube.com/watch?v=X` refuses to render in a frame, and so does `vimeo.com/N`.
+ * Both have an embed form, and the id is sitting in the URL either way.
+ *
+ * Anything unrecognised is passed through untouched. A direct .mp4 or an already-embeddable URL
+ * works as-is, and guessing at a provider we do not know would break the one case that was fine.
+ */
+
+/** `?v=` or the /embed//shorts//live/ path forms, plus the youtu.be short domain. */
+const YOUTUBE_HOSTS = ["youtube.com", "www.youtube.com", "m.youtube.com", "music.youtube.com"];
+
+function youtubeId(u: URL): string | null {
+  if (u.hostname === "youtu.be") return u.pathname.slice(1).split("/")[0] || null;
+  if (!YOUTUBE_HOSTS.includes(u.hostname)) return null;
+  const v = u.searchParams.get("v");
+  if (v) return v;
+  const m = u.pathname.match(/^\/(?:embed|shorts|live|v)\/([^/?#]+)/);
+  return m ? m[1] : null;
+}
+
+function vimeoId(u: URL): string | null {
+  if (u.hostname === "player.vimeo.com") return null; // already embeddable
+  if (!["vimeo.com", "www.vimeo.com"].includes(u.hostname)) return null;
+  // vimeo.com/123456789 and vimeo.com/123456789/abcdef (unlisted hash)
+  const m = u.pathname.match(/^\/(\d+)(?:\/([0-9a-zA-Z]+))?/);
+  if (!m) return null;
+  return m[2] ? `${m[1]}?h=${m[2]}` : m[1];
+}
+
+/**
+ * @param playUrl the server's `play_url` — a Vimeo embed URL for catalog videos, or the pasted
+ *                link for external ones.
+ * @param source  `"catalog" | "external" | "none"`; catalog URLs are already embeddable.
+ */
+export function toEmbedUrl(playUrl: string, source?: string): string {
+  const raw = (playUrl || "").trim();
+  if (!raw) return "";
+  // The catalog builds its own embed URL, and the Vimeo player options below belong to it.
+  if (source === "catalog") return withVimeoOptions(raw);
+
+  let u: URL;
+  try {
+    // Someone pasting an address bar often drops the scheme.
+    u = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`);
+  } catch {
+    return raw;
+  }
+
+  const yt = youtubeId(u);
+  if (yt) {
+    const start = u.searchParams.get("t") || u.searchParams.get("start");
+    const seconds = start ? String(parseInt(start, 10) || 0) : "";
+    // `rel=0` keeps the end-screen suggestions inside the same channel — a wall of unrelated
+    // recommendations on top of a lesson is not what anyone attached this for.
+    return `https://www.youtube.com/embed/${yt}?rel=0&modestbranding=1${seconds ? `&start=${seconds}` : ""}`;
+  }
+
+  const vm = vimeoId(u);
+  if (vm) return withVimeoOptions(`https://player.vimeo.com/video/${vm}`);
+
+  return u.toString();
+}
+
+function withVimeoOptions(url: string): string {
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}api=1&title=0&byline=0&portrait=0`;
+}
+
+/** Whether check-ins can exist for this video at all — they are built from a transcript. */
+export function supportsCheckIns(source?: string): boolean {
+  return source === "catalog";
+}


### PR DESCRIPTION
One commit, already merged to `stagging` and verified there.

## A pasted video played nowhere

The player gated on `companion.video` — the **Vimeo** record — and only catalog videos have one.
A pasted link carries its URL in `play_url` with `video: null`, so every student who opened an
admin's pasted video was told *"No video is attached to this companion yet"*, while the link sat
in the payload and in the admin's builder, plainly attached.

Three defects stacked here, and fixing only the first would still have shown a blank frame:

1. **Wrong gate** — now reads `play_url`, which the API has always sent for this purpose.
2. **Not embeddable** — `youtube.com/watch?v=X` refuses to render in an iframe. The id is moved
   into the provider's embed form (watch, `youtu.be`, shorts, live, Vimeo's unlisted `/hash`).
   Anything unrecognised passes through untouched.
3. **Could never complete** — coverage accrues from Vimeo's timeupdates and the award fires on its
   `ended` event. A plain iframe reports neither, so a student could watch the whole thing and
   register 0%: no points, and the topic never advances. The surface now says what is true and
   offers the one action that matters; server-side scoring is idempotent and monotonic, so it can
   only raise an award.

## Publish, on a course the server refuses

An unapproved instructor-authored course is refused with a 409 — the review gate holds — but the
green button was offered anyway, on a course with 0 weeks and 0 topics.

## "Request failed with status code 400"

The regenerate endpoint distinguishes *"this video cannot work"* (no transcript, so no check-ins)
from *"come back later"*, and says which in words. The admin surface printed the status line.

---

**Tests:** 14 on the URL normaliser, 75 green overall, `tsc` and `next build` clean.

Opened so production does not sit behind stagging — that gap is what left an instructor's card
routing somewhere `proxy.ts` bounced them from earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)