### PR TITLE
feat: render diagram-based questions, and fix two places the image was being dropped

### DIFF
--- a/app/assessments/[slug]/calibration/page.tsx
+++ b/app/assessments/[slug]/calibration/page.tsx
@@ -8,6 +8,8 @@ import { assessmentService } from "@/lib/services/assessment.service";
 import { adaptiveJourneyService } from "@/lib/services/adaptive-journey.service";
 import { notifyContentCompleted } from "@/lib/streak/streakCelebration";
 import type { CalibrationResult } from "@/lib/types/adaptive-journey";
+import { QuestionTitle } from "@/components/quiz/QuestionTitle";
+import { QuestionImage } from "@/components/quiz/QuestionImage";
 
 interface CalibMcq {
   id: number | string;
@@ -18,6 +20,9 @@ interface CalibMcq {
   option_d: string;
   question_style?: "single" | "multiple";
   topic?: string;
+  /** A diagram-based question's image, which the stem refers to. */
+  question_image?: string | null;
+  question_image_alt?: string | null;
 }
 
 const LETTERS = ["a", "b", "c", "d"] as const;
@@ -426,7 +431,10 @@ function CalibrationTakeInner() {
           </Stack>
 
           <Box sx={{ p: { xs: 2.5, md: 3.5 }, borderRadius: 3, bgcolor: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.08)" }}>
-            <Typography sx={{ fontWeight: 700, fontSize: "1.25rem", lineHeight: 1.4, mb: 3 }}>{q?.question_text}</Typography>
+            <Box sx={{ mb: 3 }}>
+              <QuestionTitle question={q?.question_text ?? ""} compact />
+              <QuestionImage src={q?.question_image} alt={q?.question_image_alt} compact />
+            </Box>
             <Stack spacing={1.5}>
               {LETTERS.map((L) => {
                 const text = q?.[(`option_${L}`) as keyof CalibMcq] as string;

--- a/components/adaptive-quiz/mid/QuestionCard.tsx
+++ b/components/adaptive-quiz/mid/QuestionCard.tsx
@@ -4,6 +4,7 @@ import { Box, ButtonBase, Chip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { ConfidenceInput } from "./ConfidenceInput";
 import RichHtml from "@/components/common/RichHtml";
+import { QuestionImage } from "@/components/quiz/QuestionImage";
 import { prettySkill } from "@/lib/utils/skill-label.utils";
 import type {
   AdaptiveQuestion,
@@ -133,6 +134,10 @@ export function QuestionCard({
           color: "text.primary",
         }}
       />
+
+      {/* A diagram question's image: part of the question, above the options. Renders nothing
+          when the question has no image, which is most of them. */}
+      <QuestionImage src={question.question_image} alt={question.question_image_alt} />
 
       {/* Options */}
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>

--- a/components/admin/assessment/MCQQuestionsTable.tsx
+++ b/components/admin/assessment/MCQQuestionsTable.tsx
@@ -4,6 +4,7 @@ import { Box, Typography, Paper, Chip } from "@mui/material";
 import { MCQ } from "@/lib/services/admin/admin-assessment.service";
 import { PaginationControls } from "./PaginationControls";
 
+import { QuestionImage } from "@/components/quiz/QuestionImage";
 interface MCQWithSection extends MCQ {
   sectionId: string;
 }
@@ -170,6 +171,14 @@ export function MCQQuestionsTable({
                 {mcq.question_text}
               </Typography>
             )}
+
+            {/* A diagram question's image, so an admin reviewing the bank sees what the learner
+                will see rather than an unexplained reference to a figure. */}
+            <QuestionImage
+              src={(mcq as { question_image?: string | null }).question_image}
+              alt={(mcq as { question_image_alt?: string | null }).question_image_alt}
+              compact
+            />
 
             {/* Options - styled like student-facing AnswerOption cards */}
             <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>

--- a/components/assessment/AssessmentQuizLayout.tsx
+++ b/components/assessment/AssessmentQuizLayout.tsx
@@ -14,6 +14,9 @@ export interface QuizQuestion {
   options: QuizOption[];
   /** Default single (MCQ); multiple = MSQ (checkboxes). */
   question_style?: "single" | "multiple";
+  /** A diagram-based question's image, which the stem refers to. */
+  question_image?: string | null;
+  question_image_alt?: string | null;
 }
 
 export interface QuizOption {
@@ -145,7 +148,11 @@ export const AssessmentQuizLayout = memo(
             }}
           >
             {/* Question Title */}
-            <QuestionTitle question={currentQuestion.question} />
+            <QuestionTitle
+              question={currentQuestion.question}
+              imageSrc={currentQuestion.question_image}
+              imageAlt={currentQuestion.question_image_alt}
+            />
 
             {/* Answer Options */}
             <AnswerOptionsList

--- a/components/quiz/QuestionImage.tsx
+++ b/components/quiz/QuestionImage.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Box } from "@mui/material";
+
+/**
+ * The image of a DIAGRAM-BASED question, rendered above the options.
+ *
+ * A question's image is part of the question rather than decoration: the stem refers to it and the
+ * question cannot be answered without looking at it. So it gets a deliberate block of its own here
+ * rather than being smuggled into the stem's HTML, which would leave its size and position at the
+ * mercy of wherever the author happened to put the tag.
+ *
+ * Three things this does that an <img> inside the stem does not:
+ *
+ *  - Caps the height. A tall diagram pushed the options below the fold on a laptop, which is worse
+ *    than a slightly smaller diagram. `object-fit: contain` keeps it undistorted at any shape.
+ *  - Carries real alt text, supplied by the API as its own field. A question whose image holds the
+ *    information is unanswerable without it for anyone who cannot see the image, so the seeding
+ *    gate refuses an image with no alt and this renders what it gets.
+ *  - Renders nothing at all when there is no image, so every question surface can call it
+ *    unconditionally.
+ *
+ * Deliberately a plain <img> rather than next/image: these URLs are arbitrary external references
+ * from the verified content library, which next/image will not optimise without every host being
+ * configured, and which it refuses outright for SVG.
+ */
+export interface QuestionImageProps {
+  src?: string | null;
+  alt?: string | null;
+  /** Tighter cap for the assessment layout, where the timer bar and nav already take height. */
+  compact?: boolean;
+}
+
+export function QuestionImage({ src, alt, compact }: QuestionImageProps) {
+  if (!src) return null;
+
+  return (
+    <Box
+      sx={{
+        my: compact ? 1.5 : 2,
+        display: "flex",
+        justifyContent: "center",
+        borderRadius: 2,
+        overflow: "hidden",
+        border: "1px solid",
+        borderColor: "divider",
+        bgcolor: "color-mix(in srgb, var(--card-bg, #ffffff) 60%, transparent)",
+        p: 1,
+      }}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={src}
+        alt={alt || ""}
+        loading="lazy"
+        style={{
+          maxWidth: "100%",
+          maxHeight: compact ? 260 : 340,
+          width: "auto",
+          height: "auto",
+          objectFit: "contain",
+        }}
+      />
+    </Box>
+  );
+}
+
+export default QuestionImage;

--- a/components/quiz/QuestionTitle.tsx
+++ b/components/quiz/QuestionTitle.tsx
@@ -2,6 +2,7 @@
 
 import { Box, Typography } from "@mui/material";
 import RichHtml from "@/components/common/RichHtml";
+import { QuestionImage } from "./QuestionImage";
 
 /** Check if string contains HTML tags so we can render with dangerouslySetInnerHTML */
 function hasHtml(str: unknown): str is string {
@@ -12,6 +13,9 @@ interface QuestionTitleProps {
   question: string;
   /** When true, reduce spacing so quiz fits without scroll */
   compact?: boolean;
+  /** A diagram question's image, rendered under the stem and above the options. */
+  imageSrc?: string | null;
+  imageAlt?: string | null;
 }
 
 const titleSx = {
@@ -22,7 +26,7 @@ const titleSx = {
   letterSpacing: "-0.01em",
 };
 
-export function QuestionTitle({ question, compact }: QuestionTitleProps) {
+export function QuestionTitle({ question, compact, imageSrc, imageAlt }: QuestionTitleProps) {
   return (
     <Box
       sx={{
@@ -37,6 +41,7 @@ export function QuestionTitle({ question, compact }: QuestionTitleProps) {
           {question}
         </Typography>
       )}
+      <QuestionImage src={imageSrc} alt={imageAlt} compact={compact} />
     </Box>
   );
 }

--- a/components/quiz/QuizLayout.tsx
+++ b/components/quiz/QuizLayout.tsx
@@ -199,7 +199,12 @@ export function QuizLayout({
           }}
         >
           {/* Question Title */}
-          <QuestionTitle question={currentQuestion.question} compact={isSubmodule} />
+          <QuestionTitle
+            question={currentQuestion.question}
+            compact={isSubmodule}
+            imageSrc={(currentQuestion as { question_image?: string | null }).question_image}
+            imageAlt={(currentQuestion as { question_image_alt?: string | null }).question_image_alt}
+          />
 
           {/* Answer Options */}
           <AnswerOptionsList

--- a/lib/types/adaptive-quiz.ts
+++ b/lib/types/adaptive-quiz.ts
@@ -29,6 +29,10 @@ export interface AdaptiveQuestion {
   /** ISO time the server served this question - the per-question clock runs off this (continues
    *  while away), so the live timer/points resume correctly. */
   served_at?: string | null;
+  /** A diagram-based question's image: part of the question, not decoration. Empty string when
+   *  the question is text only, which is most of them. */
+  question_image?: string | null;
+  question_image_alt?: string | null;
 }
 
 /** Live completion of a result-page remediation path (GET .../remediation-progress/). */

--- a/utils/assessment.utils.ts
+++ b/utils/assessment.utils.ts
@@ -57,10 +57,14 @@ export function convertMCQToQuizQuestion(mcq: {
   option_c: string;
   option_d: string;
   question_style?: string;
+  question_image?: string | null;
+  question_image_alt?: string | null;
 }): {
   id: number;
   question: string;
   question_style: "single" | "multiple";
+  question_image: string | null;
+  question_image_alt: string | null;
   options: Array<{
     id: string;
     label: string;
@@ -73,6 +77,11 @@ export function convertMCQToQuizQuestion(mcq: {
     id: mcq.id,
     question: mcq.question_text,
     question_style: style,
+    // This converter rebuilds the question field by field, so anything it does not name is
+    // silently dropped. A diagram question's image has to be carried explicitly or it never
+    // reaches the layout, whatever the API sent.
+    question_image: mcq.question_image ?? null,
+    question_image_alt: mcq.question_image_alt ?? null,
     options: [
       { id: "a", label: mcq.option_a, value: "a" },
       { id: "b", label: mcq.option_b, value: "b" },
@@ -123,6 +132,8 @@ export function convertQuizSectionsToSections(
       option_c: string;
       option_d: string;
       question_style?: string;
+      question_image?: string | null;
+      question_image_alt?: string | null;
     }>;
   }>
 ) {


### PR DESCRIPTION
## What

Renders a question's image on every surface that shows a question. Pairs with backend PR AI-Linc-LMS/ai-linc-backend#558, which adds `question_image` and `question_image_alt` to both question models.

## What was actually broken

Worth being precise, because it was not where I expected:

- `RichHtml` **already** sanitises and renders `<img>`, and the adaptive quiz, assessment and submodule quizzes all route through it. An image smuggled into `question_text` already rendered in three of the four places.
- **`convertMCQToQuizQuestion` rebuilds the question object field by field** and drops anything it does not name. An image would have vanished here regardless of what the API sent. This is the one that would have been hardest to diagnose: API returns it, component reads it, converter loses it in between.
- The **calibration page** rendered the stem as plain text in a `<Typography>`, so it was also the one surface where a question containing any markup showed raw tags.

## Why a component rather than an `<img>` in the stem

Since `RichHtml` already renders `<img>`, the cheap option was to do nothing and let authors put a tag in the question text. That was rejected:

- **Height cap.** A tall diagram pushes the options below the fold, which is worse than a slightly smaller diagram. `object-fit: contain` keeps it undistorted at any shape.
- **Alt text needs somewhere to live.** It arrives as its own API field. A question whose image carries the information is unanswerable without it for anyone who cannot see the image, and the backend refuses the pair without it.
- **Renders nothing when absent**, so every surface calls it unconditionally.

Plain `<img>` rather than `next/image` for the reason the client-branding work already established: arbitrary external URLs, which `next/image` will not optimise without every host configured and refuses outright for SVG.

## Surfaces covered

| Surface | Route |
|---|---|
| Adaptive quiz | `QuestionCard` |
| Assessment | `AssessmentQuizLayout` → `QuestionTitle` |
| Submodule quiz | `QuizLayout` → `QuestionTitle` |
| Calibration | fixed, was plain text |
| Admin bank preview | `MCQQuestionsTable` |

## Verification

`npx tsc --noEmit` clean against the `stagging` base. Worth doing by hand: CI here runs unit tests only, so a type error would merge green and only surface as a failed Netlify build.

Nothing renders differently for the ~2,800 existing text-only questions, which send `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)