### PR TITLE
release: student dashboard no longer looks empty for a new learner

### DIFF
--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -24,6 +24,7 @@ import { LeaderboardPanel } from "./LeaderboardPanel";
 import { ContinueCoursesRow } from "./ContinueCoursesRow";
 import { DashboardSkeleton } from "./DashboardSkeleton";
 import { DashboardModulesRail } from "./modules/DashboardModulesRow";
+import { FirstRunCoursesPanel } from "./FirstRunCoursesPanel";
 import { TodayGoalPanel } from "./TodayGoalPanel";
 
 /** Shared key so other surfaces can invalidate the learner dashboard after a scoring event. */
@@ -140,7 +141,9 @@ export function DashboardV2() {
             <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
           </Box>
         ) : (
-          <StartJourneyCard />
+          // Shows the courses they can actually start, falling back to the plain CTA when the
+          // catalog is empty — which it is by design on a tenant whose admins assign everything.
+          <FirstRunCoursesPanel fallback={<StartJourneyCard />} />
         )}
         {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
       </Box>

--- a/components/dashboard/v2/DashboardV2.tsx
+++ b/components/dashboard/v2/DashboardV2.tsx
@@ -23,7 +23,7 @@ import { UpNextPanel } from "./UpNextPanel";
 import { LeaderboardPanel } from "./LeaderboardPanel";
 import { ContinueCoursesRow } from "./ContinueCoursesRow";
 import { DashboardSkeleton } from "./DashboardSkeleton";
-import { DashboardModulesRow, DashboardModulesRail } from "./modules/DashboardModulesRow";
+import { DashboardModulesRail } from "./modules/DashboardModulesRow";
 import { TodayGoalPanel } from "./TodayGoalPanel";
 
 /** Shared key so other surfaces can invalidate the learner dashboard after a scoring event. */
@@ -38,30 +38,39 @@ function LegacyFallback() {
   return <DashboardContent courses={courses} loading={loading} />;
 }
 
-/** v2 empty state for students on an adaptive-enabled tenant who aren't in any adaptive course yet
- *  (including legacy-only students - the AdaptivePromo banner mounted above this nudges them to
- *  start). Keeps the v2 chrome instead of dropping back to the old dashboard. */
-function EmptyAdaptiveDashboard({ data, hideLeaderboard }: { data: LearnerDashboard | null; hideLeaderboard: boolean }) {
+/** The "you have no courses yet" call to action.
+ *
+ *  A CARD inside the normal dashboard, not a replacement for it. It used to be a whole alternate
+ *  layout (`EmptyAdaptiveDashboard`) that a learner with zero courses got instead of the real
+ *  dashboard — which dropped the entire right rail along with the welcome briefing, profile
+ *  completion, today's goal and every module panel. That was never necessary: every
+ *  course-dependent panel already returns null when it has nothing (CourseReadinessCard,
+ *  SkillProfilePanel, ContinueCoursesRow, UpNextPanel all do), so the real layout handles zero
+ *  courses on its own. The fork was doing by hand, worse, what the panels already did.
+ */
+function StartJourneyCard() {
   const { push } = useInstantNavigation();
   return (
-    <Stack spacing={2.5}>
-      {data && <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />}
-      <Box sx={{ p: { xs: 3, md: 5 }, borderRadius: 4, textAlign: "center", border: "1px solid #eef2f7", bgcolor: "#faf9ff" }}>
-        <Box sx={{ width: 56, height: 56, mx: "auto", mb: 2, borderRadius: "50%", display: "grid", placeItems: "center", background: "linear-gradient(135deg,#7c3aed,#a855f7)" }}>
-          <Icon icon="mdi:rocket-launch-outline" width={28} color="#fff" />
-        </Box>
-        <Typography sx={{ fontWeight: 800, fontSize: "1.15rem", color: "#0f172a" }}>Start your adaptive journey</Typography>
-        <Typography sx={{ color: "#64748b", mt: 1, mb: 2.5, maxWidth: 460, mx: "auto" }}>
-          You&apos;re not in an adaptive course yet. Adaptive courses adjust to your skill level as you learn - pick one to begin.
-        </Typography>
-        <Button onClick={() => push("/adaptive-courses")} variant="contained" endIcon={<Icon icon="mdi:arrow-right" width={18} />}
-          sx={{ textTransform: "none", fontWeight: 800, borderRadius: 2, px: 3, py: 1.1, background: "linear-gradient(135deg,#7c3aed,#db2777)" }}>
-          Browse adaptive courses
-        </Button>
+    <Box sx={{ p: { xs: 3, md: 4 }, borderRadius: 4, textAlign: "center", border: "1px solid #eef2f7", bgcolor: "#faf9ff" }}>
+      <Box sx={{ width: 56, height: 56, mx: "auto", mb: 2, borderRadius: "50%", display: "grid", placeItems: "center", background: "linear-gradient(135deg,#7c3aed,#a855f7)" }}>
+        <Icon icon="mdi:rocket-launch-outline" width={28} color="#fff" />
       </Box>
-      {!hideLeaderboard && data?.leaderboard && <LeaderboardPanel leaderboard={data.leaderboard} />}
-      <DashboardModulesRow />
-    </Stack>
+      <Typography sx={{ fontWeight: 800, fontSize: "1.15rem", color: "#0f172a" }}>Start your learning journey</Typography>
+      <Typography sx={{ color: "#64748b", mt: 1, mb: 2.5, maxWidth: 460, mx: "auto" }}>
+        Pick a course and the engine meets you at your level, adapting as you go.
+      </Typography>
+      <Button
+        // The CATALOG, not /adaptive-courses. That route is "my courses" — which is empty for
+        // exactly the learner seeing this card, so the one call to action led to a second empty
+        // page. The catalog is where the courses they can actually start live.
+        onClick={() => push("/adaptive-courses/catalog")}
+        variant="contained"
+        endIcon={<Icon icon="mdi:arrow-right" width={18} />}
+        sx={{ textTransform: "none", fontWeight: 800, borderRadius: 2, px: 3, py: 1.1, background: "linear-gradient(135deg,#7c3aed,#db2777)" }}
+      >
+        Browse courses
+      </Button>
+    </Box>
   );
 }
 
@@ -100,9 +109,13 @@ export function DashboardV2() {
   if (error) return <Typography sx={{ color: "#b91c1c", py: 6, textAlign: "center", fontWeight: 600 }}>{error}</Typography>;
   // Only tenants without the adaptive feature (403/404) or a hard failure see the old dashboard.
   if (degraded) return <LegacyFallback />;
-  // Everyone else gets v2 - even with zero adaptive courses (legacy-only / brand-new students).
-  if (!data || data.courses.length === 0) return <EmptyAdaptiveDashboard data={data} hideLeaderboard={hideLeaderboard} />;
+  // A learner with zero courses gets the SAME dashboard as everyone else, not a stripped-down
+  // alternate one. The course-dependent panels each hide themselves; what is left — the welcome
+  // briefing, profile completion, today's goal, the module panels and the leaderboard — is
+  // exactly what a brand-new learner most needs to see.
+  if (!data) return <LegacyFallback />;
 
+  const hasCourses = data.courses.length > 0;
   const activeCourse = data.courses.find((c) => c.id === activeCourseId) ?? data.courses[0];
 
   return (
@@ -122,9 +135,13 @@ export function DashboardV2() {
         <Box data-tour-id="dash-stats">
           <StatCards aggregate={data.aggregate} hideLeaderboard={hideLeaderboard} />
         </Box>
-        <Box data-tour-id="dash-courses">
-          <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
-        </Box>
+        {hasCourses ? (
+          <Box data-tour-id="dash-courses">
+            <CourseReadinessCard courses={data.courses} activeCourseId={activeCourse?.id ?? null} onSelect={setActiveCourseId} />
+          </Box>
+        ) : (
+          <StartJourneyCard />
+        )}
         {courseEnabled && <ContinueCoursesRow courses={data.courses} />}
       </Box>
 

--- a/components/dashboard/v2/FirstRunCoursesPanel.tsx
+++ b/components/dashboard/v2/FirstRunCoursesPanel.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, Button, Skeleton, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { formatMoney } from "@/lib/utils/money";
+import {
+  adaptiveCourseService,
+  type AdaptiveCourseListItem,
+} from "@/lib/services/adaptive-course.service";
+import { useB2CAllowance } from "@/lib/hooks/useB2CAllowance";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+
+/** How many to show before deferring to the catalog. Three fills the slot without turning the
+ *  dashboard into a second storefront. */
+const PREVIEW_COUNT = 3;
+
+/**
+ * What a learner with no courses sees where the course card would be.
+ *
+ * A rocket icon and a button told them to go somewhere else. This shows the actual courses they
+ * can start, with prices — which on a self-serve tenant is the product itself, and on any tenant
+ * is more use than an empty box.
+ *
+ * Falls back to the plain call-to-action whenever there is nothing to list: a tenant whose admins
+ * assign every course has an empty catalog by design, and a list of nothing would be worse than
+ * the button it replaced.
+ */
+export function FirstRunCoursesPanel({ fallback }: { fallback: React.ReactNode }) {
+  const { push } = useInstantNavigation();
+  const { isB2C, freeCoursesLeft } = useB2CAllowance();
+  const [courses, setCourses] = useState<AdaptiveCourseListItem[] | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const list = await adaptiveCourseService.getCatalog();
+        if (alive) setCourses(list);
+      } catch {
+        // A failed catalog is not an error worth showing on a dashboard — it just means we fall
+        // back to the plain CTA, which always works.
+        if (alive) setCourses([]);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (courses === null) {
+    return <Skeleton variant="rounded" height={232} sx={{ borderRadius: 4 }} />;
+  }
+  if (courses.length === 0) return <>{fallback}</>;
+
+  const preview = courses.slice(0, PREVIEW_COUNT);
+
+  return (
+    <Box sx={{ p: { xs: 2.5, md: 3 }, borderRadius: 4, border: "1px solid #eef2f7", bgcolor: "#faf9ff" }}>
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 0.5 }}>
+        <Icon icon="mdi:rocket-launch-outline" width={20} color="#7c3aed" />
+        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a" }}>
+          Start your learning journey
+        </Typography>
+      </Stack>
+      <Typography sx={{ color: "#64748b", fontSize: "0.9rem", mb: 2 }}>
+        {isB2C && freeCoursesLeft > 0
+          ? freeCoursesLeft === 1
+            ? "Pick your first course — it's on us."
+            : `Pick a course — you have ${freeCoursesLeft} free ones.`
+          : "Pick a course and the engine meets you at your level, adapting as you go."}
+      </Typography>
+
+      <Stack spacing={1}>
+        {preview.map((course) => (
+          <Box
+            key={course.id}
+            onClick={() => push("/adaptive-courses/catalog")}
+            sx={{
+              display: "flex", alignItems: "center", gap: 1.5, p: 1.5,
+              borderRadius: 2.5, bgcolor: "#fff", border: "1px solid #eef2f7",
+              cursor: "pointer", transition: "border-color .15s ease",
+              "&:hover": { borderColor: "#c4b5fd" },
+            }}
+          >
+            <Box sx={{
+              width: 36, height: 36, borderRadius: 2, flexShrink: 0, display: "grid",
+              placeItems: "center", background: "linear-gradient(135deg,#7c3aed,#a855f7)",
+            }}>
+              <Icon icon="mdi:book-open-variant" width={18} color="#fff" />
+            </Box>
+            <Box sx={{ minWidth: 0, flexGrow: 1 }}>
+              <Typography noWrap sx={{ fontWeight: 700, fontSize: "0.9rem", color: "#0f172a" }}>
+                {course.title}
+              </Typography>
+              <Typography noWrap sx={{ color: "#64748b", fontSize: "0.78rem" }}>
+                {course.module_count ? `${course.module_count} modules` : "Adaptive course"}
+              </Typography>
+            </Box>
+            <Typography sx={{ fontWeight: 800, fontSize: "0.85rem", color: "#7c3aed", flexShrink: 0 }}>
+              {course.is_paid && course.price
+                ? formatMoney(course.price, course.currency)
+                : "Free"}
+            </Typography>
+          </Box>
+        ))}
+      </Stack>
+
+      <Button
+        onClick={() => push("/adaptive-courses/catalog")}
+        variant="contained"
+        fullWidth
+        endIcon={<Icon icon="mdi:arrow-right" width={18} />}
+        sx={{
+          mt: 2, textTransform: "none", fontWeight: 800, borderRadius: 2, py: 1,
+          background: "linear-gradient(135deg,#7c3aed,#db2777)",
+        }}
+      >
+        {courses.length > PREVIEW_COUNT ? `Browse all ${courses.length} courses` : "Browse courses"}
+      </Button>
+    </Box>
+  );
+}

--- a/components/dashboard/v2/modules/DashboardModulesRow.tsx
+++ b/components/dashboard/v2/modules/DashboardModulesRow.tsx
@@ -18,11 +18,12 @@ import { JobOpeningsPanel } from "./JobOpeningsPanel";
  * The tenant-gated "What's next for you" module widgets. Each renders ONLY when
  * its module is enabled for the tenant (strict feature check), fetches its own
  * data, and hides itself on error - so a slow/missing endpoint never blanks the
- * page. Rendered two ways:
- *   - DashboardModulesRail: stacked in the right sidebar (main dashboard) so the
- *     rail fills out and each panel sizes to its content (no empty grid gaps).
- *   - DashboardModulesRow: a full-width 2-up grid (the empty-adaptive dashboard,
- *     which has no sidebar).
+ * page. Always stacked in the right sidebar.
+ *
+ * There used to be a second, full-width 2-up variant for the separate "no courses
+ * yet" dashboard. That dashboard is gone — a learner with no courses now gets the
+ * ordinary layout — and on a tenant with one of these modules enabled the 2-up grid
+ * rendered a single card beside a visibly empty column anyway.
  */
 function useGatedPanels(): ReactNode[] {
   const assessment = useIsAssessmentEnabled();
@@ -59,28 +60,3 @@ export function DashboardModulesRail() {
   );
 }
 
-/** Full-width variant (empty-adaptive dashboard, no sidebar): 2-up responsive grid. */
-export function DashboardModulesRow() {
-  const panels = useGatedPanels();
-  if (panels.length === 0) return null;
-  return (
-    <Box sx={{ mt: 2.5 }}>
-      <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1.5 }}>
-        <Icon icon="mdi:compass-outline" width={18} color="#7c3aed" />
-        <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", color: "#0f172a" }}>
-          What&apos;s next for you
-        </Typography>
-      </Stack>
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0,1fr))" },
-          gap: 2,
-          alignItems: "start",
-        }}
-      >
-        {panels}
-      </Box>
-    </Box>
-  );
-}


### PR DESCRIPTION
Promotes `stagging` to `main`. Two commits, both the same reported problem: a brand-new student saw a dashboard that read as an unfinished product.

## [#1316](https://github.com/AI-Linc-LMS/lms-platform-frontend/pull/1316) — the layout fork

`DashboardV2` swapped the entire dashboard for a bare `<Stack>` with **no right rail** whenever `courses.length === 0`, discarding the welcome briefing, profile completion, today's goal and every module panel.

The fork was never necessary — every course-dependent panel already returns `null` when empty. And the backend already builds *"Welcome, {name} — your learning starts here."* for exactly this learner; the empty dashboard computed it and threw it away on every request.

The one CTA also dead-ended, pushing to `/adaptive-courses` ("my courses"), which is empty for precisely the learner seeing it. Now points at the catalog.

## [#1317](https://github.com/AI-Linc-LMS/lms-platform-frontend/pull/1317) — the first-run panel

Replaces the rocket-icon placeholder with the actual courses and prices. Falls back to the plain CTA when the catalog is empty — which it is by design on a tenant whose admins assign everything.

## Scope

Two files changed plus one added; no other surface touched. Affects **every** tenant's dashboard for learners with no courses, which on B2B is transient (admins auto-enrol) and on B2C is every new signup.

`tsc --noEmit` clean; 119 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)