### PR TITLE
Promote: recording download restriction + attendance error surfacing

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -21,6 +21,7 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { useToast } from "@/components/common/Toast";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { useAuth } from "@/lib/auth/auth-context";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
 import { canAccessAdminArea } from "@/lib/auth/role-utils";
 import {
   adminLiveActivitiesService,
@@ -712,6 +713,8 @@ export default function LiveSessionDetailPage() {
       />
 
       <RecordingPlayerDialog
+        // Downloading a class recording is an admin act. Everyone else streams it.
+        allowDownload={isClientOrgAdminRole(user?.role)}
         open={playerOpen}
         liveClassId={activity?.id ?? null}
         title={activity?.topic_name ?? undefined}

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -40,6 +40,8 @@ import { ScheduleCalendar, type CalendarEvent } from "@/components/live-sessions
 import { getAssessments, type Assessment } from "@/lib/services/admin/admin-assessment.service";
 import adminMockInterviewService, { type AdminInterviewListItem } from "@/lib/services/admin/admin-mock-interview.service";
 import { config } from "@/lib/config";
+import { useAuth } from "@/lib/auth/auth-context";
+import { isClientOrgAdminRole } from "@/lib/auth/role-utils";
 
 /** "HH:MM" (24h) for an ISO datetime, or "" when unparseable. */
 function adminHhmm(iso?: string | null): string {
@@ -60,6 +62,7 @@ export default function AdminLiveSessionsPage() {
   // Integrations strip: expanded when something needs the admin's attention (a failed Google
   // connect round-trip, or nothing configured yet), else collapsed so the SESSIONS are the
   // first thing on screen. DERIVED (null = auto) - a manual toggle overrides the automatics.
+  const { user } = useAuth();
   const [integrationsToggled, setIntegrationsToggled] = useState<boolean | null>(null);
   // Error code from a failed Google connect round-trip (?google_connected=0&error=...) -
   // rendered as actionable troubleshooting on the Google card, not just a toast. Initialized
@@ -550,6 +553,8 @@ export default function AdminLiveSessionsPage() {
 
         {/* In-app recording playback (provider-neutral: Zoom cloud MP4s + Meet Drive files) */}
         <RecordingPlayerDialog
+          // Downloading a class recording is an admin act. Everyone else streams it.
+          allowDownload={isClientOrgAdminRole(user?.role)}
           open={Boolean(playerSession)}
           liveClassId={playerSession?.id ?? null}
           title={playerSession?.topic_name}

--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -25,6 +25,8 @@ import {
   RosterStudent,
 } from "@/lib/services/admin/admin-live-activities.service";
 import { formatDurationSeconds } from "@/lib/utils/date-utils";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+import { useToast } from "@/components/common/Toast";
 
 function fmtDate(s: string | null) {
   if (!s) return "-";
@@ -60,6 +62,7 @@ interface Props {
  */
 export function LiveSessionOccurrenceTimeline({ liveClassId, onOpenRecording }: Props) {
   const { t } = useTranslation("common");
+  const { showToast } = useToast();
   const [data, setData] = useState<OccurrenceTimelineResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [openId, setOpenId] = useState<number | null>(null);
@@ -86,6 +89,10 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, onOpenRecording }: 
       await adminLiveActivitiesService.syncAttendance(liveClassId, occId);
       await load();
       setOpenId(occId);
+    } catch (e) {
+      // Previously there was no catch at all here: a failed per-occurrence sync spun the button
+      // and then looked exactly like a successful one that found nobody.
+      showToast(getAxiosErrorDetail(e, "Couldn't sync attendance for this session."), "error");
     } finally {
       setSyncingId(null);
     }

--- a/components/admin/live-sessions/ZoomAttendanceSection.tsx
+++ b/components/admin/live-sessions/ZoomAttendanceSection.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/services/admin/admin-live-activities.service";
 import { formatDurationSeconds } from "@/lib/utils/date-utils";
 import { aggregateParticipants } from "@/lib/utils/attendance-utils";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 interface ZoomAttendanceSectionProps {
   liveClassId: number;
@@ -65,8 +66,11 @@ export function ZoomAttendanceSection({ liveClassId }: ZoomAttendanceSectionProp
         : res.message || t("adminLiveSessions.attendanceSynced");
       showToast(msg, "success");
       await fetchAttendance();
-    } catch {
-      showToast(t("adminLiveSessions.failedToSyncAttendance"), "error");
+    } catch (e) {
+      // The server says WHY — "Zoom has no completed instance of this session yet", or that the
+      // tenant's Event Subscription is off. A bare catch threw all of that away and left the
+      // admin pressing the same button against the same silent refusal.
+      showToast(getAxiosErrorDetail(e, t("adminLiveSessions.failedToSyncAttendance")), "error");
     } finally {
       setSyncing(false);
     }

--- a/components/live-sessions/RecordingPlayerDialog.tsx
+++ b/components/live-sessions/RecordingPlayerDialog.tsx
@@ -21,6 +21,17 @@ interface RecordingPlayerDialogProps {
   title?: string;
   open: boolean;
   onClose: () => void;
+  /**
+   * Show the browser's native Download control. Defaults to FALSE, so a surface that forgets to
+   * think about it gets the restricted player rather than the permissive one.
+   *
+   * Worth being precise about what this does: `controlsList="nodownload"` removes the BUTTON. It
+   * is not access control — the stream URL is still in the network tab for anyone who opens it.
+   * What actually limits the damage is that the URL carries a short-lived signed token and is
+   * proxied through the backend, so a copied link stops working shortly after; the Zoom OAuth
+   * token never reaches the browser at all. This closes the easy path, not every path.
+   */
+  allowDownload?: boolean;
 }
 
 /**
@@ -28,7 +39,13 @@ interface RecordingPlayerDialogProps {
  * the auth header), then streams the Zoom MP4 through the backend proxy - the recording plays inside
  * the platform rather than opening Zoom's page. The Zoom OAuth token never reaches the browser.
  */
-export function RecordingPlayerDialog({ liveClassId, title, open, onClose }: RecordingPlayerDialogProps) {
+export function RecordingPlayerDialog({
+  liveClassId,
+  title,
+  open,
+  onClose,
+  allowDownload = false,
+}: RecordingPlayerDialogProps) {
   const { t } = useTranslation("common");
   const [streamUrl, setStreamUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -123,6 +140,12 @@ export function RecordingPlayerDialog({ liveClassId, title, open, onClose }: Rec
             controls
             autoPlay
             src={streamUrl}
+            // Hides Download (and Picture-in-picture, which is just a second route to a
+            // detached window) unless this viewer is allowed it. Right-click is blocked for
+            // the same reason: "Save video as…" sits in that menu.
+            controlsList={allowDownload ? undefined : "nodownload noplaybackrate"}
+            disablePictureInPicture={!allowDownload}
+            onContextMenu={allowDownload ? undefined : (e) => e.preventDefault()}
             style={{ width: "100%", maxHeight: "70vh", display: "block", background: "#000" }}
           />
         ) : null}

--- a/lib/utils/api-error.ts
+++ b/lib/utils/api-error.ts
@@ -4,11 +4,20 @@ export type ApiErrorBody = {
   [key: string]: unknown;
 };
 
-/** DRF `detail` from an Axios error (string or string[]). */
+/**
+ * The server's own words from an Axios error (string or string[]), else `fallback`.
+ *
+ * Three envelopes, because this codebase has three: DRF's `detail`, an `error` string, and the
+ * `{status, message, data}` shape the Zoom/live-session endpoints return. Missing that last one
+ * is why "Zoom has no completed instance of this session yet" reached an admin as
+ * "Failed to sync attendance" — the reason was in the response the whole time.
+ *
+ * Deliberately `response.data.message` and NOT `err.message`: the latter is Axios's own
+ * "Request failed with status code 400", which is exactly the string this exists to avoid.
+ */
 export function getAxiosErrorDetail(err: unknown, fallback: string): string {
-  const raw = (err as { response?: { data?: ApiErrorBody } })?.response?.data
-    ?.detail||(err as { response?: { data?: ApiErrorBody } })?.response?.data
-    ?.error;
+  const data = (err as { response?: { data?: ApiErrorBody } })?.response?.data;
+  const raw = data?.detail ?? data?.error ?? data?.message;
   if (Array.isArray(raw)) return raw.join(". ");
   if (typeof raw === "string" && raw.trim()) return raw.trim();
   return fallback;


### PR DESCRIPTION
Already merged to `stagging` and verified there.

**Download.** The recording player used the browser's default `<video controls>`, whose overflow
menu carries Download — so any student could save a class recording. Hidden now unless the viewer
is an org admin, along with Picture-in-picture and the right-click menu ("Save video as…" lives
there). `allowDownload` defaults to false, and is gated on role rather than on which page rendered
the dialog, so routing changes can't quietly widen it.

To be precise about what it is: `controlsList="nodownload"` removes the BUTTON, not the
capability — the stream URL is still in the network tab. What limits the damage was already right
and is unchanged: a short-lived signed token, proxied through the backend, so a copied link stops
working shortly after and the Zoom OAuth token never reaches the browser.

**"Failed to sync attendance."** The server explains itself and a bare `catch` threw it away;
`getAxiosErrorDetail` was also missing the `{status, message, data}` envelope these endpoints use.
The per-occurrence timeline had no error handling at all — a failure looked exactly like a
successful sync that found nobody.

Pairs with BE #552 (merged, deployed), which makes attendance sync work without webhooks.

**Checks:** 84 unit tests green, `tsc --noEmit` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)