### PR TITLE
feat(b2c): free-assessment allowance on the assessments hub

### DIFF
--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -186,10 +186,38 @@ export default function AssessmentsPage() {
       <ModulePageHeader
         eyebrow="Learn"
         title="Assessments"
-        description="Take your assigned quizzes and tests, then review your scores and feedback in one place."
+        description={
+          isB2C
+            ? "Prove what you know. Your first few assessments are on us."
+            : "Take your assigned quizzes and tests, then review your scores and feedback in one place."
+        }
         accent="indigo"
         icon="mdi:file-document-edit"
       />
+
+      {/* B2C only. An institution's learners have no allowance, and a counter that never moves
+          is worse than no counter at all. */}
+      {isB2C && freeAssessmentsLeft > 0 && (
+        <Box
+          sx={{
+            mb: 2.5,
+            p: 2,
+            borderRadius: 3,
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            border: "1px solid rgba(124,58,237,0.28)",
+            bgcolor: "rgba(124,58,237,0.06)",
+          }}
+        >
+          <IconWrapper icon="mdi:gift-outline" size={22} />
+          <Typography sx={{ fontWeight: 700, fontSize: "0.95rem" }}>
+            {freeAssessmentsLeft === 1
+              ? "You have 1 free assessment left — spend it on any paid assessment below."
+              : `You have ${freeAssessmentsLeft} free assessments left.`}
+          </Typography>
+        </Box>
+      )}
 
       <Box>
         {/* Smart band - always shown (matches management's hero band). Real next-up

--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { Box, Typography, Skeleton, TextField, MenuItem } from "@mui/material";
@@ -12,6 +12,7 @@ import {
 } from "@/lib/services/assessment.service";
 import { useToast } from "@/components/common/Toast";
 import { AssessmentsGrid } from "@/components/assessment/AssessmentsGrid";
+import { useB2CAllowance } from "@/lib/hooks/useB2CAllowance";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { isPsychometricAssessment } from "@/lib/utils/psychometric-utils";
@@ -65,22 +66,32 @@ export default function AssessmentsPage() {
   const [nextLoading, setNextLoading] = useState(false);
   const { showToast } = useToast();
   const hasLoadedRef = useRef(false);
+  const { isB2C, freeAssessmentsLeft, refresh: refreshAllowance } = useB2CAllowance();
+
+  /**
+   * Re-fetchable so a claimed assessment flips to Start without a page reload. `showSpinner` is
+   * false on a refresh: swapping the whole grid for skeletons after the learner just spent an
+   * allowance reads as the click having failed.
+   */
+  const loadAssessments = useCallback(
+    async (showSpinner = true) => {
+      try {
+        if (showSpinner) setLoading(true);
+        setAssessments(await assessmentService.getActiveAssessments());
+      } catch {
+        showToast(t("assessments.failedToLoad"), "error");
+      } finally {
+        if (showSpinner) setLoading(false);
+      }
+    },
+    [showToast, t],
+  );
 
   useEffect(() => {
     if (hasLoadedRef.current) return;
     hasLoadedRef.current = true;
-    (async () => {
-      try {
-        setLoading(true);
-        const data = await assessmentService.getActiveAssessments();
-        setAssessments(data);
-      } catch {
-        showToast(t("assessments.failedToLoad"), "error");
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [showToast, t]);
+    void loadAssessments();
+  }, [loadAssessments]);
 
   // ---- Counts (real learner-status derivation, preserved from the prior hub) ----
   const counts = useMemo(() => {
@@ -389,7 +400,15 @@ export default function AssessmentsPage() {
               ))}
             </Box>
           ) : filteredAssessments.length > 0 ? (
-            <AssessmentsGrid assessments={paginatedAssessments} searchQuery={searchQuery} />
+            <AssessmentsGrid
+              assessments={paginatedAssessments}
+              searchQuery={searchQuery}
+              freeAssessmentsLeft={freeAssessmentsLeft}
+              onFreeClaimed={() => {
+                void refreshAllowance();
+                void loadAssessments();
+              }}
+            />
           ) : (
             <AssessmentEmptyState
               icon={searchQuery ? "mdi:file-search-outline" : "mdi:clipboard-text-outline"}

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -17,6 +17,8 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { formatMoney } from "@/lib/utils/money";
 import { useAssessmentPurchase } from "@/hooks/useAssessmentPurchase";
+import { useB2CClaim } from "@/hooks/useB2CClaim";
+import { B2C_FEATURE_ASSESSMENT } from "@/lib/services/b2c.service";
 import {
   isPsychometricAssessment,
   getPsychometricTags,
@@ -35,6 +37,16 @@ import { StatusChip, type ChipTone } from "@/components/admin/assessment/shared"
 
 interface AssessmentCardProps {
   assessment: Assessment;
+  /**
+   * B2C only: free assessments this learner has left.
+   *
+   * Passed DOWN rather than read from `useB2CAllowance` in here. The card renders once per row,
+   * so calling the hook inside it would fire one HTTP request per card on a screen that shows
+   * dozens — the same N+1 the batched entitlement lookups exist to avoid on the server.
+   */
+  freeAssessmentsLeft?: number;
+  /** Re-read the allowance after one is spent, so the whole grid agrees. */
+  onFreeClaimed?: () => void;
 }
 
 function parseDateTime(s: string | undefined | null): Date | null {
@@ -80,6 +92,8 @@ function formatRemainingTime(
 
 export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   assessment,
+  freeAssessmentsLeft = 0,
+  onFreeClaimed,
 }) => {
   const { t } = useTranslation("common");
   const theme = useTheme();
@@ -96,6 +110,31 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   const needsPurchase =
     (assessment.requires_purchase ?? false) && !assessment.purchased && !justBought;
   const isBuying = buyingSlug === assessment.slug;
+  const { claim, claimingKey } = useB2CClaim();
+  const isClaiming = claimingKey === assessment.slug;
+  // Offered as a SECONDARY action beside the price, never as the primary button: there is a small
+  // fixed number of these and no way to give one back, so it should read as a deliberate choice
+  // rather than the path of least resistance.
+  const canUseFreeAssessment = needsPurchase && freeAssessmentsLeft > 0;
+
+  const handleUseFree = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isBuying || isClaiming) return;
+    void claim(B2C_FEATURE_ASSESSMENT, assessment.id, assessment.slug, {
+      onOwned: () => {
+        setJustBought(true);
+        onFreeClaimed?.();
+        showToast(`"${stripHtmlTags(assessment.title || "")}" is yours — that was a free one.`, "success");
+      },
+      // Spent in another tab, most likely. Re-read so the button disappears, and point at the
+      // thing they can actually still do.
+      onExhausted: () => {
+        onFreeClaimed?.();
+        showToast("You've used all your free assessments. This one can be purchased.", "info");
+      },
+      onFailed: (message) => showToast(message, "error"),
+    });
+  };
 
   const submissionComplete = isLearnerAssessmentSubmissionComplete(assessment);
   const normalizedStatus = normalizeLearnerAssessmentStatus(assessment);
@@ -341,7 +380,7 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   const prefetchProps = usePrefetchOnHover(prefetchHref);
 
   const handleClick = () => {
-    if (!isClickable || loadingAction || isBuying) return;
+    if (!isClickable || loadingAction || isBuying || isClaiming) return;
 
     if (needsPurchase) {
       buy(assessment, {
@@ -859,6 +898,29 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             }
             return primaryButton;
           })()}
+
+          {canUseFreeAssessment && (
+            <LoadingButton
+              onClick={handleUseFree}
+              loading={isClaiming}
+              fullWidth
+              variant="text"
+              startIcon={<IconWrapper icon="mdi:gift-outline" size={18} />}
+              sx={{
+                mt: 1,
+                borderRadius: 2,
+                textTransform: "none",
+                fontWeight: 700,
+                fontSize: "0.85rem",
+                color: "#7c3aed",
+                "&:hover": { bgcolor: "rgba(124,58,237,0.08)" },
+              }}
+            >
+              {freeAssessmentsLeft === 1
+                ? "Use my last free assessment"
+                : "Use a free assessment"}
+            </LoadingButton>
+          )}
         </Box>
       </Card>
     </>

--- a/components/assessment/AssessmentsGrid.tsx
+++ b/components/assessment/AssessmentsGrid.tsx
@@ -9,11 +9,16 @@ import { useTranslation } from "react-i18next";
 interface AssessmentsGridProps {
   assessments: Assessment[];
   searchQuery: string;
+  /** B2C only. Read once by the page and passed down, so the grid costs one allowance call, not N. */
+  freeAssessmentsLeft?: number;
+  onFreeClaimed?: () => void;
 }
 
 export function AssessmentsGrid({
   assessments,
   searchQuery,
+  freeAssessmentsLeft = 0,
+  onFreeClaimed,
 }: AssessmentsGridProps) {
   const { t } = useTranslation("common");
 
@@ -102,7 +107,11 @@ export function AssessmentsGrid({
             overflow: "visible",
           }}
         >
-          <AssessmentCard assessment={assessment} />
+          <AssessmentCard
+            assessment={assessment}
+            freeAssessmentsLeft={freeAssessmentsLeft}
+            onFreeClaimed={onFreeClaimed}
+          />
         </Box>
       ))}
     </Box>

--- a/hooks/useB2CClaim.ts
+++ b/hooks/useB2CClaim.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { b2cService } from "@/lib/services/b2c.service";
+
+/**
+ * Spending a free allowance, in one place.
+ *
+ * Deliberately shaped like `useAssessmentPurchase.buy` so a card can treat "pay" and "use a free
+ * one" as two routes to the same outcome, rather than two different kinds of thing.
+ *
+ * `onOwned` fires only after the server confirms the grant. There is no optimistic path: there is
+ * a small fixed number of these and no way to give one back, so telling a learner they spent one
+ * before the server agrees is a promise we may not be able to keep.
+ */
+export function useB2CClaim() {
+  const [claimingKey, setClaimingKey] = useState<string | null>(null);
+
+  const claim = useCallback(
+    async (
+      featureKey: string,
+      objectId: number,
+      busyKey: string,
+      handlers: {
+        onOwned: (remaining: number) => void;
+        /** The allowance ran out — most often spent in another tab. Offer the price instead. */
+        onExhausted: () => void;
+        onFailed: (message: string) => void;
+      },
+    ) => {
+      setClaimingKey(busyKey);
+      try {
+        const result = await b2cService.claim(featureKey, objectId);
+        handlers.onOwned(result.remaining);
+      } catch (err) {
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status === 402) handlers.onExhausted();
+        else if (status === 404) handlers.onFailed("That isn't available to claim.");
+        else handlers.onFailed("Couldn't use your free allowance. Please try again.");
+      } finally {
+        setClaimingKey(null);
+      }
+    },
+    [],
+  );
+
+  return { claim, claimingKey };
+}

--- a/lib/hooks/useB2CAllowance.ts
+++ b/lib/hooks/useB2CAllowance.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   B2C_FEATURE_ADAPTIVE_COURSE,
+  B2C_FEATURE_ASSESSMENT,
   b2cService,
   type B2CAllowance,
 } from "@/lib/services/b2c.service";
@@ -10,20 +11,23 @@ import {
 interface UseB2CAllowance {
   /** True only on a tenant that actually meters free usage. */
   isB2C: boolean;
-  /** Free courses this learner has left. 0 on any non-B2C tenant. */
+  /** Free uses left for an arbitrary feature. 0 on any non-B2C tenant. */
+  remainingFor: (featureKey: string) => number;
+  /** Convenience readers for the two metered features today. */
   freeCoursesLeft: number;
+  freeAssessmentsLeft: number;
   loading: boolean;
-  /** Re-read after spending one, so the banner and the buttons agree. */
+  /** Re-read after spending one, so banners and buttons agree. */
   refresh: () => Promise<void>;
 }
 
 /**
  * The learner's remaining free allowance.
  *
- * Fails SILENTLY to "no allowance": if this call errors we must not offer a free course we
- * cannot back, because the claim would 402 and read as a broken button. The paywall itself is
- * enforced server-side regardless, so being wrong in this direction costs a missed upsell
- * rather than giving anything away.
+ * Fails SILENTLY to "no allowance": if this call errors we must not offer a free use we cannot
+ * back, because the claim would 402 and read as a broken button. The paywall is enforced
+ * server-side regardless, so being wrong in this direction costs a missed upsell rather than
+ * giving anything away.
  */
 export function useB2CAllowance(enabled = true): UseB2CAllowance {
   const [data, setData] = useState<B2CAllowance | null>(null);
@@ -44,11 +48,19 @@ export function useB2CAllowance(enabled = true): UseB2CAllowance {
     void load();
   }, [load]);
 
-  const courses = data?.features.find((f) => f.feature_key === B2C_FEATURE_ADAPTIVE_COURSE);
+  const remainingFor = useCallback(
+    (featureKey: string) => {
+      if (!data?.is_b2c) return 0;
+      return data.features.find((f) => f.feature_key === featureKey)?.remaining ?? 0;
+    },
+    [data],
+  );
 
   return {
     isB2C: Boolean(data?.is_b2c),
-    freeCoursesLeft: data?.is_b2c ? (courses?.remaining ?? 0) : 0,
+    remainingFor,
+    freeCoursesLeft: remainingFor(B2C_FEATURE_ADAPTIVE_COURSE),
+    freeAssessmentsLeft: remainingFor(B2C_FEATURE_ASSESSMENT),
     loading,
     refresh: load,
   };

--- a/lib/services/b2c.service.ts
+++ b/lib/services/b2c.service.ts
@@ -15,8 +15,17 @@ export interface B2CAllowance {
   features: B2CFeatureAllowance[];
 }
 
-/** The only metered feature today. More arrive in later phases. */
 export const B2C_FEATURE_ADAPTIVE_COURSE = "adaptive_course";
+export const B2C_FEATURE_ASSESSMENT = "assessment";
+
+export interface B2CClaimResult {
+  feature_key: string;
+  object_id: number;
+  claimed: boolean;
+  used: number;
+  allowance: number;
+  remaining: number;
+}
 
 export const b2cService = {
   /**
@@ -27,6 +36,24 @@ export const b2cService = {
    */
   async getAllowance(): Promise<B2CAllowance> {
     const { data } = await apiClient.get<B2CAllowance>(`${BASE}/allowance/`);
+    return data;
+  },
+
+  /**
+   * Spend one unit of the free allowance on a specific thing.
+   *
+   * Courses are NOT claimable here — they go through the self-enroll route, because the grant and
+   * the enrolment have to share a transaction. The backend refuses `adaptive_course` with a 400
+   * rather than silently minting an entitlement with no enrolment behind it.
+   *
+   * Throws on 402 (allowance spent) and 404 (not claimable). Callers should treat 402 as "offer
+   * to buy instead" rather than as an error.
+   */
+  async claim(featureKey: string, objectId: number): Promise<B2CClaimResult> {
+    const { data } = await apiClient.post<B2CClaimResult>(`${BASE}/claim/`, {
+      feature_key: featureKey,
+      object_id: objectId,
+    });
     return data;
   },
 };


### PR DESCRIPTION
Storefront half of the assessment meter, against backend [#581](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/581).

**Inert on every ordinary institution** — the allowance endpoint answers `is_b2c: false` there, so no free-tier affordance renders at all.

## What it adds

- Allowance banner on the assessments hub: *"You have N free assessments left"*
- A **secondary** "Use a free assessment" action on priced assessment cards
- `b2cService.claim()` + `useB2CClaim()` against the generic `POST /b2c/api/claim/`

## Design calls

**The allowance is read once by the page and passed down** through the grid to each card. Reading it inside `AssessmentCard` would fire one HTTP request *per card* on a screen that shows dozens — the same N+1 the batched entitlement lookups exist to avoid on the server.

**Spending it is a secondary action beneath the price**, never the primary button, and it's its own handler rather than a flag on the buy path. There is a small fixed number of these and no way to give one back, so it should read as a deliberate choice.

**`useB2CClaim` is shaped deliberately like `useAssessmentPurchase.buy`**, so a card treats "pay" and "use a free one" as two routes to one outcome rather than two different kinds of thing. `onOwned` fires only after the server confirms the grant — no optimistic path, for the same reason the purchase hook has none.

**A 402 on the claim** means the allowance went while the page was open (another tab). It re-reads the allowance so the button disappears and says what they can still do, rather than surfacing an error.

`useB2CAllowance` is generalised to `remainingFor(featureKey)` with named readers, so the phases after this add a key rather than a hook.

## Checks

`tsc --noEmit` clean — worth stating, since CI here runs unit tests only and a type error would merge green while only the Netlify deploy fails. 119 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)