### PR TITLE
feat(b2c): free-course allowance on the course catalog

### DIFF
--- a/app/adaptive-courses/catalog/page.tsx
+++ b/app/adaptive-courses/catalog/page.tsx
@@ -18,6 +18,7 @@ import { CatalogCourseCard } from "@/components/courses/CatalogCourseCard";
 import { AdaptiveCourseListSkeleton } from "@/components/courses/CourseSkeletons";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { useToast } from "@/components/common/Toast";
+import { useB2CAllowance } from "@/lib/hooks/useB2CAllowance";
 
 export default function AdaptiveCourseCatalogPage() {
   const { push } = useInstantNavigation();
@@ -29,6 +30,7 @@ export default function AdaptiveCourseCatalogPage() {
   const [query, setQuery] = useState("");
   const [enrollingId, setEnrollingId] = useState<number | null>(null);
   const { handlePayment } = usePayment();
+  const { isB2C, freeCoursesLeft, refresh: refreshAllowance } = useB2CAllowance(featureOn);
 
   useEffect(() => {
     if (!featureOn) {
@@ -92,6 +94,39 @@ export default function AdaptiveCourseCatalogPage() {
     });
   }
 
+  /**
+   * Spend the learner's one free course on a priced one.
+   *
+   * Separate from handleEnroll rather than a flag on it: this is irreversible and there is only
+   * one allowance, so the two paths should not be one function where a stray argument spends it.
+   * The server is still the authority — it refuses and returns the 402 once the allowance is
+   * gone, which is what the catch converges on.
+   */
+  async function handleUseFreeAllowance(course: AdaptiveCourseListItem) {
+    if (enrollingId !== null) return;
+    setEnrollingId(course.id);
+    try {
+      await adaptiveCourseService.selfEnroll(course.id, true);
+      setItems((prev) => prev.filter((c) => c.id !== course.id));
+      void refreshAllowance();
+      showToast(`"${course.title}" is yours — that was your free course.`, "success");
+      push(`/adaptive-courses/${course.id}`);
+    } catch (e) {
+      const resp = (e as { response?: { status?: number; data?: { payment_required?: boolean } } })
+        ?.response;
+      if (resp?.status === 402 && resp.data?.payment_required) {
+        // The allowance was already spent — most likely in another tab. Re-read it so the
+        // button disappears, and offer the thing they can actually do instead.
+        void refreshAllowance();
+        showToast("You've already used your free course. This one can be purchased.", "info");
+        setEnrollingId(null);
+        return;
+      }
+      showToast(e instanceof Error ? e.message : "Couldn't open that course.", "error");
+      setEnrollingId(null);
+    }
+  }
+
   async function handleEnroll(course: AdaptiveCourseListItem) {
     if (enrollingId !== null) return;
 
@@ -144,7 +179,11 @@ export default function AdaptiveCourseCatalogPage() {
       <ModulePageHeader
         eyebrow="Learn"
         title="Browse courses"
-        description="Courses your organisation has opened for you to join. Enroll in one and it moves into My courses instantly."
+        description={
+          isB2C
+            ? "Pick a course and start today. Your first one is on us."
+            : "Courses your organisation has opened for you to join. Enroll in one and it moves into My courses instantly."
+        }
         accent="purple"
         icon="mdi:compass-outline"
         action={
@@ -153,6 +192,30 @@ export default function AdaptiveCourseCatalogPage() {
           </HeaderActionButton>
         }
       />
+
+      {/* Only ever rendered on a B2C tenant — an institution's learners have no allowance and
+          would just be confused by a counter that never moves. */}
+      {isB2C && freeCoursesLeft > 0 && (
+        <Box
+          sx={{
+            mb: 2.5,
+            p: 2,
+            borderRadius: 3,
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            border: "1px solid rgba(124,58,237,0.28)",
+            bgcolor: "rgba(124,58,237,0.06)",
+          }}
+        >
+          <Icon icon="mdi:gift-outline" width={22} style={{ color: "#7c3aed" }} />
+          <Typography sx={{ fontWeight: 700, fontSize: "0.95rem" }}>
+            {freeCoursesLeft === 1
+              ? "You have 1 free course left — spend it on any course below."
+              : `You have ${freeCoursesLeft} free courses left.`}
+          </Typography>
+        </Box>
+      )}
 
       {loading && <AdaptiveCourseListSkeleton />}
 
@@ -206,6 +269,8 @@ export default function AdaptiveCourseCatalogPage() {
                 enrolling={enrollingId === course.id}
                 disabled={enrollingId !== null && enrollingId !== course.id}
                 onEnroll={() => void handleEnroll(course)}
+                canUseFreeAllowance={freeCoursesLeft > 0}
+                onUseFreeAllowance={() => void handleUseFreeAllowance(course)}
               />
             </Reveal>
           ))}

--- a/components/courses/CatalogCourseCard.tsx
+++ b/components/courses/CatalogCourseCard.tsx
@@ -15,16 +15,25 @@ export function CatalogCourseCard({
   enrolling,
   disabled,
   onEnroll,
+  canUseFreeAllowance = false,
+  onUseFreeAllowance,
 }: {
   course: AdaptiveCourseListItem;
   enrolling: boolean;
   /** True while a sibling card's enroll is in flight — greys this one out to prevent double-submit. */
   disabled?: boolean;
   onEnroll: () => void;
+  /** B2C only: this learner still has a free course left to spend. */
+  canUseFreeAllowance?: boolean;
+  onUseFreeAllowance?: () => void;
 }) {
   // A course that is priced and not yet bought. `purchased` comes from the server, so a
   // payment that settled while this page was open resolves to a plain Enroll.
   const mustBuy = Boolean(course.is_paid && !course.purchased);
+  // Spending the allowance is offered as a SECONDARY action under the price, never as the
+  // primary button: it is irreversible and there is only one of them, so it should read as a
+  // deliberate choice rather than the path of least resistance.
+  const offerFree = mustBuy && canUseFreeAllowance && Boolean(onUseFreeAllowance);
 
   return (
     <Box
@@ -175,6 +184,25 @@ export function CatalogCourseCard({
             ? `Pay ${formatMoney(course.price, course.currency)}`
             : "Enroll"}
       </Button>
+
+      {offerFree && (
+        <Button
+          onClick={onUseFreeAllowance}
+          disabled={enrolling || disabled}
+          variant="text"
+          startIcon={<Icon icon="mdi:gift-outline" width={18} />}
+          sx={{
+            mt: 1,
+            borderRadius: 2,
+            textTransform: "none",
+            fontWeight: 700,
+            color: "#7c3aed",
+            "&:hover": { bgcolor: "rgba(124,58,237,0.08)" },
+          }}
+        >
+          Use my free course
+        </Button>
+      )}
     </Box>
   );
 }

--- a/lib/hooks/useB2CAllowance.ts
+++ b/lib/hooks/useB2CAllowance.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  B2C_FEATURE_ADAPTIVE_COURSE,
+  b2cService,
+  type B2CAllowance,
+} from "@/lib/services/b2c.service";
+
+interface UseB2CAllowance {
+  /** True only on a tenant that actually meters free usage. */
+  isB2C: boolean;
+  /** Free courses this learner has left. 0 on any non-B2C tenant. */
+  freeCoursesLeft: number;
+  loading: boolean;
+  /** Re-read after spending one, so the banner and the buttons agree. */
+  refresh: () => Promise<void>;
+}
+
+/**
+ * The learner's remaining free allowance.
+ *
+ * Fails SILENTLY to "no allowance": if this call errors we must not offer a free course we
+ * cannot back, because the claim would 402 and read as a broken button. The paywall itself is
+ * enforced server-side regardless, so being wrong in this direction costs a missed upsell
+ * rather than giving anything away.
+ */
+export function useB2CAllowance(enabled = true): UseB2CAllowance {
+  const [data, setData] = useState<B2CAllowance | null>(null);
+  const [loading, setLoading] = useState(enabled);
+
+  const load = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      setData(await b2cService.getAllowance());
+    } catch {
+      setData({ is_b2c: false, features: [] });
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const courses = data?.features.find((f) => f.feature_key === B2C_FEATURE_ADAPTIVE_COURSE);
+
+  return {
+    isB2C: Boolean(data?.is_b2c),
+    freeCoursesLeft: data?.is_b2c ? (courses?.remaining ?? 0) : 0,
+    loading,
+    refresh: load,
+  };
+}

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -251,11 +251,31 @@ export const adaptiveCourseService = {
     return data;
   },
 
-  /** Enroll the current student into a self-enrollable course. Idempotent server-side. */
-  async selfEnroll(courseId: number): Promise<{ course_id: number; enrolled: boolean; already_enrolled: boolean }> {
-    const { data } = await apiClient.post<{ course_id: number; enrolled: boolean; already_enrolled: boolean }>(
+  /**
+   * Enroll the current student into a self-enrollable course. Idempotent server-side.
+   *
+   * `useFreeAllowance` spends one unit of a B2C tenant's metered free allowance on a PRICED
+   * course. It is opt-in on purpose: without it a priced course answers 402 with a quote, so a
+   * learner can never burn their one free course by opening the wrong thing. The server refuses
+   * and returns the 402 anyway once the allowance is spent, so passing it is never a way in.
+   */
+  async selfEnroll(
+    courseId: number,
+    useFreeAllowance = false,
+  ): Promise<{
+    course_id: number;
+    enrolled: boolean;
+    already_enrolled: boolean;
+    used_free_allowance?: boolean;
+  }> {
+    const { data } = await apiClient.post<{
+      course_id: number;
+      enrolled: boolean;
+      already_enrolled: boolean;
+      used_free_allowance?: boolean;
+    }>(
       `${BASE}/courses/${courseId}/enroll/`,
-      {},
+      useFreeAllowance ? { use_free_allowance: true } : {},
     );
     return data;
   },

--- a/lib/services/b2c.service.ts
+++ b/lib/services/b2c.service.ts
@@ -1,0 +1,32 @@
+import apiClient from "./api";
+
+const BASE = "/b2c/api";
+
+export interface B2CFeatureAllowance {
+  feature_key: string;
+  used: number;
+  allowance: number;
+  remaining: number;
+}
+
+export interface B2CAllowance {
+  /** False for every ordinary institution. The UI shows no free-tier affordance at all then. */
+  is_b2c: boolean;
+  features: B2CFeatureAllowance[];
+}
+
+/** The only metered feature today. More arrive in later phases. */
+export const B2C_FEATURE_ADAPTIVE_COURSE = "adaptive_course";
+
+export const b2cService = {
+  /**
+   * What this learner still gets for free.
+   *
+   * Safe to call on any tenant: a non-B2C institution answers 200 with `is_b2c: false` rather
+   * than an error, so callers never need to know which kind of tenant they are on.
+   */
+  async getAllowance(): Promise<B2CAllowance> {
+    const { data } = await apiClient.get<B2CAllowance>(`${BASE}/allowance/`);
+    return data;
+  },
+};


### PR DESCRIPTION
The storefront half of the B2C free tier, against the backend shipped in [#579](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/579) / [#580](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/580).

**Inert on every ordinary institution** — the allowance endpoint answers `is_b2c: false` there, so no free-tier affordance renders at all. Nothing changes for existing tenants.

## What it adds

- `b2cService.getAllowance()` + `useB2CAllowance()` — what the learner has left
- A banner on the catalog: *"You have 1 free course left"*
- A **secondary** "Use my free course" action on priced course cards
- `selfEnroll(courseId, useFreeAllowance)` passing the explicit backend flag

## Design calls worth knowing

**Spending the allowance is a secondary action under the price, never the primary button.** There is exactly one of them and it cannot be undone, so it should read as a deliberate choice rather than the path of least resistance. Same reasoning as the backend requiring an explicit `use_free_allowance` flag instead of spending it on any 402.

**`handleUseFreeAllowance` is its own function, not a flag on `handleEnroll`.** One function where a stray argument spends the learner's only free course is a bad shape for something irreversible.

**The hook fails silently to "no allowance" when the endpoint errors.** Offering a free course we cannot back would 402 and read as a broken button; being wrong in this direction costs a missed upsell instead of giving anything away. The paywall is enforced server-side regardless.

**A 402 on the claim path** means the allowance went while the page was open (another tab). It re-reads the allowance so the button disappears and says what they can actually do instead, rather than surfacing an error.

## Checks

`tsc --noEmit` clean — worth stating explicitly, since this repo's CI runs unit tests only, so a type error merges green and only fails the Netlify deploy. 119 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)