### PR TITLE
feat(roadmaps): organic branch layout with per-section accents

### DIFF
--- a/components/roadmaps/RoadmapSpine.test.tsx
+++ b/components/roadmaps/RoadmapSpine.test.tsx
@@ -85,7 +85,11 @@ function progressFor(g: RoadmapGraph): RoadmapProgress {
 
 afterEach(() => vi.restoreAllMocks());
 
-describe("RoadmapSpine", () => {
+// A full-size map is ~180 nodes plus their wrappers. Mounting that in jsdom genuinely takes
+// longer than the 5s default, and the branch layout added a wrapper per leaf. The generous
+// budget is deliberate: this suite exists to catch the render LOOP that took staging down
+// (React #185), and shrinking the map to fit the default would shrink away the thing under test.
+describe("RoadmapSpine", { timeout: 30_000 }, () => {
   it("mounts a full-size roadmap without looping or throwing", () => {
     stubLayout();
     const g = bigGraph();

--- a/components/roadmaps/RoadmapSpine.tsx
+++ b/components/roadmaps/RoadmapSpine.tsx
@@ -8,7 +8,7 @@ import type {
   RoadmapNode,
   RoadmapProgress,
 } from "@/lib/services/roadmaps.service";
-import { RM, SPINE_FILL, BRANCH_FILL } from "./roadmapTokens";
+import { RM, SPINE_FILL, BRANCH_FILL, SECTION_ACCENTS, type SectionAccent } from "./roadmapTokens";
 import { useTrail, type TrailRegistry } from "./RoadmapTrail";
 
 /**
@@ -36,15 +36,23 @@ function NodeBox({
   node,
   progress,
   variant,
+  accent,
   onOpen,
 }: {
   node: RoadmapNode;
   progress?: RoadmapProgress["nodes"][number];
   variant: "spine" | "branch";
+  /** Section colour. Applied ONLY to the untouched state: done/learning/skipped stay global so
+   *  progress means the same thing in every section. */
+  accent?: SectionAccent;
   onOpen: () => void;
 }) {
   const state = (progress?.selfState ?? "pending") as NodeState;
-  const s = (variant === "spine" ? SPINE_FILL : BRANCH_FILL)[state];
+  const base = (variant === "spine" ? SPINE_FILL : BRANCH_FILL)[state];
+  const s =
+    state === "pending" && accent
+      ? { ...base, bg: variant === "spine" ? accent.spine : accent.branch, text: accent.text }
+      : base;
   const verified = progress?.verifiedComplete;
 
   return (
@@ -124,6 +132,7 @@ function StepCell({
   onOpenNode,
   seq,
   registry,
+  accent,
 }: {
   node: RoadmapNode;
   branches: RoadmapNode[];
@@ -136,6 +145,7 @@ function StepCell({
   /** Position in this section's sequence, so the trail can thread through in order. */
   seq: number;
   registry: TrailRegistry;
+  accent: SectionAccent;
 }) {
   return (
     <Box sx={{ width: "100%", minWidth: 0 }}>
@@ -143,6 +153,7 @@ function StepCell({
         <NodeBox
           node={node}
           variant="spine"
+          accent={accent}
           progress={progress?.nodes?.[node.id]}
           onOpen={() => onOpenNode(node)}
         />
@@ -171,17 +182,31 @@ function StepCell({
       )}
 
       {branches.length > 0 && (
-        <Stack spacing={0.75} sx={{ mt: 3.25, pl: { xs: 2, sm: 4.25 } }}>
-          {branches.map((b, bi) => (
-            <Box key={b.id} ref={registry.sub(seq, bi)}>
-              <NodeBox
-                node={b}
-                variant="branch"
-                progress={progress?.nodes?.[b.id]}
-                onOpen={() => onOpenNode(b)}
-              />
-            </Box>
-          ))}
+        <Stack spacing={0.9} sx={{ mt: 4 }}>
+          {branches.map((b, bi) => {
+            // Leaves alternate side of the trunk and hug their own text, so the stack reads as
+            // a branch rather than as six identical rows in a column.
+            const left = bi % 2 === 0;
+            return (
+              <Box
+                key={b.id}
+                sx={{ display: "flex", justifyContent: left ? "flex-start" : "flex-end" }}
+              >
+                <Box
+                  ref={registry.sub(seq, bi)}
+                  sx={{ maxWidth: "82%", "& > *": { width: "auto" } }}
+                >
+                  <NodeBox
+                    node={b}
+                    variant="branch"
+                    accent={accent}
+                    progress={progress?.nodes?.[b.id]}
+                    onOpen={() => onOpenNode(b)}
+                  />
+                </Box>
+              </Box>
+            );
+          })}
         </Stack>
       )}
     </Box>
@@ -377,7 +402,8 @@ function RoadmapSection({
   cols: number;
   onOpenNode: (n: RoadmapNode) => void;
 }) {
-  const { wrap, registry, Trail } = useTrail();
+  const accent = SECTION_ACCENTS[si % SECTION_ACCENTS.length];
+  const { wrap, registry, Trail } = useTrail(accent.rail);
 
   const rows: RoadmapNode[][] = [];
   for (let i = 0; i < steps.length; i += cols) rows.push(steps.slice(i, i + cols));
@@ -401,7 +427,7 @@ function RoadmapSection({
                   sx={{
                     width: 21, height: 21, borderRadius: "50%",
                     display: "grid", placeItems: "center",
-                    bgcolor: INK, color: "#fff", fontSize: 11, fontWeight: 800,
+                    bgcolor: accent.rail, color: "#fff", fontSize: 11, fontWeight: 800,
                   }}
                 >
                   {si + 1}
@@ -451,6 +477,7 @@ function RoadmapSection({
                           onOpenNode={onOpenNode}
                           seq={(seq += 1)}
                           registry={registry}
+                          accent={accent}
                         />
                       </Box>
                     ))}

--- a/components/roadmaps/RoadmapTrail.tsx
+++ b/components/roadmaps/RoadmapTrail.tsx
@@ -32,7 +32,7 @@ export type TrailRegistry = {
   sub: (stepOrder: number, index: number) => (el: HTMLElement | null) => void;
 };
 
-export function useTrail() {
+export function useTrail(rail: string = RM.rail) {
   const wrap = useRef<HTMLDivElement | null>(null);
   const steps = useRef<Map<number, HTMLElement>>(new Map());
   const subs = useRef<Map<string, HTMLElement>>(new Map());
@@ -103,12 +103,18 @@ export function useTrail() {
         .sort((a, b) => Number(a[0].split(":")[1]) - Number(b[0].split(":")[1]))
         .map(([, el]) => R(el));
       if (!mine.length) return;
-      const tx = step.l + 20;
+      // Trunk straight down the step's centre: leaves hang off BOTH sides now, so an offset
+      // trunk would sit under half of them.
+      const tx = step.cx;
       const last = mine[mine.length - 1];
-      limbs += `M${step.cx},${step.b} C${step.cx},${step.b + 10} ${tx},${step.b + 10} ${tx},${step.b + 18} `;
-      limbs += `M${tx},${step.b + 18} L${tx},${last.cy} `;
-      mine.forEach((s) => {
-        limbs += `M${tx},${s.cy - 22} C${tx},${s.cy} ${tx + 2},${s.cy} ${s.l},${s.cy} `;
+      limbs += `M${tx},${step.b} L${tx},${last.cy} `;
+      // Each leaf is reached on the side it actually sits on, so the limb curves out rather
+      // than always hooking left. Leaves alternate sides, which is what gives the branch its
+      // shape; a fixed-side limb would cross the trunk for half of them.
+      mine.forEach((leaf) => {
+        const onLeft = leaf.cx < step.cx;
+        const ex = onLeft ? leaf.r : leaf.l;
+        limbs += `M${tx},${leaf.cy - 26} C${tx},${leaf.cy} ${(tx + ex) / 2},${leaf.cy} ${ex},${leaf.cy} `;
       });
     });
 
@@ -167,9 +173,9 @@ export function useTrail() {
         display: { xs: "none", sm: "block" },
       }}
     >
-      <path d={paths.limbs} fill="none" stroke={RM.railSoft} strokeWidth="2.5"
+      <path d={paths.limbs} fill="none" stroke={rail} strokeWidth="2.5" opacity={0.45}
             strokeLinecap="round" strokeLinejoin="round" />
-      <path d={paths.trail} fill="none" stroke={RM.rail} strokeWidth="3"
+      <path d={paths.trail} fill="none" stroke={rail} strokeWidth="3"
             strokeLinecap="round" strokeLinejoin="round" />
     </Box>
   );

--- a/components/roadmaps/roadmapTokens.ts
+++ b/components/roadmaps/roadmapTokens.ts
@@ -31,6 +31,23 @@ export const RM = {
 
 type Fill = { bg: string; text: string; deco: "none" | "line-through" | "underline" };
 
+/**
+ * Per-section accent. Twenty-five identical violet boxes read as a table, not a tree, so each
+ * section takes its own hue and the map gains rhythm you can navigate by ("I'm in the green
+ * one"). The PENDING fill varies; every other state stays global, because progress must mean the
+ * same thing everywhere -- a learner should never have to ask which green means done.
+ */
+export const SECTION_ACCENTS = [
+  { spine: "#c4b5fd", branch: "#ede9fe", text: "#1e1b4b", rail: "#7c3aed" }, // violet
+  { spine: "#a5d8ff", branch: "#e7f5ff", text: "#0b3d64", rail: "#1c7ed6" }, // blue
+  { spine: "#b2f2bb", branch: "#ebfbee", text: "#0b4a1e", rail: "#2f9e44" }, // green
+  { spine: "#ffd8a8", branch: "#fff4e6", text: "#6b3009", rail: "#e8590c" }, // amber
+  { spine: "#fcc2d7", branch: "#fff0f6", text: "#6b183c", rail: "#c2255c" }, // pink
+  { spine: "#d0bfff", branch: "#f3f0ff", text: "#2c1a5e", rail: "#7048e8" }, // indigo
+] as const;
+
+export type SectionAccent = (typeof SECTION_ACCENTS)[number];
+
 /** Primary spine steps: the loud row of the map. */
 export const SPINE_FILL: Record<string, Fill> = {
   // Untouched is the platform violet at full strength: the path you have not walked is the


### PR DESCRIPTION
Follow-up to the trail work: the map was structurally right but read as one uniform violet table.

## What changes

**Per-section accent** — `SECTION_ACCENTS` cycles six hues. Each section's pending nodes and its trail stroke take that hue, so you can navigate by "I'm in the green one". Done/learning/skipped stay global on purpose: progress must mean the same thing in every section.

**Leaves branch off both sides** — sub-steps alternate left/right of the trunk and size to their own text rather than filling a grid column. A step with three sub-steps now reads as a branch instead of a stack.

**Limbs follow the leaf** — the trunk drops from the step's centre and each limb exits toward the side its leaf actually sits on. The previous fixed-left limb would have crossed the trunk for half the leaves under the new layout.

## Verification

- `tsc --noEmit`, `eslint`, `next build` clean
- 91 tests pass across 10 files
- Re-confirmed the React #185 guard still bites: removing the `setPaths` bail-out makes the full-scale mount test throw "Maximum update depth exceeded", restored green

The mount test gets an explicit 30s budget. A leaf wrapper per node pushed the ~180-node render past the 5s default; shrinking the fixture would have shrunk away the loop the suite exists to catch.

## Not verified

**I could not look at this.** The image API stopped accepting screenshots partway through this session, so this is verified for structure, types and lifecycle but not for appearance. Given I took this exact surface down twice today shipping visuals I could not see, please eyeball `/roadmaps/full-stack` on staging before this goes to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)