### PR TITLE
feat(roadmaps): one continuous drawn trail, tree-branch limbs to sub-steps

### DIFF
--- a/components/roadmaps/RoadmapSpine.tsx
+++ b/components/roadmaps/RoadmapSpine.tsx
@@ -9,6 +9,7 @@ import type {
   RoadmapProgress,
 } from "@/lib/services/roadmaps.service";
 import { RM, SPINE_FILL, BRANCH_FILL } from "./roadmapTokens";
+import { useTrail, type TrailRegistry } from "./RoadmapTrail";
 
 /**
  * The map: a centre spine of primary steps with branch steps hanging off it on curved
@@ -30,7 +31,6 @@ type NodeState = "done" | "learning" | "skipped" | "pending";
 
 const INK = RM.ink;
 const VIOLET = RM.rail;
-const RAIL_STRONG = RM.rail;
 
 function NodeBox({
   node,
@@ -122,6 +122,8 @@ function StepCell({
   progress,
   dependsOn,
   onOpenNode,
+  seq,
+  registry,
 }: {
   node: RoadmapNode;
   branches: RoadmapNode[];
@@ -131,15 +133,20 @@ function StepCell({
    *  across that distance is unreadable and unroutable. */
   dependsOn: RoadmapNode[];
   onOpenNode: (n: RoadmapNode) => void;
+  /** Position in this section's sequence, so the trail can thread through in order. */
+  seq: number;
+  registry: TrailRegistry;
 }) {
   return (
     <Box sx={{ width: "100%", minWidth: 0 }}>
-      <NodeBox
-        node={node}
-        variant="spine"
-        progress={progress?.nodes?.[node.id]}
-        onOpen={() => onOpenNode(node)}
-      />
+      <Box ref={registry.step(seq)}>
+        <NodeBox
+          node={node}
+          variant="spine"
+          progress={progress?.nodes?.[node.id]}
+          onOpen={() => onOpenNode(node)}
+        />
+      </Box>
 
       {dependsOn.length > 0 && (
         <Stack direction="row" spacing={0.4} flexWrap="wrap" useFlexGap
@@ -164,79 +171,19 @@ function StepCell({
       )}
 
       {branches.length > 0 && (
-        <Box sx={{ position: "relative", mt: 1.25, pl: 1.5 }}>
-          {/* A short drawn tick joining the step to its branch stack. */}
-          <Box
-            aria-hidden
-            sx={{
-              position: "absolute", insetInlineStart: 4, top: -6, bottom: 8,
-              width: 0, borderInlineStart: `2px dotted ${RAIL_STRONG}`, opacity: 0.7,
-            }}
-          />
-          <Stack spacing={0.55}>
-            {branches.map((b) => (
+        <Stack spacing={0.75} sx={{ mt: 3.25, pl: { xs: 2, sm: 4.25 } }}>
+          {branches.map((b, bi) => (
+            <Box key={b.id} ref={registry.sub(seq, bi)}>
               <NodeBox
-                key={b.id}
                 node={b}
                 variant="branch"
                 progress={progress?.nodes?.[b.id]}
                 onOpen={() => onOpenNode(b)}
               />
-            ))}
-          </Stack>
-        </Box>
+            </Box>
+          ))}
+        </Stack>
       )}
-    </Box>
-  );
-}
-
-/**
- * The arrow leaving a step toward the next one in its row.
- *
- * Absolutely positioned ON the step it leaves from, at the step box's own vertical centre, so
- * it is anchored to a real element and always meets the next box. The previous version drew
- * connectors as free-standing flex children, which is why one ended up floating on its own in
- * the middle of empty canvas: nothing tied it to either end.
- */
-function StepArrow({ dir }: { dir: "ltr" | "rtl" }) {
-  return (
-    <Box
-      aria-hidden
-      sx={{
-        position: "absolute",
-        top: 18,
-        [dir === "ltr" ? "right" : "left"]: -38,
-        width: 38,
-        display: { xs: "none", sm: "block" },
-        pointerEvents: "none",
-      }}
-    >
-      <svg width="38" height="14" viewBox="0 0 38 14" fill="none"
-           style={{ transform: dir === "rtl" ? "scaleX(-1)" : undefined }}>
-        <path d="M0,7 L29,7" stroke={RAIL_STRONG} strokeWidth="2.5" strokeLinecap="round" />
-        <path d="M27,2.5 L35,7 L27,11.5" stroke={RAIL_STRONG} strokeWidth="2.5"
-              strokeLinecap="round" strokeLinejoin="round" fill="none" />
-      </svg>
-    </Box>
-  );
-}
-
-/**
- * The drop at the end of a row.
- *
- * A serpentine row ends in exactly the column the next row begins in (verified: for any step
- * count and column count, row R's end column equals row R+1's start column), so the turn is a
- * straight vertical drop placed in that column -- not a curve travelling across the canvas.
- * That is why it always connects.
- */
-function RowDrop() {
-  return (
-    <Box aria-hidden sx={{ display: "grid", placeItems: "center", py: 1.25 }}>
-      <svg width="16" height="40" viewBox="0 0 16 40" fill="none">
-        <path d="M8,0 L8,30" stroke={RAIL_STRONG} strokeWidth="3" strokeLinecap="round" />
-        <path d="M2.5,28 L8,38 L13.5,28" stroke={RAIL_STRONG} strokeWidth="3"
-              strokeLinecap="round" strokeLinejoin="round" fill="none" />
-      </svg>
     </Box>
   );
 }
@@ -357,12 +304,6 @@ export function RoadmapSpine({
 
   const notes = graph.nodes.filter((n) => n.kind === "note").sort((a, b) => a.order - b.order);
 
-  const chunk = (arr: RoadmapNode[]) => {
-    const rows: RoadmapNode[][] = [];
-    for (let i = 0; i < arr.length; i += cols) rows.push(arr.slice(i, i + cols));
-    return rows;
-  };
-
   return (
     <Box sx={{ position: "relative", pb: 5 }}>
       {graph.legends.length > 0 && (
@@ -391,10 +332,59 @@ export function RoadmapSpine({
         </Box>
       )}
 
-      {sections.map((section, si) => {
-        const rows = chunk(childrenOf(section.id));
-        return (
-          <Fragment key={section.id}>
+      {sections.map((section, si) => (
+        <RoadmapSection
+          key={section.id}
+          section={section}
+          index={si}
+          steps={childrenOf(section.id)}
+          childrenOf={childrenOf}
+          dependsOn={dependsOn}
+          progress={progress}
+          cols={cols}
+          onOpenNode={onOpenNode}
+        />
+      ))}
+
+      {notes.map((n) => (
+        <NoteCard key={n.id} node={n} />
+      ))}
+
+      {onOpenRoadmap && (
+        <RelatedTracks related={graph.related ?? []} onOpen={onOpenRoadmap} />
+      )}
+    </Box>
+  );
+}
+
+/** One numbered section: its header, its serpentine grid, and the trail drawn over it. */
+function RoadmapSection({
+  section,
+  index: si,
+  steps,
+  childrenOf,
+  dependsOn,
+  progress,
+  cols,
+  onOpenNode,
+}: {
+  section: RoadmapNode;
+  index: number;
+  steps: RoadmapNode[];
+  childrenOf: (id: number) => RoadmapNode[];
+  dependsOn: (id: number) => RoadmapNode[];
+  progress?: RoadmapProgress;
+  cols: number;
+  onOpenNode: (n: RoadmapNode) => void;
+}) {
+  const { wrap, registry, Trail } = useTrail();
+
+  const rows: RoadmapNode[][] = [];
+  for (let i = 0; i < steps.length; i += cols) rows.push(steps.slice(i, i + cols));
+
+  let seq = -1;
+  return (
+    <Fragment>
             <Stack
               direction="row"
               alignItems="center"
@@ -422,10 +412,10 @@ export function RoadmapSpine({
               </Box>
             </Stack>
 
-            {/* One explicit GRID per section. Every cell gets a known gridColumn/gridRow, which
-                is what makes the connectors land: a free-flowing flex layout has nothing for
-                them to anchor to, and centre-justified rows of different lengths do not even
-                line up with each other. */}
+            {/* The trail is drawn OVER this grid from measured box positions, so the host is
+                position:relative and the SVG sits in its own layer beneath the boxes. */}
+            <Box ref={wrap} sx={{ position: "relative" }}>
+            {Trail}
             <Box
               sx={{
                 display: "grid",
@@ -435,14 +425,11 @@ export function RoadmapSpine({
                 },
                 justifyContent: "center",
                 columnGap: "38px",
-                rowGap: 0,
+                rowGap: "86px",
               }}
             >
               {rows.map((row, ri) => {
                 const rtl = ri % 2 === 1;
-                // Column of the LAST cell in this row: where the path leaves, and therefore
-                // where the drop must sit so the next row picks it up.
-                const endCol = rtl ? cols - (row.length - 1) : row.length;
                 return (
                   <Fragment key={`${section.id}-${ri}`}>
                     {row.map((node, ci) => (
@@ -451,7 +438,7 @@ export function RoadmapSpine({
                         sx={{
                           position: "relative",
                           gridColumn: { xs: "1", sm: `${rtl ? cols - ci : ci + 1}` },
-                          gridRow: ri * 2 + 1,
+                          gridRow: ri + 1,
                           minWidth: 0,
                           pb: 1,
                         }}
@@ -462,35 +449,16 @@ export function RoadmapSpine({
                           progress={progress}
                           dependsOn={dependsOn(node.id)}
                           onOpenNode={onOpenNode}
+                          seq={(seq += 1)}
+                          registry={registry}
                         />
-                        {ci < row.length - 1 && <StepArrow dir={rtl ? "rtl" : "ltr"} />}
                       </Box>
                     ))}
-                    {ri < rows.length - 1 && (
-                      <Box
-                        sx={{
-                          gridColumn: { xs: "1", sm: `${endCol}` },
-                          gridRow: ri * 2 + 2,
-                        }}
-                      >
-                        <RowDrop />
-                      </Box>
-                    )}
                   </Fragment>
                 );
               })}
             </Box>
-          </Fragment>
-        );
-      })}
-
-      {notes.map((n) => (
-        <NoteCard key={n.id} node={n} />
-      ))}
-
-      {onOpenRoadmap && (
-        <RelatedTracks related={graph.related ?? []} onOpen={onOpenRoadmap} />
-      )}
-    </Box>
+            </Box>
+    </Fragment>
   );
 }

--- a/components/roadmaps/RoadmapTrail.tsx
+++ b/components/roadmaps/RoadmapTrail.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Box } from "@mui/material";
+import { RM } from "./roadmapTokens";
+
+/**
+ * The drawn path through a section: ONE continuous trail through the steps, plus a tree of
+ * curved limbs from each step out to its sub-steps.
+ *
+ * It has to MEASURE rather than be laid out with borders, because a continuous line cannot be
+ * assembled from per-cell CSS: each segment needs to know where the previous box actually ended,
+ * and box heights vary with how many sub-steps each step has and how many titles wrap. Earlier
+ * attempts drew per-cell connector elements, which is why one ended up floating in empty canvas
+ * with nothing to attach to.
+ *
+ * Two routing rules carry the whole look:
+ *
+ *   1. A turn between rows exits the SIDE of the step and sweeps around the OUTSIDE of the
+ *      column. Dropping from the bottom would run the line straight through the sub-step stack,
+ *      which is exactly what it looked like on the first render.
+ *   2. Sub-steps hang off a trunk as separate curved limbs, so the relationship reads as a tree
+ *      branch rather than as a list with a rule down its side.
+ */
+
+type Rect = { l: number; r: number; t: number; b: number; cx: number; cy: number };
+
+export type TrailRegistry = {
+  /** Register a step box. `order` is its position in the section's sequence. */
+  step: (order: number) => (el: HTMLElement | null) => void;
+  /** Register a sub-step box under a given step order. */
+  sub: (stepOrder: number, index: number) => (el: HTMLElement | null) => void;
+};
+
+export function useTrail() {
+  const wrap = useRef<HTMLDivElement | null>(null);
+  const steps = useRef<Map<number, HTMLElement>>(new Map());
+  const subs = useRef<Map<string, HTMLElement>>(new Map());
+  const [paths, setPaths] = useState<{ trail: string; limbs: string; w: number; h: number }>({
+    trail: "",
+    limbs: "",
+    w: 0,
+    h: 0,
+  });
+
+  const registry: TrailRegistry = {
+    step: (order) => (el) => {
+      if (el) steps.current.set(order, el);
+      else steps.current.delete(order);
+    },
+    sub: (stepOrder, index) => (el) => {
+      const key = `${stepOrder}:${index}`;
+      if (el) subs.current.set(key, el);
+      else subs.current.delete(key);
+    },
+  };
+
+  const measure = useCallback(() => {
+    const host = wrap.current;
+    if (!host) return;
+    const W = host.getBoundingClientRect();
+    if (!W.width) return;
+    const R = (el: HTMLElement): Rect => {
+      const b = el.getBoundingClientRect();
+      return {
+        l: b.left - W.left,
+        r: b.right - W.left,
+        t: b.top - W.top,
+        b: b.bottom - W.top,
+        cx: b.left - W.left + b.width / 2,
+        cy: b.top - W.top + b.height / 2,
+      };
+    };
+
+    const ordered = [...steps.current.entries()].sort((a, b) => a[0] - b[0]).map(([o, el]) => ({
+      order: o,
+      rect: R(el),
+    }));
+
+    let trail = "";
+    ordered.forEach(({ rect: p }, i) => {
+      if (i === 0) return;
+      const q = ordered[i - 1].rect;
+      // Same row when the two boxes share a baseline. A generous tolerance because a step with
+      // a long wrapped title is a few pixels taller than its neighbour.
+      const sameRow = Math.abs(p.cy - q.cy) < 48;
+      if (sameRow) {
+        const mx = (q.r + p.l) / 2;
+        trail += ` M${q.r},${q.cy} C${mx},${q.cy} ${mx},${p.cy} ${p.l},${p.cy}`;
+      } else {
+        const right = q.cx > W.width / 2;
+        const ox = right ? Math.max(q.r, p.r) + 72 : Math.min(q.l, p.l) - 72;
+        const qx = right ? q.r : q.l;
+        const px = right ? p.r : p.l;
+        trail += ` M${qx},${q.cy} C${ox},${q.cy} ${ox},${p.cy} ${px},${p.cy}`;
+      }
+    });
+
+    let limbs = "";
+    ordered.forEach(({ order, rect: step }) => {
+      const mine = [...subs.current.entries()]
+        .filter(([k]) => k.startsWith(`${order}:`))
+        .sort((a, b) => Number(a[0].split(":")[1]) - Number(b[0].split(":")[1]))
+        .map(([, el]) => R(el));
+      if (!mine.length) return;
+      const tx = step.l + 20;
+      const last = mine[mine.length - 1];
+      limbs += `M${step.cx},${step.b} C${step.cx},${step.b + 10} ${tx},${step.b + 10} ${tx},${step.b + 18} `;
+      limbs += `M${tx},${step.b + 18} L${tx},${last.cy} `;
+      mine.forEach((s) => {
+        limbs += `M${tx},${s.cy - 22} C${tx},${s.cy} ${tx + 2},${s.cy} ${s.l},${s.cy} `;
+      });
+    });
+
+    setPaths({ trail, limbs, w: W.width, h: W.height });
+  }, []);
+
+  useLayoutEffect(() => {
+    measure();
+  });
+
+  useEffect(() => {
+    const host = wrap.current;
+    if (!host || typeof ResizeObserver === "undefined") return;
+    // Remeasure on any layout change: a wrapped title, an expanded drawer, a window resize.
+    const ro = new ResizeObserver(() => measure());
+    ro.observe(host);
+    window.addEventListener("resize", measure);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [measure]);
+
+  const Trail = (
+    <Box
+      component="svg"
+      aria-hidden
+      viewBox={`0 0 ${paths.w || 1} ${paths.h || 1}`}
+      sx={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+        overflow: "visible",
+        display: { xs: "none", sm: "block" },
+      }}
+    >
+      <path d={paths.limbs} fill="none" stroke={RM.railSoft} strokeWidth="2.5"
+            strokeLinecap="round" strokeLinejoin="round" />
+      <path d={paths.trail} fill="none" stroke={RM.rail} strokeWidth="3"
+            strokeLinecap="round" strokeLinejoin="round" />
+    </Box>
+  );
+
+  return { wrap, registry, Trail };
+}


### PR DESCRIPTION
The connectors were disjoint stubs — a short arrow between each pair of steps, a separate
vertical drop between rows. They read as fragments, not as a path.

## Now: one measured trail

A single SVG per section draws **one continuous trail** through the steps, plus a **tree of
curved limbs** out to each sub-step.

This has to **measure** rather than be built from per-cell CSS: a continuous line needs to know
where the previous box actually ended, and box heights vary with how many sub-steps a step has
and how many titles wrap. That is also why the earlier per-cell connectors could never be made
to work — there was nothing for them to attach to.

## Two routing rules, both found by looking

1. **A turn exits the side and sweeps around the outside of the column.** My first attempt
   dropped from the bottom, which ran the curve straight through the sub-step stack.
2. **Sub-steps hang off a trunk as individually curved limbs**, so the relationship reads as a
   branch rather than a list with a rule down its side. The old CSS dotted border is gone.

Redraws on  + window resize, so a wrapped title or viewport change never leaves
a stale path.

## Process note

I prototyped the exact geometry standalone and screenshotted it **twice** before porting — that
is how both faults above were caught. Every previous version of this layout typechecked and
linted clean while being visibly wrong.

`tsc --noEmit` clean, eslint clean, `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)