### PR TITLE
feat(courses): badge a course you can only open because you are staff

### DIFF
--- a/components/courses/AdaptiveCourseCard.tsx
+++ b/components/courses/AdaptiveCourseCard.tsx
@@ -61,6 +61,22 @@ export function AdaptiveCourseCard({
         </Box>
         {/* Still shown after purchase: "Paid" is a fact about how they got access, not a CTA. */}
         <PriceTag isPaid={course.is_paid} price={course.price} currency={course.currency} />
+        {/* Staff reach priced courses without buying them, by design — they run the product. Saying
+            so matters: without this badge a superadmin sees paid courses simply open, which is
+            indistinguishable from a broken paywall and was reported as one. */}
+        {course.staff_preview && (
+          <Box
+            component="span"
+            title="You can open this because you are staff. A learner would have to buy it."
+            sx={{
+              px: 1, py: 0.3, borderRadius: 999, fontSize: "0.65rem", fontWeight: 800,
+              letterSpacing: 0.4, textTransform: "uppercase", color: "#b45309",
+              bgcolor: "color-mix(in srgb, #f59e0b 18%, transparent)",
+            }}
+          >
+            Staff preview
+          </Box>
+        )}
       </Box>
 
       <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.3, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{course.title}</Typography>

--- a/lib/services/adaptive-course.service.ts
+++ b/lib/services/adaptive-course.service.ts
@@ -146,6 +146,15 @@ export interface AdaptiveCourseListItem {
   currency?: string;
   /** This learner already holds a settled purchase for the course. */
   purchased?: boolean;
+  /**
+   * This caller can only open the course because they are STAFF (admin, superadmin, course
+   * manager, instructor), not because they hold it.
+   *
+   * The bypass is deliberate — they run the product — but it used to be invisible, so a
+   * superadmin browsing their own paid tenant saw priced courses simply open and reasonably
+   * concluded the paywall was broken. Surfaced so the UI can say so out loud.
+   */
+  staff_preview?: boolean;
   id: number;
   title: string;
   slug: string;


### PR DESCRIPTION
Pairs with backend [#588](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/588).

That PR found the reported *"I can access any course before buying"* is the **staff preview bypass working as designed** — verified with a real student on the B2C tenant, who gets 0 courses in the list and a **402** on the detail.

The defect was **silence**. A superadmin saw priced courses simply open, which looks exactly like a broken paywall. This badges it, with a tooltip saying what a learner would see instead.

Only rendered when the server says `staff_preview`, which is false for staff who actually hold the course — badging something they own would be a lie.

`tsc --noEmit` clean; 119 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)