### PR TITLE
Promote: pasted OneDrive / Drive / Dropbox / Loom links now embed

### DIFF
--- a/components/admin/adaptive-course/AddContentDialog.tsx
+++ b/components/admin/adaptive-course/AddContentDialog.tsx
@@ -43,6 +43,7 @@ import {
   attachmentLook,
   formatFileSize,
 } from "@/lib/utils/attachment-display";
+import { embedCaveat } from "@/lib/utils/video-embed";
 
 /* ------------------------------------------------------------------ palette */
 
@@ -724,6 +725,8 @@ export function AddContentDialog({
     codingMode === "bank" ? pickedProblems.size > 0 : completeProblemDrafts > 0;
   const videoReady =
     videoMode === "catalog" ? pickedVimeo !== null : videoUrl.trim().length > 0;
+  // Recomputed as they type; null for a link with no known caveat.
+  const videoCaveat = videoMode === "link" ? embedCaveat(videoUrl) : null;
 
   const primary: { label: string; ready: boolean; run: () => void } = [
     { label: "Add article", ready: articleReady, run: () => void submitArticle() },
@@ -1609,6 +1612,16 @@ export function AddContentDialog({
                     value={videoTitle}
                     onChange={(e) => setVideoTitle(e.target.value)}
                   />
+                  {/* Said at paste time, while changing the link still costs nothing. A
+                      OneDrive or Drive file shared with the organisation plays perfectly for the
+                      admin who pasted it — they are already signed in — and shows every student
+                      a sign-in wall. A bug that works for whoever set it up is the worst kind to
+                      ship, so the builder names it before the course goes anywhere. */}
+                  {videoCaveat && (
+                    <Alert severity="warning" sx={{ py: 0.5 }}>
+                      {videoCaveat}
+                    </Alert>
+                  )}
                   <Typography sx={{ fontSize: "0.75rem", color: "var(--font-secondary)" }}>
                     A pasted link has no transcript, so check-ins usually cannot be built. Catalog
                     videos are the richer option where one exists.

--- a/lib/utils/video-embed.test.ts
+++ b/lib/utils/video-embed.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { supportsCheckIns, toEmbedUrl } from "./video-embed";
+import { embedCaveat, supportsCheckIns, toEmbedUrl } from "./video-embed";
 
 describe("pasted YouTube links", () => {
   it("converts a watch URL, which cannot be framed", () => {
@@ -85,5 +85,61 @@ describe("check-ins", () => {
     expect(supportsCheckIns("catalog")).toBe(true);
     expect(supportsCheckIns("external")).toBe(false);
     expect(supportsCheckIns(undefined)).toBe(false);
+  });
+});
+
+describe("SharePoint / OneDrive", () => {
+  const SHARE =
+    "https://tisteps-my.sharepoint.com/:v:/g/personal/prashanth_g_impacteers_com/IQD8kok0pWTsTJ3H?nav=eyJhIjoxfQ&e=ooXP81";
+
+  it("asks for the embeddable player instead of the viewer page", () => {
+    // The share link is a web viewer that sends frame-ancestors, so a browser refuses to frame
+    // it at all — "refused to connect", with nothing the page can catch.
+    expect(toEmbedUrl(SHARE, "external")).toContain("action=embedview");
+  });
+
+  it("keeps the sharing token, which is what authorises the file", () => {
+    const out = toEmbedUrl(SHARE, "external");
+    expect(out).toContain("e=ooXP81");
+    expect(out).toContain("IQD8kok0pWTsTJ3H");
+  });
+
+  it("does not stack a second action param", () => {
+    const already = `${SHARE}&action=embedview`;
+    expect(toEmbedUrl(already, "external").match(/action=embedview/g)).toHaveLength(1);
+  });
+
+  it("warns that conversion does not grant access", () => {
+    // The bug that works for whoever set it up is the worst kind to ship.
+    expect(embedCaveat(SHARE)).toMatch(/Anyone with the link/i);
+  });
+});
+
+describe("other common paste sources", () => {
+  it("converts a Google Drive viewer link to /preview", () => {
+    expect(toEmbedUrl("https://drive.google.com/file/d/ABC123/view?usp=sharing", "external")).toBe(
+      "https://drive.google.com/file/d/ABC123/preview",
+    );
+  });
+
+  it("converts a Loom share link", () => {
+    expect(toEmbedUrl("https://www.loom.com/share/abc123", "external")).toBe(
+      "https://www.loom.com/embed/abc123",
+    );
+  });
+
+  it("turns a Dropbox preview into the file itself", () => {
+    const out = toEmbedUrl("https://www.dropbox.com/s/x/lesson.mp4?dl=0", "external");
+    expect(out).toContain("raw=1");
+    expect(out).not.toContain("dl=0");
+  });
+
+  it("warns about Zoom recordings, which cannot be embedded at all", () => {
+    expect(embedCaveat("https://us02web.zoom.us/rec/share/abc")).toMatch(/passcode|catalog/i);
+  });
+
+  it("says nothing about a link with no known caveat", () => {
+    expect(embedCaveat("https://www.youtube.com/watch?v=X")).toBeNull();
+    expect(embedCaveat("")).toBeNull();
   });
 });

--- a/lib/utils/video-embed.ts
+++ b/lib/utils/video-embed.ts
@@ -62,7 +62,82 @@ export function toEmbedUrl(playUrl: string, source?: string): string {
   const vm = vimeoId(u);
   if (vm) return withVimeoOptions(`https://player.vimeo.com/video/${vm}`);
 
+  // SharePoint / OneDrive for Business. A share link (`/:v:/g/personal/…`) is a web VIEWER page,
+  // and it sends frame-ancestors headers, so a browser refuses to put it in an iframe at all —
+  // "refused to connect", with nothing the page can catch. `action=embedview` asks for the
+  // embeddable player instead. It does not grant access: see `embedCaveat`.
+  if (u.hostname.endsWith(".sharepoint.com") || u.hostname === "onedrive.live.com") {
+    if (!u.searchParams.get("action")) u.searchParams.set("action", "embedview");
+    return u.toString();
+  }
+
+  // Google Drive: /file/d/<id>/view is the viewer page; /preview is the embeddable one.
+  if (u.hostname === "drive.google.com") {
+    const m = u.pathname.match(/^\/file\/d\/([^/]+)/);
+    if (m) return `https://drive.google.com/file/d/${m[1]}/preview`;
+  }
+
+  // Dropbox hands out a preview page by default; raw=1 serves the file itself.
+  if (u.hostname.endsWith("dropbox.com")) {
+    u.searchParams.delete("dl");
+    u.searchParams.set("raw", "1");
+    return u.toString();
+  }
+
+  // Loom share → embed.
+  if (u.hostname.endsWith("loom.com")) {
+    const m = u.pathname.match(/^\/share\/([^/?#]+)/);
+    if (m) return `https://www.loom.com/embed/${m[1]}`;
+  }
+
   return u.toString();
+}
+
+/**
+ * What is likely to go wrong with this link once a STUDENT opens it, in one sentence, or null.
+ *
+ * Rewriting a URL into its embeddable form is only half the problem. The other half is access,
+ * and no amount of URL surgery fixes it: a SharePoint file shared with "People in your
+ * organisation" shows a Microsoft sign-in wall to every learner, and the admin who pasted it sees
+ * it play perfectly because they are already signed in. That is the worst kind of bug to ship —
+ * it works for the person who set it up.
+ *
+ * So the builder says it at paste time, while changing the link still costs nothing.
+ */
+export function embedCaveat(rawUrl: string): string | null {
+  const raw = (rawUrl || "").trim();
+  if (!raw) return null;
+  let u: URL;
+  try {
+    u = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`);
+  } catch {
+    return "That does not look like a web address.";
+  }
+  const h = u.hostname;
+
+  if (h.endsWith(".sharepoint.com") || h === "onedrive.live.com" || h === "1drv.ms") {
+    return (
+      "OneDrive and SharePoint links only play for people who can already open the file. " +
+      "Set sharing to “Anyone with the link” or students will hit a Microsoft sign-in page — " +
+      "it will look fine to you, because you are signed in."
+    );
+  }
+  if (h === "drive.google.com" || h === "docs.google.com") {
+    return (
+      "Google Drive links only play if the file is shared with “Anyone with the link”. " +
+      "Otherwise students see a request-access screen."
+    );
+  }
+  if (h.endsWith("zoom.us")) {
+    return (
+      "Zoom recording links usually need a passcode and refuse to be embedded. " +
+      "Download the recording and upload it to the video catalog instead."
+    );
+  }
+  if (h.endsWith("dropbox.com")) {
+    return "Dropbox links play only while the file stays shared publicly.";
+  }
+  return null;
 }
 
 function withVimeoOptions(url: string): string {


### PR DESCRIPTION
Already merged to `stagging` and verified there.

A SharePoint / OneDrive share link is a web **viewer page** that sends `frame-ancestors` headers,
so the browser refuses to frame it — the student sees Chrome's own *"refused to connect"*, and the
page cannot catch it because a blocked frame fires no error a script can see.

| Pasted | Converted to |
|---|---|
| `…sharepoint.com/:v:/g/personal/…` | `&action=embedview` |
| `drive.google.com/file/d/ID/view` | `/file/d/ID/preview` |
| `dropbox.com/s/…?dl=0` | `?raw=1` |
| `loom.com/share/ID` | `loom.com/embed/ID` |

The sharing token is preserved — it is what authorises the file.

**The half URL surgery cannot fix:** a OneDrive file shared with "People in your organisation"
shows a sign-in wall to every student and plays perfectly for the admin who pasted it, because
they are already signed in. The builder now warns at paste time, while changing the link still
costs nothing, and tells Zoom-recording users to upload to the catalog instead (those cannot be
embedded at all).

**Tests:** 23 on the normaliser, 84 green, `tsc` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)