### PR TITLE
feat(roadmaps): platform palette, curved arrows, richer spine drawer

### DIFF
--- a/components/roadmaps/RoadmapCard.tsx
+++ b/components/roadmaps/RoadmapCard.tsx
@@ -6,9 +6,9 @@ import type { RoadmapCard as Card, RoadmapKind } from "@/lib/services/roadmaps.s
 
 const KIND_META: Record<RoadmapKind, { label: string; icon: string; tint: string }> = {
   role: { label: "Role", icon: "solar:case-minimalistic-bold-duotone", tint: "#7c3aed" },
-  skill: { label: "Skill", icon: "solar:layers-minimalistic-bold-duotone", tint: "#0891b2" },
-  beginner: { label: "Start here", icon: "solar:star-bold-duotone", tint: "#059669" },
-  practice: { label: "Practices", icon: "solar:checklist-minimalistic-bold-duotone", tint: "#d97706" },
+  skill: { label: "Skill", icon: "solar:layers-minimalistic-bold-duotone", tint: "#6366f1" },
+  beginner: { label: "Start here", icon: "solar:star-bold-duotone", tint: "#0d9488" },
+  practice: { label: "Practices", icon: "solar:checklist-minimalistic-bold-duotone", tint: "#db2777" },
 };
 
 /**

--- a/components/roadmaps/RoadmapNodeDrawer.tsx
+++ b/components/roadmaps/RoadmapNodeDrawer.tsx
@@ -162,6 +162,108 @@ export function RoadmapNodeDrawer({
                   </Typography>
                 )}
 
+                {/* A spine step: what it contains overall, then every sub-step. Without this
+                    the drawer for a spine node is a title and one sentence, which is the
+                    complaint that prompted it. */}
+                {detail.totals?.steps ? (
+                  <Stack direction="row" spacing={0.75} flexWrap="wrap" useFlexGap sx={{ mt: 2 }}>
+                    {[
+                      `${detail.totals.steps} steps`,
+                      detail.totals.readingMinutes ? `${detail.totals.readingMinutes} min reading` : null,
+                      detail.totals.questions ? `${detail.totals.questions} questions` : null,
+                      detail.totals.codingProblems
+                        ? `${detail.totals.codingProblems} coding problems`
+                        : null,
+                    ]
+                      .filter(Boolean)
+                      .map((f) => (
+                        <Chip
+                          key={f as string}
+                          label={f as string}
+                          size="small"
+                          sx={{
+                            height: 24, fontSize: 11.5, fontWeight: 600,
+                            bgcolor: "#ede9fe", color: "#5b21b6",
+                          }}
+                        />
+                      ))}
+                  </Stack>
+                ) : null}
+
+                {detail.steps && detail.steps.length > 0 && (
+                  <Box sx={{ mt: 2.5 }}>
+                    <Typography sx={{ fontSize: 12.5, fontWeight: 700, color: "#0f172a", mb: 1 }}>
+                      Steps in this section
+                    </Typography>
+                    <Stack spacing={0.85}>
+                      {detail.steps.map((s, i) => (
+                        <Box
+                          key={s.id}
+                          sx={{
+                            border: "1px solid #e6e8ef",
+                            borderRadius: 2,
+                            p: 1.35,
+                            bgcolor: s.selfState === "done" ? "#f6fefb" : "#fff",
+                          }}
+                        >
+                          <Stack direction="row" alignItems="flex-start" spacing={1.1}>
+                            <Box
+                              sx={{
+                                width: 21, height: 21, borderRadius: "50%", flexShrink: 0, mt: 0.2,
+                                display: "grid", placeItems: "center",
+                                bgcolor: s.selfState === "done" ? "#059669" : "#ede9fe",
+                                color: s.selfState === "done" ? "#fff" : "#5b21b6",
+                                fontSize: 10.5, fontWeight: 700,
+                              }}
+                            >
+                              {s.selfState === "done" ? <Icon icon="mdi:check" width={13} /> : i + 1}
+                            </Box>
+                            <Box sx={{ flex: 1, minWidth: 0 }}>
+                              <Typography sx={{ fontSize: 13, fontWeight: 600, color: "#0f172a" }}>
+                                {s.title}
+                              </Typography>
+                              {s.summary && (
+                                <Typography
+                                  sx={{ mt: 0.4, fontSize: 12, color: "#64748b", lineHeight: 1.5 }}
+                                >
+                                  {s.summary}
+                                </Typography>
+                              )}
+                              <Stack direction="row" spacing={1.25} sx={{ mt: 0.6, color: "#94a3b8" }}>
+                                {s.readingMinutes > 0 && (
+                                  <Typography sx={{ fontSize: 11 }}>{s.readingMinutes} min</Typography>
+                                )}
+                                {s.questions > 0 && (
+                                  <Typography sx={{ fontSize: 11 }}>{s.questions} questions</Typography>
+                                )}
+                                {s.codingProblems > 0 && (
+                                  <Typography sx={{ fontSize: 11 }}>
+                                    {s.codingProblems} coding
+                                  </Typography>
+                                )}
+                              </Stack>
+                            </Box>
+                            {s.accessible && s.courseId && s.submoduleId && (
+                              <Button
+                                size="small"
+                                onClick={() =>
+                                  push(`/adaptive-courses/${s.courseId}/submodule/${s.submoduleId}`)
+                                }
+                                sx={{
+                                  textTransform: "none", fontWeight: 600, fontSize: 12,
+                                  flexShrink: 0, minWidth: 0,
+                                }}
+                              >
+                                Open
+                              </Button>
+                            )}
+                          </Stack>
+                        </Box>
+                      ))}
+                    </Stack>
+                  </Box>
+                )}
+
                 {detail.opens.length > 0 && (
                   <Box sx={{ mt: 3 }}>
                     <Typography sx={{ fontSize: 12.5, fontWeight: 700, color: "#0f172a", mb: 1 }}>

--- a/components/roadmaps/RoadmapSpine.tsx
+++ b/components/roadmaps/RoadmapSpine.tsx
@@ -10,37 +10,42 @@ import type {
 } from "@/lib/services/roadmaps.service";
 
 /**
- * The map: a centre spine of primary steps with branch steps hanging off it, connected by
- * dotted rails. This is roadmap.sh's visual language, which works because it answers "where am
- * I and what comes next" at a glance.
+ * The map: a centre spine of primary steps with branch steps hanging off it on curved
+ * connectors, and arrowheads showing which way to travel.
  *
- * It is CSS, not a graph library. roadmap.sh hand-places absolute pixel coordinates on a fixed
- * canvas (1097px wide for /frontend), which is why their map is not responsive and why their
- * contributors cannot edit topology at all. Ours derives from (parent, order), so the same read
- * survives a phone, inherits RTL from `dir`, and needs no new dependency.
+ * CSS + inline SVG, no graph library. roadmap.sh hand-places absolute pixel coordinates on a
+ * fixed 1097px canvas, which is exactly why theirs is not responsive and why their contributors
+ * cannot edit topology. Ours derives from (parent, order), so the two-sided canvas collapses to
+ * one indented column under md, and RTL comes free from `dir`.
  *
- * Colour rule, taken from their renderer: node FILL carries progress state, so hierarchy is
- * carried by size and shade only. Text decoration doubles every state signal, so it survives
- * for colour-blind readers.
+ * Palette is the PLATFORM's (violet #7c3aed, ink #0f172a, canvas #fbfbfd), not roadmap.sh's
+ * yellow-and-blue. Their yellow is a brand asset of theirs and read as a foreign object here.
+ * The mechanic worth keeping from them is the rule, not the hue: node FILL carries progress
+ * state, so hierarchy is carried by size and weight only, and every state also changes text
+ * decoration so it survives for colour-blind readers.
  */
 
 type NodeState = "done" | "learning" | "skipped" | "pending";
 
+const INK = "#0f172a";
+const VIOLET = "#7c3aed";
+const RAIL = "#c7bdf2";
+const RAIL_STRONG = "#7c3aed";
+
 const SPINE_STYLE: Record<NodeState, { bg: string; border: string; text: string; deco: string }> = {
-  done: { bg: "#d1fae5", border: "#34d399", text: "#065f46", deco: "line-through" },
-  learning: { bg: "#ddd6fe", border: "#a78bfa", text: "#4c1d95", deco: "underline" },
-  skipped: { bg: "#e2e8f0", border: "#94a3b8", text: "#475569", deco: "line-through" },
-  pending: { bg: "#fde68a", border: "#0f172a", text: "#0f172a", deco: "none" },
+  // Untouched = the platform violet, so the path you have not walked reads as the brand.
+  pending: { bg: "#ede9fe", border: VIOLET, text: "#4c1d95", deco: "none" },
+  learning: { bg: "#fce7f3", border: "#ec4899", text: "#9d174d", deco: "underline" },
+  done: { bg: "#d1fae5", border: "#059669", text: "#065f46", deco: "line-through" },
+  skipped: { bg: "#f1f5f9", border: "#94a3b8", text: "#64748b", deco: "line-through" },
 };
 
 const BRANCH_STYLE: Record<NodeState, { bg: string; border: string; text: string; deco: string }> = {
-  done: { bg: "#ecfdf5", border: "#6ee7b7", text: "#047857", deco: "line-through" },
-  learning: { bg: "#f5f3ff", border: "#c4b5fd", text: "#5b21b6", deco: "underline" },
-  skipped: { bg: "#f1f5f9", border: "#cbd5e1", text: "#64748b", deco: "line-through" },
-  pending: { bg: "#fef3c7", border: "#0f172a", text: "#0f172a", deco: "none" },
+  pending: { bg: "#faf8ff", border: "#ddd6fe", text: INK, deco: "none" },
+  learning: { bg: "#fdf2f8", border: "#fbcfe8", text: "#9d174d", deco: "underline" },
+  done: { bg: "#ecfdf5", border: "#a7f3d0", text: "#047857", deco: "line-through" },
+  skipped: { bg: "#f8fafc", border: "#e2e8f0", text: "#94a3b8", deco: "line-through" },
 };
-
-const RAIL = "#2b78e4";
 
 function NodeBox({
   node,
@@ -54,39 +59,51 @@ function NodeBox({
   onOpen: () => void;
 }) {
   const state = (progress?.selfState ?? "pending") as NodeState;
-  const palette = variant === "spine" ? SPINE_STYLE : BRANCH_STYLE;
-  const s = palette[state];
+  const s = (variant === "spine" ? SPINE_STYLE : BRANCH_STYLE)[state];
   const verified = progress?.verifiedComplete;
 
   return (
     <Box
       component="button"
       onClick={onOpen}
-      title={node.title}
       sx={{
         appearance: "none",
         font: "inherit",
         cursor: "pointer",
         position: "relative",
-        zIndex: 1,
+        zIndex: 2,
         width: "100%",
-        textAlign: "center",
-        px: variant === "spine" ? 2 : 1.5,
-        py: variant === "spine" ? 1.15 : 0.85,
-        borderRadius: 1.5,
+        textAlign: variant === "spine" ? "center" : "start",
+        px: variant === "spine" ? 2.25 : 1.5,
+        py: variant === "spine" ? 1.3 : 0.85,
+        borderRadius: 2,
         bgcolor: s.bg,
-        border: `1.7px solid ${s.border}`,
-        boxShadow: variant === "spine" ? "2px 2px 0 rgba(15,23,42,.9)" : "1.5px 1.5px 0 rgba(15,23,42,.55)",
-        transition: "transform .12s ease, filter .12s ease",
-        "&:hover": { transform: "translateY(-1px)", filter: "brightness(0.97)" },
-        "&:focus-visible": { outline: "2px solid #7c3aed", outlineOffset: 3 },
+        border: `1.5px solid ${s.border}`,
+        boxShadow:
+          variant === "spine"
+            ? "0 4px 14px rgba(124,58,237,.16)"
+            : "0 1px 3px rgba(15,23,42,.05)",
+        transition: "transform .14s ease, box-shadow .14s ease",
+        "&:hover": {
+          transform: "translateY(-2px)",
+          boxShadow:
+            variant === "spine"
+              ? "0 8px 22px rgba(124,58,237,.26)"
+              : "0 4px 12px rgba(15,23,42,.10)",
+        },
+        "&:focus-visible": { outline: `2px solid ${VIOLET}`, outlineOffset: 3 },
       }}
     >
-      <Stack direction="row" alignItems="center" justifyContent="center" spacing={0.6}>
+      <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent={variant === "spine" ? "center" : "flex-start"}
+        spacing={0.7}
+      >
         <Typography
           component="span"
           sx={{
-            fontSize: variant === "spine" ? 14 : 12.5,
+            fontSize: variant === "spine" ? 14.5 : 12.75,
             fontWeight: variant === "spine" ? 700 : 500,
             color: s.text,
             textDecoration: s.deco,
@@ -103,14 +120,70 @@ function NodeBox({
         <Chip
           label="Optional"
           size="small"
-          sx={{ mt: 0.5, height: 16, fontSize: 9.5, bgcolor: "#ffffffaa", color: "#475569" }}
+          sx={{ mt: 0.6, height: 17, fontSize: 9.5, bgcolor: "#ffffffcc", color: "#64748b" }}
         />
       )}
     </Box>
   );
 }
 
-/** One spine step plus its branches, laid out around a vertical rail. */
+/** A curved connector from the rail out to the branch stack, with an arrowhead. */
+function CurvedConnector({ side, id }: { side: "left" | "right"; id: string }) {
+  // Drawn right-to-left when the branches sit on the left, so the arrow always points AT the
+  // branches -- the direction the reader travels.
+  const d = side === "right" ? "M0,40 C24,40 24,8 46,8" : "M46,40 C22,40 22,8 0,8";
+  return (
+    <Box
+      aria-hidden
+      sx={{ display: { xs: "none", md: "block" }, width: 48, height: 48, flexShrink: 0 }}
+    >
+      <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+        <defs>
+          <marker
+            id={`arrow-${id}`}
+            markerWidth="7"
+            markerHeight="7"
+            refX="5"
+            refY="3.5"
+            orient="auto"
+          >
+            <path d="M0,0 L6,3.5 L0,7 z" fill={RAIL_STRONG} />
+          </marker>
+        </defs>
+        <path
+          d={d}
+          stroke={RAIL_STRONG}
+          strokeWidth="1.8"
+          strokeDasharray="4 4"
+          strokeLinecap="round"
+          markerEnd={`url(#arrow-${id})`}
+        />
+      </svg>
+    </Box>
+  );
+}
+
+/** The rail segment between two spine steps, carrying a downward arrow. */
+function RailArrow() {
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        display: "flex",
+        justifyContent: { xs: "flex-start", md: "center" },
+        pl: { xs: "6px", md: 0 },
+        py: 0.5,
+      }}
+    >
+      <svg width="16" height="34" viewBox="0 0 16 34" fill="none">
+        <path d="M8,0 L8,26" stroke={RAIL} strokeWidth="3" strokeLinecap="round" />
+        <path d="M3,24 L8,32 L13,24" stroke={RAIL_STRONG} strokeWidth="2.4"
+              strokeLinecap="round" strokeLinejoin="round" fill="none" />
+      </svg>
+    </Box>
+  );
+}
+
 function SpineRow({
   node,
   branches,
@@ -124,27 +197,8 @@ function SpineRow({
   side: "left" | "right";
   onOpenNode: (n: RoadmapNode) => void;
 }) {
-  const branchCol = (
-    <Box
-      sx={{
-        display: branches.length ? "grid" : "none",
-        gap: 0.75,
-        alignContent: "center",
-        // Dotted connector from the rail out to the branch stack, mirroring roadmap.sh's
-        // topic-to-subtopic dashes.
-        position: "relative",
-        "&::before": branches.length
-          ? {
-              content: '""',
-              position: "absolute",
-              top: "50%",
-              [side === "left" ? "right" : "left"]: -24,
-              width: 24,
-              borderTop: `2px dotted ${RAIL}`,
-            }
-          : undefined,
-      }}
-    >
+  const branchStack = (
+    <Stack spacing={0.7} sx={{ width: "100%", maxWidth: 260 }}>
       {branches.map((b) => (
         <NodeBox
           key={b.id}
@@ -154,7 +208,7 @@ function SpineRow({
           onOpen={() => onOpenNode(b)}
         />
       ))}
-    </Box>
+    </Stack>
   );
 
   return (
@@ -162,37 +216,31 @@ function SpineRow({
       sx={{
         display: "grid",
         alignItems: "center",
-        columnGap: 3,
-        // Desktop: branches sit either side of a centre rail. Mobile: one column, branches
-        // indented under their spine step, because a two-sided canvas is unreadable at 380px.
-        gridTemplateColumns: { xs: "1fr", md: "minmax(0,1fr) 260px minmax(0,1fr)" },
+        gridTemplateColumns: { xs: "1fr", md: "1fr auto 1fr" },
+        justifyItems: { md: "center" },
         rowGap: { xs: 1, md: 0 },
-        py: { xs: 1, md: 1.5 },
-        position: "relative",
       }}
     >
-      {/* The rail itself: a real continuous line behind the centre column. Drawn from
-          structure rather than authored as decoration, so it can never desynchronise from the
-          order the data actually declares. */}
+      {/* Left cell */}
       <Box
-        aria-hidden
         sx={{
-          position: "absolute",
-          insetInlineStart: { xs: 13, md: "50%" },
-          top: 0,
-          bottom: 0,
-          width: 3,
-          bgcolor: RAIL,
-          transform: { md: "translateX(-50%)" },
-          zIndex: 0,
+          display: { xs: "none", md: "flex" },
+          justifyContent: "flex-end",
+          alignItems: "center",
+          width: "100%",
+          gap: 0,
         }}
-      />
-
-      <Box sx={{ display: { xs: "none", md: "block" } }}>
-        {side === "left" ? branchCol : null}
+      >
+        {side === "left" && branches.length > 0 && (
+          <>
+            {branchStack}
+            <CurvedConnector side="left" id={`l${node.id}`} />
+          </>
+        )}
       </Box>
 
-      <Box sx={{ position: "relative", zIndex: 1, ml: { xs: 4, md: 0 } }}>
+      {/* Centre: the spine step */}
+      <Box sx={{ width: { xs: "100%", md: 264 }, ml: { xs: 3.5, md: 0 } }}>
         <NodeBox
           node={node}
           variant="spine"
@@ -201,27 +249,39 @@ function SpineRow({
         />
       </Box>
 
-      <Box sx={{ display: { xs: "none", md: "block" } }}>
-        {side === "right" ? branchCol : null}
-      </Box>
-
-      {/* Mobile branch stack. */}
+      {/* Right cell */}
       <Box
         sx={{
-          display: { xs: branches.length ? "grid" : "none", md: "none" },
-          gap: 0.6,
-          ml: 6,
+          display: { xs: "none", md: "flex" },
+          justifyContent: "flex-start",
+          alignItems: "center",
+          width: "100%",
         }}
       >
-        {branches.map((b) => (
-          <NodeBox
-            key={b.id}
-            node={b}
-            variant="branch"
-            progress={progress?.nodes?.[b.id]}
-            onOpen={() => onOpenNode(b)}
-          />
-        ))}
+        {side === "right" && branches.length > 0 && (
+          <>
+            <CurvedConnector side="right" id={`r${node.id}`} />
+            {branchStack}
+          </>
+        )}
+      </Box>
+
+      {/* Mobile: branches indented under their step, since a two-sided canvas is unreadable
+          at 380px and a pannable one competes with page scroll. */}
+      <Box sx={{ display: { xs: "block", md: "none" }, ml: 5.5, mt: 0.5 }}>
+        {branches.length > 0 && (
+          <Stack spacing={0.6}>
+            {branches.map((b) => (
+              <NodeBox
+                key={b.id}
+                node={b}
+                variant="branch"
+                progress={progress?.nodes?.[b.id]}
+                onOpen={() => onOpenNode(b)}
+              />
+            ))}
+          </Stack>
+        )}
       </Box>
     </Box>
   );
@@ -242,90 +302,75 @@ export function RoadmapSpine({
   const childrenOf = (id: number) =>
     graph.nodes.filter((n) => n.parentId === id).sort((a, b) => a.order - b.order);
 
-  // Which side each spine step's branches sit on, resolved BEFORE render rather than by
-  // incrementing a counter inside the JSX. Alternating across the whole map (not per section)
-  // is what keeps the canvas visually balanced when a section has an odd number of steps.
+  // Resolved before render rather than by mutating a counter inside JSX (which
+  // react-hooks/immutability rejects). Alternating across the WHOLE map, not per section, keeps
+  // the canvas balanced when a section has an odd number of steps.
   const sideByNodeId = new Map<number, "left" | "right">();
   sections
     .flatMap((s) => childrenOf(s.id))
     .forEach((n, i) => sideByNodeId.set(n.id, i % 2 === 0 ? "right" : "left"));
 
   return (
-    <Box sx={{ position: "relative", pb: 4 }}>
+    <Box sx={{ position: "relative", pb: 5 }}>
       {graph.legends.length > 0 && (
-        <Box
+        <Stack
+          direction="row"
+          spacing={2.5}
+          justifyContent="center"
+          flexWrap="wrap"
+          useFlexGap
           sx={{
-            mb: 3,
-            mx: "auto",
-            maxWidth: 340,
-            border: "1.7px solid #0f172a",
-            borderRadius: 1.5,
-            p: 1.5,
-            bgcolor: "#fff",
+            mb: 3, mx: "auto", width: "fit-content",
+            border: "1px solid #e6e8ef", borderRadius: 2, px: 2, py: 1, bgcolor: "#fff",
           }}
         >
           {graph.legends.map((lg) => (
-            <Stack key={lg.id} direction="row" alignItems="center" spacing={1} sx={{ py: 0.25 }}>
-              <Box
-                sx={{
-                  width: 15, height: 15, borderRadius: "50%", bgcolor: lg.color,
-                  display: "grid", placeItems: "center", flexShrink: 0,
-                }}
-              >
-                <Icon icon="mdi:check" width={11} color="#fff" />
-              </Box>
-              <Typography sx={{ fontSize: 12.5, color: "#0f172a" }}>{lg.label}</Typography>
+            <Stack key={lg.id} direction="row" alignItems="center" spacing={0.75}>
+              <Box sx={{ width: 11, height: 11, borderRadius: "50%", bgcolor: lg.color }} />
+              <Typography sx={{ fontSize: 12, color: "#475569" }}>{lg.label}</Typography>
             </Stack>
           ))}
-        </Box>
+        </Stack>
       )}
 
-      {sections.map((section) => {
+      {sections.map((section, si) => {
         const spineNodes = childrenOf(section.id);
         return (
           <Fragment key={section.id}>
-            <Box sx={{ position: "relative", py: 2, textAlign: { xs: "start", md: "center" } }}>
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1.25}
+              sx={{ justifyContent: { md: "center" }, mt: si === 0 ? 0 : 3, mb: 1.5 }}
+            >
               <Box
-                aria-hidden
                 sx={{
-                  position: "absolute",
-                  insetInlineStart: { xs: 13, md: "50%" },
-                  top: 0,
-                  bottom: 0,
-                  width: 3,
-                  bgcolor: RAIL,
-                  transform: { md: "translateX(-50%)" },
-                  zIndex: 0,
-                }}
-              />
-              <Typography
-                component="h2"
-                sx={{
-                  position: "relative",
-                  zIndex: 1,
-                  display: "inline-block",
-                  bgcolor: "#fbfbfd",
-                  px: 2,
-                  ml: { xs: 4, md: 0 },
-                  fontSize: 21,
-                  fontWeight: 800,
-                  color: "#0f172a",
+                  width: 26, height: 26, borderRadius: "50%", flexShrink: 0,
+                  display: "grid", placeItems: "center",
+                  bgcolor: INK, color: "#fff", fontSize: 12, fontWeight: 700,
                 }}
               >
+                {si + 1}
+              </Box>
+              <Typography sx={{ fontSize: 18, fontWeight: 800, color: INK }}>
                 {section.title}
               </Typography>
-            </Box>
+            </Stack>
 
-            {spineNodes.map((node) => (
-              <SpineRow
-                key={node.id}
-                node={node}
-                branches={childrenOf(node.id)}
-                progress={progress}
-                side={sideByNodeId.get(node.id) ?? "right"}
-                onOpenNode={onOpenNode}
-              />
+            {spineNodes.map((node, ni) => (
+              <Fragment key={node.id}>
+                {ni > 0 && <RailArrow />}
+                <SpineRow
+                  node={node}
+                  branches={childrenOf(node.id)}
+                  progress={progress}
+                  side={sideByNodeId.get(node.id) ?? "right"}
+                  onOpenNode={onOpenNode}
+                />
+              </Fragment>
             ))}
+
+            {si < sections.length - 1 && <RailArrow />}
           </Fragment>
         );
       })}

--- a/lib/services/roadmaps.service.ts
+++ b/lib/services/roadmaps.service.ts
@@ -127,6 +127,26 @@ export interface RoadmapNodeTarget {
   content?: RoadmapTargetContent;
 }
 
+export interface RoadmapChildStep {
+  id: number;
+  title: string;
+  selfState: SelfState;
+  accessible: boolean;
+  courseId: number | null;
+  submoduleId: number | null;
+  summary: string;
+  questions: number;
+  codingProblems: number;
+  readingMinutes: number;
+}
+
+export interface RoadmapNodeTotals {
+  steps?: number;
+  questions?: number;
+  codingProblems?: number;
+  readingMinutes?: number;
+}
+
 export interface RoadmapNodeDetail {
   id: number;
   slug: string;
@@ -136,6 +156,9 @@ export interface RoadmapNodeDetail {
   isRequired: boolean;
   resources: { type: string; title: string; url: string }[];
   opens: RoadmapNodeTarget[];
+  /** Present on a spine node: its branch steps, each with its own size and state. */
+  steps?: RoadmapChildStep[];
+  totals?: RoadmapNodeTotals;
 }
 
 export const roadmapsService = {


### PR DESCRIPTION
Three fixes from your review of the shipped map. Pairs with backend #563 (merged + deployed).

## 1. Colour now matches the platform

The map was wearing roadmap.sh's yellow-and-blue — their brand asset, and it read as a foreign
object inside our violet product.

Now on the platform palette: **violet `#7c3aed`** for an untouched step, pink for learning,
emerald for done, slate for skipped, over a soft lilac rail. The card accents moved off teal and
amber onto the indigo/teal/pink family too.

The mechanic worth keeping from roadmap.sh is the **rule**, not the hue: node *fill* carries
progress state, hierarchy is carried by size and weight only, and every state also changes text
decoration so it survives for colour-blind readers.

## 2. Arrows, and curved ones

Connectors were plain straight dotted lines with no direction. Now inline SVG:

- **Curved bezier connectors** from the rail out to each branch stack, with an arrowhead
  pointing *at* the branches
- A **downward chevron on the rail** between every consecutive step, so "where do I go next" is
  answered without reading

Drawn right-to-left when branches sit on the left, so the arrow always points the way the reader
travels.

## 3. The middle node had almost nothing in it

Correct — a spine node binds nothing (it derives from its branches), so opening one gave a title
and one sentence.

It now shows **aggregate totals** for the section, then **every sub-step** with its own summary,
size, done-state and an Open button. Verified against prod:

> **HTML and document structure** — 6 steps · 80 min reading · 150 questions · 18 coding problems

Also constrains branch cards to 260px rather than stretching to the full column, which was the
main reason the canvas looked unbalanced in your screenshot.

## Verification

`tsc --noEmit` clean, eslint clean, `next build` compiles with both routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)