### PR TITLE
fix(roadmaps): separate the catalogue rows, drop the empty badge, ask before building

### DIFF
--- a/components/adaptive-journey/JourneyBoard.tsx
+++ b/components/adaptive-journey/JourneyBoard.tsx
@@ -347,13 +347,25 @@ function Hero({ board, courseId }: { board: JourneyBoardData; courseId: number }
           </Box>
           <Box sx={{ minWidth: 0 }}>
             <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-              <Typography sx={{ fontWeight: 800, fontSize: "0.92rem" }}>AI has tuned this course to you</Typography>
+              {/* "AI has tuned this" is false on a roadmap-built course: it is assembled from
+                  verified bank rows by a deterministic resolver, with no model in the loop. */}
+              <Typography sx={{ fontWeight: 800, fontSize: "0.92rem" }}>
+                {board.calibration.card
+                  ? "AI has tuned this course to you"
+                  : "Built for you from the verified library"}
+              </Typography>
               {c.fieldTier && <Chip label={`LEVEL · ${c.fieldTier.toUpperCase()}`} size="small" sx={{ height: 18, fontSize: "0.6rem", fontWeight: 800, color: "#7c3aed", bgcolor: "white" }} />}
             </Stack>
             <Typography sx={{ fontSize: "0.76rem", color: "rgba(255,255,255,0.8)", mt: 0.25, lineHeight: 1.45 }}>
-              {c.fieldTier
-                ? "Based on your calibration baseline, quizzes start at the right difficulty and articles open at your reading tier. Retake the calibration anytime to recalibrate."
-                : "Complete the calibration assessment and the course retunes itself - quizzes start at the right difficulty and articles open at your reading tier."}
+              {/* A course with no calibration card will never have one (roadmap-built courses
+                  have no admin to configure it), so neither "retake it" nor "complete it" is a
+                  thing the learner can do. The banner keeps its Resume button and drops the
+                  instruction. */}
+              {!board.calibration.card
+                ? "Assembled for you from the verified library, so every question here was written and reviewed before it reached you."
+                : c.fieldTier
+                  ? "Based on your calibration baseline, quizzes start at the right difficulty and articles open at your reading tier. Retake the calibration anytime to recalibrate."
+                  : "Complete the calibration assessment and the course retunes itself - quizzes start at the right difficulty and articles open at your reading tier."}
             </Typography>
           </Box>
         </Stack>

--- a/components/adaptive-journey/JourneyTopCards.tsx
+++ b/components/adaptive-journey/JourneyTopCards.tsx
@@ -130,6 +130,9 @@ function InterviewerCard({ interview, courseId }: { interview: JourneyBoard["int
   const { showToast } = useToast();
   const [busy, setBusy] = useState(false);
   const card = interview.card;
+  // No card means this course will never have one (a roadmap-built course has no admin to
+  // configure an interview), so render nothing rather than a stub that promises setup.
+  if (!card) return null;
   const status = card.status;
   const configured = card.configured && card.templateId != null;
 
@@ -261,10 +264,14 @@ export function JourneyTopCards({
   calibration: JourneyBoard["calibration"];
   interview: JourneyBoard["interview"];
 }) {
+  // Neither card: render nothing at all. An empty Stack still contributes its bottom margin,
+  // which would leave a band of dead space between the hero and the course overview.
+  if (!calibration.card && !interview.card) return null;
+
   return (
     <Stack direction={{ xs: "column", md: "row" }} spacing={2} sx={{ mb: 2.5 }}>
       {calibration.card && <CalibrationCard calibration={calibration} courseId={courseId} />}
-      <InterviewerCard interview={interview} courseId={courseId} />
+      {interview.card && <InterviewerCard interview={interview} courseId={courseId} />}
     </Stack>
   );
 }

--- a/components/roadmaps/BuildCourseDrawer.test.tsx
+++ b/components/roadmaps/BuildCourseDrawer.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { BuildCourseDrawer } from "./BuildCourseDrawer";
+import { roadmapsService, type RoadmapNode } from "@/lib/services/roadmaps.service";
+
+/**
+ * The read-before-you-build step, asserted against the payload the node endpoint really sends.
+ *
+ * The bug this pins: the drawer fetched the node detail and rendered NONE of its prose. A node
+ * whose `summary` was empty showed a title, four counts, and then a screen of white space above
+ * the button. The explanation is the reason this drawer exists, so it is a test, not a
+ * preference: something explanatory has to reach the DOM for a payload that carries any.
+ */
+
+const NODE: RoadmapNode = {
+  id: 412,
+  title: "Model explainability with SHAP",
+  kind: "subtopic",
+  summary: "",
+} as RoadmapNode;
+
+function renderDrawer(node: RoadmapNode = NODE) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <BuildCourseDrawer
+        slug="data-analytics-and-ai-engineer"
+        node={node}
+        onClose={vi.fn()}
+        onBuild={vi.fn()}
+      />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("BuildCourseDrawer", () => {
+  it("explains the topic even when the node's own summary is empty", async () => {
+    // The real shape: no node summary, but the target carries the submodule's description.
+    vi.spyOn(roadmapsService, "node").mockResolvedValue({
+      id: 412,
+      slug: "data-analytics-and-ai-engineer",
+      title: "Model explainability with SHAP",
+      kind: "subtopic",
+      summary: "",
+      isRequired: true,
+      resources: [],
+      opens: [
+        {
+          type: "submodule",
+          courseId: 59,
+          courseTitle: "Data Analytics",
+          submoduleId: 1915,
+          title: "Model explainability with SHAP",
+          description:
+            "Attribute a model's prediction to individual features using Shapley values.",
+          accessible: true,
+          selfEnrollable: false,
+          content: { questions: 25, codingProblems: 3, readingMinutes: 12 },
+        },
+      ],
+      totals: { steps: 1, questions: 25, codingProblems: 3, readingMinutes: 12 },
+    } as Awaited<ReturnType<typeof roadmapsService.node>>);
+
+    renderDrawer();
+
+    expect(
+      await screen.findByText(/Attribute a model's prediction to individual features/)
+    ).toBeInTheDocument();
+    expect(screen.getByText("25 questions")).toBeInTheDocument();
+  });
+
+  it("lists what a parent topic covers, so the syllabus is visible before committing", async () => {
+    vi.spyOn(roadmapsService, "node").mockResolvedValue({
+      id: 300,
+      slug: "programming-fundamentals",
+      title: "Variables, types and operators",
+      kind: "topic",
+      summary: "The vocabulary every later topic assumes.",
+      isRequired: true,
+      resources: [],
+      opens: [],
+      steps: [
+        {
+          id: 301, title: "Variables, input and output", selfState: "pending", accessible: true,
+          courseId: 59, submoduleId: 900, summary: "", questions: 20, codingProblems: 2,
+          readingMinutes: 8,
+        },
+        {
+          id: 302, title: "Data types, casting and operators", selfState: "pending", accessible: true,
+          courseId: 59, submoduleId: 901, summary: "", questions: 18, codingProblems: 2,
+          readingMinutes: 7,
+        },
+      ],
+      totals: { steps: 2, questions: 38, codingProblems: 4, readingMinutes: 15 },
+    } as Awaited<ReturnType<typeof roadmapsService.node>>);
+
+    renderDrawer({ ...NODE, id: 300, title: "Variables, types and operators", kind: "topic" });
+
+    expect(await screen.findByText("What it covers")).toBeInTheDocument();
+    expect(screen.getByText("Variables, input and output")).toBeInTheDocument();
+    expect(screen.getByText("Data types, casting and operators")).toBeInTheDocument();
+    expect(screen.getByText("2 topics")).toBeInTheDocument();
+  });
+
+  it("opens from the right and asks rather than instructs", async () => {
+    vi.spyOn(roadmapsService, "node").mockResolvedValue({
+      id: 412, slug: "s", title: "T", kind: "subtopic", summary: "A summary.",
+      isRequired: true, resources: [], opens: [], totals: {},
+    } as Awaited<ReturnType<typeof roadmapsService.node>>);
+
+    const { container } = renderDrawer();
+
+    // The map's spine sits right of centre; a left drawer covered the node just clicked.
+    expect(container.ownerDocument.querySelector(".MuiDrawer-paperAnchorRight")).not.toBeNull();
+    expect(await screen.findByText("Create a course on this?")).toBeInTheDocument();
+    expect(screen.getByText("Yes, build it")).toBeInTheDocument();
+    expect(screen.getByText("Not now")).toBeInTheDocument();
+  });
+});

--- a/components/roadmaps/BuildCourseDrawer.tsx
+++ b/components/roadmaps/BuildCourseDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Box, Drawer, Stack, Typography } from "@mui/material";
+import { Box, Drawer, Skeleton, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import {
   roadmapKeys,
@@ -13,13 +13,26 @@ import {
  * What a step is, before you commit to studying it.
  *
  * Clicking a node used to build a course immediately, which is a lot to happen from one click on
- * a map you are still reading. This restores the drawer as a reading step: what the topic
- * covers, how much material sits behind it, and then an explicit "build it".
+ * a map you are still reading. This is the reading step: what the topic is, what it covers, how
+ * much material sits behind it, and only then an explicit yes.
  *
- * The size line is the honest part of the pitch. "24 questions and 3 coding problems" is what
- * the learner is actually being offered, and it comes from the same counts the roadmap already
- * computes rather than a promise the build might not keep.
+ * Three things this gets right that the first cut did not:
+ *
+ * 1. **It opens from the right.** The map is read left to right and its spine sits right of
+ *    centre; a left drawer covered the node you just clicked. Coming from the right keeps the
+ *    thing you are asking about on screen.
+ *
+ * 2. **It explains the topic.** The node detail carries `summary`, and each target carries its
+ *    own `description` — the first version fetched all of it and rendered a four-item fact list,
+ *    so a node whose summary was empty showed a screen of nothing above the button.
+ *
+ * 3. **It asks a question.** "Build this course" as a bare button is an instruction. The learner
+ *    is making a choice, so the footer poses it and offers both answers.
  */
+
+/** Cap the covers-list so a 20-child parent does not turn the drawer into a scroll. */
+const COVERS_SHOWN = 8;
+
 export function BuildCourseDrawer({
   slug,
   node,
@@ -47,194 +60,349 @@ export function BuildCourseDrawer({
   const steps = totals.steps ?? (detail?.opens?.length ? 1 : 0);
   const reading = totals.readingMinutes ?? own.readingMinutes ?? 0;
 
+  // The explanation, in order of how specific it is to this node. The target description is the
+  // submodule's own blurb and is usually the most concrete thing available for a leaf.
+  const blurb =
+    detail?.summary?.trim() ||
+    node?.summary?.trim() ||
+    detail?.opens?.[0]?.description?.trim() ||
+    "";
+
+  // A parent lists its children; a leaf lists its targets when it opens more than one. Either
+  // way the learner sees the actual syllabus rather than a count of it.
+  const covers: { key: string; title: string; note?: string }[] =
+    detail?.steps?.length
+      ? detail.steps.map((s) => ({
+          key: `s${s.id}`,
+          title: s.title,
+          note: s.questions ? `${s.questions} questions` : undefined,
+        }))
+      : (detail?.opens ?? []).length > 1
+        ? (detail?.opens ?? []).map((o, i) => ({
+            key: `o${o.submoduleId ?? o.courseId}-${i}`,
+            title: o.title,
+            note: o.content?.questions ? `${o.content.questions} questions` : undefined,
+          }))
+        : [];
+
   const facts = [
     steps ? `${steps} ${steps === 1 ? "topic" : "topics"}` : null,
     questions ? `${questions} questions` : null,
-    coding ? `${coding} coding problems` : null,
+    coding ? `${coding} coding ${coding === 1 ? "problem" : "problems"}` : null,
     reading ? `~${reading} min reading` : null,
   ].filter(Boolean) as string[];
 
   return (
     <Drawer
-      anchor="left"
+      // Right, not left: the spine sits right of centre and a left drawer hid the clicked node.
+      anchor="right"
       open={Boolean(node)}
       onClose={busy ? undefined : onClose}
       slotProps={{
         paper: {
           sx: {
-            width: { xs: "100%", sm: 420 },
+            width: { xs: "100%", sm: 460 },
             bgcolor: "var(--card-bg)",
-            borderRight: "1px solid var(--border-default)",
+            borderLeft: "1px solid var(--border-default)",
             backgroundImage: "none",
           },
         },
       }}
     >
       {node && (
-        <Box sx={{ p: 3, display: "flex", flexDirection: "column", height: "100%" }}>
-          <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
-            <Typography
-              sx={{
-                fontSize: "0.72rem",
-                fontWeight: 600,
-                letterSpacing: "0.08em",
-                textTransform: "uppercase",
-                color: "var(--font-secondary)",
-              }}
+        <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+          {/* Scrolls; the ask below stays pinned. */}
+          <Box sx={{ flex: 1, overflowY: "auto", p: 3 }}>
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+              sx={{ mb: 2 }}
             >
-              {node.kind === "topic" ? "Topic" : "Step"}
-            </Typography>
-            <Box
-              component="button"
-              onClick={onClose}
-              aria-label="Close"
-              sx={{
-                appearance: "none",
-                border: "none",
-                bgcolor: "transparent",
-                cursor: "pointer",
-                color: "var(--font-tertiary)",
-                p: 0.5,
-              }}
-            >
-              <Icon icon="solar:close-circle-linear" width={20} />
-            </Box>
-          </Stack>
-
-          <Typography
-            sx={{
-              fontWeight: 600,
-              fontSize: "1.3rem",
-              color: "var(--font-primary)",
-              letterSpacing: "-0.01em",
-            }}
-          >
-            {node.title}
-          </Typography>
-
-          {(node.summary || detail?.summary) && (
-            <Typography
-              sx={{
-                mt: 1,
-                fontSize: "0.92rem",
-                color: "var(--font-secondary)",
-                lineHeight: 1.65,
-              }}
-            >
-              {detail?.summary || node.summary}
-            </Typography>
-          )}
-
-          {facts.length > 0 && (
-            <Stack spacing={0.75} sx={{ mt: 2.5 }}>
               <Typography
                 sx={{
                   fontSize: "0.72rem",
                   fontWeight: 600,
-                  letterSpacing: "0.06em",
+                  letterSpacing: "0.08em",
                   textTransform: "uppercase",
                   color: "var(--font-secondary)",
                 }}
               >
-                What you get
+                {node.kind === "topic" ? "Topic" : "Step"}
               </Typography>
-              {facts.map((f) => (
-                <Stack key={f} direction="row" spacing={1} alignItems="center">
-                  <Icon
-                    icon="solar:check-circle-linear"
-                    width={15}
-                    color="var(--accent-purple)"
-                  />
-                  <Typography sx={{ fontSize: "0.88rem", color: "var(--font-primary)" }}>
-                    {f}
-                  </Typography>
-                </Stack>
-              ))}
+              <Box
+                component="button"
+                onClick={onClose}
+                aria-label="Close"
+                sx={{
+                  appearance: "none",
+                  border: "none",
+                  bgcolor: "transparent",
+                  cursor: "pointer",
+                  color: "var(--font-secondary)",
+                  p: 0.5,
+                  display: "flex",
+                }}
+              >
+                <Icon icon="solar:close-circle-linear" width={20} />
+              </Box>
             </Stack>
-          )}
 
-          {isLoading && (
-            <Typography sx={{ mt: 2, fontSize: "0.85rem", color: "var(--font-tertiary)" }}>
-              Checking what is available...
+            <Typography
+              sx={{
+                fontWeight: 600,
+                fontSize: "1.35rem",
+                lineHeight: 1.25,
+                color: "var(--font-primary)",
+                letterSpacing: "-0.01em",
+              }}
+            >
+              {node.title}
             </Typography>
-          )}
 
-          {detail?.resources && detail.resources.length > 0 && (
-            <Stack spacing={0.5} sx={{ mt: 2.5 }}>
-              <Typography
-                sx={{
-                  fontSize: "0.72rem",
-                  fontWeight: 600,
-                  letterSpacing: "0.06em",
-                  textTransform: "uppercase",
-                  color: "var(--font-secondary)",
-                }}
-              >
-                Read more
-              </Typography>
-              {detail.resources.slice(0, 4).map((r) => (
-                <Box
-                  key={r.url}
-                  component="a"
-                  href={r.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
+            {isLoading && !blurb ? (
+              <Stack spacing={0.75} sx={{ mt: 1.5 }}>
+                <Skeleton variant="text" width="100%" height={18} />
+                <Skeleton variant="text" width="92%" height={18} />
+                <Skeleton variant="text" width="60%" height={18} />
+              </Stack>
+            ) : (
+              blurb && (
+                <Typography
                   sx={{
-                    fontSize: "0.85rem",
-                    color: "var(--accent-purple)",
-                    textDecoration: "underline",
+                    mt: 1.25,
+                    fontSize: "0.94rem",
+                    color: "var(--font-secondary)",
+                    lineHeight: 1.7,
                   }}
                 >
-                  {r.title}
-                </Box>
-              ))}
-            </Stack>
-          )}
+                  {blurb}
+                </Typography>
+              )
+            )}
 
-          <Box sx={{ mt: "auto", pt: 3 }}>
+            {/* The size of the thing, as a strip rather than a checklist. Ticks next to
+                "1 topic" read as completed work, which none of this is yet. */}
+            {facts.length > 0 && (
+              <Box
+                sx={{
+                  mt: 2.5,
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 0.75,
+                }}
+              >
+                {facts.map((f) => (
+                  <Box
+                    key={f}
+                    sx={{
+                      px: 1.25,
+                      py: 0.5,
+                      borderRadius: 1,
+                      border: "1px solid var(--border-default)",
+                      bgcolor: "var(--surface)",
+                      fontSize: "0.8rem",
+                      fontWeight: 500,
+                      color: "var(--font-primary)",
+                    }}
+                  >
+                    {f}
+                  </Box>
+                ))}
+              </Box>
+            )}
+
+            {covers.length > 0 && (
+              <Box sx={{ mt: 3 }}>
+                <Typography
+                  sx={{
+                    fontSize: "0.72rem",
+                    fontWeight: 600,
+                    letterSpacing: "0.06em",
+                    textTransform: "uppercase",
+                    color: "var(--font-secondary)",
+                    mb: 1,
+                  }}
+                >
+                  What it covers
+                </Typography>
+                <Stack>
+                  {covers.slice(0, COVERS_SHOWN).map((c) => (
+                    <Stack
+                      key={c.key}
+                      direction="row"
+                      alignItems="center"
+                      spacing={1.25}
+                      sx={{
+                        py: 0.9,
+                        borderBottomWidth: "1px",
+                        borderBottomStyle: "solid",
+                        borderBottomColor: "var(--border-default)",
+                      }}
+                    >
+                      <Box sx={{ display: "flex", color: "var(--accent-purple)" }}>
+                        <Icon icon="solar:hashtag-square-linear" width={15} />
+                      </Box>
+                      <Typography
+                        sx={{
+                          fontSize: "0.88rem",
+                          color: "var(--font-primary)",
+                          flex: 1,
+                          minWidth: 0,
+                        }}
+                      >
+                        {c.title}
+                      </Typography>
+                      {c.note && (
+                        <Typography
+                          sx={{
+                            fontSize: "0.76rem",
+                            color: "var(--font-secondary)",
+                            flexShrink: 0,
+                          }}
+                        >
+                          {c.note}
+                        </Typography>
+                      )}
+                    </Stack>
+                  ))}
+                </Stack>
+                {covers.length > COVERS_SHOWN && (
+                  <Typography
+                    sx={{ mt: 1, fontSize: "0.8rem", color: "var(--font-secondary)" }}
+                  >
+                    and {covers.length - COVERS_SHOWN} more
+                  </Typography>
+                )}
+              </Box>
+            )}
+
+            {detail?.resources && detail.resources.length > 0 && (
+              <Box sx={{ mt: 3 }}>
+                <Typography
+                  sx={{
+                    fontSize: "0.72rem",
+                    fontWeight: 600,
+                    letterSpacing: "0.06em",
+                    textTransform: "uppercase",
+                    color: "var(--font-secondary)",
+                    mb: 1,
+                  }}
+                >
+                  Read more
+                </Typography>
+                <Stack spacing={0.6}>
+                  {detail.resources.slice(0, 4).map((r) => (
+                    <Box
+                      key={r.url}
+                      component="a"
+                      href={r.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      sx={{
+                        fontSize: "0.85rem",
+                        color: "var(--accent-purple)",
+                        textDecoration: "underline",
+                      }}
+                    >
+                      {r.title}
+                    </Box>
+                  ))}
+                </Stack>
+              </Box>
+            )}
+          </Box>
+
+          {/* The ask. Pinned, so it is reachable whatever the length of the syllabus above. */}
+          <Box
+            sx={{
+              p: 3,
+              borderTopWidth: "1px",
+              borderTopStyle: "solid",
+              borderTopColor: "var(--border-default)",
+              bgcolor: "var(--card-bg)",
+            }}
+          >
             <Typography
-              sx={{ fontSize: "0.8rem", color: "var(--font-tertiary)", mb: 1.25 }}
-            >
-              We will build you an adaptive course from this, using questions from the verified
-              bank. It is yours alone, and you will find it in Courses.
-            </Typography>
-            <Box
-              component="button"
-              onClick={() => onBuild(node)}
-              disabled={busy}
               sx={{
-                appearance: "none",
-                border: "none",
-                cursor: busy ? "default" : "pointer",
-                font: "inherit",
-                width: "100%",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: 1,
-                px: 2.5,
-                py: 1.35,
-                borderRadius: 999,
-                bgcolor: busy
-                  ? "color-mix(in srgb, var(--accent-purple) 30%, #1e1b4b)"
-                  : "color-mix(in srgb, var(--accent-purple) 65%, #1e1b4b)",
-                color: "#fff",
-                fontSize: "0.95rem",
+                fontSize: "1rem",
                 fontWeight: 600,
+                color: "var(--font-primary)",
+                mb: 0.5,
               }}
             >
-              {busy ? (
-                <>
-                  <Icon icon="svg-spinners:180-ring-with-bg" width={17} />
-                  Starting
-                </>
-              ) : (
-                <>
-                  <Icon icon="solar:magic-stick-3-linear" width={17} />
-                  Build this course
-                </>
-              )}
-            </Box>
+              Create a course on this?
+            </Typography>
+            <Typography
+              sx={{ fontSize: "0.82rem", color: "var(--font-secondary)", mb: 1.75, lineHeight: 1.6 }}
+            >
+              We will assemble it from the verified question bank, not generate it with AI. It is
+              yours alone, and you will find it in Courses.
+            </Typography>
+
+            <Stack direction="row" spacing={1.25}>
+              <Box
+                component="button"
+                onClick={onClose}
+                disabled={busy}
+                sx={{
+                  appearance: "none",
+                  cursor: busy ? "default" : "pointer",
+                  font: "inherit",
+                  px: 2.25,
+                  py: 1.25,
+                  borderRadius: 999,
+                  borderWidth: "1px",
+                  borderStyle: "solid",
+                  borderColor: "var(--border-default)",
+                  bgcolor: "transparent",
+                  color: "var(--font-secondary)",
+                  fontSize: "0.9rem",
+                  fontWeight: 500,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Not now
+              </Box>
+              <Box
+                component="button"
+                onClick={() => onBuild(node)}
+                disabled={busy}
+                sx={{
+                  appearance: "none",
+                  border: "none",
+                  cursor: busy ? "default" : "pointer",
+                  font: "inherit",
+                  flex: 1,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 1,
+                  px: 2.5,
+                  py: 1.25,
+                  borderRadius: 999,
+                  bgcolor: busy
+                    ? "color-mix(in srgb, var(--accent-purple) 30%, #1e1b4b)"
+                    : "color-mix(in srgb, var(--accent-purple) 65%, #1e1b4b)",
+                  color: "#fff",
+                  fontSize: "0.95rem",
+                  fontWeight: 600,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {busy ? (
+                  <>
+                    <Icon icon="svg-spinners:180-ring-with-bg" width={17} />
+                    Starting
+                  </>
+                ) : (
+                  <>
+                    <Icon icon="solar:magic-stick-3-linear" width={17} />
+                    Yes, build it
+                  </>
+                )}
+              </Box>
+            </Stack>
           </Box>
         </Box>
       )}

--- a/components/roadmaps/RoadmapIndex.test.tsx
+++ b/components/roadmaps/RoadmapIndex.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RoadmapIndex } from "./RoadmapIndex";
+import type { RoadmapCard } from "@/lib/services/roadmaps.service";
+
+/**
+ * The catalogue is a LIST, and a list has to read as one.
+ *
+ * Both assertions here are regressions caught by looking at the shipped page rather than by
+ * reading the code, which is why they are pinned:
+ *
+ * 1. A New/Updated badge sat at the end of most rows. It fired on 14 of 20 entries, so it told a
+ *    learner nothing and gave every row a second ragged edge. The flags still exist on the API
+ *    card; the rule is that this surface does not render them.
+ *
+ * 2. The rows had no delimiter, so a four-column grid of bare text read as a wall. Each row now
+ *    carries a bottom hairline. The rowGap must stay 0 or the hairlines break into floating
+ *    dashes instead of forming one rule down the column.
+ */
+
+function card(slug: string, over: Partial<RoadmapCard> = {}): RoadmapCard {
+  return {
+    slug,
+    cardTitle: slug,
+    pageTitle: slug.toUpperCase(),
+    kind: "skill",
+    isNew: true,
+    isRevamped: true,
+    ...over,
+  } as RoadmapCard;
+}
+
+describe("RoadmapIndex", () => {
+  it("renders no New/Updated badge, even when the API sets both flags", () => {
+    render(
+      <RoadmapIndex
+        title="Skill based"
+        icon="solar:layers-minimalistic-linear"
+        roadmaps={[card("java"), card("sql"), card("dsa")]}
+        onOpen={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("JAVA")).toBeInTheDocument();
+    expect(screen.queryByText("Updated")).not.toBeInTheDocument();
+    expect(screen.queryByText("New")).not.toBeInTheDocument();
+  });
+
+  it("gives every entry a separating hairline", () => {
+    render(
+      <RoadmapIndex
+        title="Skill based"
+        icon="solar:layers-minimalistic-linear"
+        roadmaps={[card("java"), card("sql")]}
+        onOpen={vi.fn()}
+      />
+    );
+
+    const rows = screen.getAllByRole("button");
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      // `border: none` is declared earlier in the same sx block; this asserts the later
+      // borderBottom is the one that wins, which is the whole separation treatment.
+      expect(getComputedStyle(row).borderBottomStyle).toBe("solid");
+    }
+  });
+
+  it("prefers a company display name over the page title", () => {
+    render(
+      <RoadmapIndex
+        title="Company based"
+        icon="solar:buildings-2-linear"
+        roadmaps={[
+          card("tcs", {
+            kind: "company",
+            company: {
+              companySlug: "tcs",
+              displayName: "TCS",
+              logoUrl: "https://example.test/tcs.svg",
+              badge: "Mass Recruiter",
+              difficulty: "Medium",
+              packageRange: "3.5 - 7 LPA",
+              rounds: 3,
+            },
+          }),
+        ]}
+        onOpen={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("TCS")).toBeInTheDocument();
+    expect(screen.queryByText("TCS".toUpperCase() + " ")).not.toBeInTheDocument();
+  });
+});

--- a/components/roadmaps/RoadmapIndex.tsx
+++ b/components/roadmaps/RoadmapIndex.tsx
@@ -54,8 +54,11 @@ export function RoadmapIndex({
       <Box
         sx={{
           display: "grid",
-          columnGap: 2.5,
-          rowGap: 0.25,
+          // No row gap: the rows butt against each other so their hairlines form one continuous
+          // rule down each column. A gap here would break the rule into floating dashes, which
+          // is what made the list read as a wall of text.
+          columnGap: 5,
+          rowGap: 0,
           gridTemplateColumns: {
             xs: "1fr",
             sm: "repeat(2, minmax(0,1fr))",
@@ -85,10 +88,17 @@ export function RoadmapIndex({
                 alignItems: "center",
                 gap: 1.25,
                 px: 1,
-                py: 0.9,
-                borderRadius: 1.5,
+                py: 1.05,
                 bgcolor: "transparent",
                 color: "var(--font-primary)",
+                // One hairline per row. This is the separation: it delimits every entry and
+                // makes the column boundaries obvious, without a card's worth of chrome.
+                // Declared after `border: none` above, so it is the one that survives. Longhand
+                // rather than the `border-bottom` shorthand: a shorthand carrying a var() is
+                // dropped wholesale by parsers that do not resolve custom properties.
+                borderBottomWidth: "1px",
+                borderBottomStyle: "solid",
+                borderBottomColor: "var(--border-default)",
                 transition: "background-color .12s ease",
                 "&:hover": { bgcolor: "var(--surface)" },
                 "&:focus-visible": {
@@ -121,6 +131,9 @@ export function RoadmapIndex({
                 </Box>
               )}
 
+              {/* The name, and nothing else. There WAS an New/Updated badge here; it fired on
+                  14 of 20 entries, so it distinguished nothing and only added a second
+                  ragged edge to every row. A badge that is almost always on is decoration. */}
               <Typography
                 sx={{
                   fontSize: "0.92rem",
@@ -133,21 +146,6 @@ export function RoadmapIndex({
               >
                 {company?.displayName ?? r.pageTitle}
               </Typography>
-
-              {(r.isNew || r.isRevamped) && (
-                <Box
-                  component="span"
-                  sx={{
-                    ml: "auto",
-                    fontSize: "0.68rem",
-                    fontWeight: 600,
-                    color: "var(--accent-purple)",
-                    flexShrink: 0,
-                  }}
-                >
-                  {r.isNew ? "New" : "Updated"}
-                </Box>
-              )}
             </Box>
           );
         })}

--- a/lib/types/adaptive-journey.ts
+++ b/lib/types/adaptive-journey.ts
@@ -142,7 +142,9 @@ export interface JourneyBoard {
       points: number;
       configured: boolean;
       status: "done" | "not_started" | "not_configured";
-    };
+      // Null on a course that will never have one — a roadmap-built course has no admin to
+      // configure an interview, so the board sends nothing rather than a "being set up" stub.
+    } | null;
   };
   weeks: JourneyWeekView[];
 }


### PR DESCRIPTION
Four fixes from looking at the shipped pages.

## 1. The catalogue read as a wall of text
Rows had no delimiter. Each now carries a bottom hairline, with `rowGap: 0` so they form one continuous rule down each column rather than floating dashes. Longhand border properties — a shorthand carrying a `var()` is dropped by parsers that don't resolve custom properties (which is also why the first version of the test failed).

## 2. The New/Updated badge said nothing
It fired on **14 of 20** entries. A badge that is almost always on is decoration, and it gave every row a second ragged edge. The flags stay on the API card; this surface stops rendering them.

## 3. The drawer opened over the node you just clicked
The spine sits right of centre and the drawer came from the left. Now `anchor="right"`.

## 4. The drawer explained nothing
It fetched a node detail carrying `summary` and a per-target `description` and rendered **none of it** — a node with an empty summary showed a title, four counts, and a screen of white space. It now leads with the explanation, lists what a parent topic covers, shows size as a strip rather than ticks (a tick beside "1 topic" reads as completed work), and closes by asking *"Create a course on this?"* with both answers.

## Plus: no calibration or mock-interview cards on roadmap-built courses
Backend counterpart: ai-linc-backend #600. Making `interview.card` nullable to match the board surfaced **16 unguarded reads** in `InterviewerCard` — it read `card.status` directly and would have crashed on the new payload.

## Tests
6 new tests across `RoadmapIndex` and `BuildCourseDrawer`, asserted against the real node payload shape. Full suite 121 passing, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)