### PR TITLE
feat(roadmaps): note cards, dependency chips, related tracks + phase-2 fixes

### DIFF
--- a/app/roadmaps/[slug]/page.tsx
+++ b/app/roadmaps/[slug]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useParams } from "next/navigation";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Box, Container, Stack, Tooltip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
@@ -64,6 +65,7 @@ export default function RoadmapDetailPage() {
   const params = useParams();
   const slug = String(params?.slug ?? "");
   const queryClient = useQueryClient();
+  const { push } = useInstantNavigation();
   const [openNode, setOpenNode] = useState<RoadmapNode | null>(null);
 
   const graphQuery = useQuery({
@@ -89,8 +91,19 @@ export default function RoadmapDetailPage() {
       await queryClient.cancelQueries({ queryKey: roadmapKeys.progress(slug) });
       const previous = queryClient.getQueryData<RoadmapProgress>(roadmapKeys.progress(slug));
       if (previous) {
-        const nodes = { ...previous.nodes, [nodeId]: { ...previous.nodes[nodeId], selfState: state } };
-        const declared = Object.values(nodes);
+        // Marking a SPINE step cascades to the branches it rolls up (the server does the same),
+        // so the optimistic view has to cascade too or the bar jumps when the response lands.
+        const cascade = (graphQuery.data?.nodes ?? [])
+          .filter((n) => n.parentId === nodeId && n.isTrackable)
+          .map((n) => n.id);
+        const nodes = { ...previous.nodes };
+        for (const id of [nodeId, ...cascade]) {
+          if (nodes[id]) nodes[id] = { ...nodes[id], selfState: state };
+        }
+        // Only LEAF nodes are in the server's denominator, so counting spine nodes here made the
+        // optimistic bar disagree with the value that arrived a moment later. `isLeaf` is the
+        // discriminator the server already sends for exactly this.
+        const declared = Object.values(nodes).filter((n) => n.isLeaf !== false);
         const done = declared.filter((n) => n.selfState === "done").length;
         const skipped = declared.filter((n) => n.selfState === "skipped").length;
         queryClient.setQueryData<RoadmapProgress>(roadmapKeys.progress(slug), {
@@ -195,7 +208,12 @@ export default function RoadmapDetailPage() {
         )}
 
         {graph && (
-          <RoadmapSpine graph={graph} progress={progress} onOpenNode={setOpenNode} />
+          <RoadmapSpine
+            graph={graph}
+            progress={progress}
+            onOpenNode={setOpenNode}
+            onOpenRoadmap={(s) => push(`/roadmaps/${s}`)}
+          />
         )}
       </Container>
 

--- a/components/roadmaps/RoadmapSpine.tsx
+++ b/components/roadmaps/RoadmapSpine.tsx
@@ -189,6 +189,90 @@ function BranchFan({ side, count }: { side: "left" | "right"; count: number }) {
   );
 }
 
+/**
+ * A prose card beside the path: "Build a portfolio of projects" and friends.
+ *
+ * Deliberately NOT a step. It carries advice the map cannot express as something you tick, so
+ * it must never enter the progress denominator -- the backend keeps `note` out of
+ * TRACKABLE_NODE_KINDS for exactly that reason, and this component has no state control.
+ */
+function NoteCard({ node }: { node: RoadmapNode }) {
+  const items = node.items ?? [];
+  return (
+    <Box
+      sx={{
+        maxWidth: 520,
+        mx: "auto",
+        my: 3,
+        p: 2.25,
+        borderRadius: 2.5,
+        border: "1px solid #e6e8ef",
+        bgcolor: "#fff",
+        boxShadow: "0 2px 10px rgba(15,23,42,.05)",
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: items.length ? 1.5 : 0 }}>
+        <Icon icon="solar:lightbulb-bolt-bold-duotone" width={19} color={VIOLET} />
+        <Typography sx={{ fontSize: 14.5, fontWeight: 800, color: INK }}>{node.title}</Typography>
+      </Stack>
+      <Stack spacing={1.25}>
+        {items.map((it) => (
+          <Box key={it.title}>
+            <Typography sx={{ fontSize: 13, fontWeight: 700, color: VIOLET }}>
+              {it.title}
+            </Typography>
+            <Typography sx={{ fontSize: 12.75, color: "#475569", lineHeight: 1.55 }}>
+              {it.text}
+            </Typography>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
+/** "Keep learning with the following relevant track." */
+function RelatedTracks({
+  related,
+  onOpen,
+}: {
+  related: NonNullable<RoadmapGraph["related"]>;
+  onOpen: (slug: string) => void;
+}) {
+  if (!related.length) return null;
+  return (
+    <Box
+      sx={{
+        maxWidth: 520, mx: "auto", mt: 4, p: 2.25, borderRadius: 2.5,
+        border: `1.5px solid ${VIOLET}`, bgcolor: "#faf8ff", textAlign: "center",
+      }}
+    >
+      <Typography sx={{ fontSize: 14, fontWeight: 800, color: INK, mb: 1.5 }}>
+        Keep learning with the following relevant track
+      </Typography>
+      <Stack direction="row" spacing={1} justifyContent="center" flexWrap="wrap" useFlexGap>
+        {related.map((r) => (
+          <Box
+            key={r.slug}
+            component="button"
+            onClick={() => onOpen(r.slug)}
+            sx={{
+              appearance: "none", font: "inherit", cursor: "pointer",
+              px: 2, py: 1, borderRadius: 2, border: "none",
+              bgcolor: VIOLET, color: "#fff", fontSize: 13, fontWeight: 700,
+              transition: "background-color .15s ease, transform .15s ease",
+              "&:hover": { bgcolor: "#5b21b6", transform: "translateY(-2px)" },
+              "&:focus-visible": { outline: `2px solid ${INK}`, outlineOffset: 2 },
+            }}
+          >
+            {r.pageTitle}
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+}
+
 /** The rail segment between two spine steps, carrying a downward arrow. */
 function RailArrow() {
   return (
@@ -215,12 +299,17 @@ function SpineRow({
   branches,
   progress,
   side,
+  dependsOn,
   onOpenNode,
 }: {
   node: RoadmapNode;
   branches: RoadmapNode[];
   progress?: RoadmapProgress;
   side: "left" | "right";
+  /** Steps in OTHER sections this one genuinely needs. Shown inline rather than as a drawn
+   *  edge: a long line across a tall canvas is unreadable, while "needs: JavaScript" right
+   *  under the box is not. */
+  dependsOn: RoadmapNode[];
   onOpenNode: (n: RoadmapNode) => void;
 }) {
   // position:relative so the fan can stretch to exactly this stack's height.
@@ -272,6 +361,30 @@ function SpineRow({
           progress={progress?.nodes?.[node.id]}
           onOpen={() => onOpenNode(node)}
         />
+        {dependsOn.length > 0 && (
+          <Stack
+            direction="row" spacing={0.5} flexWrap="wrap" useFlexGap
+            justifyContent="center" sx={{ mt: 0.75 }}
+          >
+            <Typography sx={{ fontSize: 10.5, color: "#94a3b8", alignSelf: "center" }}>
+              needs
+            </Typography>
+            {dependsOn.map((d) => (
+              <Chip
+                key={d.id}
+                label={d.title}
+                size="small"
+                onClick={() => onOpenNode(d)}
+                icon={<Icon icon="solar:arrow-right-up-linear" width={11} />}
+                sx={{
+                  height: 19, fontSize: 10, cursor: "pointer",
+                  bgcolor: "#f1f5f9", color: "#475569",
+                  "&:hover": { bgcolor: "#ede9fe", color: "#5b21b6" },
+                }}
+              />
+            ))}
+          </Stack>
+        )}
       </Box>
 
       {/* Right cell */}
@@ -312,10 +425,12 @@ export function RoadmapSpine({
   graph,
   progress,
   onOpenNode,
+  onOpenRoadmap,
 }: {
   graph: RoadmapGraph;
   progress?: RoadmapProgress;
   onOpenNode: (node: RoadmapNode) => void;
+  onOpenRoadmap?: (slug: string) => void;
 }) {
   const sections = graph.nodes
     .filter((n) => n.kind === "milestone")
@@ -326,6 +441,17 @@ export function RoadmapSpine({
   // Resolved before render rather than by mutating a counter inside JSX (which
   // react-hooks/immutability rejects). Alternating across the WHOLE map, not per section, keeps
   // the canvas balanced when a section has an odd number of steps.
+  const byId = new Map(graph.nodes.map((n) => [n.id, n]));
+  // "needs X" is read off the depends edges, so the graph data is the single source and the
+  // chips can never drift from the topology the seeder declared.
+  const dependsOn = (id: number) =>
+    graph.edges
+      .filter((e) => e.kind === "depends" && e.to === id)
+      .map((e) => byId.get(e.from))
+      .filter((n): n is RoadmapNode => Boolean(n));
+
+  const notes = graph.nodes.filter((n) => n.kind === "note").sort((a, b) => a.order - b.order);
+
   const sideByNodeId = new Map<number, "left" | "right">();
   sections
     .flatMap((s) => childrenOf(s.id))
@@ -386,6 +512,7 @@ export function RoadmapSpine({
                   branches={childrenOf(node.id)}
                   progress={progress}
                   side={sideByNodeId.get(node.id) ?? "right"}
+                  dependsOn={dependsOn(node.id)}
                   onOpenNode={onOpenNode}
                 />
               </Fragment>
@@ -395,6 +522,14 @@ export function RoadmapSpine({
           </Fragment>
         );
       })}
+
+      {notes.map((n) => (
+        <NoteCard key={n.id} node={n} />
+      ))}
+
+      {onOpenRoadmap && (
+        <RelatedTracks related={graph.related ?? []} onOpen={onOpenRoadmap} />
+      )}
     </Box>
   );
 }

--- a/lib/services/roadmaps.service.ts
+++ b/lib/services/roadmaps.service.ts
@@ -11,9 +11,9 @@ const BASE = "/roadmaps/api";
  */
 
 export type RoadmapKind = "role" | "skill" | "beginner" | "practice";
-export type NodeKind = "topic" | "subtopic" | "milestone" | "label";
+export type NodeKind = "topic" | "subtopic" | "milestone" | "label" | "note";
 export type SelfState = "pending" | "learning" | "done" | "skipped";
-export type EdgeKind = "sequence" | "contains";
+export type EdgeKind = "sequence" | "contains" | "depends";
 
 export interface RoadmapCard {
   slug: string;
@@ -53,6 +53,16 @@ export interface RoadmapNode {
   isRequired: boolean;
   isTrackable: boolean;
   legendId: number | null;
+  summary?: string;
+  /** `note` nodes only: prose blocks such as project ideas. */
+  items?: { title: string; text: string }[];
+}
+
+export interface RelatedRoadmap {
+  slug: string;
+  cardTitle: string;
+  pageTitle: string;
+  kind: RoadmapKind;
 }
 
 export interface RoadmapEdge {
@@ -77,6 +87,8 @@ export interface RoadmapGraph {
   nodes: RoadmapNode[];
   edges: RoadmapEdge[];
   legends: RoadmapLegend[];
+  /** Only the ones this tenant can actually reach. */
+  related?: RelatedRoadmap[];
 }
 
 export interface RoadmapNodeProgress {


### PR DESCRIPTION
Renders backend #569, and carries the frontend half of the RCA phase-2 fixes.

## New

**Note cards** — a prose card beside the path for *"Build a portfolio of projects"*. No state
control, deliberately: a note is advice you cannot tick, and a Done button would put it in a
denominator it must never be in.

**Dependency chips** — a `depends` edge renders as a **"needs: JavaScript"** chip under the step,
clickable straight to the prerequisite. Chips rather than drawn connectors because a line across
a 4000px canvas is unreadable and unroutable, while a chip under the box says the same thing
where the reader already is. Read off `graph.edges`, so they cannot drift from the topology.

**Related tracks** — a *"Keep learning with the following relevant track"* block at the foot of
the map, rendered only from what the API says this tenant can reach.

## Phase-2 fixes also in here

- **Optimistic coverage counted spine nodes.** Only leaves are in the server's denominator, so
  the optimistic bar disagreed with the value that landed a moment later. Now filtered on
  `isLeaf`.
- **Spine marking now cascades** in the optimistic view too, matching the server, so the bar does
  not jump when the response arrives.

## Verification

`tsc --noEmit` clean, eslint clean, `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)