### PR TITLE
feat(auth): show a real screen when the workspace is deactivated

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,7 @@ import { DirectionSync } from "@/components/providers/DirectionSync";
 import { TelemetryProvider } from "@/components/providers/TelemetryProvider";
 import { ProfileActivationBlocker } from "@/components/auth/ProfileActivationBlocker";
 import { TenantSetupBlocker } from "@/components/auth/TenantSetupBlocker";
+import { TenantDeactivatedGate } from "@/components/auth/TenantDeactivatedGate";
 import { XPGainProvider } from "@/components/community/XPGainProvider";
 import { XpCelebrationOverlay } from "@/components/common/XpCelebrationOverlay";
 import { PointsPrimer } from "@/components/common/PointsPrimer";
@@ -127,15 +128,19 @@ export default async function RootLayout({
                           <CameraRouteGuard>
                             <TelemetryProvider>
                               <ToastProvider>
-                                <XPGainProvider>
-                                  <TourProvider>
-                                    <ProfileActivationBlocker />
-                                    <TenantSetupBlocker />
-                                    {children}
-                                    <PointsPrimer />
-                                    <XpCelebrationOverlay />
-                                  </TourProvider>
-                                </XPGainProvider>
+                                {/* Wraps rather than sits beside the app: a deactivated tenant
+                                    must have the fetching tree UNMOUNTED, not covered. */}
+                                <TenantDeactivatedGate>
+                                  <XPGainProvider>
+                                    <TourProvider>
+                                      <ProfileActivationBlocker />
+                                      <TenantSetupBlocker />
+                                      {children}
+                                      <PointsPrimer />
+                                      <XpCelebrationOverlay />
+                                    </TourProvider>
+                                  </XPGainProvider>
+                                </TenantDeactivatedGate>
                               </ToastProvider>
                             </TelemetryProvider>
                           </CameraRouteGuard>

--- a/components/auth/TenantDeactivatedGate.tsx
+++ b/components/auth/TenantDeactivatedGate.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { ReactNode } from "react";
+import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
+import { useTenantDeactivated } from "@/lib/auth/tenant-status";
+import { WorkspaceDeactivatedScreen } from "@/components/auth/WorkspaceDeactivatedNotice";
+
+/**
+ * Replaces the whole app with the deactivated screen when the institution has been switched off.
+ *
+ * Two signals, because they arrive at different moments. Client-info is public and already in
+ * hand at first paint, so it covers the signed-out visitor at /login before a single
+ * authenticated call is made; the 403 `tenant_inactive` latch covers the session that was
+ * already open when the switch was thrown.
+ *
+ * Unlike ProfileActivationBlocker and TenantSetupBlocker this REPLACES children instead of
+ * sitting beside them. Laying the screen over a still-mounted dashboard would leave every
+ * widget, poller and retry underneath it hammering an API that now 403s on everything -
+ * the wall of failed requests this screen exists to replace. Unmounting the tree is what makes
+ * the screen quiet, and is what stops it feeding itself more 403s.
+ *
+ * `is_active` is compared to an explicit false: the SSR fallback payload used when the API is
+ * unreachable carries no such field, and treating "unknown" as deactivated would lock out a
+ * whole tenant over a transient backend blip.
+ */
+export function TenantDeactivatedGate({ children }: { children: ReactNode }) {
+  const { clientInfo } = useClientInfo();
+  const deactivatedByApi = useTenantDeactivated();
+
+  if (deactivatedByApi || clientInfo?.is_active === false) {
+    return <WorkspaceDeactivatedScreen />;
+  }
+
+  return <>{children}</>;
+}

--- a/components/auth/WorkspaceDeactivatedNotice.tsx
+++ b/components/auth/WorkspaceDeactivatedNotice.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Box, Container, Paper, Typography } from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import { useTranslation } from "react-i18next";
+import { IconWrapper } from "@/components/common/IconWrapper";
+
+/**
+ * The deactivated-workspace message itself, without page chrome, so a host that already owns a
+ * shell can render exactly the same words as the full-page screen below.
+ *
+ * It names no support address, phone number or billing link on purpose. The platform does not
+ * know which of those an institution wants its learners to use, and a guessed one sends people
+ * somewhere nobody is reading - worse than the honest "ask your administrator".
+ */
+export function WorkspaceDeactivatedNotice() {
+  const { t } = useTranslation("common");
+
+  return (
+    <Box sx={{ textAlign: "center" }}>
+      <Box sx={{ mb: 3, display: "flex", justifyContent: "center" }}>
+        <Box
+          sx={{
+            width: { xs: 88, sm: 104 },
+            height: { xs: 88, sm: 104 },
+            borderRadius: "50%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            bgcolor: (theme) => alpha(theme.palette.warning.main, 0.12),
+            color: "warning.main",
+          }}
+        >
+          <IconWrapper icon="mdi:lock-outline" size={48} />
+        </Box>
+      </Box>
+
+      <Typography
+        component="h1"
+        variant="h5"
+        sx={{ fontWeight: 700, color: "text.primary", mb: 1.5 }}
+      >
+        {t("auth.workspaceDeactivatedTitle", {
+          defaultValue: "Workspace deactivated",
+        })}
+      </Typography>
+
+      <Typography
+        variant="body1"
+        color="text.secondary"
+        sx={{ lineHeight: 1.7, fontSize: "0.9375rem", maxWidth: 480, mx: "auto" }}
+      >
+        {t("auth.workspaceDeactivatedBody", {
+          defaultValue:
+            "Your institution's access to this platform has been suspended. Please contact your administrator for more information.",
+        })}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * The notice as a standalone page. Rendered in place of the app, so it carries its own
+ * background and centering rather than inheriting a shell it no longer sits inside.
+ *
+ * It deliberately renders nothing interactive: no retry, no "back to dashboard", no link that
+ * would mount a route and start it fetching. Every authenticated call is 403ing, so any action
+ * offered here would just fail in front of the person it was offered to.
+ */
+export function WorkspaceDeactivatedScreen() {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "background.default",
+        py: { xs: 4, sm: 8 },
+        px: { xs: 2, sm: 3 },
+      }}
+    >
+      <Container maxWidth="sm">
+        <Paper
+          elevation={0}
+          sx={{
+            p: { xs: 4, sm: 6 },
+            borderRadius: 3,
+            border: "1px solid",
+            borderColor: "divider",
+            backgroundColor: "background.paper",
+          }}
+        >
+          <WorkspaceDeactivatedNotice />
+        </Paper>
+      </Container>
+    </Box>
+  );
+}

--- a/lib/auth/tenant-status.ts
+++ b/lib/auth/tenant-status.ts
@@ -1,0 +1,57 @@
+"use client";
+
+/**
+ * Tenant deactivation store - a module-level flag (no provider) so the axios response
+ * interceptor, which runs outside React, can put the whole app into the "workspace
+ * deactivated" state. Mirrors lib/xp/xpCelebration.
+ *
+ * Kept in its own module rather than inside lib/services/api.ts so a component can subscribe
+ * without importing axios, and so api.ts keeps importing nothing that reaches back into the
+ * component tree.
+ */
+import { useSyncExternalStore } from "react";
+import { authUtils } from "./auth-utils";
+
+/** The backend's machine-readable code for "this institution has been deactivated". */
+export const TENANT_INACTIVE_CODE = "tenant_inactive";
+
+let deactivated = false;
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+function getSnapshot() {
+  return deactivated;
+}
+
+/**
+ * Latch the app into the deactivated state and drop the session.
+ *
+ * One-way on purpose: nothing sets this back to false. It is only ever raised by a server that
+ * is refusing every request, so a reactivated tenant needs a fresh load regardless, and a
+ * resettable flag would let one stale in-flight response drop the user back into a shell whose
+ * every call still 403s.
+ *
+ * Tokens are cleared here rather than at the call site so no future caller can raise the flag
+ * and forget the sign-out: leaving them set lets the user walk back into a shell that looks
+ * signed in and fails on everything it touches.
+ */
+export function markTenantDeactivated() {
+  if (deactivated) return;
+  deactivated = true;
+  authUtils.clearTokens();
+  listeners.forEach((l) => l());
+}
+
+/** True once the backend has answered any request with 403 `tenant_inactive`. */
+export function isTenantDeactivated() {
+  return deactivated;
+}
+
+export function useTenantDeactivated(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/lib/services/api.tenant-inactive.test.ts
+++ b/lib/services/api.tenant-inactive.test.ts
@@ -1,0 +1,68 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import Cookies from "js-cookie";
+import { describe, expect, it } from "vitest";
+import apiClient from "./api";
+import { isTenantDeactivated } from "@/lib/auth/tenant-status";
+
+/**
+ * The deactivated-tenant latch is a ONE-WAY module flag, so the whole contract has to be
+ * asserted in a single pass: once it is raised, no later test in this file could observe the
+ * "before" state again.
+ */
+
+/** Reject the way a real backend does, so the response interceptor sees a genuine AxiosError. */
+function rejectWith(status: number, data: unknown) {
+  return async () => {
+    const error = new AxiosError(
+      `Request failed with status code ${status}`,
+      String(status),
+      undefined,
+      null,
+      {
+        status,
+        statusText: "",
+        data,
+        headers: new AxiosHeaders(),
+        config: { headers: new AxiosHeaders() },
+      },
+    );
+    throw error;
+  };
+}
+
+describe("403 tenant_inactive", () => {
+  it("clears the session, latches the flag, and never settles the caller's promise", async () => {
+    Cookies.set("access_token", "a");
+    Cookies.set("refresh_token", "r");
+    Cookies.set("user_role", "student");
+    expect(isTenantDeactivated()).toBe(false);
+
+    apiClient.defaults.adapter = rejectWith(403, { code: "tenant_inactive" });
+
+    const settled = await Promise.race([
+      apiClient.get("/anything/").then(
+        () => "resolved",
+        () => "rejected",
+      ),
+      new Promise<string>((r) => setTimeout(() => r("pending"), 50)),
+    ]);
+
+    // Pending on purpose: a settled rejection would let every in-flight widget stack its own
+    // error toast on top of the deactivated screen.
+    expect(settled).toBe("pending");
+    expect(isTenantDeactivated()).toBe(true);
+    expect(Cookies.get("access_token")).toBeUndefined();
+    expect(Cookies.get("refresh_token")).toBeUndefined();
+    expect(Cookies.get("user_role")).toBeUndefined();
+  });
+
+  it("leaves an ordinary 403 alone, so a per-object permission denial still reaches its caller", async () => {
+    apiClient.defaults.adapter = rejectWith(403, {
+      detail: "You do not have permission to perform this action.",
+    });
+
+    await expect(apiClient.get("/anything/")).rejects.toMatchObject({
+      response: { status: 403 },
+    });
+  });
+});

--- a/lib/services/api.ts
+++ b/lib/services/api.ts
@@ -7,6 +7,10 @@ import axios, {
 import Cookies from "js-cookie";
 import { config } from "../config";
 import { getClientDeviceClass } from "../utils/assessment-device";
+import {
+  markTenantDeactivated,
+  TENANT_INACTIVE_CODE,
+} from "../auth/tenant-status";
 
 // Create axios instance.
 // A request timeout is essential: without it a slow/hung prod endpoint (or a flaky network)
@@ -164,6 +168,17 @@ apiClient.interceptors.response.use(
     const originalRequest = error.config as InternalAxiosRequestConfig & {
       _retry?: boolean;
     };
+
+    // The institution has been deactivated. The backend answers EVERY request with this code
+    // while that lasts, so there is nothing to retry and nothing a caller could usefully show.
+    // Latch the app into the deactivated screen and swallow the rejection: a settled rejection
+    // here lets each in-flight widget stack its own "something went wrong" toast on top of the
+    // one screen that is already explaining the real reason.
+    const body = error.response?.data as { code?: string } | undefined;
+    if (error.response?.status === 403 && body?.code === TENANT_INACTIVE_CODE) {
+      markTenantDeactivated();
+      return new Promise(() => {});
+    }
 
     // Handle 401 errors (unauthorized)
     if (error.response?.status === 401 && !originalRequest._retry) {

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -305,6 +305,8 @@
     "profileInactiveTitle": "Your account isn’t active yet",
     "profileInactiveDefault": "Your account for this organization is not active yet. An administrator may still need to activate it. Please check back later or contact your organization if this continues.",
     "profileActivatedToast": "Your account is active. Redirecting…",
+    "workspaceDeactivatedTitle": "Workspace deactivated",
+    "workspaceDeactivatedBody": "Your institution's access to this platform has been suspended. Please contact your administrator for more information.",
     "signInWithGoogle": "Sign in with Google",
     "googleSignInFailed": "Google sign-in failed. Please try again.",
     "googleError": "Google sign-in encountered an error. Please try again.",


### PR DESCRIPTION
Pairs with ai-linc-backend#596.

The backend now answers `403 {"code": "tenant_inactive"}` on every request for a switched-off institution. Without this, a learner on a deactivated tenant sees a wall of failed requests and a generic error.

Latches on that code, clears tokens through the same helper `logout()` already uses, and renders a full-page notice. The latch is one-way and the notice fires no authenticated requests, so it cannot loop.

This is the honest replacement for "pause the tenant's Netlify site": the same outcome for the user, but instant, reversible, and correct on every hosting stack rather than only the ones we provisioned.

Targets `stagging` per the usual frontend flow. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)