### PR TITLE
feat(roadmaps): spine-and-branch map, richer node drawer

### DIFF
--- a/components/roadmaps/RoadmapNodeDrawer.tsx
+++ b/components/roadmaps/RoadmapNodeDrawer.tsx
@@ -165,70 +165,102 @@ export function RoadmapNodeDrawer({
                 {detail.opens.length > 0 && (
                   <Box sx={{ mt: 3 }}>
                     <Typography sx={{ fontSize: 12.5, fontWeight: 700, color: "#0f172a", mb: 1 }}>
-                      Practise this
+                      {detail.opens.length === 1 ? "What is in this step" : "What is in this step"}
                     </Typography>
-                    <Stack spacing={1}>
-                      {detail.opens.map((t) => (
-                        <Box
-                          key={`${t.type}-${t.submoduleId ?? t.courseId}`}
-                          sx={{
-                            border: "1px solid #e6e8ef",
-                            borderRadius: 2,
-                            p: 1.5,
-                            bgcolor: t.accessible ? "#fff" : "#f8fafc",
-                          }}
-                        >
-                          <Stack direction="row" alignItems="center" spacing={1}>
-                            <Icon
-                              icon={
-                                t.accessible
-                                  ? "solar:play-circle-bold-duotone"
-                                  : "solar:lock-keyhole-minimalistic-bold-duotone"
-                              }
-                              width={18}
-                              color={t.accessible ? "#7c3aed" : "#94a3b8"}
-                            />
-                            <Box sx={{ flex: 1, minWidth: 0 }}>
-                              <Typography sx={{ fontSize: 13.5, fontWeight: 600, color: "#0f172a" }}>
-                                {t.title}
-                              </Typography>
-                              <Typography sx={{ fontSize: 11.5, color: "#64748b" }}>
-                                {t.courseTitle}
-                              </Typography>
-                            </Box>
-                            {t.accessible ? (
-                              <Button
-                                size="small"
-                                onClick={() =>
-                                  push(
-                                    t.submoduleId
-                                      ? `/adaptive-courses/${t.courseId}/submodule/${t.submoduleId}`
-                                      : `/adaptive-courses/${t.courseId}`
-                                  )
+                    <Stack spacing={1.25}>
+                      {detail.opens.map((t) => {
+                        const c = t.content ?? {};
+                        const facts = [
+                          c.readingMinutes ? `${c.readingMinutes} min read` : c.article ? "Article" : null,
+                          c.questions ? `${c.questions} question${c.questions === 1 ? "" : "s"}` : null,
+                          c.codingProblems
+                            ? `${c.codingProblems} coding problem${c.codingProblems === 1 ? "" : "s"}`
+                            : null,
+                        ].filter(Boolean) as string[];
+                        return (
+                          <Box
+                            key={`${t.type}-${t.submoduleId ?? t.courseId}`}
+                            sx={{
+                              border: "1px solid #e6e8ef",
+                              borderRadius: 2,
+                              p: 1.5,
+                              bgcolor: t.accessible ? "#fff" : "#f8fafc",
+                            }}
+                          >
+                            <Stack direction="row" alignItems="flex-start" spacing={1}>
+                              <Icon
+                                icon={
+                                  t.accessible
+                                    ? "solar:play-circle-bold-duotone"
+                                    : "solar:lock-keyhole-minimalistic-bold-duotone"
                                 }
-                                sx={{ textTransform: "none", fontWeight: 600, fontSize: 12.5 }}
-                              >
-                                Open
-                              </Button>
-                            ) : (
-                              <Chip
-                                label={t.selfEnrollable ? "Join course" : "Locked"}
-                                size="small"
-                                onClick={
-                                  t.selfEnrollable
-                                    ? () => push(`/adaptive-courses/${t.courseId}`)
-                                    : undefined
-                                }
-                                sx={{
-                                  height: 22,
-                                  fontSize: 11,
-                                  cursor: t.selfEnrollable ? "pointer" : "default",
-                                }}
+                                width={18}
+                                color={t.accessible ? "#7c3aed" : "#94a3b8"}
+                                style={{ marginTop: 2, flexShrink: 0 }}
                               />
-                            )}
-                          </Stack>
-                        </Box>
-                      ))}
+                              <Box sx={{ flex: 1, minWidth: 0 }}>
+                                <Typography sx={{ fontSize: 13.5, fontWeight: 600, color: "#0f172a" }}>
+                                  {t.title}
+                                </Typography>
+                                <Typography sx={{ fontSize: 11.5, color: "#64748b" }}>
+                                  {t.courseTitle}
+                                </Typography>
+                                {(c.articleSummary || t.description) && (
+                                  <Typography
+                                    sx={{ mt: 0.75, fontSize: 12.5, color: "#475569", lineHeight: 1.55 }}
+                                  >
+                                    {c.articleSummary || t.description}
+                                  </Typography>
+                                )}
+                                {facts.length > 0 && (
+                                  <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap sx={{ mt: 1 }}>
+                                    {facts.map((f) => (
+                                      <Chip
+                                        key={f}
+                                        label={f}
+                                        size="small"
+                                        sx={{
+                                          height: 20, fontSize: 10.5, fontWeight: 600,
+                                          bgcolor: "#f1f5f9", color: "#475569",
+                                        }}
+                                      />
+                                    ))}
+                                  </Stack>
+                                )}
+                              </Box>
+                              {t.accessible ? (
+                                <Button
+                                  size="small"
+                                  onClick={() =>
+                                    push(
+                                      t.submoduleId
+                                        ? `/adaptive-courses/${t.courseId}/submodule/${t.submoduleId}`
+                                        : `/adaptive-courses/${t.courseId}`
+                                    )
+                                  }
+                                  sx={{ textTransform: "none", fontWeight: 600, fontSize: 12.5, flexShrink: 0 }}
+                                >
+                                  Open
+                                </Button>
+                              ) : (
+                                <Chip
+                                  label={t.selfEnrollable ? "Join" : "Locked"}
+                                  size="small"
+                                  onClick={
+                                    t.selfEnrollable
+                                      ? () => push(`/adaptive-courses/${t.courseId}`)
+                                      : undefined
+                                  }
+                                  sx={{
+                                    height: 22, fontSize: 11, flexShrink: 0,
+                                    cursor: t.selfEnrollable ? "pointer" : "default",
+                                  }}
+                                />
+                              )}
+                            </Stack>
+                          </Box>
+                        );
+                      })}
                     </Stack>
                     {detail.opens.some((t) => !t.accessible) && (
                       <Typography sx={{ mt: 1, fontSize: 11.5, color: "#94a3b8" }}>

--- a/components/roadmaps/RoadmapSpine.tsx
+++ b/components/roadmaps/RoadmapSpine.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Fragment } from "react";
 import { Box, Chip, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import type {
@@ -9,86 +10,219 @@ import type {
 } from "@/lib/services/roadmaps.service";
 
 /**
- * The map.
+ * The map: a centre spine of primary steps with branch steps hanging off it, connected by
+ * dotted rails. This is roadmap.sh's visual language, which works because it answers "where am
+ * I and what comes next" at a glance.
  *
- * Deliberately CSS, not a graph library. roadmap.sh hand-places absolute pixel coordinates on a
- * fixed-width canvas (1097px for /frontend), which is why their map is not responsive and why
- * their contributors cannot edit topology at all. Our layout derives from (parent, order), so a
- * centre spine with branch cards gives the same visual read while staying responsive, inheriting
- * RTL from `dir`, and scrolling normally on a phone instead of fighting the page for pan
- * gestures.
+ * It is CSS, not a graph library. roadmap.sh hand-places absolute pixel coordinates on a fixed
+ * canvas (1097px wide for /frontend), which is why their map is not responsive and why their
+ * contributors cannot edit topology at all. Ours derives from (parent, order), so the same read
+ * survives a phone, inherits RTL from `dir`, and needs no new dependency.
  *
- * Colour follows roadmap.sh's one genuinely good rule: the node fill carries PROGRESS, so
- * hierarchy is expressed by size and weight only. Text decoration doubles the signal so state
- * survives for colour-blind readers.
+ * Colour rule, taken from their renderer: node FILL carries progress state, so hierarchy is
+ * carried by size and shade only. Text decoration doubles every state signal, so it survives
+ * for colour-blind readers.
  */
 
-const STATE_STYLE = {
-  done: { bg: "#ecfdf5", border: "#6ee7b7", text: "#065f46", deco: "line-through" },
+type NodeState = "done" | "learning" | "skipped" | "pending";
+
+const SPINE_STYLE: Record<NodeState, { bg: string; border: string; text: string; deco: string }> = {
+  done: { bg: "#d1fae5", border: "#34d399", text: "#065f46", deco: "line-through" },
+  learning: { bg: "#ddd6fe", border: "#a78bfa", text: "#4c1d95", deco: "underline" },
+  skipped: { bg: "#e2e8f0", border: "#94a3b8", text: "#475569", deco: "line-through" },
+  pending: { bg: "#fde68a", border: "#0f172a", text: "#0f172a", deco: "none" },
+};
+
+const BRANCH_STYLE: Record<NodeState, { bg: string; border: string; text: string; deco: string }> = {
+  done: { bg: "#ecfdf5", border: "#6ee7b7", text: "#047857", deco: "line-through" },
   learning: { bg: "#f5f3ff", border: "#c4b5fd", text: "#5b21b6", deco: "underline" },
   skipped: { bg: "#f1f5f9", border: "#cbd5e1", text: "#64748b", deco: "line-through" },
-  pending: { bg: "#ffffff", border: "#e6e8ef", text: "#0f172a", deco: "none" },
-} as const;
+  pending: { bg: "#fef3c7", border: "#0f172a", text: "#0f172a", deco: "none" },
+};
 
-function NodeCard({
+const RAIL = "#2b78e4";
+
+function NodeBox({
   node,
   progress,
+  variant,
   onOpen,
 }: {
   node: RoadmapNode;
   progress?: RoadmapProgress["nodes"][number];
+  variant: "spine" | "branch";
   onOpen: () => void;
 }) {
-  const state = progress?.selfState ?? "pending";
-  const style = STATE_STYLE[state];
+  const state = (progress?.selfState ?? "pending") as NodeState;
+  const palette = variant === "spine" ? SPINE_STYLE : BRANCH_STYLE;
+  const s = palette[state];
   const verified = progress?.verifiedComplete;
-  const units = progress ? `${progress.unitsComplete}/${progress.unitsTotal}` : null;
 
   return (
     <Box
       component="button"
       onClick={onOpen}
+      title={node.title}
       sx={{
         appearance: "none",
         font: "inherit",
         cursor: "pointer",
+        position: "relative",
+        zIndex: 1,
         width: "100%",
-        textAlign: "start",
-        px: 1.75,
-        py: 1.25,
-        borderRadius: 2.5,
-        bgcolor: style.bg,
-        border: `1.5px solid ${style.border}`,
-        transition: "transform .15s ease, box-shadow .15s ease",
-        "&:hover": { transform: "translateY(-2px)", boxShadow: "0 8px 20px rgba(15,23,42,.08)" },
-        "&:focus-visible": { outline: "2px solid #7c3aed", outlineOffset: 2 },
+        textAlign: "center",
+        px: variant === "spine" ? 2 : 1.5,
+        py: variant === "spine" ? 1.15 : 0.85,
+        borderRadius: 1.5,
+        bgcolor: s.bg,
+        border: `1.7px solid ${s.border}`,
+        boxShadow: variant === "spine" ? "2px 2px 0 rgba(15,23,42,.9)" : "1.5px 1.5px 0 rgba(15,23,42,.55)",
+        transition: "transform .12s ease, filter .12s ease",
+        "&:hover": { transform: "translateY(-1px)", filter: "brightness(0.97)" },
+        "&:focus-visible": { outline: "2px solid #7c3aed", outlineOffset: 3 },
       }}
     >
-      <Stack direction="row" alignItems="center" spacing={1}>
+      <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.6}>
         <Typography
+          component="span"
           sx={{
-            flex: 1,
-            fontSize: node.kind === "subtopic" ? 13 : 14.5,
-            fontWeight: node.kind === "subtopic" ? 500 : 700,
-            color: style.text,
-            textDecoration: style.deco,
+            fontSize: variant === "spine" ? 14 : 12.5,
+            fontWeight: variant === "spine" ? 700 : 500,
+            color: s.text,
+            textDecoration: s.deco,
+            lineHeight: 1.35,
           }}
         >
           {node.title}
         </Typography>
         {verified && (
-          <Icon icon="solar:verified-check-bold" width={17} color="#059669" aria-label="Verified complete" />
-        )}
-        {!node.isRequired && (
-          <Chip label="Optional" size="small"
-            sx={{ height: 18, fontSize: 10, bgcolor: "#f1f5f9", color: "#64748b" }} />
+          <Icon icon="solar:verified-check-bold" width={15} color="#059669" aria-label="Verified" />
         )}
       </Stack>
-      {units && progress!.unitsTotal > 0 && (
-        <Typography sx={{ mt: 0.4, fontSize: 11, color: "#64748b" }}>
-          {units} topics done
-        </Typography>
+      {!node.isRequired && variant === "spine" && (
+        <Chip
+          label="Optional"
+          size="small"
+          sx={{ mt: 0.5, height: 16, fontSize: 9.5, bgcolor: "#ffffffaa", color: "#475569" }}
+        />
       )}
+    </Box>
+  );
+}
+
+/** One spine step plus its branches, laid out around a vertical rail. */
+function SpineRow({
+  node,
+  branches,
+  progress,
+  side,
+  onOpenNode,
+}: {
+  node: RoadmapNode;
+  branches: RoadmapNode[];
+  progress?: RoadmapProgress;
+  side: "left" | "right";
+  onOpenNode: (n: RoadmapNode) => void;
+}) {
+  const branchCol = (
+    <Box
+      sx={{
+        display: branches.length ? "grid" : "none",
+        gap: 0.75,
+        alignContent: "center",
+        // Dotted connector from the rail out to the branch stack, mirroring roadmap.sh's
+        // topic-to-subtopic dashes.
+        position: "relative",
+        "&::before": branches.length
+          ? {
+              content: '""',
+              position: "absolute",
+              top: "50%",
+              [side === "left" ? "right" : "left"]: -24,
+              width: 24,
+              borderTop: `2px dotted ${RAIL}`,
+            }
+          : undefined,
+      }}
+    >
+      {branches.map((b) => (
+        <NodeBox
+          key={b.id}
+          node={b}
+          variant="branch"
+          progress={progress?.nodes?.[b.id]}
+          onOpen={() => onOpenNode(b)}
+        />
+      ))}
+    </Box>
+  );
+
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        alignItems: "center",
+        columnGap: 3,
+        // Desktop: branches sit either side of a centre rail. Mobile: one column, branches
+        // indented under their spine step, because a two-sided canvas is unreadable at 380px.
+        gridTemplateColumns: { xs: "1fr", md: "minmax(0,1fr) 260px minmax(0,1fr)" },
+        rowGap: { xs: 1, md: 0 },
+        py: { xs: 1, md: 1.5 },
+        position: "relative",
+      }}
+    >
+      {/* The rail itself: a real continuous line behind the centre column. Drawn from
+          structure rather than authored as decoration, so it can never desynchronise from the
+          order the data actually declares. */}
+      <Box
+        aria-hidden
+        sx={{
+          position: "absolute",
+          insetInlineStart: { xs: 13, md: "50%" },
+          top: 0,
+          bottom: 0,
+          width: 3,
+          bgcolor: RAIL,
+          transform: { md: "translateX(-50%)" },
+          zIndex: 0,
+        }}
+      />
+
+      <Box sx={{ display: { xs: "none", md: "block" } }}>
+        {side === "left" ? branchCol : null}
+      </Box>
+
+      <Box sx={{ position: "relative", zIndex: 1, ml: { xs: 4, md: 0 } }}>
+        <NodeBox
+          node={node}
+          variant="spine"
+          progress={progress?.nodes?.[node.id]}
+          onOpen={() => onOpenNode(node)}
+        />
+      </Box>
+
+      <Box sx={{ display: { xs: "none", md: "block" } }}>
+        {side === "right" ? branchCol : null}
+      </Box>
+
+      {/* Mobile branch stack. */}
+      <Box
+        sx={{
+          display: { xs: branches.length ? "grid" : "none", md: "none" },
+          gap: 0.6,
+          ml: 6,
+        }}
+      >
+        {branches.map((b) => (
+          <NodeBox
+            key={b.id}
+            node={b}
+            variant="branch"
+            progress={progress?.nodes?.[b.id]}
+            onOpen={() => onOpenNode(b)}
+          />
+        ))}
+      </Box>
     </Box>
   );
 }
@@ -102,134 +236,99 @@ export function RoadmapSpine({
   progress?: RoadmapProgress;
   onOpenNode: (node: RoadmapNode) => void;
 }) {
-  // Sections are the milestone nodes; everything else hangs off one of them by parentId.
   const sections = graph.nodes
     .filter((n) => n.kind === "milestone")
     .sort((a, b) => a.order - b.order);
   const childrenOf = (id: number) =>
     graph.nodes.filter((n) => n.parentId === id).sort((a, b) => a.order - b.order);
 
-  // A roadmap with no milestones is still renderable: treat every root node as its own row.
-  const orphans = graph.nodes
-    .filter((n) => n.kind !== "milestone" && n.parentId === null)
-    .sort((a, b) => a.order - b.order);
+  // Which side each spine step's branches sit on, resolved BEFORE render rather than by
+  // incrementing a counter inside the JSX. Alternating across the whole map (not per section)
+  // is what keeps the canvas visually balanced when a section has an odd number of steps.
+  const sideByNodeId = new Map<number, "left" | "right">();
+  sections
+    .flatMap((s) => childrenOf(s.id))
+    .forEach((n, i) => sideByNodeId.set(n.id, i % 2 === 0 ? "right" : "left"));
 
   return (
-    <Box sx={{ position: "relative", py: 2 }}>
-      {sections.map((section, i) => {
-        const children = childrenOf(section.id);
-        return (
-          <Box key={section.id} sx={{ position: "relative", mb: 4 }}>
-            {/* The connector. A pseudo-rail behind the content rather than a drawn node, so it
-                cannot desynchronise from the actual structure the way roadmap.sh's decorative
-                line-segment nodes do. */}
-            {i < sections.length - 1 && (
-              <Box
-                aria-hidden
-                sx={{
-                  position: "absolute",
-                  insetInlineStart: { xs: 15, md: "50%" },
-                  top: 34,
-                  bottom: -34,
-                  width: 2,
-                  bgcolor: "#e6e8ef",
-                  transform: { md: "translateX(-50%)" },
-                }}
-              />
-            )}
-
-            <Stack
-              direction="row"
-              alignItems="center"
-              spacing={1.25}
-              sx={{
-                position: "relative",
-                justifyContent: { md: "center" },
-                mb: 2,
-              }}
-            >
-              <Box
-                sx={{
-                  width: 32,
-                  height: 32,
-                  borderRadius: "50%",
-                  display: "grid",
-                  placeItems: "center",
-                  bgcolor: "#140b2b",
-                  color: "#fff",
-                  fontSize: 13,
-                  fontWeight: 700,
-                  flexShrink: 0,
-                  zIndex: 1,
-                }}
-              >
-                {i + 1}
-              </Box>
-              <Typography sx={{ fontWeight: 800, fontSize: 17, color: "#0f172a" }}>
-                {section.title}
-              </Typography>
-            </Stack>
-
-            <Box
-              sx={{
-                display: "grid",
-                gap: 1.25,
-                gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
-                ml: { xs: 4.5, md: 0 },
-                maxWidth: { md: 860 },
-                mx: { md: "auto" },
-              }}
-            >
-              {children.map((node) => (
-                <NodeCard
-                  key={node.id}
-                  node={node}
-                  progress={progress?.nodes?.[node.id]}
-                  onOpen={() => onOpenNode(node)}
-                />
-              ))}
-            </Box>
-          </Box>
-        );
-      })}
-
-      {orphans.length > 0 && (
+    <Box sx={{ position: "relative", pb: 4 }}>
+      {graph.legends.length > 0 && (
         <Box
           sx={{
-            display: "grid",
-            gap: 1.25,
-            gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0, 1fr))" },
-            maxWidth: { md: 860 },
-            mx: { md: "auto" },
+            mb: 3,
+            mx: "auto",
+            maxWidth: 340,
+            border: "1.7px solid #0f172a",
+            borderRadius: 1.5,
+            p: 1.5,
+            bgcolor: "#fff",
           }}
         >
-          {orphans.map((node) => (
-            <NodeCard
-              key={node.id}
-              node={node}
-              progress={progress?.nodes?.[node.id]}
-              onOpen={() => onOpenNode(node)}
-            />
+          {graph.legends.map((lg) => (
+            <Stack key={lg.id} direction="row" alignItems="center" spacing={1} sx={{ py: 0.25 }}>
+              <Box
+                sx={{
+                  width: 15, height: 15, borderRadius: "50%", bgcolor: lg.color,
+                  display: "grid", placeItems: "center", flexShrink: 0,
+                }}
+              >
+                <Icon icon="mdi:check" width={11} color="#fff" />
+              </Box>
+              <Typography sx={{ fontSize: 12.5, color: "#0f172a" }}>{lg.label}</Typography>
+            </Stack>
           ))}
         </Box>
       )}
 
-      {graph.legends.length > 0 && (
-        <Stack
-          direction="row"
-          spacing={2}
-          flexWrap="wrap"
-          useFlexGap
-          sx={{ mt: 3, justifyContent: "center" }}
-        >
-          {graph.legends.map((lg) => (
-            <Stack key={lg.id} direction="row" alignItems="center" spacing={0.75}>
-              <Box sx={{ width: 10, height: 10, borderRadius: "50%", bgcolor: lg.color }} />
-              <Typography sx={{ fontSize: 12, color: "#64748b" }}>{lg.label}</Typography>
-            </Stack>
-          ))}
-        </Stack>
-      )}
+      {sections.map((section) => {
+        const spineNodes = childrenOf(section.id);
+        return (
+          <Fragment key={section.id}>
+            <Box sx={{ position: "relative", py: 2, textAlign: { xs: "start", md: "center" } }}>
+              <Box
+                aria-hidden
+                sx={{
+                  position: "absolute",
+                  insetInlineStart: { xs: 13, md: "50%" },
+                  top: 0,
+                  bottom: 0,
+                  width: 3,
+                  bgcolor: RAIL,
+                  transform: { md: "translateX(-50%)" },
+                  zIndex: 0,
+                }}
+              />
+              <Typography
+                component="h2"
+                sx={{
+                  position: "relative",
+                  zIndex: 1,
+                  display: "inline-block",
+                  bgcolor: "#fbfbfd",
+                  px: 2,
+                  ml: { xs: 4, md: 0 },
+                  fontSize: 21,
+                  fontWeight: 800,
+                  color: "#0f172a",
+                }}
+              >
+                {section.title}
+              </Typography>
+            </Box>
+
+            {spineNodes.map((node) => (
+              <SpineRow
+                key={node.id}
+                node={node}
+                branches={childrenOf(node.id)}
+                progress={progress}
+                side={sideByNodeId.get(node.id) ?? "right"}
+                onOpenNode={onOpenNode}
+              />
+            ))}
+          </Fragment>
+        );
+      })}
     </Box>
   );
 }

--- a/lib/services/roadmaps.service.ts
+++ b/lib/services/roadmaps.service.ts
@@ -81,6 +81,8 @@ export interface RoadmapGraph {
 
 export interface RoadmapNodeProgress {
   selfState: SelfState;
+  /** False for a spine node that derives from its branches; only leaves count in the totals. */
+  isLeaf?: boolean;
   /** Derived from real submissions. Nothing self-declared can set this. */
   verifiedComplete: boolean;
   unitsComplete: number;
@@ -102,15 +104,27 @@ export interface RoadmapProgress {
   nodes: Record<number, RoadmapNodeProgress>;
 }
 
+export interface RoadmapTargetContent {
+  article?: boolean;
+  articleTitle?: string;
+  articleSummary?: string;
+  readingMinutes?: number | null;
+  questions?: number;
+  codingProblems?: number;
+}
+
 export interface RoadmapNodeTarget {
   type: "submodule" | "course";
   courseId: number;
   courseTitle: string;
   submoduleId?: number;
   title: string;
+  description?: string;
   /** Answered by the same gate the course surfaces use. Roadmaps add no second grant path. */
   accessible: boolean;
   selfEnrollable: boolean;
+  /** What is actually inside, so the learner knows what they are committing to. */
+  content?: RoadmapTargetContent;
 }
 
 export interface RoadmapNodeDetail {


### PR DESCRIPTION
Rebuilds the map to look like roadmap.sh, and makes clicking a node actually tell you something.
Pairs with backend #562 (merged and deployed).

## The map

Centre rail, primary steps on it, branch steps either side on dotted connectors, legend box at
the top. The previous version was a stack of cards, which does not answer "where am I and what
comes next" at a glance — the whole job of a roadmap.

Backed by real data now: the Frontend map is **180 nodes** (25 spine, 150 branches) against
roadmap.sh's 156.

## Still no graph library

Their canvas is hand-placed absolute pixels at a fixed 1097px wide. That is precisely why it is
not responsive and why their contributors cannot edit topology. Ours derives from
`(parent, order)`, so:

- the two-sided canvas collapses to a single indented column under `md` — survives a phone
  instead of competing with it for pan gestures
- RTL comes free from `dir`, no mirrored coordinates (this app ships a near-complete `ar` locale)

## Colour

Node **fill** carries progress state, so hierarchy is carried by size and shade only — spine
amber and bold, branches paler and lighter. Every state also changes text decoration, so it
survives for colour-blind readers.

## Drawer

Now reports what is in a step: article summary, reading time, question count, coding-problem
count.

## Verification

`tsc --noEmit` clean (CI runs unit tests only, so a type error would otherwise merge green),
eslint clean, `next build` compiles with both routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)