### PR TITLE
feat(roadmaps): the roadmap builds you a course instead of showing you content

### DIFF
--- a/app/roadmaps/[slug]/page.tsx
+++ b/app/roadmaps/[slug]/page.tsx
@@ -11,7 +11,6 @@ import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { RoadmapSpine } from "@/components/roadmaps/RoadmapSpine";
 import { RoadmapNodeDrawer } from "@/components/roadmaps/RoadmapNodeDrawer";
 import { RoadmapFaqs } from "@/components/roadmaps/RoadmapFaqs";
-import { Metric } from "@/components/roadmaps/surfaces";
 import { CompanyHiringProcess } from "@/components/roadmaps/CompanyHiringProcess";
 import { CompanyQuickStats } from "@/components/roadmaps/CompanyQuickStats";
 import {
@@ -125,60 +124,6 @@ export default function RoadmapDetailPage() {
       />
 
       <Container maxWidth={false} sx={{ py: 3, px: { xs: 2, md: 3 } }}>
-        {progress && progress.total > 0 && (
-          <Box
-            sx={{
-              display: "grid",
-              gridTemplateColumns: { xs: "repeat(2, minmax(0,1fr))", md: "repeat(3, minmax(0,1fr))" },
-              gap: 1.5,
-              mb: 2.5,
-            }}
-          >
-            <Metric
-              label="Covered"
-              value={`${Math.round(progress.coverage * 100)}%`}
-              sub="you marked these done"
-              icon="solar:check-read-linear"
-            />
-            <Metric
-              label="Mastered"
-              value={`${Math.round(progress.mastery * 100)}%`}
-              sub="you actually passed these"
-              icon="solar:medal-ribbon-star-linear"
-            />
-            <Metric
-              label="Steps"
-              value={`${progress.mastered}/${progress.total}`}
-              sub="verified of total"
-              icon="solar:checklist-minimalistic-linear"
-            />
-          </Box>
-        )}
-
-        {/* An honest admission rather than a silently wrong number. Only an admin can fix it,
-            but hiding it would let mastery look complete while content is missing. */}
-        {progress && progress.contentGaps > 0 && (
-          <Stack
-            direction="row"
-            spacing={1}
-            alignItems="center"
-            sx={{
-              mb: 2,
-              px: 1.75,
-              py: 1.25,
-              borderRadius: 2,
-              bgcolor: "#fffbeb",
-              border: "1px solid #fde68a",
-            }}
-          >
-            <Icon icon="solar:danger-triangle-bold-duotone" width={18} color="#b45309" />
-            <Typography sx={{ fontSize: 12.5, color: "#92400e" }}>
-              {progress.contentGaps} step{progress.contentGaps === 1 ? "" : "s"} on this roadmap
-              have no content yet and are not counted toward your progress.
-            </Typography>
-          </Stack>
-        )}
-
         {graphQuery.isLoading && (
           <Typography sx={{ py: 4, color: "#64748b" }}>Loading roadmap...</Typography>
         )}

--- a/app/roadmaps/[slug]/page.tsx
+++ b/app/roadmaps/[slug]/page.tsx
@@ -3,19 +3,22 @@
 import { useState } from "react";
 import { useParams } from "next/navigation";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { RoadmapSpine } from "@/components/roadmaps/RoadmapSpine";
-import { RoadmapNodeDrawer } from "@/components/roadmaps/RoadmapNodeDrawer";
+import { ForgeProgressDialog } from "@/components/roadmaps/ForgeProgressDialog";
 import { RoadmapFaqs } from "@/components/roadmaps/RoadmapFaqs";
 import { CompanyHiringProcess } from "@/components/roadmaps/CompanyHiringProcess";
 import { CompanyQuickStats } from "@/components/roadmaps/CompanyQuickStats";
 import {
+  ForgeUnavailableError,
+  forgeService,
   roadmapKeys,
   roadmapsService,
+  type ForgeJob,
   type RoadmapNode,
   type RoadmapProgress,
   type SelfState,
@@ -32,9 +35,30 @@ import {
 export default function RoadmapDetailPage() {
   const params = useParams();
   const slug = String(params?.slug ?? "");
-  const queryClient = useQueryClient();
   const { push } = useInstantNavigation();
-  const [openNode, setOpenNode] = useState<RoadmapNode | null>(null);
+  const [job, setJob] = useState<ForgeJob | null>(null);
+  const [forgeError, setForgeError] = useState<string | null>(null);
+
+  /**
+   * Clicking a step now BUILDS a course from it rather than opening a reading drawer.
+   *
+   * The roadmap is a place to choose what to learn; the learning happens in an adaptive course
+   * assembled from the same verified material the node already points at. A milestone is not a
+   * unit of study, so only trackable nodes are actionable.
+   */
+  const buildFromNode = async (node: RoadmapNode) => {
+    if (!node.isTrackable) return;
+    setForgeError(null);
+    try {
+      setJob(await forgeService.create({ nodeId: node.id }));
+    } catch (err) {
+      setForgeError(
+        err instanceof ForgeUnavailableError
+          ? err.message
+          : "Something went wrong starting that build."
+      );
+    }
+  };
 
   const graphQuery = useQuery({
     queryKey: roadmapKeys.graph(slug),
@@ -43,59 +67,7 @@ export default function RoadmapDetailPage() {
     staleTime: 30 * 60 * 1000,
   });
 
-  const progressQuery = useQuery({
-    queryKey: roadmapKeys.progress(slug),
-    queryFn: () => roadmapsService.progress(slug),
-    enabled: Boolean(slug),
-    staleTime: 30 * 1000,
-  });
-
-  const setState = useMutation({
-    mutationFn: ({ nodeId, state }: { nodeId: number; state: SelfState }) =>
-      roadmapsService.setNodeState(slug, nodeId, state),
-    // Optimistic: marking a node is a pure annotation, so a round-trip before the UI reacts
-    // makes bulk self-assessment feel broken.
-    onMutate: async ({ nodeId, state }) => {
-      await queryClient.cancelQueries({ queryKey: roadmapKeys.progress(slug) });
-      const previous = queryClient.getQueryData<RoadmapProgress>(roadmapKeys.progress(slug));
-      if (previous) {
-        // Marking a SPINE step cascades to the branches it rolls up (the server does the same),
-        // so the optimistic view has to cascade too or the bar jumps when the response lands.
-        const cascade = (graphQuery.data?.nodes ?? [])
-          .filter((n) => n.parentId === nodeId && n.isTrackable)
-          .map((n) => n.id);
-        const nodes = { ...previous.nodes };
-        for (const id of [nodeId, ...cascade]) {
-          if (nodes[id]) nodes[id] = { ...nodes[id], selfState: state };
-        }
-        // Only LEAF nodes are in the server's denominator, so counting spine nodes here made the
-        // optimistic bar disagree with the value that arrived a moment later. `isLeaf` is the
-        // discriminator the server already sends for exactly this.
-        const declared = Object.values(nodes).filter((n) => n.isLeaf !== false);
-        const done = declared.filter((n) => n.selfState === "done").length;
-        const skipped = declared.filter((n) => n.selfState === "skipped").length;
-        queryClient.setQueryData<RoadmapProgress>(roadmapKeys.progress(slug), {
-          ...previous,
-          nodes,
-          done,
-          skipped,
-          coverage: previous.total ? (done + skipped) / previous.total : 0,
-          // mastery is intentionally NOT recomputed here: it is derived from real submissions
-          // on the server and no client action may move it.
-        });
-      }
-      return { previous };
-    },
-    onError: (_e, _v, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(roadmapKeys.progress(slug), ctx.previous);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: roadmapKeys.progress(slug) });
-    },
-  });
-
   const graph = graphQuery.data;
-  const progress = progressQuery.data;
 
   if (graphQuery.isError) {
     return (
@@ -139,7 +111,6 @@ export default function RoadmapDetailPage() {
             <CompanyQuickStats
               company={graph.company}
               content={graph.content}
-              mastery={progress?.mastery}
             />
             <CompanyHiringProcess
               stages={graph.company.hiringProcess}
@@ -151,25 +122,23 @@ export default function RoadmapDetailPage() {
         {graph && (
           <RoadmapSpine
             graph={graph}
-            progress={progress}
-            onOpenNode={setOpenNode}
-            onSetNodeState={(node, state) => setState.mutate({ nodeId: node.id, state })}
+            onOpenNode={buildFromNode}
             onOpenRoadmap={(s) => push(`/roadmaps/${s}`)}
           />
+        )}
+
+        {forgeError && (
+          <Typography
+            sx={{ mt: 2, fontSize: "0.88rem", color: "var(--accent-red)", textAlign: "center" }}
+          >
+            {forgeError}
+          </Typography>
         )}
 
         {graph?.faqs && graph.faqs.length > 0 && <RoadmapFaqs faqs={graph.faqs} />}
       </Container>
 
-      <RoadmapNodeDrawer
-        slug={slug}
-        node={openNode}
-        selfState={(openNode && progress?.nodes?.[openNode.id]?.selfState) || "pending"}
-        onClose={() => setOpenNode(null)}
-        onSetState={(state) =>
-          openNode && setState.mutate({ nodeId: openNode.id, state })
-        }
-      />
+      <ForgeProgressDialog job={job} open={Boolean(job)} onClose={() => setJob(null)} />
     </PageShell>
   );
 }

--- a/app/roadmaps/[slug]/step/[nodeId]/page.tsx
+++ b/app/roadmaps/[slug]/step/[nodeId]/page.tsx
@@ -1,592 +1,110 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect } from "react";
 import { useParams } from "next/navigation";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
-import { ModulePageHeader, HeaderActionButton } from "@/components/common/ModulePageHeader";
 import { Surface } from "@/components/roadmaps/surfaces";
-import { NODE_STATES } from "@/components/roadmaps/NodeStateMenu";
-import {
-  roadmapKeys,
-  roadmapsService,
-  type SelfState,
-} from "@/lib/services/roadmaps.service";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
-import { stepUnitHref } from "@/lib/roadmap-step-links";
 
 /**
- * One step of a roadmap.
+ * Retired surface, kept as a signpost.
  *
- * This route exists because a roadmap step used to open
- * `/adaptive-courses/{courseId}/submodule/{submoduleId}`, which frames the work as course
- * work: "Back to course", course points, journey sequencing. Roadmaps and adaptive courses are
- * separate products over the same content, and a learner who chose a roadmap should stay in it.
- *
- * What is roadmap-owned here: the framing, the position ("step 4 of 48"), moving to the next
- * step, and marking status. What is NOT forked: the article reader, the quiz engine and the
- * coding editor are shared runtimes, and a per-module copy of a Monaco editor would rot.
- * Those are opened with `?from=`, so their back control returns here rather than to the course.
+ * A roadmap step used to be somewhere you read content. Learning now happens in an adaptive
+ * course built from the same verified material, so there is nothing to browse here. The route
+ * stays rather than 404ing because links to it exist in the wild - bookmarks, and anything a
+ * learner shared - and a dead end is a worse answer than a sentence explaining where the
+ * content went.
  */
-export default function RoadmapStepPage() {
+export default function RetiredRoadmapStepPage() {
   const params = useParams();
   const slug = String(params?.slug ?? "");
-  const nodeId = Number(params?.nodeId ?? 0);
-  const { push } = useInstantNavigation();
-  const qc = useQueryClient();
+  const { push, prefetch } = useInstantNavigation();
 
-  const graphQuery = useQuery({
-    queryKey: roadmapKeys.graph(slug),
-    queryFn: () => roadmapsService.graph(slug),
-    staleTime: 30 * 60 * 1000,
-    enabled: Boolean(slug),
-  });
-  const detailQuery = useQuery({
-    queryKey: roadmapKeys.node(slug, nodeId),
-    queryFn: () => roadmapsService.node(slug, nodeId),
-    staleTime: 10 * 60 * 1000,
-    enabled: Boolean(slug && nodeId),
-  });
-  const progressQuery = useQuery({
-    queryKey: roadmapKeys.progress(slug),
-    queryFn: () => roadmapsService.progress(slug),
-    staleTime: 30 * 1000,
-    enabled: Boolean(slug),
-  });
-
-  const setState = useMutation({
-    mutationFn: (state: SelfState) => roadmapsService.setNodeState(slug, nodeId, state),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: roadmapKeys.progress(slug) });
-    },
-  });
-
-  const graph = graphQuery.data;
-  const detail = detailQuery.data;
-  const selfState = progressQuery.data?.nodes?.[nodeId]?.selfState ?? "pending";
-
-  /** Leaf order across the whole map, so "next" means the next thing to actually do. */
-  const leaves = useMemo(
-    () => (graph?.nodes ?? []).filter((n) => n.kind === "subtopic"),
-    [graph]
-  );
-  const current = leaves.find((n) => n.id === nodeId);
-  const siblings = useMemo(
-    () =>
-      current?.parentId
-        ? leaves.filter((n) => n.parentId === current.parentId && n.id !== nodeId)
-        : [],
-    [leaves, current, nodeId]
-  );
-  const roundTitle = useMemo(() => {
-    const parent = (graph?.nodes ?? []).find((n) => n.id === current?.parentId);
-    if (!parent) return "";
-    const grand = (graph?.nodes ?? []).find((n) => n.id === parent.parentId);
-    return grand?.title || parent.title;
-  }, [graph, current]);
-
-  const roundLeaves = useMemo(
-    () => (current?.parentId ? leaves.filter((n) => n.parentId === current.parentId) : []),
-    [leaves, current]
-  );
-  const roundDone = roundLeaves.filter((n) => {
-    const st = progressQuery.data?.nodes?.[n.id]?.selfState;
-    return st === "done" || st === "skipped";
-  }).length;
-
-  const index = leaves.findIndex((n) => n.id === nodeId);
-  const prev = index > 0 ? leaves[index - 1] : null;
-  const next = index >= 0 && index < leaves.length - 1 ? leaves[index + 1] : null;
-
-  const backToMap = () => push(`/roadmaps/${slug}`);
-
-  const target = detail?.opens?.[0];
-  const heroIcon = (() => {
-    const c = target?.content ?? {};
-    if ((c.codingProblems ?? 0) > 0) return "solar:code-square-bold-duotone";
-    if ((c.questions ?? 0) > 0) return "solar:checklist-minimalistic-bold-duotone";
-    return "solar:book-2-bold-duotone";
-  })();
-  const content = target?.content ?? {};
-
-  const units = [
-    content.article && content.articleId && {
-      key: "article",
-      kind: "article" as const,
-      label: "Read",
-      icon: "solar:book-2-linear",
-      title: content.articleTitle || "Article",
-      meta: content.readingMinutes ? `~${content.readingMinutes} min read` : "Article",
-      summary: content.articleSummary,
-    },
-    (content.questions ?? 0) > 0 && content.quizConfigId && {
-      key: "quiz",
-      kind: "quiz" as const,
-      label: "Practise",
-      icon: "solar:checklist-minimalistic-linear",
-      title: "Practice questions",
-      meta: `${content.questions} questions`,
-      summary: "",
-    },
-    (content.codingProblems ?? 0) > 0 && content.codingProblemId && {
-      key: "coding",
-      kind: "coding" as const,
-      label: "Solve",
-      icon: "solar:code-square-linear",
-      title: "Coding problems",
-      meta: `${content.codingProblems} problems`,
-      summary: "",
-    },
-  ].filter(Boolean) as {
-    key: string;
-    kind: "article" | "quiz" | "coding";
-    label: string;
-    icon: string;
-    title: string;
-    meta: string;
-    summary?: string;
-  }[];
+  useEffect(() => {
+    prefetch(`/roadmaps/${slug}`);
+  }, [prefetch, slug]);
 
   return (
     <PageShell>
-      <ModulePageHeader
-        eyebrow={graph?.pageTitle ?? "Roadmap"}
-        title={detail?.title ?? "Step"}
-        description={detail?.summary}
-        accent="purple"
-        icon={heroIcon}
-        action={
-          <HeaderActionButton
-            variant="ghost"
-            icon="solar:map-point-wave-linear"
-            onClick={backToMap}
-          >
-            Back to the map
-          </HeaderActionButton>
-        }
-        hideGuide
-      />
-
-      <Container maxWidth={false} sx={{ py: 3, px: { xs: 2, md: 3 }, maxWidth: 1080, mx: "auto" }}>
-        {detailQuery.isLoading && (
-          <Typography sx={{ color: "var(--font-tertiary)" }}>Loading step...</Typography>
-        )}
-
-        {detailQuery.isError && (
-          <Surface>
-            <Typography sx={{ fontWeight: 600, color: "var(--font-primary)" }}>
-              Step not found
-            </Typography>
-            <Typography sx={{ mt: 0.5, fontSize: "0.85rem", color: "var(--font-tertiary)" }}>
-              It may have been removed from this roadmap.
-            </Typography>
-          </Surface>
-        )}
-
-        {detail && roundLeaves.length > 1 && (
-          <Surface sx={{ mb: 2.5, py: 1.75 }}>
-            <Stack
-              direction="row"
-              alignItems="center"
-              justifyContent="space-between"
-              sx={{ mb: 1 }}
+      <Container maxWidth={false} sx={{ py: 6, px: { xs: 2, md: 3 }, maxWidth: 720, mx: "auto" }}>
+        <Surface>
+          <Stack spacing={2} alignItems="flex-start">
+            <Box
+              sx={{
+                width: 44,
+                height: 44,
+                borderRadius: 2,
+                display: "grid",
+                placeItems: "center",
+                bgcolor: "color-mix(in srgb, var(--accent-purple) 12%, transparent)",
+                color: "var(--accent-purple)",
+              }}
             >
-              <Typography
-                sx={{
-                  fontSize: "0.74rem",
-                  fontWeight: 600,
-                  letterSpacing: "0.06em",
-                  textTransform: "uppercase",
-                  color: "var(--font-secondary)",
-                }}
-              >
-                {roundTitle || "This round"}
-              </Typography>
-              <Typography sx={{ fontSize: "0.8rem", color: "var(--font-secondary)" }}>
-                {roundDone} of {roundLeaves.length} marked
-              </Typography>
-            </Stack>
-            {/* One segment per step. The current step is the tall one, so position is
-                readable at a glance without counting. */}
-            <Stack direction="row" spacing={0.5} sx={{ alignItems: "flex-end" }}>
-              {roundLeaves.map((n) => {
-                const st = progressQuery.data?.nodes?.[n.id]?.selfState ?? "pending";
-                const isCurrent = n.id === nodeId;
-                const filled = st === "done" || st === "learning";
-                return (
-                  <Box
-                    key={n.id}
-                    component="button"
-                    aria-label={n.title}
-                    onClick={() => push(`/roadmaps/${slug}/step/${n.id}`)}
-                    title={n.title}
-                    sx={{
-                      appearance: "none",
-                      border: "none",
-                      cursor: "pointer",
-                      p: 0,
-                      flex: 1,
-                      minWidth: 4,
-                      height: isCurrent ? 14 : 8,
-                      borderRadius: 999,
-                      bgcolor: isCurrent
-                        ? "var(--accent-purple)"
-                        : filled
-                          ? "color-mix(in srgb, var(--accent-purple) 45%, transparent)"
-                          : "var(--border-default)",
-                      "&:hover": {
-                        bgcolor: isCurrent
-                          ? "var(--accent-purple)"
-                          : "color-mix(in srgb, var(--accent-purple) 70%, transparent)",
-                      },
-                    }}
-                  />
-                );
-              })}
-            </Stack>
-          </Surface>
-        )}
+              <Icon icon="solar:map-point-wave-linear" width={22} />
+            </Box>
 
-        {detail && (
-          <Stack spacing={2.5}>
-            <Surface>
-              <Stack
-                direction="row"
-                alignItems="center"
-                spacing={1.5}
-                sx={{ flexWrap: "wrap", rowGap: 1 }}
-              >
-                <Typography
-                  sx={{
-                    fontSize: "0.74rem",
-                    fontWeight: 600,
-                    letterSpacing: "0.06em",
-                    textTransform: "uppercase",
-                    color: "var(--font-secondary)",
-                  }}
-                >
-                  Mark this step
-                </Typography>
-                <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap", rowGap: 1 }}>
-                  {NODE_STATES.map((st) => {
-                    const active = selfState === st.value;
-                    return (
-                      <Box
-                        key={st.value}
-                        component="button"
-                        onClick={() => setState.mutate(active ? "pending" : st.value)}
-                        sx={{
-                          appearance: "none",
-                          cursor: "pointer",
-                          font: "inherit",
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 0.75,
-                          px: 1.5,
-                          py: 0.75,
-                          borderRadius: 999,
-                          border: "1px solid",
-                          borderColor: active
-                            ? "var(--accent-purple)"
-                            : "var(--border-default)",
-                          bgcolor: active
-                            ? "color-mix(in srgb, var(--accent-purple) 10%, transparent)"
-                            : "var(--card-bg)",
-                          color: active ? "var(--accent-purple)" : "var(--font-primary)",
-                          fontSize: "0.85rem",
-                          fontWeight: 500,
-                        }}
-                      >
-                        <Icon icon={st.icon} width={15} />
-                        {st.label}
-                      </Box>
-                    );
-                  })}
-                </Stack>
-                {index >= 0 && (
-                  <Typography
-                    sx={{
-                      ml: "auto",
-                      fontSize: "0.82rem",
-                      fontWeight: 500,
-                      color: "var(--font-secondary)",
-                    }}
-                  >
-                    Step {index + 1} of {leaves.length}
-                  </Typography>
-                )}
-              </Stack>
-            </Surface>
+            <Typography
+              sx={{ fontWeight: 600, fontSize: "1.3rem", color: "var(--font-primary)" }}
+            >
+              Steps now become your own course
+            </Typography>
+            <Typography
+              sx={{ fontSize: "0.95rem", color: "var(--font-secondary)", lineHeight: 1.65 }}
+            >
+              Pick a step on the roadmap and we build you an adaptive course from it, assembled
+              from the verified question bank. You will find it in Courses, and your progress is
+              tracked there rather than on the map.
+            </Typography>
 
-            {target && !target.accessible && (
-              <Surface>
-                <Stack direction="row" spacing={1.25} alignItems="center">
-                  <Icon icon="solar:lock-keyhole-linear" width={18} />
-                  <Typography sx={{ fontSize: "0.88rem", color: "var(--font-secondary)" }}>
-                    This step is locked. It belongs to {target.courseTitle}, which your
-                    institution has not opened for you yet.
-                  </Typography>
-                </Stack>
-              </Surface>
-            )}
-
-            {units.length > 0 && target?.accessible && (
+            <Stack direction="row" spacing={1.25} sx={{ pt: 0.5 }}>
               <Box
+                component="button"
+                onClick={() => push(`/roadmaps/${slug}`)}
                 sx={{
-                  display: "grid",
-                  gap: 1.5,
-                  // A lone unit spans the row rather than sitting in a half-width column
-                  // beside nothing, which is the same dead space in miniature.
-                  gridTemplateColumns: {
-                    xs: "1fr",
-                    md: units.length === 1 ? "1fr" : "repeat(2, minmax(0,1fr))",
-                  },
+                  appearance: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  font: "inherit",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 0.75,
+                  px: 2.25,
+                  py: 1,
+                  borderRadius: 999,
+                  bgcolor: "color-mix(in srgb, var(--accent-purple) 65%, #1e1b4b)",
+                  color: "#fff",
+                  fontSize: "0.88rem",
+                  fontWeight: 600,
                 }}
               >
-                {units.map((u) => (
-                  <Surface key={u.key} sx={{ display: "flex", flexDirection: "column" }}>
-                    <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mb: 1 }}>
-                      <Box
-                        sx={{
-                          width: 34,
-                          height: 34,
-                          borderRadius: 2,
-                          display: "grid",
-                          placeItems: "center",
-                          bgcolor: "color-mix(in srgb, var(--accent-purple) 12%, transparent)",
-                          color: "var(--accent-purple)",
-                        }}
-                      >
-                        <Icon icon={u.icon} width={17} />
-                      </Box>
-                      <Box sx={{ minWidth: 0 }}>
-                        <Typography
-                          sx={{
-                            fontWeight: 600,
-                            fontSize: "1rem",
-                            color: "var(--font-primary)",
-                          }}
-                        >
-                          {u.title}
-                        </Typography>
-                        <Typography
-                          sx={{ fontSize: "0.82rem", fontWeight: 500, color: "var(--font-secondary)" }}
-                        >
-                          {u.meta}
-                        </Typography>
-                      </Box>
-                    </Stack>
-                    {u.summary && (
-                      <Typography
-                        sx={{
-                          fontSize: "0.85rem",
-                          color: "var(--font-secondary)",
-                          lineHeight: 1.55,
-                          mb: 1.5,
-                        }}
-                      >
-                        {u.summary}
-                      </Typography>
-                    )}
-                    <Box
-                      component="button"
-                      onClick={() => {
-                        const href = stepUnitHref(
-                          target,
-                          u.kind,
-                          `/roadmaps/${slug}/step/${nodeId}`
-                        );
-                        if (href) push(href);
-                      }}
-                      sx={{
-                        mt: "auto",
-                        alignSelf: "flex-start",
-                        appearance: "none",
-                        cursor: "pointer",
-                        font: "inherit",
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.75,
-                        px: 2.25,
-                        py: 1.05,
-                        borderRadius: 999,
-                        border: "none",
-                        // The raw accent is a LIGHT violet in some tenant themes (#c084fc),
-                        // and white on it measures ~2.2:1 -- the button read as washed out and
-                        // failed AA. Darkening the accent keeps the brand hue while putting
-                        // the label back over 4.5:1 on every theme.
-                        bgcolor: "color-mix(in srgb, var(--accent-purple) 65%, #1e1b4b)",
-                        color: "#fff",
-                        fontSize: "0.9rem",
-                        fontWeight: 600,
-                        "&:hover": {
-                          bgcolor: "color-mix(in srgb, var(--accent-purple) 45%, #1e1b4b)",
-                        },
-                      }}
-                    >
-                      {u.label}
-                      <Icon icon="solar:alt-arrow-right-linear" width={16} />
-                    </Box>
-                  </Surface>
-                ))}
+                Back to the roadmap
+                <Icon icon="solar:alt-arrow-right-linear" width={16} />
               </Box>
-            )}
-
-            {detail.resources.length > 0 && (
-              <Surface>
-                <Typography
-                  sx={{
-                    fontSize: "0.74rem",
-                    fontWeight: 600,
-                    letterSpacing: "0.06em",
-                    textTransform: "uppercase",
-                    color: "var(--font-secondary)",
-                    mb: 1.25,
-                  }}
-                >
-                  Read more
-                </Typography>
-                <Stack spacing={0.75}>
-                  {detail.resources.map((r) => (
-                    <Box
-                      key={r.url}
-                      component="a"
-                      href={r.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      sx={{
-                        fontSize: "0.85rem",
-                        color: "var(--accent-purple)",
-                        textDecoration: "underline",
-                      }}
-                    >
-                      {r.title}
-                    </Box>
-                  ))}
-                </Stack>
-              </Surface>
-            )}
-
-            {siblings.length > 0 && (
-              <Surface>
-                <Typography
-                  sx={{
-                    fontSize: "0.74rem",
-                    fontWeight: 600,
-                    letterSpacing: "0.06em",
-                    textTransform: "uppercase",
-                    color: "var(--font-secondary)",
-                    mb: 1.25,
-                  }}
-                >
-                  {roundTitle ? `More in ${roundTitle}` : "More in this round"}
-                </Typography>
-                <Box
-                  sx={{
-                    display: "grid",
-                    gap: 0.75,
-                    gridTemplateColumns: { xs: "1fr", md: "repeat(2, minmax(0,1fr))" },
-                  }}
-                >
-                  {siblings.map((n) => {
-                    const st = progressQuery.data?.nodes?.[n.id]?.selfState ?? "pending";
-                    const marker = NODE_STATES.find((x) => x.value === st);
-                    return (
-                      <Box
-                        key={n.id}
-                        component="button"
-                        onClick={() => push(`/roadmaps/${slug}/step/${n.id}`)}
-                        sx={{
-                          appearance: "none",
-                          cursor: "pointer",
-                          font: "inherit",
-                          textAlign: "start",
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 1,
-                          px: 1.25,
-                          py: 0.9,
-                          borderRadius: 2,
-                          border: "1px solid transparent",
-                          bgcolor: "transparent",
-                          color: "var(--font-primary)",
-                          fontSize: "0.88rem",
-                          fontWeight: 500,
-                          minWidth: 0,
-                          "&:hover": {
-                            borderColor: "var(--border-default)",
-                            bgcolor: "var(--surface)",
-                          },
-                        }}
-                      >
-                        <Icon
-                          icon={marker?.icon ?? "solar:record-linear"}
-                          width={15}
-                          color={st === "pending" ? "var(--font-tertiary)" : marker?.tone}
-                        />
-                        <Box
-                          component="span"
-                          sx={{
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {n.title}
-                        </Box>
-                      </Box>
-                    );
-                  })}
-                </Box>
-              </Surface>
-            )}
-
-            {/* Move through the map without returning to it between every step. */}
-            <Stack direction="row" spacing={1.5} sx={{ pt: 0.5, flexWrap: "wrap" }}>
-              {prev && (
-                <Box
-                  component="button"
-                  onClick={() => push(`/roadmaps/${slug}/step/${prev.id}`)}
-                  sx={navBtn}
-                >
-                  <Icon icon="solar:alt-arrow-left-linear" width={15} />
-                  Previous step
-                </Box>
-              )}
-              {next && (
-                <Box
-                  component="button"
-                  onClick={() => push(`/roadmaps/${slug}/step/${next.id}`)}
-                  sx={{ ...navBtn, ml: "auto" }}
-                >
-                  Next step
-                  <Icon icon="solar:alt-arrow-right-linear" width={15} />
-                </Box>
-              )}
+              <Box
+                component="button"
+                onClick={() => push("/adaptive-courses")}
+                sx={{
+                  appearance: "none",
+                  cursor: "pointer",
+                  font: "inherit",
+                  px: 2,
+                  py: 1,
+                  borderRadius: 999,
+                  border: "1px solid var(--border-default)",
+                  bgcolor: "var(--card-bg)",
+                  color: "var(--font-primary)",
+                  fontSize: "0.88rem",
+                  fontWeight: 500,
+                }}
+              >
+                My courses
+              </Box>
             </Stack>
           </Stack>
-        )}
+        </Surface>
       </Container>
     </PageShell>
   );
 }
-
-const navBtn = {
-  appearance: "none",
-  cursor: "pointer",
-  font: "inherit",
-  display: "flex",
-  alignItems: "center",
-  gap: 0.6,
-  px: 1.75,
-  py: 0.85,
-  borderRadius: 999,
-  border: "1px solid var(--border-default)",
-  bgcolor: "var(--card-bg)",
-  color: "var(--font-primary)",
-  fontSize: "0.88rem",
-  fontWeight: 500,
-  "&:hover": { borderColor: "var(--accent-purple)", color: "var(--accent-purple)" },
-} as const;

--- a/app/roadmaps/page.tsx
+++ b/app/roadmaps/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
@@ -10,9 +10,14 @@ import { Reveal } from "@/components/scorecard/shared";
 import { RoadmapCard } from "@/components/roadmaps/RoadmapCard";
 import { CompanyRoadmapCard } from "@/components/roadmaps/CompanyRoadmapCard";
 import { SectionHeading, Surface } from "@/components/roadmaps/surfaces";
+import { CreateCourseBar } from "@/components/roadmaps/CreateCourseBar";
+import { ForgeProgressDialog } from "@/components/roadmaps/ForgeProgressDialog";
 import {
+  ForgeUnavailableError,
+  forgeService,
   roadmapKeys,
   roadmapsService,
+  type ForgeJob,
   type RoadmapCard as Card,
 } from "@/lib/services/roadmaps.service";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
@@ -59,6 +64,28 @@ export default function RoadmapsPage() {
 
   const visibleCompanies = companies;
   const claimed = new Set(visibleCompanies.map((r) => r.slug));
+
+  const [job, setJob] = useState<ForgeJob | null>(null);
+  const [building, setBuilding] = useState(false);
+  const [forgeError, setForgeError] = useState<string | null>(null);
+
+  const createFromPrompt = async (prompt: string) => {
+    setForgeError(null);
+    setBuilding(true);
+    try {
+      setJob(await forgeService.create({ prompt }));
+    } catch (err) {
+      // A 422 is the expected "we have nothing for that" answer, not a crash: it carries a
+      // sentence written for the learner, so show it rather than a generic failure.
+      setForgeError(
+        err instanceof ForgeUnavailableError
+          ? err.message
+          : "Something went wrong starting that build."
+      );
+    } finally {
+      setBuilding(false);
+    }
+  };
 
   const companyGrid = {
     xs: "repeat(2, minmax(0, 1fr))",
@@ -184,7 +211,25 @@ export default function RoadmapsPage() {
             </Box>
           </Box>
         )}
+        {forgeError && (
+          <Typography
+            sx={{ mt: 2, fontSize: "0.88rem", color: "var(--accent-red)", textAlign: "center" }}
+          >
+            {forgeError}
+          </Typography>
+        )}
+
+        {!isLoading && all.length > 0 && (
+          <CreateCourseBar
+            roadmaps={all}
+            busy={building}
+            onSubmit={createFromPrompt}
+            onPickRoadmap={(slug) => push(`/roadmaps/${slug}`)}
+          />
+        )}
       </Container>
+
+      <ForgeProgressDialog job={job} open={Boolean(job)} onClose={() => setJob(null)} />
     </PageShell>
   );
 }

--- a/app/roadmaps/page.tsx
+++ b/app/roadmaps/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Box, Container, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
-import { SearchFilterBar, SegmentedTabs } from "@/components/common/list";
 import { Reveal } from "@/components/scorecard/shared";
 import { RoadmapCard } from "@/components/roadmaps/RoadmapCard";
 import { CompanyRoadmapCard } from "@/components/roadmaps/CompanyRoadmapCard";
@@ -39,8 +38,6 @@ import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
  */
 export default function RoadmapsPage() {
   const { push, prefetch } = useInstantNavigation();
-  const [category, setCategory] = useState<string>("all");
-  const [query, setQuery] = useState("");
 
   const { data, isLoading, isError } = useQuery({
     queryKey: roadmapKeys.catalog,
@@ -54,34 +51,14 @@ export default function RoadmapsPage() {
   );
 
   const categories = data?.categories ?? [];
-  const active = categories.find((c) => c.slug === category) ?? categories[0];
-
-  const q = query.trim().toLowerCase();
-  const matchesCard = (r?: Card) => {
-    if (!q) return true;
-    if (!r) return false;
-    // Company name is matched explicitly: "tcs" must find a roadmap whose title is "TCS
-    // Placement Preparation" and whose summary may never repeat the name.
-    return (
-      r.pageTitle.toLowerCase().includes(q) ||
-      r.summary.toLowerCase().includes(q) ||
-      (r.company?.displayName ?? "").toLowerCase().includes(q)
-    );
-  };
-  const matches = (slug: string) => matchesCard(bySlug[slug]);
+  // Always the "all" view: the taxonomy tabs are gone, so every section is on one page.
+  const active = categories.find((c) => c.slug === "all") ?? categories[0];
 
   const all = data?.roadmaps ?? [];
   const companies = useMemo(() => all.filter((r) => r.kind === "company" && r.company), [all]);
 
-  const onAllView = (active?.slug ?? "all") === "all";
-  const visibleCompanies = onAllView ? companies.filter(matchesCard) : [];
+  const visibleCompanies = companies;
   const claimed = new Set(visibleCompanies.map((r) => r.slug));
-
-  const tabs = categories.map((c) => ({
-    value: c.slug,
-    label: c.title,
-    count: new Set(c.sections.flatMap((s) => s.roadmaps)).size,
-  }));
 
   const companyGrid = {
     xs: "repeat(2, minmax(0, 1fr))",
@@ -108,19 +85,6 @@ export default function RoadmapsPage() {
       />
 
       <Container maxWidth={false} sx={{ py: 3, px: { xs: 2, md: 3 } }}>
-        <Stack spacing={1.5} sx={{ mb: 1 }}>
-          <SearchFilterBar
-            search={query}
-            onSearchChange={setQuery}
-            searchPlaceholder="Search roadmaps and companies"
-          />
-          {tabs.length > 1 && (
-            <Box data-tour-id="roadmap-categories">
-              <SegmentedTabs tabs={tabs} value={active?.slug ?? "all"} onChange={setCategory} />
-            </Box>
-          )}
-        </Stack>
-
         {isLoading && (
           <Typography sx={{ mt: 4, color: "var(--font-tertiary)" }}>
             Loading roadmaps...
@@ -156,9 +120,7 @@ export default function RoadmapsPage() {
 
         {!isLoading &&
           active?.sections.map((section) => {
-            const visible = section.roadmaps
-              .filter(matches)
-              .filter((slug) => !claimed.has(slug));
+            const visible = section.roadmaps.filter((slug) => !claimed.has(slug));
             if (!visible.length) return null;
             const isCompanySection = visible.every((slug) => bySlug[slug]?.kind === "company");
             return (

--- a/components/roadmaps/CompanyQuickStats.tsx
+++ b/components/roadmaps/CompanyQuickStats.tsx
@@ -84,19 +84,14 @@ function Cell({
 export function CompanyQuickStats({
   company,
   content,
-  mastery,
 }: {
   company: RoadmapCompany;
   content?: RoadmapContentTotals;
-  /** 0..1, derived from the learner's own submissions. Undefined until progress loads. */
-  mastery?: number;
 }) {
   const practice = [
     content?.questions ? `${content.questions.toLocaleString()} questions` : null,
     content?.codingProblems ? `${content.codingProblems} coding` : null,
   ].filter(Boolean) as string[];
-
-  const readiness = mastery == null ? null : Math.round(mastery * 100);
 
   return (
     <Box
@@ -111,13 +106,6 @@ export function CompanyQuickStats({
       }}
     >
       {company.rounds > 0 && <Cell label="Rounds" value={company.rounds} />}
-
-      <Cell
-        label="Your readiness"
-        value={readiness == null ? "..." : `${readiness}%`}
-        accent={readiness != null && readiness > 0 ? "var(--accent-green)" : undefined}
-        hint="The share of steps you have genuinely passed, derived from your own submissions. Marking a step done by hand does not move it."
-      />
 
       {practice.length > 0 && (
         <Cell

--- a/components/roadmaps/CompanyRoadmap.test.tsx
+++ b/components/roadmaps/CompanyRoadmap.test.tsx
@@ -55,16 +55,11 @@ const CONTENT: RoadmapContentTotals = {
 
 describe("CompanyQuickStats", () => {
   it("shows the practice it really reaches, not a fabricated competitiveness score", () => {
-    render(<CompanyQuickStats company={ACCENTURE} content={CONTENT} mastery={0} />);
+    render(<CompanyQuickStats company={ACCENTURE} content={CONTENT} />);
     // One cell, "952 questions · 40 coding": the strip abbreviates to fit a grid cell.
     expect(screen.getByText(/952 questions/)).toBeInTheDocument();
     expect(screen.getByText(/40 coding/)).toBeInTheDocument();
     expect(screen.queryByText(/competitiveness/i)).not.toBeInTheDocument();
-  });
-
-  it("derives readiness from mastery rather than from a stored literal", () => {
-    render(<CompanyQuickStats company={ACCENTURE} content={CONTENT} mastery={0.42} />);
-    expect(screen.getByText("42%")).toBeInTheDocument();
   });
 
   it("renders a qualified negative-marking rule verbatim instead of a yes/no chip", () => {
@@ -74,13 +69,13 @@ describe("CompanyQuickStats", () => {
       negativeMarking:
         "Generally No (some drives apply -0.25 only in the quantitative section)",
     };
-    render(<CompanyQuickStats company={wipro} content={CONTENT} mastery={0} />);
+    render(<CompanyQuickStats company={wipro} content={CONTENT} />);
     expect(screen.getByText(/-0.25 only in the quantitative section/)).toBeInTheDocument();
   });
 
   it("shows hiring estimates only alongside the date they were true on", () => {
     const { rerender } = render(
-      <CompanyQuickStats company={ACCENTURE} content={CONTENT} mastery={0} />
+      <CompanyQuickStats company={ACCENTURE} content={CONTENT} />
     );
     expect(screen.getByText(/Estimates, as of/)).toBeInTheDocument();
     expect(screen.getByText(/~8-10 lakh\/year/)).toBeInTheDocument();
@@ -90,7 +85,6 @@ describe("CompanyQuickStats", () => {
       <CompanyQuickStats
         company={{ ...ACCENTURE, estimates: null }}
         content={CONTENT}
-        mastery={0}
       />
     );
     expect(screen.queryByText(/~8-10 lakh\/year/)).not.toBeInTheDocument();

--- a/components/roadmaps/CreateCourseBar.tsx
+++ b/components/roadmaps/CreateCourseBar.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { AnimatePresence, motion } from "framer-motion";
+import type { RoadmapCard } from "@/lib/services/roadmaps.service";
+
+/**
+ * The sticky "build me a course" bar at the foot of the roadmap catalog.
+ *
+ * Two deliberate choices:
+ *
+ * 1. **The placeholder rotates through real examples.** An empty box with "Search..." tells a
+ *    learner nothing about what they may ask for. Cycling concrete phrases teaches the input's
+ *    range without a paragraph of instructions above it.
+ *
+ * 2. **It suggests as you type, from roadmaps that actually exist.** Course building resolves
+ *    against verified material by keyword; free text that matches nothing is a dead end, and a
+ *    dead end in the one box on the page is worse than no box. Suggestions steer people onto
+ *    paths we can genuinely build, while still allowing a raw phrase.
+ *
+ * The rotation pauses the moment the field is focused or has any text: animation behind a
+ * cursor is a distraction, not a delight.
+ */
+
+const EXAMPLES = [
+  "React hooks and state",
+  "SQL joins and window functions",
+  "Data structures for interviews",
+  "Python for data analysis",
+  "Aptitude and logical reasoning",
+  "System design fundamentals",
+  "Power BI dashboards",
+  "Web performance and accessibility",
+];
+
+const ROTATE_MS = 2600;
+
+export function CreateCourseBar({
+  roadmaps,
+  onSubmit,
+  onPickRoadmap,
+  busy = false,
+}: {
+  roadmaps: RoadmapCard[];
+  onSubmit: (prompt: string) => void;
+  onPickRoadmap: (slug: string) => void;
+  busy?: boolean;
+}) {
+  const [value, setValue] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [exampleIndex, setExampleIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const idle = !focused && value.trim() === "";
+
+  useEffect(() => {
+    if (!idle) return;
+    const t = window.setInterval(
+      () => setExampleIndex((i) => (i + 1) % EXAMPLES.length),
+      ROTATE_MS
+    );
+    return () => window.clearInterval(t);
+  }, [idle]);
+
+  const q = value.trim().toLowerCase();
+  const suggestions = useMemo(() => {
+    if (q.length < 2) return [];
+    return roadmaps
+      .filter(
+        (r) =>
+          r.pageTitle.toLowerCase().includes(q) ||
+          r.cardTitle.toLowerCase().includes(q) ||
+          (r.company?.displayName ?? "").toLowerCase().includes(q)
+      )
+      .slice(0, 5);
+  }, [roadmaps, q]);
+
+  const submit = () => {
+    const text = value.trim();
+    if (!text || busy) return;
+    onSubmit(text);
+  };
+
+  return (
+    <Box
+      sx={{
+        position: "sticky",
+        bottom: 0,
+        zIndex: 5,
+        mt: 4,
+        mx: { xs: -2, md: -3 },
+        px: { xs: 2, md: 3 },
+        pt: 2,
+        pb: 2.5,
+        bgcolor: "var(--card-bg)",
+        borderTop: "1px solid var(--border-default)",
+      }}
+    >
+      <Box sx={{ maxWidth: 860, mx: "auto", position: "relative" }}>
+        {suggestions.length > 0 && (
+          <Box
+            sx={{
+              position: "absolute",
+              bottom: "calc(100% + 8px)",
+              left: 0,
+              right: 0,
+              borderRadius: 2,
+              border: "1px solid var(--border-default)",
+              bgcolor: "var(--card-bg)",
+              overflow: "hidden",
+            }}
+          >
+            {suggestions.map((r) => (
+              <Box
+                key={r.slug}
+                component="button"
+                onMouseDown={(e: React.MouseEvent) => {
+                  // mousedown, not click: blur would close the list first.
+                  e.preventDefault();
+                  onPickRoadmap(r.slug);
+                }}
+                sx={{
+                  appearance: "none",
+                  border: "none",
+                  width: "100%",
+                  textAlign: "start",
+                  cursor: "pointer",
+                  px: 1.75,
+                  py: 1.1,
+                  bgcolor: "transparent",
+                  color: "var(--font-primary)",
+                  fontSize: "0.88rem",
+                  fontWeight: 500,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 1,
+                  "&:hover": { bgcolor: "var(--surface)" },
+                }}
+              >
+                <Icon icon="solar:map-point-wave-linear" width={15} />
+                {r.pageTitle}
+                <Box
+                  component="span"
+                  sx={{ ml: "auto", fontSize: "0.75rem", color: "var(--font-tertiary)" }}
+                >
+                  open roadmap
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        )}
+
+        <Stack direction="row" spacing={1.25} alignItems="center">
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              position: "relative",
+              display: "flex",
+              alignItems: "center",
+              borderRadius: 999,
+              border: "1px solid var(--border-default)",
+              bgcolor: "var(--surface)",
+              px: 2,
+              height: 52,
+              "&:focus-within": {
+                borderColor: "var(--accent-purple)",
+              },
+            }}
+          >
+            <Icon icon="solar:magic-stick-3-linear" width={18} />
+            <Box
+              component="input"
+              ref={inputRef}
+              value={value}
+              disabled={busy}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+              onFocus={() => setFocused(true)}
+              onBlur={() => setFocused(false)}
+              onKeyDown={(e: React.KeyboardEvent) => {
+                if (e.key === "Enter") submit();
+              }}
+              aria-label="Describe the course you want"
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                ml: 1.25,
+                border: "none",
+                outline: "none",
+                bgcolor: "transparent",
+                font: "inherit",
+                fontSize: "0.95rem",
+                color: "var(--font-primary)",
+              }}
+            />
+
+            {/* The animated placeholder sits BEHIND the real input, which keeps its own
+                placeholder empty. Rendering it as text means it can animate; a real
+                placeholder attribute cannot. */}
+            {idle && (
+              <Box
+                aria-hidden
+                sx={{
+                  position: "absolute",
+                  left: 52,
+                  right: 16,
+                  pointerEvents: "none",
+                  overflow: "hidden",
+                  height: 24,
+                }}
+              >
+                <AnimatePresence mode="wait">
+                  <motion.div
+                    key={exampleIndex}
+                    initial={{ y: 14, opacity: 0 }}
+                    animate={{ y: 0, opacity: 1 }}
+                    exit={{ y: -14, opacity: 0 }}
+                    transition={{ duration: 0.28, ease: "easeOut" }}
+                  >
+                    <Typography
+                      sx={{
+                        fontSize: "0.95rem",
+                        color: "var(--font-tertiary)",
+                        lineHeight: "24px",
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      Build me a course on {EXAMPLES[exampleIndex]}
+                    </Typography>
+                  </motion.div>
+                </AnimatePresence>
+              </Box>
+            )}
+          </Box>
+
+          <Box
+            component="button"
+            onClick={submit}
+            disabled={busy || !value.trim()}
+            sx={{
+              appearance: "none",
+              border: "none",
+              cursor: busy || !value.trim() ? "default" : "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
+              px: 2.5,
+              height: 52,
+              borderRadius: 999,
+              fontSize: "0.9rem",
+              fontWeight: 600,
+              color: "#fff",
+              bgcolor:
+                busy || !value.trim()
+                  ? "color-mix(in srgb, var(--accent-purple) 30%, #1e1b4b)"
+                  : "color-mix(in srgb, var(--accent-purple) 65%, #1e1b4b)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {busy ? (
+              <>
+                <Icon icon="svg-spinners:180-ring-with-bg" width={17} />
+                Building
+              </>
+            ) : (
+              <>
+                <Icon icon="solar:add-circle-linear" width={17} />
+                Create course
+              </>
+            )}
+          </Box>
+        </Stack>
+
+        <Typography
+          sx={{ mt: 1, fontSize: "0.76rem", color: "var(--font-tertiary)", textAlign: "center" }}
+        >
+          Built from the verified question bank, not generated by AI.
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/components/roadmaps/ForgeProgressDialog.tsx
+++ b/components/roadmaps/ForgeProgressDialog.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Box, Dialog, Stack, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+import { forgeKeys, forgeService, type ForgeJob } from "@/lib/services/roadmaps.service";
+import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+
+/**
+ * Watching a course get built.
+ *
+ * The build is genuinely incremental on the server (one topic at a time), so this shows the
+ * real thing rather than a spinner with an invented percentage: each topic flips to done as its
+ * content is copied. That honesty is the point of the screen. A learner who is told "no AI, we
+ * are assembling reviewed material" and then sees the topics land one by one believes it.
+ *
+ * Polling stops the moment the job is terminal, so a finished dialog left open costs nothing.
+ */
+export function ForgeProgressDialog({
+  job,
+  open,
+  onClose,
+}: {
+  job: ForgeJob | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const { push } = useInstantNavigation();
+  const jobId = job?.id ?? 0;
+
+  const { data } = useQuery({
+    queryKey: forgeKeys.job(jobId),
+    queryFn: () => forgeService.job(jobId),
+    enabled: open && jobId > 0 && !job?.alreadyBuilt,
+    initialData: job ?? undefined,
+    // Stop the moment there is nothing left to watch.
+    refetchInterval: (q) => {
+      const s = q.state.data?.status;
+      return s === "completed" || s === "failed" || s === "cancelled" ? false : 1200;
+    },
+  });
+
+  const live = data ?? job;
+  const done = live?.status === "completed";
+  const failed = live?.status === "failed";
+  // Read from the LIVE job, not the one we opened with: otherwise a dialog that started at
+  // "queued" can never be dismissed, because its close handler is still looking at that.
+  const terminal = done || failed || live?.status === "cancelled";
+
+  // Nothing was rebuilt because they already had it: say so rather than animating a fake build.
+  const reused = Boolean(job?.alreadyBuilt);
+
+  if (!live) return null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={terminal || reused ? onClose : undefined}
+      maxWidth="sm"
+      fullWidth
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: 3,
+            border: "1px solid var(--border-default)",
+            bgcolor: "var(--card-bg)",
+            boxShadow: "none",
+            backgroundImage: "none",
+          },
+        },
+      }}
+    >
+      <Box sx={{ p: { xs: 2.5, md: 3 } }}>
+        <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 2 }}>
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: 2,
+              display: "grid",
+              placeItems: "center",
+              bgcolor: "color-mix(in srgb, var(--accent-purple) 12%, transparent)",
+              color: "var(--accent-purple)",
+            }}
+          >
+            <Icon
+              icon={
+                done || reused
+                  ? "solar:check-circle-bold"
+                  : failed
+                    ? "solar:danger-triangle-linear"
+                    : "solar:magic-stick-3-linear"
+              }
+              width={20}
+            />
+          </Box>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography
+              sx={{ fontWeight: 600, fontSize: "1.05rem", color: "var(--font-primary)" }}
+            >
+              {reused
+                ? "You already have this course"
+                : done
+                  ? "Your course is ready"
+                  : failed
+                    ? "We could not finish this one"
+                    : "Building your course"}
+            </Typography>
+            <Typography sx={{ fontSize: "0.85rem", color: "var(--font-secondary)" }}>
+              {live.title}
+            </Typography>
+          </Box>
+        </Stack>
+
+        {!reused && (
+          <>
+            <Box
+              sx={{
+                height: 6,
+                borderRadius: 999,
+                bgcolor: "var(--surface)",
+                border: "1px solid var(--border-default)",
+                overflow: "hidden",
+                mb: 1,
+              }}
+            >
+              <Box
+                sx={{
+                  width: `${live.percent}%`,
+                  height: "100%",
+                  bgcolor: "var(--accent-purple)",
+                  transition: "width .4s ease",
+                }}
+              />
+            </Box>
+            <Typography
+              sx={{ fontSize: "0.8rem", color: "var(--font-secondary)", mb: 2 }}
+            >
+              {live.completedItems} of {live.totalItems} topics assembled from the verified bank
+            </Typography>
+
+            <Stack spacing={0.5} sx={{ maxHeight: 240, overflowY: "auto", mb: 2 }}>
+              {live.items.map((it) => (
+                <Stack
+                  key={it.order}
+                  direction="row"
+                  spacing={1}
+                  alignItems="center"
+                  sx={{ py: 0.35 }}
+                >
+                  <Icon
+                    icon={
+                      it.status === "done"
+                        ? "solar:check-circle-bold"
+                        : it.status === "failed"
+                          ? "solar:close-circle-linear"
+                          : it.status === "running"
+                            ? "svg-spinners:180-ring-with-bg"
+                            : "solar:record-linear"
+                    }
+                    width={15}
+                    color={
+                      it.status === "done"
+                        ? "var(--accent-green)"
+                        : it.status === "failed"
+                          ? "var(--accent-red)"
+                          : "var(--font-tertiary)"
+                    }
+                  />
+                  <Typography
+                    sx={{
+                      fontSize: "0.84rem",
+                      color:
+                        it.status === "pending"
+                          ? "var(--font-tertiary)"
+                          : "var(--font-primary)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {it.title}
+                  </Typography>
+                </Stack>
+              ))}
+            </Stack>
+          </>
+        )}
+
+        <Stack direction="row" spacing={1.25} justifyContent="flex-end">
+          {(terminal || reused) && (
+            <Box
+              component="button"
+              onClick={onClose}
+              sx={{
+                appearance: "none",
+                cursor: "pointer",
+                font: "inherit",
+                px: 2,
+                py: 1,
+                borderRadius: 999,
+                border: "1px solid var(--border-default)",
+                bgcolor: "var(--card-bg)",
+                color: "var(--font-primary)",
+                fontSize: "0.88rem",
+                fontWeight: 500,
+              }}
+            >
+              Stay here
+            </Box>
+          )}
+          {(done || reused) && live.courseId && (
+            <Box
+              component="button"
+              onClick={() => push(`/adaptive-courses/${live.courseId}`)}
+              sx={{
+                appearance: "none",
+                cursor: "pointer",
+                font: "inherit",
+                display: "flex",
+                alignItems: "center",
+                gap: 0.75,
+                px: 2.25,
+                py: 1,
+                borderRadius: 999,
+                border: "none",
+                bgcolor: "color-mix(in srgb, var(--accent-purple) 65%, #1e1b4b)",
+                color: "#fff",
+                fontSize: "0.88rem",
+                fontWeight: 600,
+              }}
+            >
+              Start learning
+              <Icon icon="solar:alt-arrow-right-linear" width={16} />
+            </Box>
+          )}
+        </Stack>
+
+        {(done || reused) && (
+          <Typography
+            sx={{ mt: 1.5, fontSize: "0.78rem", color: "var(--font-tertiary)", textAlign: "right" }}
+          >
+            You will also find it in Courses.
+          </Typography>
+        )}
+      </Box>
+    </Dialog>
+  );
+}

--- a/lib/services/roadmaps.service.ts
+++ b/lib/services/roadmaps.service.ts
@@ -1,6 +1,8 @@
 import apiClient from "./api";
 
 const BASE = "/roadmaps/api";
+/** The forge lives under the adaptive-quiz mount, beside the courses it creates. */
+const BASE_ADAPTIVE = "/adaptive-quiz/api";
 
 /**
  * Roadmaps: a navigation layer over the verified content library.
@@ -286,4 +288,76 @@ export const roadmapKeys = {
   graph: (slug: string) => ["roadmaps", "graph", slug] as const,
   progress: (slug: string) => ["roadmaps", "progress", slug] as const,
   node: (slug: string, nodeId: number) => ["roadmaps", "node", slug, nodeId] as const,
+};
+
+/* ------------------------------------------------------------------ course forge ------ */
+
+export type ForgeStatus =
+  | "queued"
+  | "resolving"
+  | "building"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface ForgeJobItem {
+  order: number;
+  title: string;
+  moduleTitle: string;
+  status: "pending" | "running" | "done" | "failed";
+}
+
+export interface ForgeJob {
+  id: number;
+  status: ForgeStatus;
+  title: string;
+  sourceKind: "roadmap_node" | "prompt";
+  totalItems: number;
+  completedItems: number;
+  failedItems: number;
+  percent: number;
+  courseId: number | null;
+  isStalled: boolean;
+  items: ForgeJobItem[];
+  errors: { at: string; where: string; message: string }[];
+  /** Set when the learner already had this course: nothing was rebuilt. */
+  alreadyBuilt?: boolean;
+}
+
+/** Raised for a 422: the server has no material, and the message is learner-facing. */
+export class ForgeUnavailableError extends Error {
+  code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export const forgeService = {
+  /** Ask for a course. Pass a roadmap node id OR free text, never both. */
+  create: async (body: { nodeId?: number; prompt?: string }): Promise<ForgeJob> => {
+    try {
+      const { data } = await apiClient.post(`${BASE_ADAPTIVE}/forge/`, body);
+      return data;
+    } catch (err) {
+      const res = (err as { response?: { status?: number; data?: Record<string, string> } })
+        .response;
+      if (res?.status === 422) {
+        throw new ForgeUnavailableError(
+          res.data?.detail || "We do not have material for that yet.",
+          res.data?.code || "no_material"
+        );
+      }
+      throw err;
+    }
+  },
+
+  job: async (id: number): Promise<ForgeJob> => {
+    const { data } = await apiClient.get(`${BASE_ADAPTIVE}/forge/${id}/`);
+    return data;
+  },
+};
+
+export const forgeKeys = {
+  job: (id: number) => ["forge", "job", id] as const,
 };


### PR DESCRIPTION
Pairs with backend PR AI-Linc-LMS/ai-linc-backend#597 — that must merge and deploy first.

The roadmap becomes a place to **choose**; the learning happens in an adaptive course built from the same verified material.

## What changed

**Sticky create-course bar** on the catalog. The placeholder rotates through real examples, because an empty box labelled "Search" teaches nothing about what may be asked for. It also **suggests matching roadmaps as you type**: building resolves against verified material by keyword, so free text matching nothing is a dead end — and a dead end in the only input on the page is worse than no input. Rotation stops the moment the field is focused or has text.

**Clicking a step builds a course from it**, replacing the reading drawer. Milestones aren't units of study, so only trackable nodes are actionable.

**A live build dialog** showing each topic flip to done as its content is copied. The server build genuinely is incremental, so this shows the real thing rather than a spinner with an invented percentage — which matters for a feature whose whole claim is "assembled from reviewed material, not generated".

**The step route is retired to a signpost.** Links to it exist in the wild, and a sentence explaining where the content went beats a 404.

**The last completion UI is gone** — the readiness cell followed the metrics and node fills. Progress lives on the course now; a roadmap reporting a second percentage would answer the same question twice.

## Detail worth noting

A 422 from the builder is the *expected* "we have nothing for that yet" answer and carries a sentence written for the learner, so it surfaces as that rather than a generic failure.

tsc clean, 120 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)