### PR TITLE
feat(roadmaps): adopt roadmap.sh's presentation language across the whole surface

### DIFF
--- a/app/roadmaps/[slug]/page.tsx
+++ b/app/roadmaps/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { RoadmapSpine } from "@/components/roadmaps/RoadmapSpine";
 import { RoadmapNodeDrawer } from "@/components/roadmaps/RoadmapNodeDrawer";
+import { RoadmapFaqs } from "@/components/roadmaps/RoadmapFaqs";
 import {
   roadmapKeys,
   roadmapsService,
@@ -43,8 +44,9 @@ function StatTile({
         sx={{
           flex: 1,
           minWidth: 130,
-          border: "1px solid #e6e8ef",
-          borderRadius: 2.5,
+          border: "2px solid #0f172a",
+          borderRadius: 1.25,
+          boxShadow: "3px 3px 0 #0f172a",
           px: 2,
           py: 1.5,
           bgcolor: "#fff",
@@ -190,9 +192,10 @@ export default function RoadmapDetailPage() {
               mb: 2,
               px: 1.75,
               py: 1.25,
-              borderRadius: 2,
-              bgcolor: "#fffbeb",
-              border: "1px solid #fde68a",
+              borderRadius: 1.25,
+              bgcolor: "#fef3c7",
+              border: "2px solid #0f172a",
+              boxShadow: "3px 3px 0 #0f172a",
             }}
           >
             <Icon icon="solar:danger-triangle-bold-duotone" width={18} color="#b45309" />
@@ -215,6 +218,8 @@ export default function RoadmapDetailPage() {
             onOpenRoadmap={(s) => push(`/roadmaps/${s}`)}
           />
         )}
+
+        {graph?.faqs && graph.faqs.length > 0 && <RoadmapFaqs faqs={graph.faqs} />}
       </Container>
 
       <RoadmapNodeDrawer

--- a/components/roadmaps/RoadmapFaqs.tsx
+++ b/components/roadmaps/RoadmapFaqs.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Collapse, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { RM } from "./roadmapTokens";
+
+/**
+ * Frequently asked questions, at the foot of the map.
+ *
+ * These answer the thing the map itself cannot: whether the path is worth weeks of the
+ * learner's life. "Is this a good career", "how long will this take", "do I need a degree".
+ * A roadmap without them is a diagram; with them it is advice.
+ *
+ * Rendered as real buttons with aria-expanded rather than a click-handler div, so the whole
+ * block is keyboard reachable and announced correctly.
+ */
+export function RoadmapFaqs({ faqs }: { faqs: { question: string; answer: string }[] }) {
+  const [open, setOpen] = useState<number | null>(0);
+  if (!faqs.length) return null;
+
+  return (
+    <Box sx={{ maxWidth: 720, mx: "auto", mt: 6 }}>
+      {/* A drawn label, matching the section headers on the canvas above. */}
+      <Box
+        sx={{
+          width: "fit-content", mb: 2, px: 2, py: 0.9, borderRadius: 1.25,
+          bgcolor: "#fff", border: RM.border, boxShadow: RM.shadow(3),
+        }}
+      >
+        <Typography component="h2" sx={{ fontSize: 16, fontWeight: 800, color: RM.ink }}>
+          Frequently asked questions
+        </Typography>
+      </Box>
+
+      <Stack spacing={1}>
+        {faqs.map((f, i) => {
+          const isOpen = open === i;
+          return (
+            <Box
+              key={f.question}
+              sx={{
+                border: RM.border,
+                borderRadius: 1.25,
+                boxShadow: RM.shadow(3),
+                bgcolor: "#fff",
+                overflow: "hidden",
+              }}
+            >
+              <Box
+                component="button"
+                aria-expanded={isOpen}
+                onClick={() => setOpen(isOpen ? null : i)}
+                sx={{
+                  appearance: "none",
+                  font: "inherit",
+                  cursor: "pointer",
+                  border: "none",
+                  width: "100%",
+                  textAlign: "start",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  px: 2,
+                  py: 1.5,
+                  bgcolor: "transparent",
+                  "&:hover": { bgcolor: "#f5f3ff" },
+                  "&:focus-visible": { outline: `3px solid ${RM.rail}`, outlineOffset: -3 },
+                }}
+              >
+                <Typography sx={{ flex: 1, fontSize: 14, fontWeight: 700, color: "#0f172a" }}>
+                  {f.question}
+                </Typography>
+                <Icon
+                  icon="mdi:chevron-down"
+                  width={19}
+                  style={{
+                    flexShrink: 0,
+                    color: "#94a3b8",
+                    transform: isOpen ? "rotate(180deg)" : "none",
+                    transition: "transform .18s ease",
+                  }}
+                />
+              </Box>
+              <Collapse in={isOpen} unmountOnExit>
+                <Typography
+                  sx={{
+                    px: 2,
+                    pb: 2,
+                    fontSize: 13.5,
+                    color: "#475569",
+                    lineHeight: 1.65,
+                  }}
+                >
+                  {f.answer}
+                </Typography>
+              </Collapse>
+            </Box>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}

--- a/components/roadmaps/RoadmapSpine.tsx
+++ b/components/roadmaps/RoadmapSpine.tsx
@@ -8,6 +8,7 @@ import type {
   RoadmapNode,
   RoadmapProgress,
 } from "@/lib/services/roadmaps.service";
+import { RM, SPINE_FILL, BRANCH_FILL } from "./roadmapTokens";
 
 /**
  * The map: a centre spine of primary steps with branch steps hanging off it on curved
@@ -27,25 +28,9 @@ import type {
 
 type NodeState = "done" | "learning" | "skipped" | "pending";
 
-const INK = "#0f172a";
-const VIOLET = "#7c3aed";
-const RAIL = "#c7bdf2";
-const RAIL_STRONG = "#7c3aed";
-
-const SPINE_STYLE: Record<NodeState, { bg: string; border: string; text: string; deco: string }> = {
-  // Untouched = the platform violet, so the path you have not walked reads as the brand.
-  pending: { bg: "#ede9fe", border: VIOLET, text: "#4c1d95", deco: "none" },
-  learning: { bg: "#fce7f3", border: "#ec4899", text: "#9d174d", deco: "underline" },
-  done: { bg: "#d1fae5", border: "#059669", text: "#065f46", deco: "line-through" },
-  skipped: { bg: "#f1f5f9", border: "#94a3b8", text: "#64748b", deco: "line-through" },
-};
-
-const BRANCH_STYLE: Record<NodeState, { bg: string; border: string; text: string; deco: string }> = {
-  pending: { bg: "#faf8ff", border: "#ddd6fe", text: INK, deco: "none" },
-  learning: { bg: "#fdf2f8", border: "#fbcfe8", text: "#9d174d", deco: "underline" },
-  done: { bg: "#ecfdf5", border: "#a7f3d0", text: "#047857", deco: "line-through" },
-  skipped: { bg: "#f8fafc", border: "#e2e8f0", text: "#94a3b8", deco: "line-through" },
-};
+const INK = RM.ink;
+const VIOLET = RM.rail;
+const RAIL_STRONG = RM.rail;
 
 function NodeBox({
   node,
@@ -59,7 +44,7 @@ function NodeBox({
   onOpen: () => void;
 }) {
   const state = (progress?.selfState ?? "pending") as NodeState;
-  const s = (variant === "spine" ? SPINE_STYLE : BRANCH_STYLE)[state];
+  const s = (variant === "spine" ? SPINE_FILL : BRANCH_FILL)[state];
   const verified = progress?.verifiedComplete;
 
   return (
@@ -74,27 +59,27 @@ function NodeBox({
         zIndex: 2,
         width: "100%",
         textAlign: variant === "spine" ? "center" : "start",
-        px: variant === "spine" ? 2.25 : 1.5,
-        py: variant === "spine" ? 1.3 : 0.85,
-        borderRadius: 2,
+        px: variant === "spine" ? 2 : 1.4,
+        py: variant === "spine" ? 1.05 : 0.7,
+        borderRadius: 1.25,
         bgcolor: s.bg,
-        border: `1.5px solid ${s.border}`,
-        boxShadow:
-          variant === "spine"
-            ? "0 4px 14px rgba(124,58,237,.16)"
-            : "0 1px 2px rgba(15,23,42,.04)",
-        transition:
-          "transform .15s ease, box-shadow .15s ease, border-color .15s ease, background-color .15s ease",
+        // Hard outline + hard offset shadow, no blur. This pairing is what makes the canvas
+        // read as a drawn poster rather than a list of cards.
+        border: RM.border,
+        boxShadow: RM.shadow(variant === "spine" ? 3 : 2),
+        transition: "transform .1s ease, box-shadow .1s ease, filter .1s ease",
+        // Hover presses the sticker toward the page instead of lifting it: the shadow shortens
+        // as the box moves into it, which is the interaction the flat style implies.
         "&:hover": {
-          transform: "translateY(-3px)",
-          borderColor: VIOLET,
-          boxShadow:
-            variant === "spine"
-              ? "0 14px 30px rgba(124,58,237,.34)"
-              : "0 10px 22px rgba(124,58,237,.22)",
+          transform: "translate(1px, 1px)",
+          boxShadow: RM.shadow(variant === "spine" ? 2 : 1),
+          filter: "brightness(1.04)",
         },
-        "&:active": { transform: "translateY(-1px)" },
-        "&:focus-visible": { outline: `2px solid ${VIOLET}`, outlineOffset: 3 },
+        "&:active": {
+          transform: "translate(3px, 3px)",
+          boxShadow: RM.shadow(0),
+        },
+        "&:focus-visible": { outline: `3px solid ${VIOLET}`, outlineOffset: 3 },
       }}
     >
       <Stack
@@ -106,8 +91,8 @@ function NodeBox({
         <Typography
           component="span"
           sx={{
-            fontSize: variant === "spine" ? 14.5 : 12.75,
-            fontWeight: variant === "spine" ? 700 : 500,
+            fontSize: variant === "spine" ? 14 : 12.5,
+            fontWeight: variant === "spine" ? 700 : 600,
             color: s.text,
             textDecoration: s.deco,
             lineHeight: 1.35,
@@ -177,11 +162,11 @@ function BranchFan({ side, count }: { side: "left" | "right"; count: number }) {
                 : `M${W},50 C${W * 0.45},50 ${W * 0.55},${y} 0,${y}`
             }
             stroke={RAIL_STRONG}
-            strokeWidth="1.6"
-            strokeDasharray="3 4"
+            strokeWidth="2.2"
+            strokeDasharray="1 6"
             strokeLinecap="round"
             vectorEffect="non-scaling-stroke"
-            opacity={0.55}
+            opacity={0.8}
           />
         ))}
       </svg>
@@ -203,12 +188,12 @@ function NoteCard({ node }: { node: RoadmapNode }) {
       sx={{
         maxWidth: 520,
         mx: "auto",
-        my: 3,
+        my: 3.5,
         p: 2.25,
-        borderRadius: 2.5,
-        border: "1px solid #e6e8ef",
+        borderRadius: 1.25,
+        border: RM.border,
         bgcolor: "#fff",
-        boxShadow: "0 2px 10px rgba(15,23,42,.05)",
+        boxShadow: RM.shadow(4),
       }}
     >
       <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: items.length ? 1.5 : 0 }}>
@@ -243,8 +228,8 @@ function RelatedTracks({
   return (
     <Box
       sx={{
-        maxWidth: 520, mx: "auto", mt: 4, p: 2.25, borderRadius: 2.5,
-        border: `1.5px solid ${VIOLET}`, bgcolor: "#faf8ff", textAlign: "center",
+        maxWidth: 520, mx: "auto", mt: 4.5, p: 2.25, borderRadius: 1.25,
+        border: RM.border, boxShadow: RM.shadow(4), bgcolor: "#fff", textAlign: "center",
       }}
     >
       <Typography sx={{ fontSize: 14, fontWeight: 800, color: INK, mb: 1.5 }}>
@@ -258,11 +243,13 @@ function RelatedTracks({
             onClick={() => onOpen(r.slug)}
             sx={{
               appearance: "none", font: "inherit", cursor: "pointer",
-              px: 2, py: 1, borderRadius: 2, border: "none",
-              bgcolor: VIOLET, color: "#fff", fontSize: 13, fontWeight: 700,
-              transition: "background-color .15s ease, transform .15s ease",
-              "&:hover": { bgcolor: "#5b21b6", transform: "translateY(-2px)" },
-              "&:focus-visible": { outline: `2px solid ${INK}`, outlineOffset: 2 },
+              px: 2.25, py: 1, borderRadius: 1.25,
+              border: RM.border, boxShadow: RM.shadow(3),
+              bgcolor: "#4f46e5", color: "#fff", fontSize: 13, fontWeight: 700,
+              transition: "transform .1s ease, box-shadow .1s ease",
+              "&:hover": { transform: "translate(1px,1px)", boxShadow: RM.shadow(2) },
+              "&:active": { transform: "translate(3px,3px)", boxShadow: RM.shadow(0) },
+              "&:focus-visible": { outline: `3px solid ${INK}`, outlineOffset: 3 },
             }}
           >
             {r.pageTitle}
@@ -286,8 +273,8 @@ function RailArrow() {
       }}
     >
       <svg width="16" height="34" viewBox="0 0 16 34" fill="none">
-        <path d="M8,0 L8,26" stroke={RAIL} strokeWidth="3" strokeLinecap="round" />
-        <path d="M3,24 L8,32 L13,24" stroke={RAIL_STRONG} strokeWidth="2.4"
+        <path d="M8,0 L8,25" stroke={RAIL_STRONG} strokeWidth="3.5" strokeLinecap="round" />
+        <path d="M2.5,23 L8,32 L13.5,23" stroke={RAIL_STRONG} strokeWidth="3"
               strokeLinecap="round" strokeLinejoin="round" fill="none" />
       </svg>
     </Box>
@@ -460,24 +447,29 @@ export function RoadmapSpine({
   return (
     <Box sx={{ position: "relative", pb: 5 }}>
       {graph.legends.length > 0 && (
-        <Stack
-          direction="row"
-          spacing={2.5}
-          justifyContent="center"
-          flexWrap="wrap"
-          useFlexGap
+        <Box
           sx={{
-            mb: 3, mx: "auto", width: "fit-content",
-            border: "1px solid #e6e8ef", borderRadius: 2, px: 2, py: 1, bgcolor: "#fff",
+            mb: 3.5, mx: "auto", width: "fit-content", minWidth: 210,
+            border: RM.border, borderRadius: 1.25, boxShadow: RM.shadow(3),
+            px: 2, py: 1.25, bgcolor: "#fff",
           }}
         >
           {graph.legends.map((lg) => (
-            <Stack key={lg.id} direction="row" alignItems="center" spacing={0.75}>
-              <Box sx={{ width: 11, height: 11, borderRadius: "50%", bgcolor: lg.color }} />
-              <Typography sx={{ fontSize: 12, color: "#475569" }}>{lg.label}</Typography>
+            <Stack key={lg.id} direction="row" alignItems="center" spacing={1} sx={{ py: 0.3 }}>
+              <Box
+                sx={{
+                  width: 17, height: 17, borderRadius: "50%", bgcolor: lg.color,
+                  display: "grid", placeItems: "center", flexShrink: 0,
+                }}
+              >
+                <Icon icon="mdi:check-bold" width={11} color="#fff" />
+              </Box>
+              <Typography sx={{ fontSize: 12.5, color: INK, fontWeight: 500 }}>
+                {lg.label}
+              </Typography>
             </Stack>
           ))}
-        </Stack>
+        </Box>
       )}
 
       {sections.map((section, si) => {
@@ -488,20 +480,28 @@ export function RoadmapSpine({
               direction="row"
               alignItems="center"
               spacing={1.25}
-              sx={{ justifyContent: { md: "center" }, mt: si === 0 ? 0 : 3, mb: 1.5 }}
+              sx={{ justifyContent: { md: "center" }, mt: si === 0 ? 0 : 3.5, mb: 2 }}
             >
               <Box
                 sx={{
-                  width: 26, height: 26, borderRadius: "50%", flexShrink: 0,
-                  display: "grid", placeItems: "center",
-                  bgcolor: INK, color: "#fff", fontSize: 12, fontWeight: 700,
+                  px: 2.25, py: 0.9, borderRadius: 1.25, flexShrink: 0,
+                  bgcolor: "#fff", border: RM.border, boxShadow: RM.shadow(3),
+                  display: "flex", alignItems: "center", gap: 1,
                 }}
               >
-                {si + 1}
+                <Box
+                  sx={{
+                    width: 21, height: 21, borderRadius: "50%",
+                    display: "grid", placeItems: "center",
+                    bgcolor: INK, color: "#fff", fontSize: 11, fontWeight: 800,
+                  }}
+                >
+                  {si + 1}
+                </Box>
+                <Typography sx={{ fontSize: 17, fontWeight: 800, color: INK }}>
+                  {section.title}
+                </Typography>
               </Box>
-              <Typography sx={{ fontSize: 18, fontWeight: 800, color: INK }}>
-                {section.title}
-              </Typography>
             </Stack>
 
             {spineNodes.map((node, ni) => (

--- a/components/roadmaps/roadmapTokens.ts
+++ b/components/roadmaps/roadmapTokens.ts
@@ -1,0 +1,51 @@
+/**
+ * The roadmap canvas design tokens.
+ *
+ * This surface deliberately does NOT look like the rest of the product, and that is the point.
+ * roadmap.sh reads as a hand-drawn poster: hard black outlines, flat fills, offset shadows with
+ * no blur, and a dense layout you scan rather than read. That aesthetic is doing real work --
+ * it makes a 180-node map feel like an object you can take in at a glance instead of a list.
+ *
+ * What we take from them: the STRUCTURE and the RULES.
+ *   - a hard 2px ink outline on every node, and a hard offset shadow (no blur)
+ *   - flat fills, never gradients
+ *   - node FILL carries progress state, so hierarchy is left to size and shade
+ *   - a completed map visibly drains toward grey, which is the "burn down" signal
+ *   - text decoration doubles every state, so it survives for colour-blind readers
+ *
+ * What we do NOT take: their yellow. #fdff00 is roadmap.sh's brand asset and read as a foreign
+ * object inside a violet product (that was the note on the first cut). The hue is ours, the
+ * language is theirs. Flipping to their exact palette is a one-line change here if wanted.
+ */
+
+export const RM = {
+  ink: "#0f172a",
+  canvas: "#fbfbfd",
+  rail: "#7c3aed",
+  railSoft: "#c4b5fd",
+
+  /** Hard offset shadow, no blur. The single biggest contributor to the poster feel. */
+  shadow: (n = 3) => `${n}px ${n}px 0 ${RM.ink}`,
+  border: `2px solid #0f172a`,
+} as const;
+
+type Fill = { bg: string; text: string; deco: "none" | "line-through" | "underline" };
+
+/** Primary spine steps: the loud row of the map. */
+export const SPINE_FILL: Record<string, Fill> = {
+  // Untouched is the platform violet at full strength: the path you have not walked is the
+  // brightest thing on the canvas, which is what pulls the eye down the spine.
+  pending: { bg: "#c4b5fd", text: "#1e1b4b", deco: "none" },
+  learning: { bg: "#fbcfe8", text: "#500724", deco: "underline" },
+  // Their exact done treatment: drain to grey and strike the text. A finished map goes quiet.
+  done: { bg: "#cbcbcb", text: "#334155", deco: "line-through" },
+  skipped: { bg: "#e2e8f0", text: "#64748b", deco: "line-through" },
+};
+
+/** Branch steps: same language, one step down in weight. */
+export const BRANCH_FILL: Record<string, Fill> = {
+  pending: { bg: "#ede9fe", text: "#1e1b4b", deco: "none" },
+  learning: { bg: "#fce7f3", text: "#500724", deco: "underline" },
+  done: { bg: "#e5e5e5", text: "#475569", deco: "line-through" },
+  skipped: { bg: "#f1f5f9", text: "#94a3b8", deco: "line-through" },
+};

--- a/lib/services/roadmaps.service.ts
+++ b/lib/services/roadmaps.service.ts
@@ -89,6 +89,7 @@ export interface RoadmapGraph {
   legends: RoadmapLegend[];
   /** Only the ones this tenant can actually reach. */
   related?: RelatedRoadmap[];
+  faqs?: { question: string; answer: string }[];
 }
 
 export interface RoadmapNodeProgress {


### PR DESCRIPTION
The map had roadmap.sh's **structure** but not its **presentation**, so it still read as a stack
of product cards rather than a drawn poster. That difference is not decoration: the poster look
is what lets a 180-node map be taken in at a glance instead of read as a list.

## What changed

Extracted the canvas into `components/roadmaps/roadmapTokens.ts` and applied it everywhere:

- **Hard 2px ink outline + hard offset shadow, no blur.** That pairing is the single biggest
  contributor to the drawn feel — soft blurred shadows were most of why the earlier version
  looked like the rest of the product.
- **Flat fills, tighter radii and padding**, so the canvas is dense the way theirs is.
- **Hover presses the box toward the page** (translate 1px, shadow shortens); `:active` pushes it
  flush (shadow 0). A flat sticker that *lifts* on hover contradicts itself; one that presses
  does not.
- **Legend** is a bordered key box with filled check badges, not a row of dots.
- **Section titles, note cards, related-track buttons, stat tiles, the content-gap banner and the
  FAQ accordion** all carry the same outline and offset shadow, so the surface reads as one
  object.
- **Rail and fan strokes** thickened to their weight (3.5 / 2.2) with a round dotted pattern.

Their **"done"** treatment is adopted verbatim, because it is the best idea in their renderer: a
completed step drains to grey `#cbcbcb` with the text struck through, so a finished map visibly
goes quiet. Text decoration doubles every state for colour-blind readers.

## One deliberate departure

**The hue stays ours.** `#fdff00` is roadmap.sh's brand asset and read as a foreign object inside
a violet product — which was your note on the first cut. The *language* is theirs, the *colour*
is ours.

If you want their exact yellow-and-blue too, it is a one-line change in `roadmapTokens.ts` and I
will do it — just say so.

Their hand-drawn font (Balsamiq) is **not** adopted: fonts here are an allowlisted per-tenant
setting, so a canvas-specific typeface is a platform decision rather than a component one.

## Verification

`tsc --noEmit` clean, eslint clean, `next build` compiles with both routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)