### PR TITLE
release: roadmap catalog ordering + b2c free-assessment claim + Google auth feedback

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -38,10 +38,37 @@ interface LoginFormValues {
   password: string;
 }
 
+/**
+ * What to tell someone whose Google sign-in bounced them back here.
+ *
+ * The backend classifies the failure (`central_auth/google_errors.py`) rather than sending one
+ * generic sentence, because the three causes have three different answers — and the old single
+ * message named the auth code, which sent a production investigation chasing redirect URIs when
+ * the real cause was a rotated client secret.
+ *
+ * Kept deliberately vague about the CAUSE for the misconfiguration case: a learner can do nothing
+ * with "invalid_client", and the actionable detail belongs in the server log, not on a login page.
+ */
+const GOOGLE_AUTH_ERRORS: Record<string, string> = {
+  google_misconfigured:
+    "Google sign-in isn't available right now. Our team has been notified — please sign in with your email and password.",
+  google_retry:
+    "That Google sign-in link had already been used. Please try signing in with Google again.",
+  google_unavailable:
+    "We couldn't reach Google just then. Please try again in a moment.",
+};
+
 export default function LoginPage() {
   const { t } = useTranslation("common");
   const router = useRouter();
   const searchParams = useSearchParams();
+  const googleAuthError = (() => {
+    const code = searchParams.get("auth_error");
+    if (!code) return "";
+    // An unknown code still deserves a message: a silent bounce back to a blank login page reads
+    // as the Google button simply not working.
+    return GOOGLE_AUTH_ERRORS[code] ?? "Google sign-in didn't complete. Please try again.";
+  })();
   const {
     login,
     isAuthenticated,
@@ -166,6 +193,23 @@ export default function LoginPage() {
           })}
         </Typography>
         <Box sx={{ display: { xs: "none", md: "block" }, mb: 4 }} />
+
+        {googleAuthError && (
+          <Box
+            role="alert"
+            sx={{
+              mb: 3,
+              p: 1.75,
+              borderRadius: 2,
+              border: "1px solid rgba(239,68,68,0.35)",
+              backgroundColor: "rgba(239,68,68,0.08)",
+            }}
+          >
+            <Typography sx={{ ...TYPE.body, fontFamily: FONT, fontWeight: 600, color: "#b91c1c" }}>
+              {googleAuthError}
+            </Typography>
+          </Box>
+        )}
 
         <Box sx={{ mb: 3 }}>
           <GoogleSignIn disabled={loading} />

--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -186,10 +186,38 @@ export default function AssessmentsPage() {
       <ModulePageHeader
         eyebrow="Learn"
         title="Assessments"
-        description="Take your assigned quizzes and tests, then review your scores and feedback in one place."
+        description={
+          isB2C
+            ? "Prove what you know. Your first few assessments are on us."
+            : "Take your assigned quizzes and tests, then review your scores and feedback in one place."
+        }
         accent="indigo"
         icon="mdi:file-document-edit"
       />
+
+      {/* B2C only. An institution's learners have no allowance, and a counter that never moves
+          is worse than no counter at all. */}
+      {isB2C && freeAssessmentsLeft > 0 && (
+        <Box
+          sx={{
+            mb: 2.5,
+            p: 2,
+            borderRadius: 3,
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            border: "1px solid rgba(124,58,237,0.28)",
+            bgcolor: "rgba(124,58,237,0.06)",
+          }}
+        >
+          <IconWrapper icon="mdi:gift-outline" size={22} />
+          <Typography sx={{ fontWeight: 700, fontSize: "0.95rem" }}>
+            {freeAssessmentsLeft === 1
+              ? "You have 1 free assessment left — spend it on any paid assessment below."
+              : `You have ${freeAssessmentsLeft} free assessments left.`}
+          </Typography>
+        </Box>
+      )}
 
       <Box>
         {/* Smart band - always shown (matches management's hero band). Real next-up

--- a/app/assessments/page.tsx
+++ b/app/assessments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { Box, Typography, Skeleton, TextField, MenuItem } from "@mui/material";
@@ -12,6 +12,7 @@ import {
 } from "@/lib/services/assessment.service";
 import { useToast } from "@/components/common/Toast";
 import { AssessmentsGrid } from "@/components/assessment/AssessmentsGrid";
+import { useB2CAllowance } from "@/lib/hooks/useB2CAllowance";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { isPsychometricAssessment } from "@/lib/utils/psychometric-utils";
@@ -65,22 +66,32 @@ export default function AssessmentsPage() {
   const [nextLoading, setNextLoading] = useState(false);
   const { showToast } = useToast();
   const hasLoadedRef = useRef(false);
+  const { isB2C, freeAssessmentsLeft, refresh: refreshAllowance } = useB2CAllowance();
+
+  /**
+   * Re-fetchable so a claimed assessment flips to Start without a page reload. `showSpinner` is
+   * false on a refresh: swapping the whole grid for skeletons after the learner just spent an
+   * allowance reads as the click having failed.
+   */
+  const loadAssessments = useCallback(
+    async (showSpinner = true) => {
+      try {
+        if (showSpinner) setLoading(true);
+        setAssessments(await assessmentService.getActiveAssessments());
+      } catch {
+        showToast(t("assessments.failedToLoad"), "error");
+      } finally {
+        if (showSpinner) setLoading(false);
+      }
+    },
+    [showToast, t],
+  );
 
   useEffect(() => {
     if (hasLoadedRef.current) return;
     hasLoadedRef.current = true;
-    (async () => {
-      try {
-        setLoading(true);
-        const data = await assessmentService.getActiveAssessments();
-        setAssessments(data);
-      } catch {
-        showToast(t("assessments.failedToLoad"), "error");
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [showToast, t]);
+    void loadAssessments();
+  }, [loadAssessments]);
 
   // ---- Counts (real learner-status derivation, preserved from the prior hub) ----
   const counts = useMemo(() => {
@@ -389,7 +400,15 @@ export default function AssessmentsPage() {
               ))}
             </Box>
           ) : filteredAssessments.length > 0 ? (
-            <AssessmentsGrid assessments={paginatedAssessments} searchQuery={searchQuery} />
+            <AssessmentsGrid
+              assessments={paginatedAssessments}
+              searchQuery={searchQuery}
+              freeAssessmentsLeft={freeAssessmentsLeft}
+              onFreeClaimed={() => {
+                void refreshAllowance();
+                void loadAssessments();
+              }}
+            />
           ) : (
             <AssessmentEmptyState
               icon={searchQuery ? "mdi:file-search-outline" : "mdi:clipboard-text-outline"}

--- a/app/roadmaps/page.tsx
+++ b/app/roadmaps/page.tsx
@@ -10,7 +10,7 @@ import { SearchFilterBar, SegmentedTabs } from "@/components/common/list";
 import { Reveal } from "@/components/scorecard/shared";
 import { RoadmapCard } from "@/components/roadmaps/RoadmapCard";
 import { CompanyRoadmapCard } from "@/components/roadmaps/CompanyRoadmapCard";
-import { Metric, SectionHeading, Surface } from "@/components/roadmaps/surfaces";
+import { SectionHeading, Surface } from "@/components/roadmaps/surfaces";
 import {
   roadmapKeys,
   roadmapsService,
@@ -29,9 +29,13 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
  * Categories are TABS rather than a left rail. The rail cost 220px of the widest content on
  * the page to render six words, and it competed with the sidebar immediately beside it.
  *
- * Companies get their own section above the rest: they answer a different question ("who am I
- * interviewing with") than the rest of the catalog ("what do I want to learn"), and a learner
- * with a drive next week should not have to know which category we filed Accenture under.
+ * Companies sit in their own section at the END. They answer a different question ("who am I
+ * interviewing with") than the rest of the catalog ("what do I want to learn"), so they are
+ * kept separate rather than filed under a category; but the catalog is a learning surface
+ * first, so the skills come before the recruiters.
+ *
+ * There is no stat row. "9 roadmaps / 9 companies / 468 steps" restated what the page below
+ * already shows and pushed the actual content down a screen.
  */
 export default function RoadmapsPage() {
   const { push, prefetch } = useInstantNavigation();
@@ -73,8 +77,6 @@ export default function RoadmapsPage() {
   const visibleCompanies = onAllView ? companies.filter(matchesCard) : [];
   const claimed = new Set(visibleCompanies.map((r) => r.slug));
 
-  const totalTopics = all.reduce((n, r) => n + (r.topicCount || 0), 0);
-
   const tabs = categories.map((c) => ({
     value: c.slug,
     label: c.title,
@@ -106,38 +108,6 @@ export default function RoadmapsPage() {
       />
 
       <Container maxWidth={false} sx={{ py: 3, px: { xs: 2, md: 3 } }}>
-        {!isLoading && all.length > 0 && (
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: {
-                xs: "repeat(2, minmax(0,1fr))",
-                md: "repeat(3, minmax(0,1fr))",
-              },
-              gap: 1.5,
-              mb: 2.5,
-            }}
-          >
-            <Metric
-              label="Roadmaps"
-              value={all.length}
-              icon="solar:map-point-wave-linear"
-            />
-            <Metric
-              label="Companies"
-              value={companies.length}
-              sub="with a full hiring process"
-              icon="solar:buildings-2-linear"
-            />
-            <Metric
-              label="Steps"
-              value={totalTopics.toLocaleString()}
-              sub="verified topics you can be scored on"
-              icon="solar:checklist-minimalistic-linear"
-            />
-          </Box>
-        )}
-
         <Stack spacing={1.5} sx={{ mb: 1 }}>
           <SearchFilterBar
             search={query}
@@ -182,28 +152,6 @@ export default function RoadmapsPage() {
               </Typography>
             </Stack>
           </Surface>
-        )}
-
-        {visibleCompanies.length > 0 && (
-          <Box sx={{ mt: 3 }}>
-            <SectionHeading
-              icon="solar:buildings-2-linear"
-              title="Prepare for a company"
-              count={visibleCompanies.length}
-              noun="company"
-            />
-            <Box sx={{ display: "grid", gap: 1.5, gridTemplateColumns: companyGrid }}>
-              {visibleCompanies.map((roadmap, idx) => (
-                <Reveal key={roadmap.slug} delay={Math.min(idx, 8) * 0.04}>
-                  <CompanyRoadmapCard
-                    roadmap={roadmap}
-                    onOpen={() => push(`/roadmaps/${roadmap.slug}`)}
-                    onHover={() => prefetch(`/roadmaps/${roadmap.slug}`)}
-                  />
-                </Reveal>
-              ))}
-            </Box>
-          </Box>
         )}
 
         {!isLoading &&
@@ -252,6 +200,28 @@ export default function RoadmapsPage() {
               </Box>
             );
           })}
+
+        {visibleCompanies.length > 0 && (
+          <Box sx={{ mt: 3 }}>
+            <SectionHeading
+              icon="solar:buildings-2-linear"
+              title="Prepare for a company"
+              count={visibleCompanies.length}
+              noun="company"
+            />
+            <Box sx={{ display: "grid", gap: 1.5, gridTemplateColumns: companyGrid }}>
+              {visibleCompanies.map((roadmap, idx) => (
+                <Reveal key={roadmap.slug} delay={Math.min(idx, 8) * 0.04}>
+                  <CompanyRoadmapCard
+                    roadmap={roadmap}
+                    onOpen={() => push(`/roadmaps/${roadmap.slug}`)}
+                    onHover={() => prefetch(`/roadmaps/${roadmap.slug}`)}
+                  />
+                </Reveal>
+              ))}
+            </Box>
+          </Box>
+        )}
       </Container>
     </PageShell>
   );

--- a/components/assessment/AssessmentCard.tsx
+++ b/components/assessment/AssessmentCard.tsx
@@ -17,6 +17,8 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import { LoadingButton } from "@/components/common/LoadingButton";
 import { formatMoney } from "@/lib/utils/money";
 import { useAssessmentPurchase } from "@/hooks/useAssessmentPurchase";
+import { useB2CClaim } from "@/hooks/useB2CClaim";
+import { B2C_FEATURE_ASSESSMENT } from "@/lib/services/b2c.service";
 import {
   isPsychometricAssessment,
   getPsychometricTags,
@@ -35,6 +37,16 @@ import { StatusChip, type ChipTone } from "@/components/admin/assessment/shared"
 
 interface AssessmentCardProps {
   assessment: Assessment;
+  /**
+   * B2C only: free assessments this learner has left.
+   *
+   * Passed DOWN rather than read from `useB2CAllowance` in here. The card renders once per row,
+   * so calling the hook inside it would fire one HTTP request per card on a screen that shows
+   * dozens — the same N+1 the batched entitlement lookups exist to avoid on the server.
+   */
+  freeAssessmentsLeft?: number;
+  /** Re-read the allowance after one is spent, so the whole grid agrees. */
+  onFreeClaimed?: () => void;
 }
 
 function parseDateTime(s: string | undefined | null): Date | null {
@@ -80,6 +92,8 @@ function formatRemainingTime(
 
 export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   assessment,
+  freeAssessmentsLeft = 0,
+  onFreeClaimed,
 }) => {
   const { t } = useTranslation("common");
   const theme = useTheme();
@@ -96,6 +110,31 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   const needsPurchase =
     (assessment.requires_purchase ?? false) && !assessment.purchased && !justBought;
   const isBuying = buyingSlug === assessment.slug;
+  const { claim, claimingKey } = useB2CClaim();
+  const isClaiming = claimingKey === assessment.slug;
+  // Offered as a SECONDARY action beside the price, never as the primary button: there is a small
+  // fixed number of these and no way to give one back, so it should read as a deliberate choice
+  // rather than the path of least resistance.
+  const canUseFreeAssessment = needsPurchase && freeAssessmentsLeft > 0;
+
+  const handleUseFree = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isBuying || isClaiming) return;
+    void claim(B2C_FEATURE_ASSESSMENT, assessment.id, assessment.slug, {
+      onOwned: () => {
+        setJustBought(true);
+        onFreeClaimed?.();
+        showToast(`"${stripHtmlTags(assessment.title || "")}" is yours — that was a free one.`, "success");
+      },
+      // Spent in another tab, most likely. Re-read so the button disappears, and point at the
+      // thing they can actually still do.
+      onExhausted: () => {
+        onFreeClaimed?.();
+        showToast("You've used all your free assessments. This one can be purchased.", "info");
+      },
+      onFailed: (message) => showToast(message, "error"),
+    });
+  };
 
   const submissionComplete = isLearnerAssessmentSubmissionComplete(assessment);
   const normalizedStatus = normalizeLearnerAssessmentStatus(assessment);
@@ -341,7 +380,7 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
   const prefetchProps = usePrefetchOnHover(prefetchHref);
 
   const handleClick = () => {
-    if (!isClickable || loadingAction || isBuying) return;
+    if (!isClickable || loadingAction || isBuying || isClaiming) return;
 
     if (needsPurchase) {
       buy(assessment, {
@@ -859,6 +898,29 @@ export const AssessmentCard: React.FC<AssessmentCardProps> = ({
             }
             return primaryButton;
           })()}
+
+          {canUseFreeAssessment && (
+            <LoadingButton
+              onClick={handleUseFree}
+              loading={isClaiming}
+              fullWidth
+              variant="text"
+              startIcon={<IconWrapper icon="mdi:gift-outline" size={18} />}
+              sx={{
+                mt: 1,
+                borderRadius: 2,
+                textTransform: "none",
+                fontWeight: 700,
+                fontSize: "0.85rem",
+                color: "#7c3aed",
+                "&:hover": { bgcolor: "rgba(124,58,237,0.08)" },
+              }}
+            >
+              {freeAssessmentsLeft === 1
+                ? "Use my last free assessment"
+                : "Use a free assessment"}
+            </LoadingButton>
+          )}
         </Box>
       </Card>
     </>

--- a/components/assessment/AssessmentsGrid.tsx
+++ b/components/assessment/AssessmentsGrid.tsx
@@ -9,11 +9,16 @@ import { useTranslation } from "react-i18next";
 interface AssessmentsGridProps {
   assessments: Assessment[];
   searchQuery: string;
+  /** B2C only. Read once by the page and passed down, so the grid costs one allowance call, not N. */
+  freeAssessmentsLeft?: number;
+  onFreeClaimed?: () => void;
 }
 
 export function AssessmentsGrid({
   assessments,
   searchQuery,
+  freeAssessmentsLeft = 0,
+  onFreeClaimed,
 }: AssessmentsGridProps) {
   const { t } = useTranslation("common");
 
@@ -102,7 +107,11 @@ export function AssessmentsGrid({
             overflow: "visible",
           }}
         >
-          <AssessmentCard assessment={assessment} />
+          <AssessmentCard
+            assessment={assessment}
+            freeAssessmentsLeft={freeAssessmentsLeft}
+            onFreeClaimed={onFreeClaimed}
+          />
         </Box>
       ))}
     </Box>

--- a/hooks/useB2CClaim.ts
+++ b/hooks/useB2CClaim.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { b2cService } from "@/lib/services/b2c.service";
+
+/**
+ * Spending a free allowance, in one place.
+ *
+ * Deliberately shaped like `useAssessmentPurchase.buy` so a card can treat "pay" and "use a free
+ * one" as two routes to the same outcome, rather than two different kinds of thing.
+ *
+ * `onOwned` fires only after the server confirms the grant. There is no optimistic path: there is
+ * a small fixed number of these and no way to give one back, so telling a learner they spent one
+ * before the server agrees is a promise we may not be able to keep.
+ */
+export function useB2CClaim() {
+  const [claimingKey, setClaimingKey] = useState<string | null>(null);
+
+  const claim = useCallback(
+    async (
+      featureKey: string,
+      objectId: number,
+      busyKey: string,
+      handlers: {
+        onOwned: (remaining: number) => void;
+        /** The allowance ran out — most often spent in another tab. Offer the price instead. */
+        onExhausted: () => void;
+        onFailed: (message: string) => void;
+      },
+    ) => {
+      setClaimingKey(busyKey);
+      try {
+        const result = await b2cService.claim(featureKey, objectId);
+        handlers.onOwned(result.remaining);
+      } catch (err) {
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status === 402) handlers.onExhausted();
+        else if (status === 404) handlers.onFailed("That isn't available to claim.");
+        else handlers.onFailed("Couldn't use your free allowance. Please try again.");
+      } finally {
+        setClaimingKey(null);
+      }
+    },
+    [],
+  );
+
+  return { claim, claimingKey };
+}

--- a/lib/hooks/useB2CAllowance.ts
+++ b/lib/hooks/useB2CAllowance.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   B2C_FEATURE_ADAPTIVE_COURSE,
+  B2C_FEATURE_ASSESSMENT,
   b2cService,
   type B2CAllowance,
 } from "@/lib/services/b2c.service";
@@ -10,20 +11,23 @@ import {
 interface UseB2CAllowance {
   /** True only on a tenant that actually meters free usage. */
   isB2C: boolean;
-  /** Free courses this learner has left. 0 on any non-B2C tenant. */
+  /** Free uses left for an arbitrary feature. 0 on any non-B2C tenant. */
+  remainingFor: (featureKey: string) => number;
+  /** Convenience readers for the two metered features today. */
   freeCoursesLeft: number;
+  freeAssessmentsLeft: number;
   loading: boolean;
-  /** Re-read after spending one, so the banner and the buttons agree. */
+  /** Re-read after spending one, so banners and buttons agree. */
   refresh: () => Promise<void>;
 }
 
 /**
  * The learner's remaining free allowance.
  *
- * Fails SILENTLY to "no allowance": if this call errors we must not offer a free course we
- * cannot back, because the claim would 402 and read as a broken button. The paywall itself is
- * enforced server-side regardless, so being wrong in this direction costs a missed upsell
- * rather than giving anything away.
+ * Fails SILENTLY to "no allowance": if this call errors we must not offer a free use we cannot
+ * back, because the claim would 402 and read as a broken button. The paywall is enforced
+ * server-side regardless, so being wrong in this direction costs a missed upsell rather than
+ * giving anything away.
  */
 export function useB2CAllowance(enabled = true): UseB2CAllowance {
   const [data, setData] = useState<B2CAllowance | null>(null);
@@ -44,11 +48,19 @@ export function useB2CAllowance(enabled = true): UseB2CAllowance {
     void load();
   }, [load]);
 
-  const courses = data?.features.find((f) => f.feature_key === B2C_FEATURE_ADAPTIVE_COURSE);
+  const remainingFor = useCallback(
+    (featureKey: string) => {
+      if (!data?.is_b2c) return 0;
+      return data.features.find((f) => f.feature_key === featureKey)?.remaining ?? 0;
+    },
+    [data],
+  );
 
   return {
     isB2C: Boolean(data?.is_b2c),
-    freeCoursesLeft: data?.is_b2c ? (courses?.remaining ?? 0) : 0,
+    remainingFor,
+    freeCoursesLeft: remainingFor(B2C_FEATURE_ADAPTIVE_COURSE),
+    freeAssessmentsLeft: remainingFor(B2C_FEATURE_ASSESSMENT),
     loading,
     refresh: load,
   };

--- a/lib/services/b2c.service.ts
+++ b/lib/services/b2c.service.ts
@@ -15,8 +15,17 @@ export interface B2CAllowance {
   features: B2CFeatureAllowance[];
 }
 
-/** The only metered feature today. More arrive in later phases. */
 export const B2C_FEATURE_ADAPTIVE_COURSE = "adaptive_course";
+export const B2C_FEATURE_ASSESSMENT = "assessment";
+
+export interface B2CClaimResult {
+  feature_key: string;
+  object_id: number;
+  claimed: boolean;
+  used: number;
+  allowance: number;
+  remaining: number;
+}
 
 export const b2cService = {
   /**
@@ -27,6 +36,24 @@ export const b2cService = {
    */
   async getAllowance(): Promise<B2CAllowance> {
     const { data } = await apiClient.get<B2CAllowance>(`${BASE}/allowance/`);
+    return data;
+  },
+
+  /**
+   * Spend one unit of the free allowance on a specific thing.
+   *
+   * Courses are NOT claimable here — they go through the self-enroll route, because the grant and
+   * the enrolment have to share a transaction. The backend refuses `adaptive_course` with a 400
+   * rather than silently minting an entitlement with no enrolment behind it.
+   *
+   * Throws on 402 (allowance spent) and 404 (not claimable). Callers should treat 402 as "offer
+   * to buy instead" rather than as an error.
+   */
+  async claim(featureKey: string, objectId: number): Promise<B2CClaimResult> {
+    const { data } = await apiClient.post<B2CClaimResult>(`${BASE}/claim/`, {
+      feature_key: featureKey,
+      object_id: objectId,
+    });
     return data;
   },
 };


### PR DESCRIPTION
Promotes `stagging` to `main`. Seven commits, from three separate lines of work.

**Roadmaps** (mine, the rest of this work is already in main)
- Companies move to the last section of the catalog; the skills come first because the catalog is a learning surface.
- The stat row ("9 roadmaps / 9 companies / 468 steps") is removed: it restated what the page below already showed and pushed the content down most of a screen.
- The Absolute Beginners section and the Programming Fundamentals placement are backend spec changes, already live in prod.

**b2c** (#1314) — free-assessment allowance on the assessments hub.

**auth** (#1313) — Google sign-in failures now say why instead of bouncing to a blank login page.

Backend for the roadmap changes is already merged and deployed: 22 published roadmaps granted to clients 5 and 34, with 43 other tenants verified to see none.

CI green on stagging. 119 frontend tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)