### PR TITLE
feat(roadmaps): company roadmaps on the catalog and the roadmap page

### DIFF
--- a/app/roadmaps/[slug]/page.tsx
+++ b/app/roadmaps/[slug]/page.tsx
@@ -11,6 +11,9 @@ import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { RoadmapSpine } from "@/components/roadmaps/RoadmapSpine";
 import { RoadmapNodeDrawer } from "@/components/roadmaps/RoadmapNodeDrawer";
 import { RoadmapFaqs } from "@/components/roadmaps/RoadmapFaqs";
+import { CompanyHiringProcess } from "@/components/roadmaps/CompanyHiringProcess";
+import { CompanyQuickStats } from "@/components/roadmaps/CompanyQuickStats";
+import { CompanyIntroVideo } from "@/components/roadmaps/CompanyIntroVideo";
 import {
   roadmapKeys,
   roadmapsService,
@@ -207,6 +210,38 @@ export default function RoadmapDetailPage() {
 
         {graphQuery.isLoading && (
           <Typography sx={{ py: 4, color: "#64748b" }}>Loading roadmap...</Typography>
+        )}
+
+        {/* Company preamble: the funnel, the format, and the intro video, above the map.
+            A candidate needs to know what the process IS before a map of it means anything. */}
+        {graph?.company && (
+          <Box
+            sx={{
+              mb: 3,
+              display: "grid",
+              gap: 2.5,
+              gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 1fr) 300px" },
+              alignItems: "start",
+            }}
+          >
+            <Stack spacing={2.5}>
+              {graph.company.introVideoUrl && (
+                <CompanyIntroVideo
+                  url={graph.company.introVideoUrl}
+                  title={graph.company.introVideoTitle || `${graph.company.displayName} overview`}
+                />
+              )}
+              <CompanyHiringProcess
+                stages={graph.company.hiringProcess}
+                syllabus={graph.company.syllabus}
+              />
+            </Stack>
+            <CompanyQuickStats
+              company={graph.company}
+              content={graph.content}
+              mastery={progress?.mastery}
+            />
+          </Box>
         )}
 
         {graph && (

--- a/app/roadmaps/page.tsx
+++ b/app/roadmaps/page.tsx
@@ -69,7 +69,12 @@ export default function RoadmapsPage() {
     () => (data?.roadmaps ?? []).filter((r) => r.kind === "company" && r.company),
     [data]
   );
-  const visibleCompanies = companies.filter(matchesCard);
+  // The rail is the companies' home, but only on the "all" view. Once a learner has picked a
+  // category, the grid below is what they are reading, so the rail would be the same nine
+  // cards twice on one screen. Showing them in exactly one place per view is the rule.
+  const onAllView = (active?.slug ?? "all") === "all";
+  const visibleCompanies = onAllView ? companies.filter(matchesCard) : [];
+  const railSlugs = new Set(visibleCompanies.map((r) => r.slug));
 
   return (
     <PageShell>
@@ -239,7 +244,11 @@ export default function RoadmapsPage() {
 
             <Box>
               {active?.sections.map((section) => {
-                const visible = section.roadmaps.filter(matches);
+                // Anything the rail already rendered is dropped here, so a section that held
+                // only companies disappears rather than repeating them under a heading.
+                const visible = section.roadmaps
+                  .filter(matches)
+                  .filter((slug) => !railSlugs.has(slug));
                 if (!visible.length) return null;
                 const isCompanySection = visible.every(
                   (slug) => bySlug[slug]?.kind === "company"

--- a/app/roadmaps/page.tsx
+++ b/app/roadmaps/page.tsx
@@ -9,7 +9,13 @@ import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { SearchFilterBar } from "@/components/common/list";
 import { Reveal } from "@/components/scorecard/shared";
 import { RoadmapCard } from "@/components/roadmaps/RoadmapCard";
-import { roadmapKeys, roadmapsService } from "@/lib/services/roadmaps.service";
+import { CompanyRoadmapCard } from "@/components/roadmaps/CompanyRoadmapCard";
+import { RM } from "@/components/roadmaps/roadmapTokens";
+import {
+  roadmapKeys,
+  roadmapsService,
+  type RoadmapCard as Card,
+} from "@/lib/services/roadmaps.service";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 
 /**
@@ -19,6 +25,12 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
  * the one idea worth taking wholesale from roadmap.sh: the same roadmap appearing under several
  * headings is the feature, not a bug, because it optimises for the learner finding it from
  * wherever they started looking.
+ *
+ * Companies get a rail of their own ABOVE the category grid rather than a section inside it.
+ * They are chosen by a different question -- "who am I interviewing with" rather than "what do
+ * I want to learn" -- and a learner who arrives with a drive next week should not have to know
+ * which category we filed Accenture under. They remain in the grid too, so nothing is reachable
+ * from only one place.
  */
 export default function RoadmapsPage() {
   const { push, prefetch } = useInstantNavigation();
@@ -40,13 +52,24 @@ export default function RoadmapsPage() {
   const active = categories.find((c) => c.slug === category) ?? categories[0];
 
   const q = query.trim().toLowerCase();
-  const matches = (slug: string) => {
+  const matchesCard = (r?: Card) => {
     if (!q) return true;
-    const r = bySlug[slug];
-    return Boolean(
-      r && (r.pageTitle.toLowerCase().includes(q) || r.summary.toLowerCase().includes(q))
+    if (!r) return false;
+    // Company name is searched explicitly: "tcs" must find the TCS roadmap even though the
+    // page title is "TCS Placement Preparation" and the summary may never repeat the name.
+    return (
+      r.pageTitle.toLowerCase().includes(q) ||
+      r.summary.toLowerCase().includes(q) ||
+      (r.company?.displayName ?? "").toLowerCase().includes(q)
     );
   };
+  const matches = (slug: string) => matchesCard(bySlug[slug]);
+
+  const companies = useMemo(
+    () => (data?.roadmaps ?? []).filter((r) => r.kind === "company" && r.company),
+    [data]
+  );
+  const visibleCompanies = companies.filter(matchesCard);
 
   return (
     <PageShell>
@@ -63,7 +86,7 @@ export default function RoadmapsPage() {
         <SearchFilterBar
           search={query}
           onSearchChange={setQuery}
-          searchPlaceholder="Search roadmaps"
+          searchPlaceholder="Search roadmaps and companies"
         />
 
         {isLoading && (
@@ -86,6 +109,74 @@ export default function RoadmapsPage() {
               Your institution has not published any roadmaps. Once they do, they will appear here.
             </Typography>
           </Stack>
+        )}
+
+        {/* Company rail. Hidden entirely when a tenant holds no company roadmaps, rather than
+            rendered as an empty heading. */}
+        {!isLoading && visibleCompanies.length > 0 && (
+          <Box sx={{ mt: 3 }}>
+            <Stack
+              direction="row"
+              alignItems="baseline"
+              spacing={1.25}
+              sx={{ mb: 1.5, flexWrap: "wrap" }}
+            >
+              <Box
+                sx={{
+                  width: 26,
+                  height: 26,
+                  borderRadius: 1.5,
+                  border: RM.border,
+                  boxShadow: RM.shadow(2),
+                  bgcolor: "#c4b5fd",
+                  display: "grid",
+                  placeItems: "center",
+                  color: RM.ink,
+                  alignSelf: "center",
+                }}
+              >
+                <Icon icon="solar:buildings-2-bold-duotone" width={15} />
+              </Box>
+              <Typography sx={{ fontWeight: 800, fontSize: 17, color: RM.ink }}>
+                Prepare for a company
+              </Typography>
+              <Typography sx={{ fontSize: 13, color: "#64748b" }}>
+                The real hiring process, round by round, with the questions that round asks.
+              </Typography>
+            </Stack>
+
+            <Box
+              sx={{
+                display: "grid",
+                gap: 1.75,
+                gridTemplateColumns: {
+                  xs: "repeat(2, minmax(0, 1fr))",
+                  sm: "repeat(3, minmax(0, 1fr))",
+                  md: "repeat(4, minmax(0, 1fr))",
+                  xl: "repeat(5, minmax(0, 1fr))",
+                },
+              }}
+            >
+              {visibleCompanies.map((roadmap, idx) => (
+                <Reveal key={roadmap.slug} delay={Math.min(idx, 8) * 0.05}>
+                  <CompanyRoadmapCard
+                    roadmap={roadmap}
+                    onOpen={() => push(`/roadmaps/${roadmap.slug}`)}
+                    onHover={() => prefetch(`/roadmaps/${roadmap.slug}`)}
+                  />
+                </Reveal>
+              ))}
+            </Box>
+
+            <Box
+              sx={{
+                mt: 3.5,
+                mb: 0.5,
+                height: 1,
+                bgcolor: "#e6e8ef",
+              }}
+            />
+          </Box>
         )}
 
         {!isLoading && categories.length > 0 && (
@@ -150,6 +241,9 @@ export default function RoadmapsPage() {
               {active?.sections.map((section) => {
                 const visible = section.roadmaps.filter(matches);
                 if (!visible.length) return null;
+                const isCompanySection = visible.every(
+                  (slug) => bySlug[slug]?.kind === "company"
+                );
                 return (
                   <Box key={section.title} sx={{ mb: 3.5 }}>
                     <Typography
@@ -168,19 +262,29 @@ export default function RoadmapsPage() {
                       sx={{
                         display: "grid",
                         gap: 1.75,
-                        gridTemplateColumns: {
-                          xs: "1fr",
-                          sm: "repeat(2, minmax(0, 1fr))",
-                          lg: "repeat(3, minmax(0, 1fr))",
-                        },
+                        gridTemplateColumns: isCompanySection
+                          ? {
+                              xs: "repeat(2, minmax(0, 1fr))",
+                              sm: "repeat(3, minmax(0, 1fr))",
+                              lg: "repeat(4, minmax(0, 1fr))",
+                            }
+                          : {
+                              xs: "1fr",
+                              sm: "repeat(2, minmax(0, 1fr))",
+                              lg: "repeat(3, minmax(0, 1fr))",
+                            },
                       }}
                     >
                       {visible.map((slug, idx) => {
                         const roadmap = bySlug[slug];
                         if (!roadmap) return null;
+                        const Component =
+                          roadmap.kind === "company" && roadmap.company
+                            ? CompanyRoadmapCard
+                            : RoadmapCard;
                         return (
                           <Reveal key={slug} delay={Math.min(idx, 8) * 0.06}>
-                            <RoadmapCard
+                            <Component
                               roadmap={roadmap}
                               onOpen={() => push(`/roadmaps/${slug}`)}
                               onHover={() => prefetch(`/roadmaps/${slug}`)}

--- a/components/roadmaps/CompanyHiringProcess.tsx
+++ b/components/roadmaps/CompanyHiringProcess.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { Box, Chip, Stack, Typography } from "@mui/material";
+import type {
+  RoadmapHiringStage,
+  RoadmapSyllabusRound,
+} from "@/lib/services/roadmaps.service";
+import { RM } from "./roadmapTokens";
+
+/**
+ * The hiring funnel: one numbered step per published stage.
+ *
+ * This is the editorial spine the roadmap's milestones were generated from, so the two must
+ * stay legible as the same sequence. It reads top to bottom with a continuous rail because a
+ * hiring process is genuinely linear, unlike the map below it, which is a graph.
+ */
+export function CompanyHiringProcess({
+  stages,
+  syllabus,
+}: {
+  stages: RoadmapHiringStage[];
+  syllabus?: RoadmapSyllabusRound[];
+}) {
+  if (!stages?.length) return null;
+
+  // Round format details are keyed by a loose name match: the two arrays are authored
+  // separately per company and their labels agree only sometimes ("Coding Round" vs "Coding").
+  // A miss simply means no format chip, never a wrong one attached to the wrong stage.
+  const formatFor = (stage: string) => {
+    const key = stage.toLowerCase();
+    return (syllabus ?? []).find((s) => {
+      const r = (s.round || "").toLowerCase();
+      return r === key || r.includes(key) || key.includes(r);
+    });
+  };
+
+  return (
+    <Box
+      sx={{
+        border: RM.border,
+        borderRadius: 3,
+        bgcolor: "#fff",
+        boxShadow: RM.shadow(3),
+        p: { xs: 2, md: 3 },
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 11.5,
+          fontWeight: 800,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+          color: "#7c3aed",
+          mb: 2,
+        }}
+      >
+        The hiring process
+      </Typography>
+
+      <Box component="ol" sx={{ listStyle: "none", m: 0, p: 0, position: "relative" }}>
+        {stages.map((step, i) => {
+          const format = formatFor(step.stage);
+          const isLast = i === stages.length - 1;
+          return (
+            <Box
+              component="li"
+              key={`${step.stage}-${i}`}
+              sx={{ display: "flex", gap: 2, position: "relative", pb: isLast ? 0 : 3 }}
+            >
+              {/* The rail is drawn per item and stops at the last one, so it never overshoots
+                  past the final badge the way a single absolutely-positioned line does. */}
+              {!isLast && (
+                <Box
+                  aria-hidden
+                  sx={{
+                    position: "absolute",
+                    left: 15,
+                    top: 32,
+                    bottom: 0,
+                    width: 2,
+                    bgcolor: "#e9d5ff",
+                  }}
+                />
+              )}
+              <Box
+                sx={{
+                  width: 32,
+                  height: 32,
+                  borderRadius: "50%",
+                  bgcolor: "#7c3aed",
+                  color: "#fff",
+                  display: "grid",
+                  placeItems: "center",
+                  fontWeight: 800,
+                  fontSize: 14,
+                  flexShrink: 0,
+                  zIndex: 1,
+                }}
+              >
+                {i + 1}
+              </Box>
+              <Box sx={{ minWidth: 0, pt: 0.25 }}>
+                <Stack
+                  direction="row"
+                  alignItems="center"
+                  spacing={1}
+                  sx={{ flexWrap: "wrap", rowGap: 0.5 }}
+                >
+                  <Typography sx={{ fontWeight: 700, fontSize: 15.5, color: RM.ink }}>
+                    {step.stage}
+                  </Typography>
+                  {format?.type === "Elimination" && (
+                    <Chip
+                      label="Elimination"
+                      size="small"
+                      sx={{
+                        height: 20,
+                        fontSize: 10.5,
+                        fontWeight: 700,
+                        bgcolor: "#fef2f2",
+                        color: "#b91c1c",
+                      }}
+                    />
+                  )}
+                  {format?.type === "Final" && (
+                    <Chip
+                      label="Final"
+                      size="small"
+                      sx={{
+                        height: 20,
+                        fontSize: 10.5,
+                        fontWeight: 700,
+                        bgcolor: "#ecfdf5",
+                        color: "#047857",
+                      }}
+                    />
+                  )}
+                </Stack>
+                {step.detail && (
+                  <Typography sx={{ mt: 0.4, fontSize: 13.5, color: "#475569", lineHeight: 1.55 }}>
+                    {step.detail}
+                  </Typography>
+                )}
+                {format?.info && (
+                  <Typography sx={{ mt: 0.4, fontSize: 12.5, color: "#7c3aed", fontWeight: 600 }}>
+                    {format.info}
+                  </Typography>
+                )}
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/components/roadmaps/CompanyIntroVideo.tsx
+++ b/components/roadmaps/CompanyIntroVideo.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { toEmbedUrl } from "@/lib/utils/video-embed";
+import { RM } from "./roadmapTokens";
+
+/**
+ * The company overview video.
+ *
+ * The URL is stored as pasted (a `vimeo.com/N` share link), so it goes through the shared
+ * `toEmbedUrl` rather than being reformatted here: that helper already knows every provider
+ * form this product accepts, and a second private copy of that logic is how the two drift.
+ *
+ * Lazy-loaded and not autoplaying. It sits above the map, and a video that starts itself on a
+ * page the learner opened to read a hiring process is an interruption, not a feature.
+ */
+export function CompanyIntroVideo({ url, title }: { url: string; title: string }) {
+  const embed = toEmbedUrl(url);
+  if (!embed) return null;
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          position: "relative",
+          width: "100%",
+          aspectRatio: "16 / 9",
+          borderRadius: 3,
+          overflow: "hidden",
+          border: RM.border,
+          boxShadow: RM.shadow(3),
+          bgcolor: "#0f172a",
+        }}
+      >
+        <Box
+          component="iframe"
+          src={embed}
+          title={title}
+          loading="lazy"
+          allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          sx={{ position: "absolute", inset: 0, width: "100%", height: "100%", border: 0 }}
+        />
+      </Box>
+      <Typography sx={{ mt: 1, fontSize: 13, fontWeight: 600, color: "#475569" }}>
+        {title}
+      </Typography>
+    </Box>
+  );
+}

--- a/components/roadmaps/CompanyQuickStats.tsx
+++ b/components/roadmaps/CompanyQuickStats.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { Box, Stack, Tooltip, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type {
+  RoadmapCompany,
+  RoadmapContentTotals,
+} from "@/lib/services/roadmaps.service";
+import { RM } from "./roadmapTokens";
+
+/**
+ * The quick-stats panel.
+ *
+ * Every row here is either authored per company (rounds, exam format, the negative-marking
+ * rule) or computed from something real (the practice this map reaches, the learner's own
+ * mastery). The panel this replaces carried a "Competitiveness" percentage that was a static
+ * literal authored once per company; it is not reproduced, because a number a learner makes
+ * decisions from has to be one we can stand behind.
+ *
+ * Hiring estimates render only with the date they were true on. The server omits the whole
+ * object when it cannot supply a date, so there is no branch here that can leak an undated one.
+ */
+function Row({
+  label,
+  value,
+  hint,
+  accent,
+}: {
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+  accent?: string;
+}) {
+  return (
+    <Box
+      sx={{
+        border: "1px solid #e6e8ef",
+        borderRadius: 2,
+        px: 1.75,
+        py: 1.4,
+        bgcolor: "#fff",
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mb: 0.4 }}>
+        <Typography
+          sx={{
+            fontSize: 10.5,
+            fontWeight: 700,
+            letterSpacing: 0.5,
+            textTransform: "uppercase",
+            color: "#94a3b8",
+          }}
+        >
+          {label}
+        </Typography>
+        {hint && (
+          <Tooltip title={hint} arrow enterTouchDelay={0}>
+            <Box sx={{ display: "flex", color: "#cbd5e1", cursor: "help" }}>
+              <Icon icon="solar:info-circle-linear" width={13} />
+            </Box>
+          </Tooltip>
+        )}
+      </Stack>
+      <Typography
+        sx={{
+          fontSize: 14.5,
+          fontWeight: 700,
+          color: accent ?? RM.ink,
+          lineHeight: 1.4,
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+export function CompanyQuickStats({
+  company,
+  content,
+  mastery,
+}: {
+  company: RoadmapCompany;
+  content?: RoadmapContentTotals;
+  /** 0..1, derived from the learner's own submissions. Undefined until progress loads. */
+  mastery?: number;
+}) {
+  const practice = [
+    content?.questions ? `${content.questions.toLocaleString()} questions` : null,
+    content?.codingProblems ? `${content.codingProblems} coding problems` : null,
+  ].filter(Boolean) as string[];
+
+  const readiness = mastery == null ? null : Math.round(mastery * 100);
+
+  return (
+    <Stack spacing={1.25}>
+      <Typography
+        sx={{
+          fontSize: 11.5,
+          fontWeight: 800,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+          color: "#7c3aed",
+        }}
+      >
+        Quick stats
+      </Typography>
+
+      {company.rounds > 0 && <Row label="Total rounds" value={company.rounds} />}
+
+      {company.examType && <Row label="Type of exam" value={company.examType} />}
+
+      {company.negativeMarking && (
+        <Row
+          label="Negative marking"
+          value={company.negativeMarking}
+          hint="Taken from the published pattern. Confirm against your drive notification, since it varies by drive."
+        />
+      )}
+
+      {practice.length > 0 && (
+        <Row
+          label="Practice available"
+          value={practice.join(" · ")}
+          hint="Counted from the content this roadmap actually reaches, not an estimate."
+        />
+      )}
+
+      <Row
+        label="Your readiness"
+        value={readiness == null ? "..." : `${readiness}%`}
+        accent={readiness != null && readiness > 0 ? "#059669" : undefined}
+        hint="The share of steps you have genuinely passed, derived from your own submissions. Marking a step done by hand does not move it."
+      />
+
+      {company.estimates && (
+        <Box
+          sx={{
+            border: "1px dashed #e2e8f0",
+            borderRadius: 2,
+            px: 1.75,
+            py: 1.4,
+            bgcolor: "#fbfbfd",
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: 10.5,
+              fontWeight: 700,
+              letterSpacing: 0.5,
+              textTransform: "uppercase",
+              color: "#94a3b8",
+              mb: 0.6,
+            }}
+          >
+            Market estimates
+          </Typography>
+          {company.estimates.applicants && (
+            <Typography sx={{ fontSize: 13, color: "#334155" }}>
+              Applicants: <b>{company.estimates.applicants}</b>
+            </Typography>
+          )}
+          {company.estimates.openRoles && (
+            <Typography sx={{ fontSize: 13, color: "#334155" }}>
+              Open roles: <b>{company.estimates.openRoles}</b>
+            </Typography>
+          )}
+          {/* The date is not decoration: it is what makes these figures honest to show. */}
+          <Typography sx={{ mt: 0.6, fontSize: 11.5, color: "#94a3b8" }}>
+            Estimates, as of{" "}
+            {new Date(company.estimates.asOf).toLocaleDateString(undefined, {
+              month: "short",
+              year: "numeric",
+            })}
+            {company.estimates.sourceUrl ? (
+              <>
+                {" · "}
+                <Box
+                  component="a"
+                  href={company.estimates.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{ color: "#7c3aed", textDecoration: "underline" }}
+                >
+                  source
+                </Box>
+              </>
+            ) : null}
+          </Typography>
+        </Box>
+      )}
+    </Stack>
+  );
+}

--- a/components/roadmaps/CompanyRoadmap.test.tsx
+++ b/components/roadmaps/CompanyRoadmap.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CompanyQuickStats } from "./CompanyQuickStats";
+import { CompanyHiringProcess } from "./CompanyHiringProcess";
+import { CompanyRoadmapCard } from "./CompanyRoadmapCard";
+import type {
+  RoadmapCard,
+  RoadmapCompany,
+  RoadmapContentTotals,
+} from "@/lib/services/roadmaps.service";
+
+/**
+ * The company surface, rendered with the SHAPE the backend really sends.
+ *
+ * The values here were taken from the seeded Accenture and Wipro payloads rather than invented,
+ * because the two things most likely to break this surface are both properties of the real
+ * data: a `negativeMarking` that is a qualified sentence rather than "No", and an `estimates`
+ * object that is null whenever it cannot be dated.
+ */
+
+const ACCENTURE: RoadmapCompany = {
+  companySlug: "accenture",
+  displayName: "Accenture",
+  logoUrl: "https://upload.wikimedia.org/wikipedia/commons/c/cd/Accenture.svg",
+  badge: "Top Recruiter",
+  difficulty: "Medium",
+  packageRange: "4.5 - 6.5 LPA",
+  rounds: 5,
+  examType: "Cognitive + Technical + Coding + Communication",
+  negativeMarking: "No",
+  hiringProcess: [
+    { stage: "Application / Eligibility", detail: "B.E/B.Tech/MCA/MSc with ~65%" },
+    { stage: "Coding Round", detail: "2-3 coding problems in a timed window" },
+    { stage: "HR Interview", detail: "Communication, attitude, role fit and offer" },
+  ],
+  syllabus: [
+    { round: "Coding Round", info: "2-3 problems · ~45-60 min", type: "Elimination" },
+    { round: "Technical & HR Interview", info: "Two-panel", type: "Final" },
+  ],
+  introVideoUrl: "https://vimeo.com/1213174334",
+  introVideoTitle: "Accenture Overview",
+  estimates: {
+    applicants: "~8-10 lakh/year",
+    openRoles: "~40,000-50,000/year (India)",
+    asOf: "2026-08-12",
+    sourceUrl: null,
+  },
+};
+
+const CONTENT: RoadmapContentTotals = {
+  questions: 952,
+  codingProblems: 40,
+  articles: 0,
+  steps: 45,
+};
+
+describe("CompanyQuickStats", () => {
+  it("shows the practice it really reaches, not a fabricated competitiveness score", () => {
+    render(<CompanyQuickStats company={ACCENTURE} content={CONTENT} mastery={0} />);
+    expect(screen.getByText(/952 questions/)).toBeInTheDocument();
+    expect(screen.getByText(/40 coding problems/)).toBeInTheDocument();
+    expect(screen.queryByText(/competitiveness/i)).not.toBeInTheDocument();
+  });
+
+  it("derives readiness from mastery rather than from a stored literal", () => {
+    render(<CompanyQuickStats company={ACCENTURE} content={CONTENT} mastery={0.42} />);
+    expect(screen.getByText("42%")).toBeInTheDocument();
+  });
+
+  it("renders a qualified negative-marking rule verbatim instead of a yes/no chip", () => {
+    const wipro: RoadmapCompany = {
+      ...ACCENTURE,
+      displayName: "Wipro",
+      negativeMarking:
+        "Generally No (some drives apply -0.25 only in the quantitative section)",
+    };
+    render(<CompanyQuickStats company={wipro} content={CONTENT} mastery={0} />);
+    expect(screen.getByText(/-0.25 only in the quantitative section/)).toBeInTheDocument();
+  });
+
+  it("shows hiring estimates only alongside the date they were true on", () => {
+    const { rerender } = render(
+      <CompanyQuickStats company={ACCENTURE} content={CONTENT} mastery={0} />
+    );
+    expect(screen.getByText(/Estimates, as of/)).toBeInTheDocument();
+    expect(screen.getByText(/~8-10 lakh\/year/)).toBeInTheDocument();
+
+    // The server withholds the whole object when it cannot date it; nothing may leak through.
+    rerender(
+      <CompanyQuickStats
+        company={{ ...ACCENTURE, estimates: null }}
+        content={CONTENT}
+        mastery={0}
+      />
+    );
+    expect(screen.queryByText(/~8-10 lakh\/year/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Market estimates/)).not.toBeInTheDocument();
+  });
+});
+
+describe("CompanyHiringProcess", () => {
+  it("numbers every published stage in order", () => {
+    render(
+      <CompanyHiringProcess stages={ACCENTURE.hiringProcess} syllabus={ACCENTURE.syllabus} />
+    );
+    expect(screen.getByText("Application / Eligibility")).toBeInTheDocument();
+    expect(screen.getByText("HR Interview")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("attaches a round's format only to the stage it belongs to", () => {
+    render(
+      <CompanyHiringProcess stages={ACCENTURE.hiringProcess} syllabus={ACCENTURE.syllabus} />
+    );
+    expect(screen.getByText("2-3 problems · ~45-60 min")).toBeInTheDocument();
+    // "Application / Eligibility" matches no syllabus round, so it gets no elimination chip.
+    expect(screen.getAllByText("Elimination")).toHaveLength(1);
+  });
+
+  it("renders nothing rather than an empty frame when no funnel is published", () => {
+    const { container } = render(<CompanyHiringProcess stages={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("CompanyRoadmapCard", () => {
+  const card: RoadmapCard = {
+    slug: "accenture",
+    cardTitle: "Accenture",
+    pageTitle: "Accenture Placement Preparation",
+    kind: "company",
+    summary: "Accenture's fresher hiring in India.",
+    isNew: false,
+    isRevamped: false,
+    topicCount: 50,
+    company: ACCENTURE,
+  };
+
+  it("leads with the logo and the facts a candidate picks on", () => {
+    render(<CompanyRoadmapCard roadmap={card} onOpen={() => {}} />);
+    expect(screen.getByText("Accenture")).toBeInTheDocument();
+    expect(screen.getByText(/5 rounds/)).toBeInTheDocument();
+    expect(screen.getByText("Top Recruiter")).toBeInTheDocument();
+  });
+
+  it("falls back to initials when a tenant's company has no logo", () => {
+    render(
+      <CompanyRoadmapCard
+        roadmap={{ ...card, company: { ...ACCENTURE, logoUrl: "" } }}
+        onOpen={() => {}}
+      />
+    );
+    expect(screen.getByText("AC")).toBeInTheDocument();
+  });
+
+  it("renders nothing for a roadmap that carries no company block", () => {
+    const { container } = render(
+      <CompanyRoadmapCard roadmap={{ ...card, company: null }} onOpen={() => {}} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/components/roadmaps/CompanyRoadmapCard.tsx
+++ b/components/roadmaps/CompanyRoadmapCard.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { Box, ButtonBase, Chip, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import type { RoadmapCard as Card } from "@/lib/services/roadmaps.service";
+import { RM } from "./roadmapTokens";
+
+/**
+ * A recruiter tile for the "Prepare for a company" rail.
+ *
+ * Deliberately a different object from `RoadmapCard`: a company is chosen by recognising a
+ * logo, not by reading a summary, so the logo is the card and the prose is cut to a single
+ * line of facts. It wears the poster chrome (hard 2px outline, offset shadow, press-on-hover)
+ * that the map canvas uses, which is what ties the catalog to the roadmap it opens.
+ *
+ * Logos are arbitrary external URLs (Wikimedia SVGs), so they render through a plain `img`.
+ * `next/image` blocks SVG by default and has bitten this codebase before on client branding.
+ */
+export function CompanyRoadmapCard({
+  roadmap,
+  coverage,
+  onOpen,
+  onHover,
+}: {
+  roadmap: Card;
+  coverage?: number;
+  onOpen: () => void;
+  onHover?: () => void;
+}) {
+  const company = roadmap.company;
+  if (!company) return null;
+
+  const pct = coverage != null ? Math.round(coverage * 100) : null;
+  const facts = [
+    company.rounds ? `${company.rounds} rounds` : null,
+    company.difficulty || null,
+    roadmap.topicCount ? `${roadmap.topicCount} steps` : null,
+  ].filter(Boolean) as string[];
+
+  return (
+    <ButtonBase
+      onClick={onOpen}
+      onMouseEnter={onHover}
+      onFocus={onHover}
+      aria-label={`Open the ${company.displayName} preparation roadmap`}
+      sx={{
+        width: "100%",
+        height: "100%",
+        textAlign: "left",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+        borderRadius: 2.5,
+        border: RM.border,
+        bgcolor: "#fff",
+        p: 2,
+        boxShadow: RM.shadow(3),
+        transition: "transform .14s ease, box-shadow .14s ease",
+        // Press the sticker rather than lift it: the shadow shortens by exactly the distance
+        // the card travels, so the object reads as physically pushed down.
+        "&:hover": { transform: "translate(1px, 1px)", boxShadow: RM.shadow(2) },
+        "&:active": { transform: "translate(3px, 3px)", boxShadow: RM.shadow(0) },
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1.25} sx={{ mb: 1.25 }}>
+        <Box
+          sx={{
+            width: 46,
+            height: 46,
+            borderRadius: 2,
+            border: "1px solid #e6e8ef",
+            bgcolor: "#fff",
+            display: "grid",
+            placeItems: "center",
+            flexShrink: 0,
+            overflow: "hidden",
+            p: 0.75,
+          }}
+        >
+          {company.logoUrl ? (
+            <Box
+              component="img"
+              src={company.logoUrl}
+              alt=""
+              loading="lazy"
+              sx={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
+            />
+          ) : (
+            <Typography sx={{ fontWeight: 800, color: RM.rail, fontSize: 16 }}>
+              {company.displayName.slice(0, 2).toUpperCase()}
+            </Typography>
+          )}
+        </Box>
+        <Box sx={{ minWidth: 0 }}>
+          <Typography
+            sx={{ fontWeight: 800, fontSize: 15.5, color: RM.ink, lineHeight: 1.25 }}
+            noWrap
+          >
+            {company.displayName}
+          </Typography>
+          {company.packageRange && (
+            <Typography sx={{ fontSize: 12, color: "#475569" }} noWrap>
+              {company.packageRange}
+            </Typography>
+          )}
+        </Box>
+      </Stack>
+
+      {company.badge && (
+        <Chip
+          label={company.badge}
+          size="small"
+          sx={{
+            alignSelf: "flex-start",
+            height: 21,
+            fontSize: 11,
+            fontWeight: 700,
+            bgcolor: "#f3f0ff",
+            color: "#5b21b6",
+            mb: 1,
+          }}
+        />
+      )}
+
+      <Box sx={{ mt: "auto", pt: 0.5 }}>
+        {pct != null && pct > 0 && (
+          <Box sx={{ mb: 1 }}>
+            <Box sx={{ height: 5, borderRadius: 3, bgcolor: "#eef2f7", overflow: "hidden" }}>
+              <Box sx={{ width: `${pct}%`, height: "100%", bgcolor: RM.rail }} />
+            </Box>
+            <Typography sx={{ mt: 0.5, fontSize: 11, color: "#64748b" }}>
+              {pct}% covered
+            </Typography>
+          </Box>
+        )}
+        <Stack
+          direction="row"
+          alignItems="center"
+          spacing={0.75}
+          sx={{ color: "#64748b", flexWrap: "wrap" }}
+        >
+          <Icon icon="solar:layers-minimalistic-bold-duotone" width={14} />
+          <Typography sx={{ fontSize: 12 }}>{facts.join(" · ")}</Typography>
+        </Stack>
+      </Box>
+    </ButtonBase>
+  );
+}

--- a/components/roadmaps/RoadmapCard.tsx
+++ b/components/roadmaps/RoadmapCard.tsx
@@ -9,6 +9,7 @@ const KIND_META: Record<RoadmapKind, { label: string; icon: string; tint: string
   skill: { label: "Skill", icon: "solar:layers-minimalistic-bold-duotone", tint: "#6366f1" },
   beginner: { label: "Start here", icon: "solar:star-bold-duotone", tint: "#0d9488" },
   practice: { label: "Practices", icon: "solar:checklist-minimalistic-bold-duotone", tint: "#db2777" },
+  company: { label: "Company", icon: "solar:buildings-2-bold-duotone", tint: "#0369a1" },
 };
 
 /**

--- a/lib/services/roadmaps.service.ts
+++ b/lib/services/roadmaps.service.ts
@@ -10,10 +10,73 @@ const BASE = "/roadmaps/api";
  * Do not merge them.
  */
 
-export type RoadmapKind = "role" | "skill" | "beginner" | "practice";
+export type RoadmapKind = "role" | "skill" | "beginner" | "practice" | "company";
 export type NodeKind = "topic" | "subtopic" | "milestone" | "label" | "note";
 export type SelfState = "pending" | "learning" | "done" | "skipped";
 export type EdgeKind = "sequence" | "contains" | "depends";
+
+/** The few company fields a catalog card needs: enough to draw a logo tile, no more. */
+export interface RoadmapCompanyCard {
+  companySlug: string;
+  displayName: string;
+  logoUrl: string;
+  badge: string;
+  difficulty: string;
+  packageRange: string;
+  rounds: number;
+}
+
+export interface RoadmapHiringStage {
+  stage: string;
+  detail: string;
+}
+
+export interface RoadmapSyllabusRound {
+  round: string;
+  info: string;
+  type: "Elimination" | "Final" | string;
+}
+
+/**
+ * Dated hiring estimates.
+ *
+ * The server sends `null` for the whole object rather than an undated figure, so there is no
+ * code path in which a number renders without the date it was true on. Do not "helpfully"
+ * default `asOf` on the client.
+ */
+export interface RoadmapCompanyEstimates {
+  applicants: string | null;
+  openRoles: string | null;
+  asOf: string;
+  sourceUrl: string | null;
+}
+
+/**
+ * The employer half of a company roadmap.
+ *
+ * Note what is absent: there is no `readiness` / `competitiveness` field. The source system
+ * carried a static per-company literal under that name and its UI rendered it as though it
+ * were measured. Readiness here comes from `RoadmapProgress.mastery`, which is derived from
+ * the learner's own submissions.
+ */
+export interface RoadmapCompany extends RoadmapCompanyCard {
+  examType: string;
+  /** Free text, NOT a boolean: real answers are qualified per drive and per section. */
+  negativeMarking: string;
+  hiringProcess: RoadmapHiringStage[];
+  syllabus: RoadmapSyllabusRound[];
+  introVideoUrl: string;
+  introVideoTitle: string;
+  estimates: RoadmapCompanyEstimates | null;
+}
+
+/** How much practice the map actually reaches. Counted server-side from real bindings. */
+export interface RoadmapContentTotals {
+  questions: number;
+  codingProblems: number;
+  articles: number;
+  steps: number;
+}
 
 export interface RoadmapCard {
   slug: string;
@@ -24,6 +87,8 @@ export interface RoadmapCard {
   isNew: boolean;
   isRevamped: boolean;
   topicCount: number;
+  /** Present only on `kind === "company"`. */
+  company?: RoadmapCompanyCard | null;
 }
 
 export interface RoadmapCategorySection {
@@ -90,6 +155,9 @@ export interface RoadmapGraph {
   /** Only the ones this tenant can actually reach. */
   related?: RelatedRoadmap[];
   faqs?: { question: string; answer: string }[];
+  /** Present only on `kind === "company"`. */
+  company?: RoadmapCompany | null;
+  content?: RoadmapContentTotals;
 }
 
 export interface RoadmapNodeProgress {


### PR DESCRIPTION
Frontend for company-based roadmaps. Pairs with backend PR AI-Linc-LMS/ai-linc-backend#575 - merge that first.

## Catalog

Companies get a **"Prepare for a company" rail above the category grid**, not a section inside it. They answer a different question ("who am I interviewing with") than the rest of the catalog ("what do I want to learn"), and a learner with a drive next week should not have to know which category we filed Accenture under.

The rail owns them on the "all" view and anything it renders is dropped from the grid below, so the same nine cards never appear twice on one screen; picking a category hides the rail and the grid becomes their single home. Search now matches the company name, since "tcs" has to find a roadmap titled "TCS Placement Preparation".

`CompanyRoadmapCard` is a distinct object from `RoadmapCard`: a company is chosen by recognising a logo, so the logo leads and the prose is cut to a line of facts. Logos are arbitrary Wikimedia SVG URLs, so they render through a plain `img` - `next/image` blocks SVG and has bitten this codebase before on client branding.

## Roadmap page

A company preamble above the map: the intro video, the numbered hiring funnel with each round's real format and whether it eliminates, and the quick-stats panel.

The stats panel is the honest version of the one it replaces. Every row is authored per company or computed from something real. **"Your readiness" is the learner's own mastery, derived from submissions** - there is no "Competitiveness" row, because that number was a static literal in the source system. Hiring estimates render only beside the date they were true on, which the server enforces by omitting the object entirely when it cannot date it.

`negativeMarking` renders as free text rather than a yes/no chip, because several companies publish qualified rules a chip would misreport.

Reuses the shared `toEmbedUrl` for the Vimeo link rather than a second private copy.

## Verification

Ran against a local backend with all nine companies seeded, signed in as a real student: catalog and detail pages both render correctly. That is how the two bugs in this branch were found - the duplicate cards, and em dashes reaching the card - neither of which the test suite noticed.

10 new tests written against the real seeded payload shapes (including the qualified `negativeMarking` and the null `estimates`); 104 frontend tests pass; `tsc --noEmit` clean.

Note: this repo's CI does not typecheck, so the tsc run above is the only gate on type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)