### PR TITLE
feat(roadmaps): student surface for Roadmaps

### DIFF
--- a/app/roadmaps/[slug]/loading.tsx
+++ b/app/roadmaps/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+export default function Loading() {
+  return <PageShimmerLayout variant="list" />;
+}

--- a/app/roadmaps/[slug]/page.tsx
+++ b/app/roadmaps/[slug]/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Box, Container, Stack, Tooltip, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { RoadmapSpine } from "@/components/roadmaps/RoadmapSpine";
+import { RoadmapNodeDrawer } from "@/components/roadmaps/RoadmapNodeDrawer";
+import {
+  roadmapKeys,
+  roadmapsService,
+  type RoadmapNode,
+  type RoadmapProgress,
+  type SelfState,
+} from "@/lib/services/roadmaps.service";
+
+/**
+ * One roadmap.
+ *
+ * The graph and the progress overlay are two queries on purpose: the graph is identical for
+ * every learner in the tenant and cached hard, the overlay is per learner and invalidated on
+ * every state write.
+ */
+
+function StatTile({
+  label,
+  value,
+  hint,
+  tint,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+  tint: string;
+}) {
+  return (
+    <Tooltip title={hint} arrow>
+      <Box
+        sx={{
+          flex: 1,
+          minWidth: 130,
+          border: "1px solid #e6e8ef",
+          borderRadius: 2.5,
+          px: 2,
+          py: 1.5,
+          bgcolor: "#fff",
+        }}
+      >
+        <Typography sx={{ fontSize: 11.5, color: "#64748b", fontWeight: 600 }}>
+          {label}
+        </Typography>
+        <Typography sx={{ fontSize: 22, fontWeight: 800, color: tint, lineHeight: 1.2 }}>
+          {value}
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+}
+
+export default function RoadmapDetailPage() {
+  const params = useParams();
+  const slug = String(params?.slug ?? "");
+  const queryClient = useQueryClient();
+  const [openNode, setOpenNode] = useState<RoadmapNode | null>(null);
+
+  const graphQuery = useQuery({
+    queryKey: roadmapKeys.graph(slug),
+    queryFn: () => roadmapsService.graph(slug),
+    enabled: Boolean(slug),
+    staleTime: 30 * 60 * 1000,
+  });
+
+  const progressQuery = useQuery({
+    queryKey: roadmapKeys.progress(slug),
+    queryFn: () => roadmapsService.progress(slug),
+    enabled: Boolean(slug),
+    staleTime: 30 * 1000,
+  });
+
+  const setState = useMutation({
+    mutationFn: ({ nodeId, state }: { nodeId: number; state: SelfState }) =>
+      roadmapsService.setNodeState(slug, nodeId, state),
+    // Optimistic: marking a node is a pure annotation, so a round-trip before the UI reacts
+    // makes bulk self-assessment feel broken.
+    onMutate: async ({ nodeId, state }) => {
+      await queryClient.cancelQueries({ queryKey: roadmapKeys.progress(slug) });
+      const previous = queryClient.getQueryData<RoadmapProgress>(roadmapKeys.progress(slug));
+      if (previous) {
+        const nodes = { ...previous.nodes, [nodeId]: { ...previous.nodes[nodeId], selfState: state } };
+        const declared = Object.values(nodes);
+        const done = declared.filter((n) => n.selfState === "done").length;
+        const skipped = declared.filter((n) => n.selfState === "skipped").length;
+        queryClient.setQueryData<RoadmapProgress>(roadmapKeys.progress(slug), {
+          ...previous,
+          nodes,
+          done,
+          skipped,
+          coverage: previous.total ? (done + skipped) / previous.total : 0,
+          // mastery is intentionally NOT recomputed here: it is derived from real submissions
+          // on the server and no client action may move it.
+        });
+      }
+      return { previous };
+    },
+    onError: (_e, _v, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(roadmapKeys.progress(slug), ctx.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: roadmapKeys.progress(slug) });
+    },
+  });
+
+  const graph = graphQuery.data;
+  const progress = progressQuery.data;
+
+  if (graphQuery.isError) {
+    return (
+      <PageShell>
+        <Container sx={{ py: 8, textAlign: "center" }}>
+          <Icon icon="solar:map-point-wave-bold-duotone" width={44} color="#cbd5e1" />
+          <Typography sx={{ mt: 1.5, fontWeight: 700, color: "#0f172a" }}>
+            Roadmap not found
+          </Typography>
+          <Typography sx={{ mt: 0.5, fontSize: 14, color: "#64748b" }}>
+            It may not be published for your institution.
+          </Typography>
+        </Container>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Roadmap"
+        title={graph?.pageTitle ?? "Roadmap"}
+        description={graph?.summary}
+        accent="purple"
+        icon="solar:map-point-wave-bold-duotone"
+      />
+
+      <Container maxWidth={false} sx={{ py: 3, px: { xs: 2, md: 3 } }}>
+        {progress && progress.total > 0 && (
+          <Stack direction="row" spacing={1.5} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+            <StatTile
+              label="Covered"
+              value={`${Math.round(progress.coverage * 100)}%`}
+              hint="Steps you have marked done or skipped. This is your own record of what you have dealt with."
+              tint="#7c3aed"
+            />
+            <StatTile
+              label="Mastered"
+              value={`${Math.round(progress.mastery * 100)}%`}
+              hint="Steps where you actually passed the quizzes and coding problems. Only this counts toward certification."
+              tint="#059669"
+            />
+            <StatTile
+              label="Steps"
+              value={`${progress.mastered}/${progress.total}`}
+              hint="Verified steps out of the total on this roadmap."
+              tint="#0f172a"
+            />
+          </Stack>
+        )}
+
+        {/* An honest admission rather than a silently wrong number. Only an admin can fix it,
+            but hiding it would let mastery look complete while content is missing. */}
+        {progress && progress.contentGaps > 0 && (
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            sx={{
+              mb: 2,
+              px: 1.75,
+              py: 1.25,
+              borderRadius: 2,
+              bgcolor: "#fffbeb",
+              border: "1px solid #fde68a",
+            }}
+          >
+            <Icon icon="solar:danger-triangle-bold-duotone" width={18} color="#b45309" />
+            <Typography sx={{ fontSize: 12.5, color: "#92400e" }}>
+              {progress.contentGaps} step{progress.contentGaps === 1 ? "" : "s"} on this roadmap
+              have no content yet and are not counted toward your progress.
+            </Typography>
+          </Stack>
+        )}
+
+        {graphQuery.isLoading && (
+          <Typography sx={{ py: 4, color: "#64748b" }}>Loading roadmap...</Typography>
+        )}
+
+        {graph && (
+          <RoadmapSpine graph={graph} progress={progress} onOpenNode={setOpenNode} />
+        )}
+      </Container>
+
+      <RoadmapNodeDrawer
+        slug={slug}
+        node={openNode}
+        selfState={(openNode && progress?.nodes?.[openNode.id]?.selfState) || "pending"}
+        onClose={() => setOpenNode(null)}
+        onSetState={(state) =>
+          openNode && setState.mutate({ nodeId: openNode.id, state })
+        }
+      />
+    </PageShell>
+  );
+}

--- a/app/roadmaps/loading.tsx
+++ b/app/roadmaps/loading.tsx
@@ -1,0 +1,7 @@
+import PageShimmerLayout from "@/components/common/PageShimmerLayout";
+
+// Route-segment shimmer - renders instantly as the navigation Suspense fallback so the page never
+// flashes blank during the transition.
+export default function Loading() {
+  return <PageShimmerLayout variant="grid" />;
+}

--- a/app/roadmaps/page.tsx
+++ b/app/roadmaps/page.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Box, Container, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { PageShell } from "@/components/common/PageShell";
+import { ModulePageHeader } from "@/components/common/ModulePageHeader";
+import { SearchFilterBar } from "@/components/common/list";
+import { Reveal } from "@/components/scorecard/shared";
+import { RoadmapCard } from "@/components/roadmaps/RoadmapCard";
+import { roadmapKeys, roadmapsService } from "@/lib/services/roadmaps.service";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+
+/**
+ * The roadmap catalog.
+ *
+ * A category is not a flat filtered list, it is a curated set of editorial sections. That is
+ * the one idea worth taking wholesale from roadmap.sh: the same roadmap appearing under several
+ * headings is the feature, not a bug, because it optimises for the learner finding it from
+ * wherever they started looking.
+ */
+export default function RoadmapsPage() {
+  const { push, prefetch } = useInstantNavigation();
+  const [category, setCategory] = useState<string>("all");
+  const [query, setQuery] = useState("");
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: roadmapKeys.catalog,
+    queryFn: roadmapsService.catalog,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const bySlug = useMemo(
+    () => Object.fromEntries((data?.roadmaps ?? []).map((r) => [r.slug, r])),
+    [data]
+  );
+
+  const categories = data?.categories ?? [];
+  const active = categories.find((c) => c.slug === category) ?? categories[0];
+
+  const q = query.trim().toLowerCase();
+  const matches = (slug: string) => {
+    if (!q) return true;
+    const r = bySlug[slug];
+    return Boolean(
+      r && (r.pageTitle.toLowerCase().includes(q) || r.summary.toLowerCase().includes(q))
+    );
+  };
+
+  return (
+    <PageShell>
+      <ModulePageHeader
+        eyebrow="Learn"
+        title="Roadmaps"
+        description="Pick a path and follow it. Every step is a verified topic you can practise and be scored on."
+        accent="purple"
+        icon="solar:map-point-wave-bold-duotone"
+        guideKey="roadmaps"
+      />
+
+      <Container maxWidth={false} sx={{ py: 3, px: { xs: 2, md: 3 } }}>
+        <SearchFilterBar
+          search={query}
+          onSearchChange={setQuery}
+          searchPlaceholder="Search roadmaps"
+        />
+
+        {isLoading && (
+          <Typography sx={{ mt: 4, color: "#64748b" }}>Loading roadmaps...</Typography>
+        )}
+
+        {isError && (
+          <Typography sx={{ mt: 4, color: "#b91c1c" }}>
+            We could not load the roadmaps. Please try again.
+          </Typography>
+        )}
+
+        {!isLoading && !isError && (data?.roadmaps?.length ?? 0) === 0 && (
+          <Stack alignItems="center" spacing={1.5} sx={{ py: 8, textAlign: "center" }}>
+            <Icon icon="solar:map-point-wave-bold-duotone" width={44} color="#cbd5e1" />
+            <Typography sx={{ fontWeight: 700, color: "#0f172a" }}>
+              No roadmaps yet
+            </Typography>
+            <Typography sx={{ fontSize: 14, color: "#64748b", maxWidth: 380 }}>
+              Your institution has not published any roadmaps. Once they do, they will appear here.
+            </Typography>
+          </Stack>
+        )}
+
+        {!isLoading && categories.length > 0 && (
+          <Box
+            sx={{
+              mt: 2.5,
+              display: "grid",
+              gap: 3,
+              gridTemplateColumns: { xs: "1fr", md: "220px minmax(0, 1fr)" },
+            }}
+          >
+            {/* Category rail. Horizontal scroll on mobile rather than a dropdown, so the
+                breadth of what is on offer is visible rather than hidden behind a tap. */}
+            <Box
+              data-tour-id="roadmap-categories"
+              sx={{
+                display: "flex",
+                flexDirection: { xs: "row", md: "column" },
+                gap: 0.5,
+                overflowX: { xs: "auto", md: "visible" },
+                pb: { xs: 1, md: 0 },
+              }}
+            >
+              {categories.map((c) => {
+                const count = new Set(c.sections.flatMap((s) => s.roadmaps)).size;
+                const isActive = c.slug === active?.slug;
+                return (
+                  <Box
+                    key={c.slug}
+                    component="button"
+                    onClick={() => setCategory(c.slug)}
+                    sx={{
+                      appearance: "none",
+                      font: "inherit",
+                      cursor: "pointer",
+                      border: "none",
+                      textAlign: "start",
+                      whiteSpace: "nowrap",
+                      px: 1.5,
+                      py: 1,
+                      borderRadius: 2,
+                      bgcolor: isActive ? "#f1f5f9" : "transparent",
+                      color: isActive ? "#0f172a" : "#475569",
+                      fontWeight: isActive ? 700 : 500,
+                      fontSize: 13.5,
+                      display: "flex",
+                      justifyContent: "space-between",
+                      gap: 1.5,
+                      "&:hover": { bgcolor: "#f8fafc" },
+                    }}
+                  >
+                    <span>{c.title}</span>
+                    <Box component="span" sx={{ color: "#94a3b8", fontWeight: 500 }}>
+                      {count}
+                    </Box>
+                  </Box>
+                );
+              })}
+            </Box>
+
+            <Box>
+              {active?.sections.map((section) => {
+                const visible = section.roadmaps.filter(matches);
+                if (!visible.length) return null;
+                return (
+                  <Box key={section.title} sx={{ mb: 3.5 }}>
+                    <Typography
+                      sx={{
+                        fontSize: 11.5,
+                        fontWeight: 700,
+                        letterSpacing: 0.6,
+                        textTransform: "uppercase",
+                        color: "#94a3b8",
+                        mb: 1.25,
+                      }}
+                    >
+                      {section.title}
+                    </Typography>
+                    <Box
+                      sx={{
+                        display: "grid",
+                        gap: 1.75,
+                        gridTemplateColumns: {
+                          xs: "1fr",
+                          sm: "repeat(2, minmax(0, 1fr))",
+                          lg: "repeat(3, minmax(0, 1fr))",
+                        },
+                      }}
+                    >
+                      {visible.map((slug, idx) => {
+                        const roadmap = bySlug[slug];
+                        if (!roadmap) return null;
+                        return (
+                          <Reveal key={slug} delay={Math.min(idx, 8) * 0.06}>
+                            <RoadmapCard
+                              roadmap={roadmap}
+                              onOpen={() => push(`/roadmaps/${slug}`)}
+                              onHover={() => prefetch(`/roadmaps/${slug}`)}
+                            />
+                          </Reveal>
+                        );
+                      })}
+                    </Box>
+                  </Box>
+                );
+              })}
+            </Box>
+          </Box>
+        )}
+      </Container>
+    </PageShell>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -69,7 +69,7 @@ const STUDENT_SECTIONS: NavSection[] = [
     labelKey: "navSection.learn",
     label: "Learn",
     icon: "mdi:school-outline",
-    itemFeatures: ["course", "adaptive_quiz", "assessment"],
+    itemFeatures: ["course", "adaptive_quiz", "assessment", "roadmaps"],
   },
   {
     id: "career",
@@ -446,6 +446,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
       icon: "mdi:book-education-outline",
       featureName: "adaptive_quiz",
       descKey: "navDesc.adaptiveCourses",
+    },
+    // Roadmaps sits directly under Adaptive Courses because it is the layer ABOVE them: it is
+    // how you choose what to learn and see where you are across several courses, while the
+    // journey board is how you actually do one. Gated on its own feature so it is opt-in per
+    // tenant, matching the default-deny grant model on the backend (a tenant with no published
+    // roadmap mapping would otherwise land on an empty page).
+    {
+      label: "Roadmaps",
+      labelKey: "nav.roadmaps",
+      path: "/roadmaps",
+      icon: "mdi:map-marker-path",
+      featureName: "roadmaps",
+      descKey: "navDesc.roadmaps",
     },
     {
       label: "Courses",

--- a/components/roadmaps/RoadmapCard.tsx
+++ b/components/roadmaps/RoadmapCard.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Box, ButtonBase, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { RoadmapCard as Card, RoadmapKind } from "@/lib/services/roadmaps.service";
+
+const KIND_META: Record<RoadmapKind, { label: string; icon: string; tint: string }> = {
+  role: { label: "Role", icon: "solar:case-minimalistic-bold-duotone", tint: "#7c3aed" },
+  skill: { label: "Skill", icon: "solar:layers-minimalistic-bold-duotone", tint: "#0891b2" },
+  beginner: { label: "Start here", icon: "solar:star-bold-duotone", tint: "#059669" },
+  practice: { label: "Practices", icon: "solar:checklist-minimalistic-bold-duotone", tint: "#d97706" },
+};
+
+/**
+ * A roadmap in the catalog grid. Modelled on AdaptiveCourseCard (ButtonBase, flex column so
+ * meta pins to the bottom, hover lift) so the two surfaces read as one product.
+ *
+ * `coverage` is the self-declared bar. It is shown only once the learner has actually started,
+ * because a row of 0% bars across a catalog reads as failure rather than as opportunity.
+ */
+export function RoadmapCard({
+  roadmap,
+  coverage,
+  onOpen,
+  onHover,
+}: {
+  roadmap: Card;
+  coverage?: number;
+  onOpen: () => void;
+  onHover?: () => void;
+}) {
+  const meta = KIND_META[roadmap.kind] ?? KIND_META.skill;
+  const pct = coverage != null ? Math.round(coverage * 100) : null;
+
+  return (
+    <ButtonBase
+      onClick={onOpen}
+      onMouseEnter={onHover}
+      onFocus={onHover}
+      sx={{
+        width: "100%",
+        height: "100%",
+        textAlign: "left",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+        borderRadius: 3,
+        border: "1px solid #e6e8ef",
+        bgcolor: "#fff",
+        p: 2.25,
+        transition: "transform .18s ease, box-shadow .18s ease, border-color .18s ease",
+        "&:hover": {
+          transform: "translateY(-3px)",
+          borderColor: "#c7d2fe",
+          boxShadow: "0 10px 28px rgba(15,23,42,0.08)",
+        },
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1.25 }}>
+        <Box
+          sx={{
+            width: 34,
+            height: 34,
+            borderRadius: 2,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: `${meta.tint}14`,
+            color: meta.tint,
+            flexShrink: 0,
+          }}
+        >
+          <Icon icon={meta.icon} width={19} />
+        </Box>
+        <Chip
+          label={meta.label}
+          size="small"
+          sx={{
+            height: 21,
+            fontSize: 11,
+            fontWeight: 600,
+            bgcolor: `${meta.tint}12`,
+            color: meta.tint,
+          }}
+        />
+        {roadmap.isNew && (
+          <Chip label="New" size="small"
+            sx={{ height: 21, fontSize: 11, fontWeight: 600, bgcolor: "#ecfdf5", color: "#047857" }} />
+        )}
+        {!roadmap.isNew && roadmap.isRevamped && (
+          <Chip label="Updated" size="small"
+            sx={{ height: 21, fontSize: 11, fontWeight: 600, bgcolor: "#eff6ff", color: "#1d4ed8" }} />
+        )}
+      </Stack>
+
+      <Typography sx={{ fontWeight: 700, fontSize: 16, color: "#0f172a", lineHeight: 1.3 }}>
+        {roadmap.pageTitle}
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.75,
+          fontSize: 13,
+          color: "#475569",
+          lineHeight: 1.5,
+          display: "-webkit-box",
+          WebkitLineClamp: 3,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+        }}
+      >
+        {roadmap.summary}
+      </Typography>
+
+      {/* Meta pinned to the bottom so cards of different text lengths still line up. */}
+      <Box sx={{ mt: "auto", pt: 1.5 }}>
+        {pct != null && pct > 0 && (
+          <Box sx={{ mb: 1 }}>
+            <Box sx={{ height: 5, borderRadius: 3, bgcolor: "#eef2f7", overflow: "hidden" }}>
+              <Box sx={{ width: `${pct}%`, height: "100%", bgcolor: "#7c3aed" }} />
+            </Box>
+            <Typography sx={{ mt: 0.5, fontSize: 11, color: "#64748b" }}>
+              {pct}% covered
+            </Typography>
+          </Box>
+        )}
+        <Stack direction="row" alignItems="center" spacing={0.75} sx={{ color: "#64748b" }}>
+          <Icon icon="solar:documents-minimalistic-bold-duotone" width={15} />
+          <Typography sx={{ fontSize: 12 }}>
+            {roadmap.topicCount} {roadmap.topicCount === 1 ? "topic" : "topics"}
+          </Typography>
+        </Stack>
+      </Box>
+    </ButtonBase>
+  );
+}

--- a/components/roadmaps/RoadmapNodeDrawer.tsx
+++ b/components/roadmaps/RoadmapNodeDrawer.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Drawer,
+  IconButton,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  roadmapKeys,
+  roadmapsService,
+  type RoadmapNode,
+  type SelfState,
+} from "@/lib/services/roadmaps.service";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+
+/**
+ * The node drawer. Content is fetched per node rather than embedded in the graph payload, so
+ * the graph stays small and cacheable.
+ *
+ * Two rules this UI must not break:
+ *  - The status control writes a SELF-DECLARED annotation. It moves the coverage bar and can
+ *    never move mastery, so the copy says "covered", not "completed".
+ *  - Opening the content goes through the normal course gate. When `accessible` is false the
+ *    learner is told why and offered the course, rather than being handed a second, parallel
+ *    route into content they are not enrolled in.
+ */
+
+const STATES: { value: SelfState; label: string; icon: string; key: string }[] = [
+  { value: "done", label: "Done", icon: "solar:check-circle-bold", key: "D" },
+  { value: "learning", label: "Learning", icon: "solar:book-bookmark-bold", key: "L" },
+  { value: "skipped", label: "Skip", icon: "solar:close-circle-bold", key: "S" },
+];
+
+const RESOURCE_TINT: Record<string, string> = {
+  official: "#1d4ed8",
+  opensource: "#0f172a",
+  article: "#b45309",
+  course: "#047857",
+  video: "#7c3aed",
+  book: "#be123c",
+  podcast: "#7c3aed",
+  feed: "#c026d3",
+  roadmap: "#0f172a",
+};
+
+export function RoadmapNodeDrawer({
+  slug,
+  node,
+  selfState,
+  onClose,
+  onSetState,
+}: {
+  slug: string;
+  node: RoadmapNode | null;
+  selfState: SelfState;
+  onClose: () => void;
+  onSetState: (state: SelfState) => void;
+}) {
+  const { push } = useInstantNavigation();
+
+  // useQuery rather than an effect: it keys the result to the node, so reopening a node is
+  // instant and switching nodes can never flash the previous node's content (which a
+  // fetch-into-state effect does, because the old detail is still in state while the new
+  // request is in flight).
+  const { data: detail, isLoading: loading } = useQuery({
+    queryKey: roadmapKeys.node(slug, node?.id ?? 0),
+    queryFn: () => roadmapsService.node(slug, node!.id),
+    enabled: Boolean(node),
+    staleTime: 10 * 60 * 1000,
+  });
+
+  // Single-key shortcuts, as on roadmap.sh. Cheap, and they make bulk self-assessment fast.
+  useEffect(() => {
+    if (!node?.isTrackable) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      if (target && ["INPUT", "TEXTAREA"].includes(target.tagName)) return;
+      const match = STATES.find((s) => s.key.toLowerCase() === e.key.toLowerCase());
+      if (match) {
+        e.preventDefault();
+        onSetState(match.value);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [node, onSetState]);
+
+  return (
+    <Drawer
+      anchor="right"
+      open={Boolean(node)}
+      onClose={onClose}
+      PaperProps={{ sx: { width: { xs: "100%", sm: 460 }, p: 0 } }}
+    >
+      {node && (
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ px: 2.5, py: 1.75, borderBottom: "1px solid #e6e8ef" }}
+          >
+            {node.isTrackable ? (
+              <Stack direction="row" spacing={0.75}>
+                {STATES.map((s) => {
+                  const active = selfState === s.value;
+                  return (
+                    <Button
+                      key={s.value}
+                      size="small"
+                      onClick={() => onSetState(active ? "pending" : s.value)}
+                      startIcon={<Icon icon={s.icon} width={15} />}
+                      sx={{
+                        textTransform: "none",
+                        fontSize: 12.5,
+                        fontWeight: 600,
+                        borderRadius: 2,
+                        color: active ? "#fff" : "#475569",
+                        bgcolor: active ? "#7c3aed" : "transparent",
+                        border: `1px solid ${active ? "#7c3aed" : "#e6e8ef"}`,
+                        "&:hover": { bgcolor: active ? "#5b21b6" : "#f8fafc" },
+                      }}
+                    >
+                      {s.label}
+                    </Button>
+                  );
+                })}
+              </Stack>
+            ) : (
+              <Typography sx={{ fontSize: 13, color: "#64748b" }}>Section</Typography>
+            )}
+            <IconButton onClick={onClose} size="small" aria-label="Close">
+              <Icon icon="solar:close-circle-linear" width={22} />
+            </IconButton>
+          </Stack>
+
+          <Box sx={{ px: 2.5, py: 2.5, overflowY: "auto", flex: 1 }}>
+            <Typography sx={{ fontSize: 22, fontWeight: 800, color: "#0f172a", lineHeight: 1.25 }}>
+              {node.title}
+            </Typography>
+
+            {loading && (
+              <Box sx={{ display: "grid", placeItems: "center", py: 4 }}>
+                <CircularProgress size={22} />
+              </Box>
+            )}
+
+            {detail && (
+              <>
+                {detail.summary && (
+                  <Typography sx={{ mt: 1.5, fontSize: 14.5, color: "#475569", lineHeight: 1.65 }}>
+                    {detail.summary}
+                  </Typography>
+                )}
+
+                {detail.opens.length > 0 && (
+                  <Box sx={{ mt: 3 }}>
+                    <Typography sx={{ fontSize: 12.5, fontWeight: 700, color: "#0f172a", mb: 1 }}>
+                      Practise this
+                    </Typography>
+                    <Stack spacing={1}>
+                      {detail.opens.map((t) => (
+                        <Box
+                          key={`${t.type}-${t.submoduleId ?? t.courseId}`}
+                          sx={{
+                            border: "1px solid #e6e8ef",
+                            borderRadius: 2,
+                            p: 1.5,
+                            bgcolor: t.accessible ? "#fff" : "#f8fafc",
+                          }}
+                        >
+                          <Stack direction="row" alignItems="center" spacing={1}>
+                            <Icon
+                              icon={
+                                t.accessible
+                                  ? "solar:play-circle-bold-duotone"
+                                  : "solar:lock-keyhole-minimalistic-bold-duotone"
+                              }
+                              width={18}
+                              color={t.accessible ? "#7c3aed" : "#94a3b8"}
+                            />
+                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                              <Typography sx={{ fontSize: 13.5, fontWeight: 600, color: "#0f172a" }}>
+                                {t.title}
+                              </Typography>
+                              <Typography sx={{ fontSize: 11.5, color: "#64748b" }}>
+                                {t.courseTitle}
+                              </Typography>
+                            </Box>
+                            {t.accessible ? (
+                              <Button
+                                size="small"
+                                onClick={() =>
+                                  push(
+                                    t.submoduleId
+                                      ? `/adaptive-courses/${t.courseId}/submodule/${t.submoduleId}`
+                                      : `/adaptive-courses/${t.courseId}`
+                                  )
+                                }
+                                sx={{ textTransform: "none", fontWeight: 600, fontSize: 12.5 }}
+                              >
+                                Open
+                              </Button>
+                            ) : (
+                              <Chip
+                                label={t.selfEnrollable ? "Join course" : "Locked"}
+                                size="small"
+                                onClick={
+                                  t.selfEnrollable
+                                    ? () => push(`/adaptive-courses/${t.courseId}`)
+                                    : undefined
+                                }
+                                sx={{
+                                  height: 22,
+                                  fontSize: 11,
+                                  cursor: t.selfEnrollable ? "pointer" : "default",
+                                }}
+                              />
+                            )}
+                          </Stack>
+                        </Box>
+                      ))}
+                    </Stack>
+                    {detail.opens.some((t) => !t.accessible) && (
+                      <Typography sx={{ mt: 1, fontSize: 11.5, color: "#94a3b8" }}>
+                        Locked steps need enrolment in the course that owns them.
+                      </Typography>
+                    )}
+                  </Box>
+                )}
+
+                {detail.resources.length > 0 && (
+                  <Box sx={{ mt: 3 }}>
+                    <Typography sx={{ fontSize: 12.5, fontWeight: 700, color: "#0f172a", mb: 1 }}>
+                      Read more
+                    </Typography>
+                    <Stack spacing={0.75}>
+                      {detail.resources.map((r) => (
+                        <Stack key={r.url} direction="row" alignItems="center" spacing={1}>
+                          <Chip
+                            label={r.type}
+                            size="small"
+                            sx={{
+                              height: 19,
+                              fontSize: 10,
+                              fontWeight: 600,
+                              textTransform: "capitalize",
+                              bgcolor: `${RESOURCE_TINT[r.type] ?? "#64748b"}14`,
+                              color: RESOURCE_TINT[r.type] ?? "#64748b",
+                            }}
+                          />
+                          <Typography
+                            component="a"
+                            href={r.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{
+                              fontSize: 13.5,
+                              color: "#7c3aed",
+                              textDecoration: "underline",
+                              "&:hover": { color: "#5b21b6" },
+                            }}
+                          >
+                            {r.title}
+                          </Typography>
+                        </Stack>
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
+              </>
+            )}
+          </Box>
+        </Box>
+      )}
+    </Drawer>
+  );
+}

--- a/components/roadmaps/RoadmapSpine.tsx
+++ b/components/roadmaps/RoadmapSpine.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type {
+  RoadmapGraph,
+  RoadmapNode,
+  RoadmapProgress,
+} from "@/lib/services/roadmaps.service";
+
+/**
+ * The map.
+ *
+ * Deliberately CSS, not a graph library. roadmap.sh hand-places absolute pixel coordinates on a
+ * fixed-width canvas (1097px for /frontend), which is why their map is not responsive and why
+ * their contributors cannot edit topology at all. Our layout derives from (parent, order), so a
+ * centre spine with branch cards gives the same visual read while staying responsive, inheriting
+ * RTL from `dir`, and scrolling normally on a phone instead of fighting the page for pan
+ * gestures.
+ *
+ * Colour follows roadmap.sh's one genuinely good rule: the node fill carries PROGRESS, so
+ * hierarchy is expressed by size and weight only. Text decoration doubles the signal so state
+ * survives for colour-blind readers.
+ */
+
+const STATE_STYLE = {
+  done: { bg: "#ecfdf5", border: "#6ee7b7", text: "#065f46", deco: "line-through" },
+  learning: { bg: "#f5f3ff", border: "#c4b5fd", text: "#5b21b6", deco: "underline" },
+  skipped: { bg: "#f1f5f9", border: "#cbd5e1", text: "#64748b", deco: "line-through" },
+  pending: { bg: "#ffffff", border: "#e6e8ef", text: "#0f172a", deco: "none" },
+} as const;
+
+function NodeCard({
+  node,
+  progress,
+  onOpen,
+}: {
+  node: RoadmapNode;
+  progress?: RoadmapProgress["nodes"][number];
+  onOpen: () => void;
+}) {
+  const state = progress?.selfState ?? "pending";
+  const style = STATE_STYLE[state];
+  const verified = progress?.verifiedComplete;
+  const units = progress ? `${progress.unitsComplete}/${progress.unitsTotal}` : null;
+
+  return (
+    <Box
+      component="button"
+      onClick={onOpen}
+      sx={{
+        appearance: "none",
+        font: "inherit",
+        cursor: "pointer",
+        width: "100%",
+        textAlign: "start",
+        px: 1.75,
+        py: 1.25,
+        borderRadius: 2.5,
+        bgcolor: style.bg,
+        border: `1.5px solid ${style.border}`,
+        transition: "transform .15s ease, box-shadow .15s ease",
+        "&:hover": { transform: "translateY(-2px)", boxShadow: "0 8px 20px rgba(15,23,42,.08)" },
+        "&:focus-visible": { outline: "2px solid #7c3aed", outlineOffset: 2 },
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Typography
+          sx={{
+            flex: 1,
+            fontSize: node.kind === "subtopic" ? 13 : 14.5,
+            fontWeight: node.kind === "subtopic" ? 500 : 700,
+            color: style.text,
+            textDecoration: style.deco,
+          }}
+        >
+          {node.title}
+        </Typography>
+        {verified && (
+          <Icon icon="solar:verified-check-bold" width={17} color="#059669" aria-label="Verified complete" />
+        )}
+        {!node.isRequired && (
+          <Chip label="Optional" size="small"
+            sx={{ height: 18, fontSize: 10, bgcolor: "#f1f5f9", color: "#64748b" }} />
+        )}
+      </Stack>
+      {units && progress!.unitsTotal > 0 && (
+        <Typography sx={{ mt: 0.4, fontSize: 11, color: "#64748b" }}>
+          {units} topics done
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+export function RoadmapSpine({
+  graph,
+  progress,
+  onOpenNode,
+}: {
+  graph: RoadmapGraph;
+  progress?: RoadmapProgress;
+  onOpenNode: (node: RoadmapNode) => void;
+}) {
+  // Sections are the milestone nodes; everything else hangs off one of them by parentId.
+  const sections = graph.nodes
+    .filter((n) => n.kind === "milestone")
+    .sort((a, b) => a.order - b.order);
+  const childrenOf = (id: number) =>
+    graph.nodes.filter((n) => n.parentId === id).sort((a, b) => a.order - b.order);
+
+  // A roadmap with no milestones is still renderable: treat every root node as its own row.
+  const orphans = graph.nodes
+    .filter((n) => n.kind !== "milestone" && n.parentId === null)
+    .sort((a, b) => a.order - b.order);
+
+  return (
+    <Box sx={{ position: "relative", py: 2 }}>
+      {sections.map((section, i) => {
+        const children = childrenOf(section.id);
+        return (
+          <Box key={section.id} sx={{ position: "relative", mb: 4 }}>
+            {/* The connector. A pseudo-rail behind the content rather than a drawn node, so it
+                cannot desynchronise from the actual structure the way roadmap.sh's decorative
+                line-segment nodes do. */}
+            {i < sections.length - 1 && (
+              <Box
+                aria-hidden
+                sx={{
+                  position: "absolute",
+                  insetInlineStart: { xs: 15, md: "50%" },
+                  top: 34,
+                  bottom: -34,
+                  width: 2,
+                  bgcolor: "#e6e8ef",
+                  transform: { md: "translateX(-50%)" },
+                }}
+              />
+            )}
+
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1.25}
+              sx={{
+                position: "relative",
+                justifyContent: { md: "center" },
+                mb: 2,
+              }}
+            >
+              <Box
+                sx={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: "50%",
+                  display: "grid",
+                  placeItems: "center",
+                  bgcolor: "#140b2b",
+                  color: "#fff",
+                  fontSize: 13,
+                  fontWeight: 700,
+                  flexShrink: 0,
+                  zIndex: 1,
+                }}
+              >
+                {i + 1}
+              </Box>
+              <Typography sx={{ fontWeight: 800, fontSize: 17, color: "#0f172a" }}>
+                {section.title}
+              </Typography>
+            </Stack>
+
+            <Box
+              sx={{
+                display: "grid",
+                gap: 1.25,
+                gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
+                ml: { xs: 4.5, md: 0 },
+                maxWidth: { md: 860 },
+                mx: { md: "auto" },
+              }}
+            >
+              {children.map((node) => (
+                <NodeCard
+                  key={node.id}
+                  node={node}
+                  progress={progress?.nodes?.[node.id]}
+                  onOpen={() => onOpenNode(node)}
+                />
+              ))}
+            </Box>
+          </Box>
+        );
+      })}
+
+      {orphans.length > 0 && (
+        <Box
+          sx={{
+            display: "grid",
+            gap: 1.25,
+            gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
+            maxWidth: { md: 860 },
+            mx: { md: "auto" },
+          }}
+        >
+          {orphans.map((node) => (
+            <NodeCard
+              key={node.id}
+              node={node}
+              progress={progress?.nodes?.[node.id]}
+              onOpen={() => onOpenNode(node)}
+            />
+          ))}
+        </Box>
+      )}
+
+      {graph.legends.length > 0 && (
+        <Stack
+          direction="row"
+          spacing={2}
+          flexWrap="wrap"
+          useFlexGap
+          sx={{ mt: 3, justifyContent: "center" }}
+        >
+          {graph.legends.map((lg) => (
+            <Stack key={lg.id} direction="row" alignItems="center" spacing={0.75}>
+              <Box sx={{ width: 10, height: 10, borderRadius: "50%", bgcolor: lg.color }} />
+              <Typography sx={{ fontSize: 12, color: "#64748b" }}>{lg.label}</Typography>
+            </Stack>
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}

--- a/lib/guide/registry.ts
+++ b/lib/guide/registry.ts
@@ -289,6 +289,61 @@ export const PAGE_GUIDES: Record<string, PageGuideContent> = {
     ],
     tip: "The guided tour reads aloud and highlights each feature on the page. Press the speaker toggle to read silently.",
   },
+  "/roadmaps": {
+    tourSteps: [
+      {
+        targetId: "page-header",
+        title: "Roadmaps",
+        narration: "A roadmap is a path through our courses, laid out in the order that actually makes sense to learn them. Pick one and it tells you what to do next.",
+        placement: "bottom",
+        icon: "mdi:map-marker-path",
+        color: "#a78bfa",
+      },
+      {
+        targetId: "roadmap-categories",
+        title: "Browse by category",
+        narration: "Categories group the roadmaps by area. A roadmap can sit in more than one, so you will find it from wherever you started looking.",
+        placement: "right",
+        icon: "mdi:format-list-bulleted",
+        color: "#0ea5e9",
+      },
+      {
+        title: "Every step is real",
+        narration: "Each step on a roadmap is a verified topic with articles, quizzes and coding problems behind it. Your progress is measured on what you actually passed, not on what you ticked off.",
+        icon: "mdi:check-decagram-outline",
+        color: "#22c55e",
+      },
+    ],
+    headerTitle: "Find your path",
+    headerSubtitle: "Curated routes through our verified courses, so you always know what to learn next.",
+    features: [
+      {
+        icon: "mdi:map-marker-path",
+        color: "#6366f1",
+        title: "Role, skill or beginner",
+        text: "Role roadmaps train you for a job. Skill roadmaps go deep on one technology. Beginner roadmaps assume you have never written code.",
+      },
+      {
+        icon: "mdi:check-decagram-outline",
+        color: "#22c55e",
+        title: "Two kinds of progress",
+        text: "Covered is what you have marked yourself. Mastered is what you actually passed. Only mastered counts toward certification.",
+      },
+      {
+        icon: "mdi:gesture-tap-button",
+        color: "#0ea5e9",
+        title: "Mark as you go",
+        text: "Open any step and mark it Done, Learning or Skip. Keyboard shortcuts D, L and S make it quick.",
+      },
+      {
+        icon: "mdi:rocket-launch-outline",
+        color: "#ec4899",
+        title: "Jump straight into practice",
+        text: "Each step links to the exact topic behind it, so you go from the map into the real content in one click.",
+      },
+    ],
+    tip: "Skipping a step is a real answer. It moves your covered bar without pretending you mastered it, which keeps the map honest about where you actually are.",
+  },
   "/adaptive-courses": {
     tourSteps: [
       {

--- a/lib/services/roadmaps.service.ts
+++ b/lib/services/roadmaps.service.ts
@@ -1,0 +1,165 @@
+import apiClient from "./api";
+
+const BASE = "/roadmaps/api";
+
+/**
+ * Roadmaps: a navigation layer over the verified content library.
+ *
+ * The graph and the progress overlay are deliberately two calls. The graph is identical for
+ * every learner in the tenant and cacheable per (slug, version); the overlay is per learner.
+ * Do not merge them.
+ */
+
+export type RoadmapKind = "role" | "skill" | "beginner" | "practice";
+export type NodeKind = "topic" | "subtopic" | "milestone" | "label";
+export type SelfState = "pending" | "learning" | "done" | "skipped";
+export type EdgeKind = "sequence" | "contains";
+
+export interface RoadmapCard {
+  slug: string;
+  cardTitle: string;
+  pageTitle: string;
+  kind: RoadmapKind;
+  summary: string;
+  isNew: boolean;
+  isRevamped: boolean;
+  topicCount: number;
+}
+
+export interface RoadmapCategorySection {
+  title: string;
+  /** Slugs, not card objects: one roadmap legitimately appears in several sections. */
+  roadmaps: string[];
+}
+
+export interface RoadmapCategory {
+  slug: string;
+  title: string;
+  sections: RoadmapCategorySection[];
+}
+
+export interface RoadmapCatalog {
+  categories: RoadmapCategory[];
+  roadmaps: RoadmapCard[];
+}
+
+export interface RoadmapNode {
+  id: number;
+  slug: string;
+  title: string;
+  kind: NodeKind;
+  order: number;
+  parentId: number | null;
+  isRequired: boolean;
+  isTrackable: boolean;
+  legendId: number | null;
+}
+
+export interface RoadmapEdge {
+  from: number;
+  to: number;
+  kind: EdgeKind;
+}
+
+export interface RoadmapLegend {
+  id: number;
+  label: string;
+  color: string;
+}
+
+export interface RoadmapGraph {
+  slug: string;
+  cardTitle: string;
+  pageTitle: string;
+  kind: RoadmapKind;
+  summary: string;
+  version: number;
+  nodes: RoadmapNode[];
+  edges: RoadmapEdge[];
+  legends: RoadmapLegend[];
+}
+
+export interface RoadmapNodeProgress {
+  selfState: SelfState;
+  /** Derived from real submissions. Nothing self-declared can set this. */
+  verifiedComplete: boolean;
+  unitsComplete: number;
+  unitsTotal: number;
+  hasContentGap: boolean;
+}
+
+export interface RoadmapProgress {
+  total: number;
+  done: number;
+  skipped: number;
+  learning: number;
+  mastered: number;
+  /** (done + skipped) / total. Self-declared: the bar the learner sees. */
+  coverage: number;
+  /** mastered / total. Derived: the only number that may gate anything we certify. */
+  mastery: number;
+  contentGaps: number;
+  nodes: Record<number, RoadmapNodeProgress>;
+}
+
+export interface RoadmapNodeTarget {
+  type: "submodule" | "course";
+  courseId: number;
+  courseTitle: string;
+  submoduleId?: number;
+  title: string;
+  /** Answered by the same gate the course surfaces use. Roadmaps add no second grant path. */
+  accessible: boolean;
+  selfEnrollable: boolean;
+}
+
+export interface RoadmapNodeDetail {
+  id: number;
+  slug: string;
+  title: string;
+  kind: NodeKind;
+  summary: string;
+  isRequired: boolean;
+  resources: { type: string; title: string; url: string }[];
+  opens: RoadmapNodeTarget[];
+}
+
+export const roadmapsService = {
+  catalog: async (): Promise<RoadmapCatalog> => {
+    const { data } = await apiClient.get(`${BASE}/catalog/`);
+    return data;
+  },
+
+  graph: async (slug: string): Promise<RoadmapGraph> => {
+    const { data } = await apiClient.get(`${BASE}/${slug}/`);
+    return data;
+  },
+
+  progress: async (slug: string): Promise<RoadmapProgress> => {
+    const { data } = await apiClient.get(`${BASE}/${slug}/progress/`);
+    return data;
+  },
+
+  node: async (slug: string, nodeId: number): Promise<RoadmapNodeDetail> => {
+    const { data } = await apiClient.get(`${BASE}/${slug}/nodes/${nodeId}/`);
+    return data;
+  },
+
+  setNodeState: async (slug: string, nodeId: number, state: SelfState) => {
+    const { data } = await apiClient.post(`${BASE}/${slug}/nodes/${nodeId}/state/`, { state });
+    return data as { nodeId: number; selfState: SelfState };
+  },
+
+  follow: async (slug: string, following: boolean) => {
+    const { data } = await apiClient.post(`${BASE}/${slug}/follow/`, { following });
+    return data as { slug: string; following: boolean };
+  },
+};
+
+/** Query keys, so the graph and the overlay can be invalidated independently. */
+export const roadmapKeys = {
+  catalog: ["roadmaps", "catalog"] as const,
+  graph: (slug: string) => ["roadmaps", "graph", slug] as const,
+  progress: (slug: string) => ["roadmaps", "progress", slug] as const,
+  node: (slug: string, nodeId: number) => ["roadmaps", "node", slug, nodeId] as const,
+};

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -31,7 +31,8 @@
     "support": "تذاكري",
     "adminTickets": "إدارة التذاكر",
     "adaptiveQuizzes": "الاختبارات التكيفية",
-    "adminAdaptiveQuizzes": "الاختبارات التكيفية"
+    "adminAdaptiveQuizzes": "الاختبارات التكيفية",
+    "roadmaps": "خرائط التعلم"
   },
   "certificatesUpload": {
     "heroBadge": "إدارة · التخزين",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -35,7 +35,8 @@
     "adaptiveCourses": "Adaptive Courses",
     "adminTickets": "Ticket Management",
     "adaptiveQuizzes": "Adaptive Course",
-    "adminAdaptiveQuizzes": "Adaptive Course Builder"
+    "adminAdaptiveQuizzes": "Adaptive Course Builder",
+    "roadmaps": "Roadmaps"
   },
   "navSection": {
     "learn": "Learn",
@@ -78,7 +79,8 @@
     "admin_scorecard": "Track student performance and readiness scorecards.",
     "admin_certificates": "Upload and manage course completion certificates.",
     "admin_jobs_v2": "Post jobs and curate opportunities for students.",
-    "admin_attendance": "Review attendance across live sessions and cohorts."
+    "admin_attendance": "Review attendance across live sessions and cohorts.",
+    "roadmaps": "Curated paths through our verified courses, so you always know what to learn next."
   },
   "certificatesUpload": {
     "heroBadge": "Admin · Storage",

--- a/proxy.ts
+++ b/proxy.ts
@@ -20,6 +20,7 @@ const INSTRUCTOR_BLOCKED_PREFIXES = [
   "/points-system",
   "/proctoring-demo",
   "/resume",
+  "/roadmaps",
 ];
 
 function normalizeRole(role?: string): string {


### PR DESCRIPTION
Student UI for Roadmaps. Backend is ai-linc-backend #561 (stacked on #560).

**Needs the backend deployed first** — the endpoints do not exist until then.

## What this adds

- `/roadmaps` — catalog with a category rail. A category is a set of curated editorial sections
  rather than a flat filtered list, and a roadmap appearing under several is intentional.
- `/roadmaps/[slug]` — the map, plus a node drawer with the status control and links into the
  real content.

## Why there is no graph library

roadmap.sh hand-places absolute pixel coordinates on a fixed-width canvas (1097px for
`/frontend`). That is why their map is not responsive, and why their contributors are barred
from editing topology at all. Our layout derives from `(parent, order)`, so a CSS grid spine
gives the same visual read while staying responsive, inheriting RTL from `dir`, and scrolling
normally on a phone instead of competing with the page for pan gestures.

`package.json` has no react-flow, dagre, elk or cytoscape. Adding one for a static authored
layout would buy nothing.

## Two numbers, kept honest

| | |
|---|---|
| **Covered** | what the learner marked done or skipped |
| **Mastered** | what they actually passed |

The optimistic update recomputes **coverage only**. Mastery is derived server-side from real
submissions and no client action may move it. Content gaps are shown rather than hidden —
suppressing them would let mastery read as complete while content is missing.

## Access

Node targets report `accessible` from the same gate the course surfaces use. Roadmaps add no
second grant path, so a locked step offers the course rather than a back door into it.

## Also

Establishes the missing TanStack Query convention. Query was installed and persisted but had
exactly **one** `useQuery` call in the entire app; this adds `roadmapKeys` so the cacheable
graph and the per-learner overlay invalidate independently.

## Verification

`tsc --noEmit` clean (CI runs unit tests only, so a type error would otherwise merge green and
only fail at Netlify), eslint clean, 84 unit tests pass, `next build` succeeds with both routes
registered.

## Rollout

Nav is gated on a `roadmaps` feature, opt-in per tenant, matching the backend's default-deny
grant model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)