### PR TITLE
hotfix(roadmaps): trail hook looped forever and crashed the page

### DIFF
--- a/components/roadmaps/RoadmapTrail.test.tsx
+++ b/components/roadmaps/RoadmapTrail.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { useTrail } from "./RoadmapTrail";
+
+/**
+ * Regression: the trail hook ran a layout effect on every render and unconditionally set state
+ * with a fresh object, so setPaths -> render -> effect -> setPaths never terminated. That
+ * shipped and took the whole roadmap page down with React error #185.
+ *
+ * jsdom reports zero-size rects, so the guard has to be exercised with stubbed geometry --
+ * otherwise `measure` returns early on `!W.width` and the test would pass against broken code.
+ */
+function stubLayout() {
+  // Geometry must be STABLE per element. A counter-based stub returns different rects on every
+  // call, so the measure can never settle and the test would fail even against correct code --
+  // which is exactly what it did on the first attempt.
+  const seen = new Map<HTMLElement, number>();
+  return vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockImplementation(function (this: HTMLElement) {
+      const host = this.dataset?.trailHost === "1";
+      if (!seen.has(this)) seen.set(this, seen.size);
+      const top = host ? 0 : (seen.get(this) as number) * 60;
+      return {
+        left: 0, right: 200, top, bottom: top + 40,
+        width: 200, height: host ? 400 : 40, x: 0, y: top,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+function Harness() {
+  const { wrap, registry, Trail } = useTrail();
+  return (
+    <div ref={wrap} data-trail-host="1">
+      {Trail}
+      <div ref={registry.step(0)}>step one</div>
+      <div ref={registry.sub(0, 0)}>sub one</div>
+      <div ref={registry.step(1)}>step two</div>
+    </div>
+  );
+}
+
+describe("useTrail", () => {
+  it("settles instead of looping forever", () => {
+    stubLayout();
+    // A runaway update loop throws "Maximum update depth exceeded" out of render.
+    expect(() => render(<Harness />)).not.toThrow();
+  });
+
+  it("renders both path layers", () => {
+    stubLayout();
+    const { container } = render(<Harness />);
+    expect(container.querySelectorAll("path")).toHaveLength(2);
+  });
+
+  it("maps the viewBox 1:1 so measured coordinates are not rescaled", () => {
+    stubLayout();
+    const { container } = render(<Harness />);
+    expect(container.querySelector("svg")?.getAttribute("preserveAspectRatio")).toBe("none");
+  });
+});

--- a/components/roadmaps/RoadmapTrail.tsx
+++ b/components/roadmaps/RoadmapTrail.tsx
@@ -112,9 +112,24 @@ export function useTrail() {
       });
     });
 
-    setPaths({ trail, limbs, w: W.width, h: W.height });
+    // BAIL OUT when nothing moved. This is load-bearing, not an optimisation: the layout effect
+    // below runs after every render, so returning a fresh object unconditionally meant
+    // setPaths -> render -> effect -> setPaths forever. That shipped, and it took the whole
+    // roadmap page down with React error #185 (maximum update depth exceeded). Returning `prev`
+    // makes React bail out of the re-render and the loop terminates on the first stable measure.
+    setPaths((prev) =>
+      prev.trail === trail &&
+      prev.limbs === limbs &&
+      prev.w === W.width &&
+      prev.h === W.height
+        ? prev
+        : { trail, limbs, w: W.width, h: W.height }
+    );
   }, []);
 
+  // Runs after every render on purpose: box positions change for reasons that are not props
+  // (a title wrapping, a font loading, the drawer opening). Safe only because `measure` bails
+  // out above when the geometry is unchanged.
   useLayoutEffect(() => {
     measure();
   });
@@ -137,6 +152,11 @@ export function useTrail() {
       component="svg"
       aria-hidden
       viewBox={`0 0 ${paths.w || 1} ${paths.h || 1}`}
+      // The path is measured in the container's own pixel space, so the viewBox must map to the
+      // element 1:1. The default "meet" would uniformly scale and centre it, which silently
+      // offsets every line the moment the measured size and the rendered size disagree by even
+      // a pixel (during a resize, or before fonts settle).
+      preserveAspectRatio="none"
       sx={{
         position: "absolute",
         inset: 0,


### PR DESCRIPTION
**Staging was down** on every roadmap detail page with React error #185, *maximum update depth
exceeded*. Mine, shipped in #1306.

## Cause

`useLayoutEffect(() => { measure(); })` has **no dependency array**, so it runs after every
render — and `measure` ended in an unconditional `setPaths({ ... })`. A fresh object is never
`Object.is`-equal to the previous state, so React re-rendered → ran the effect → set state →
forever. The component never reached a frame.

## Fix

`measure` now returns the **previous state object** when geometry is unchanged, so React bails
out of the re-render and the loop terminates on the first stable measure.

The effect still runs every render on purpose — box positions move for reasons that aren't props
(a title wrapping, a font loading, the drawer opening) — and that's only safe now the setter
bails.

Also pins `preserveAspectRatio="none"`: the path is measured in the container's pixel space, so
the viewBox must map 1:1. SVG's default "meet" uniformly scales and centres, silently offsetting
every line whenever measured and rendered sizes disagree by a pixel.

## Why it shipped

I verified #1306 by screenshotting a **static HTML prototype** — which contains no React at all.
The geometry was correct and the component was still unrunnable.

Static prototypes verify geometry. They say nothing about lifecycle.

## The test

Renders the real hook with stubbed layout. I confirmed it **fails against the broken version**
and passes against the fix — a regression test that passes on the bug it's meant to catch is
worthless.

Two things the test needed: jsdom reports zero-size rects (so `measure` returns early and would
pass against broken code without a stub), and the stub must be **stable per element** — my first
counter-based version never settled and failed correct code too.

87 unit tests pass, `tsc` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)