### PR TITLE
feat(adaptive): show a course as modules instead of weeks

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -36,6 +36,9 @@ import {
   type AdminAdaptiveCourseDetail,
   type AdminAdaptiveCourseModule,
   type AdminAdaptiveCourseSubModule,
+  previewModuleTitleCleanup,
+  applyModuleTitleCleanup,
+  type ModuleTitleCleanupProposal,
 } from "@/lib/services/admin/admin-adaptive-course.service";
 import { CourseQuizEditor } from "@/components/admin/adaptive-course/CourseQuizEditor";
 import { AdminArticleViewer } from "@/components/admin/adaptive-course/AdminArticleViewer";
@@ -44,6 +47,7 @@ import { MatchedVideoReview } from "@/components/adaptive-video/admin/MatchedVid
 import { CourseStudentsPanel } from "@/components/admin/adaptive-course/CourseStudentsPanel";
 import { CourseCoverArtPanel } from "@/components/admin/adaptive-course/CourseCoverArtPanel";
 import { CourseSettingsPanel } from "@/components/admin/adaptive-course/CourseSettingsPanel";
+import { ModuleTitleCleanupDialog } from "@/components/admin/adaptive-course/ModuleTitleCleanupDialog";
 import { CalibrationAdminSection } from "@/components/admin/adaptive-course/CalibrationAdminSection";
 import { CohortScheduleSection } from "@/components/admin/adaptive-course/CohortScheduleSection";
 import { ModuleNavigator, MODULES_PER_PAGE } from "@/components/admin/adaptive-course/ModuleNavigator";
@@ -290,11 +294,58 @@ export default function AdminAdaptiveCourseDetailPage() {
 
   async function handleToggleContentLock() {
     if (!course) return;
+    const unit = course.module_only_structure ? "modules" : "weeks";
     await applySetting("content_locked", !course.content_locked, (c) =>
       c.content_locked
-        ? "Content locked: weeks unlock on the cohort schedule and late work loses points."
-        : "Content unlocked: students can open any week now and always earn full XP.",
+        ? `Content locked: ${unit} unlock on the cohort schedule and late work loses points.`
+        : `Content unlocked: students can open any ${unit.slice(0, -1)} now and always earn full XP.`,
     );
+  }
+
+  const [cleanupProposals, setCleanupProposals] = useState<ModuleTitleCleanupProposal[]>([]);
+  const [cleanupOpen, setCleanupOpen] = useState(false);
+  const [cleanupApplying, setCleanupApplying] = useState(false);
+
+  /** Ask whether anything needs tidying. Silent when there is nothing — no dialog for no work. */
+  async function checkTitleCleanup() {
+    if (!course) return;
+    try {
+      const res = await previewModuleTitleCleanup(course.id);
+      if (res.count > 0) {
+        setCleanupProposals(res.proposals);
+        setCleanupOpen(true);
+      }
+    } catch {
+      // Cosmetic. A failure here must not make the toggle itself look broken.
+    }
+  }
+
+  async function applyTitleCleanup(moduleIds: number[]) {
+    if (!course) return;
+    setCleanupApplying(true);
+    try {
+      const res = await applyModuleTitleCleanup(course.id, moduleIds);
+      showToast(`Renamed ${res.renamed} module${res.renamed === 1 ? "" : "s"}.`, "success");
+      setCleanupOpen(false);
+      await load();
+    } catch {
+      showToast("Couldn't rename the modules.", "error");
+    } finally {
+      setCleanupApplying(false);
+    }
+  }
+
+  async function handleToggleModuleStructure() {
+    if (!course) return;
+    await applySetting("module_only_structure", !course.module_only_structure, (c) =>
+      c.module_only_structure
+        ? "Students now see modules instead of weeks. Scheduling and points are unchanged."
+        : "Back to weeks.",
+    );
+    // Offer the title cleanup only when turning it ON, and only if there is anything to clean.
+    // Most courses have modules literally titled "Week 1", which would otherwise read
+    // "Module 1 · Week 1" in the builder's own module list.
+    if (!course.module_only_structure) void checkTitleCleanup();
   }
 
   /** The instructor says their course is finished and hands it to an admin. */
@@ -659,6 +710,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                   onToggleAutoEnroll={() => void handleToggleAutoEnroll()}
                   onToggleSelfEnroll={() => void handleToggleSelfEnroll()}
                   onToggleContentLock={() => void handleToggleContentLock()}
+                  onToggleModuleStructure={() => void handleToggleModuleStructure()}
                   onToggleClipboard={() => void handleToggleClipboard()}
                   onOpenPricing={() => setPricingOpen(true)}
                   onAssignCohorts={() => setAssignCohortsOpen(true)}
@@ -1539,6 +1591,14 @@ export default function AdminAdaptiveCourseDetailPage() {
           if (!deleting) setPendingDelete(null);
         }}
       />
+      <ModuleTitleCleanupDialog
+        open={cleanupOpen}
+        proposals={cleanupProposals}
+        applying={cleanupApplying}
+        onApply={(ids) => void applyTitleCleanup(ids)}
+        onClose={() => setCleanupOpen(false)}
+      />
+
     </MainLayout>
   );
 }

--- a/components/adaptive-journey/JourneyBoard.tsx
+++ b/components/adaptive-journey/JourneyBoard.tsx
@@ -212,16 +212,23 @@ function NodeRow({ node, courseId, stepNo, dueAt }: { node: JourneyNodeView; cou
   );
 }
 
-function WeekCard({ week, courseId, startStep }: { week: JourneyWeekView; courseId: number; startStep: number }) {
+function WeekCard({ week, courseId, startStep, unitNoun = "Week" }: {
+  week: JourneyWeekView; courseId: number; startStep: number; unitNoun?: string;
+}) {
   const pct = week.totals.total > 0 ? Math.round((week.totals.earned / week.totals.total) * 100) : 0;
   const dl = daysLeft(week.schedule?.dueAt);
   const locked = week.nodes.every((n) => n.status === "locked");
 
-  // "Week N" header label; only append the module title when it adds something - modules are often
-  // literally titled "Week 1", which would otherwise render "Week 1 · Week 1".
-  const autoLabel = week.weekNo === 0 ? "Get started" : `Week ${week.weekNo}`;
+  // The unit heading, named by the course: "Module 3" or "Week 3". The title is only appended
+  // when it adds something — nearly every module in production is literally titled "Week 1",
+  // which would otherwise render "Module 1 · Week 1". The server already suppresses those, and
+  // this stays as a second line of defence for a board served before that shipped.
+  const autoLabel = week.weekNo === 0 ? "Get started" : `${unitNoun} ${week.weekNo}`;
   const title = (week.title || "").trim();
-  const showTitle = !!title && title.toLowerCase() !== autoLabel.toLowerCase() && !/^week\s*\d+$/i.test(title);
+  const showTitle =
+    !!title &&
+    title.toLowerCase() !== autoLabel.toLowerCase() &&
+    !/^(week|module)\s*\d+$/i.test(title);
 
   return (
     <Box sx={{ border: "1px solid #e9e6f7", borderRadius: 4, overflow: "hidden", bgcolor: "#fff", mb: 2, boxShadow: "0 12px 30px -24px rgba(99,102,241,0.45)" }}>
@@ -474,7 +481,13 @@ export function JourneyBoard({ courseId }: { courseId: number; showHeader?: bool
           )}
 
           {board.weeks.map((w, i) => (
-            <WeekCard key={w.weekNo} week={w} courseId={courseId} startStep={stepStarts[i] ?? 0} />
+            <WeekCard
+              key={w.weekNo}
+              week={w}
+              courseId={courseId}
+              startStep={stepStarts[i] ?? 0}
+              unitNoun={board.unitNoun || "Week"}
+            />
           ))}
         </Box>
 

--- a/components/admin/adaptive-course/CourseSettingsPanel.tsx
+++ b/components/admin/adaptive-course/CourseSettingsPanel.tsx
@@ -135,6 +135,7 @@ export interface CourseSettingsPanelProps {
   onToggleAutoEnroll: () => void;
   onToggleSelfEnroll: () => void;
   onToggleContentLock: () => void;
+  onToggleModuleStructure: () => void;
   onToggleClipboard: () => void;
   onOpenPricing: () => void;
   onAssignCohorts: () => void;
@@ -157,6 +158,7 @@ export function CourseSettingsPanel({
   onToggleAutoEnroll,
   onToggleSelfEnroll,
   onToggleContentLock,
+  onToggleModuleStructure,
   onToggleClipboard,
   onOpenPricing,
   onAssignCohorts,
@@ -168,6 +170,7 @@ export function CourseSettingsPanel({
   scheduleSlot,
 }: CourseSettingsPanelProps) {
   const summary = course.enrollment_summary;
+  const moduleOnly = Boolean(course.module_only_structure);
   const cohorts = course.assigned_cohorts ?? [];
 
   // Catalog listing is DERIVED, not a peer switch: a paid course is listed whether or not
@@ -368,9 +371,23 @@ export function CourseSettingsPanel({
         />
       </SettingsCard>
 
-      <SettingsCard icon="mdi:calendar-clock-outline" title="Pacing" subtitle="How fast students can move">
+      <SettingsCard
+        icon="mdi:calendar-clock-outline"
+        title="Pacing"
+        subtitle={`How fast students can move${moduleOnly ? " · shown as modules" : ""}`}
+      >
+        {/* Vocabulary only. It sits beside the pacing switch because that is where an admin
+            thinks about weeks — but it deliberately does NOT change pacing: a module-framed
+            course still releases on a schedule if the switch below is on. */}
         <SettingRow
-          label="Release weeks on a schedule"
+          label="Use modules instead of weeks"
+          help="Students see “Module 1”, “Module 2” instead of “Week 1”. Scheduling, unlocking and points are unchanged."
+          checked={Boolean(course.module_only_structure)}
+          pending={pendingSetting === "module_only_structure"}
+          onChange={onToggleModuleStructure}
+        />
+        <SettingRow
+          label={moduleOnly ? "Release modules on a schedule" : "Release weeks on a schedule"}
           help="Off means the whole course is open immediately."
           checked={course.content_locked}
           pending={pendingSetting === "content_locked"}

--- a/components/admin/adaptive-course/ModuleTitleCleanupDialog.tsx
+++ b/components/admin/adaptive-course/ModuleTitleCleanupDialog.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box, Button, Checkbox, Dialog, DialogActions, DialogContent, DialogTitle, Stack, Typography,
+} from "@mui/material";
+
+/**
+ * Offer to clean module titles that are only a week label.
+ *
+ * Nearly every module in production is titled *nothing but* "Week 1" — a title that was never a
+ * name, just the position stored again as text. On a module-framed course that reads
+ * "Module 1 · Week 1".
+ *
+ * Preview first, and every row is opt-out. This rewrites almost every module of an affected
+ * course, so an admin should see the exact list rather than discover it afterwards — and a
+ * rename that produced an empty title would be worse than the duplication it fixes, which is
+ * why the server proposes "Module 3" rather than stripping "Week 3" down to nothing.
+ */
+
+export interface TitleCleanupProposal {
+  module_id: number;
+  weekno: number;
+  current_title: string;
+  suggested_title: string;
+}
+
+export function ModuleTitleCleanupDialog({
+  open,
+  proposals,
+  applying,
+  onApply,
+  onClose,
+}: {
+  open: boolean;
+  proposals: TitleCleanupProposal[];
+  applying: boolean;
+  onApply: (moduleIds: number[]) => void;
+  onClose: () => void;
+}) {
+  // Everything is selected by default — the common case is "yes, tidy them all" — but each row
+  // can be declined, so an admin who has hand-named one module does not lose that name.
+  const [declined, setDeclined] = useState<Set<number>>(new Set());
+
+  const toggle = (id: number) =>
+    setDeclined((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const selected = proposals.filter((p) => !declined.has(p.module_id));
+
+  return (
+    <Dialog open={open} onClose={applying ? undefined : onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ fontWeight: 800, pb: 0.5 }}>
+        Tidy up module titles?
+        <Typography sx={{ fontSize: "0.82rem", color: "text.secondary", fontWeight: 500, mt: 0.5 }}>
+          {proposals.length} module{proposals.length === 1 ? "" : "s"} {proposals.length === 1 ? "is" : "are"} named
+          after a week. Without this they read like “Module 1 · Week 1”.
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Stack spacing={0.5}>
+          {proposals.map((p) => {
+            const off = declined.has(p.module_id);
+            return (
+              <Stack
+                key={p.module_id}
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                sx={{ py: 0.5, opacity: off ? 0.45 : 1 }}
+              >
+                <Checkbox
+                  size="small"
+                  checked={!off}
+                  onChange={() => toggle(p.module_id)}
+                  disabled={applying}
+                />
+                <Typography sx={{ fontSize: "0.85rem", flex: 1, minWidth: 0 }}>
+                  <Box component="span" sx={{ color: "text.secondary" }}>
+                    {p.current_title || "(untitled)"}
+                  </Box>
+                  <Box component="span" sx={{ mx: 1, color: "text.disabled" }}>→</Box>
+                  <Box component="span" sx={{ fontWeight: 700 }}>{p.suggested_title}</Box>
+                </Typography>
+              </Stack>
+            );
+          })}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, py: 2 }}>
+        <Button onClick={onClose} disabled={applying} sx={{ textTransform: "none" }}>
+          Leave them as they are
+        </Button>
+        <Button
+          variant="contained"
+          disabled={applying || selected.length === 0}
+          onClick={() => onApply(selected.map((p) => p.module_id))}
+          sx={{ textTransform: "none", fontWeight: 700 }}
+        >
+          {applying
+            ? "Renaming…"
+            : `Rename ${selected.length} module${selected.length === 1 ? "" : "s"}`}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/lib/services/admin/admin-adaptive-course.service.ts
+++ b/lib/services/admin/admin-adaptive-course.service.ts
@@ -328,6 +328,8 @@ export interface AdminAdaptiveCourseListItem {
   currency: string;
   /** Weekly cohort gate. False = every week open + full XP (admin toggle). */
   content_locked: boolean;
+  /** Frames the course as modules rather than weeks. Vocabulary only — gating and points are unchanged. */
+  module_only_structure?: boolean;
   /** Course-wide copy/paste policy for the code editor. Was per coding set. */
   allow_clipboard: boolean;
   /** "" unless an instructor built this course. */
@@ -852,6 +854,7 @@ export const adminAdaptiveCourseService = {
       title?: string;
       description?: string;
       content_locked?: boolean;
+      module_only_structure?: boolean;
       auto_enroll?: boolean;
       self_enroll_enabled?: boolean;
       is_paid?: boolean;
@@ -1114,3 +1117,35 @@ export const adminAdaptiveCourseService = {
   },
 
 };
+
+
+export interface ModuleTitleCleanupProposal {
+  module_id: number;
+  weekno: number;
+  current_title: string;
+  suggested_title: string;
+}
+
+/**
+ * Module titles that are only a week label, and what they would become.
+ *
+ * Preview and apply are separate calls on purpose: this rewrites almost every module of an
+ * affected course, so the admin sees the list before anything is written.
+ */
+export async function previewModuleTitleCleanup(
+  courseId: number,
+): Promise<{ count: number; proposals: ModuleTitleCleanupProposal[] }> {
+  const { data } = await apiClient.get(`${BASE}/courses/${courseId}/modules/title-cleanup/`);
+  return data;
+}
+
+export async function applyModuleTitleCleanup(
+  courseId: number,
+  moduleIds?: number[],
+): Promise<{ renamed: number }> {
+  const { data } = await apiClient.post(
+    `${BASE}/courses/${courseId}/modules/title-cleanup/`,
+    moduleIds ? { module_ids: moduleIds } : {},
+  );
+  return data;
+}

--- a/lib/types/adaptive-journey.ts
+++ b/lib/types/adaptive-journey.ts
@@ -83,6 +83,9 @@ export interface AdminCertificateConfig {
 export interface JourneyBoard {
   /** Admin content-lock. false = every step is open, no deadlines, full XP anytime. */
   contentLocked: boolean;
+  /** "Week" or "Module" — what this course calls one unit. Vocabulary only. */
+  unitNoun?: string;
+  moduleOnlyStructure?: boolean;
   course: {
     id: number;
     title: string;


### PR DESCRIPTION
The builder half of [BE #557](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/557). A per-course toggle: students and admins see `Module 1` instead of `Week 1`.

### The toggle
Lives in **Pacing**, beside the release-schedule switch — that's where an admin thinks about weeks. It is deliberately **not coupled** to it: a module-framed course still releases on a schedule, still locks, still penalises late work. The switch below relabels itself to *"Release modules on a schedule"* so the two read as one decision about the same units.

### The title cleanup
Turning it **on** offers to tidy module titles — a dialog listing every proposed rename, each row opt-out, applied only on confirm. It appears only when there's something to rename, never on turning the toggle off, and a failed fetch is swallowed (the cleanup is cosmetic and must not make the toggle look broken).

This matters because **676 of 758 production module titles are literally "Week N"** — without it a course reads `Module 1 · Week 1`.

### Student board
Takes its heading noun from the board payload instead of hardcoding `Week`, and the title-suppression rule now covers both nouns. The board already had a workaround comment about the `Week 1 · Week 1` duplication; it now handles the module case too, with the server suppressing those titles as the primary defence and this as a second one for a board served before that shipped.

`tsc --noEmit` clean, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
