### PR TITLE
fix(course-builder): a stale refresh could overwrite the tree with older data

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { CoursePricingDialog } from "@/components/admin/adaptive-course/CoursePricingDialog";
@@ -218,14 +218,35 @@ export default function AdminAdaptiveCourseDetailPage() {
   const perSubmodule = EST_CONCEPTS_PER_SUBMODULE * Math.max(difficulties.length, 1) * perCell;
   const estTotalQuestions = submodulesToAdd * perSubmodule;
 
+  /**
+   * Guards against the responses racing each other.
+   *
+   * Every edit anywhere in the tree refreshes the WHOLE course, and about ten call sites can
+   * fire it (rename, delete, add, article saved, coding deleted, video changed, and so on). They
+   * are plain GETs with nothing sequencing them, so on a large course two can easily be in
+   * flight at once and the last to ARRIVE wins rather than the last to be ASKED. The visible
+   * result is a tree that redraws with data older than what it had a moment ago, which reads as
+   * the page re-rendering repeatedly for no reason.
+   *
+   * A monotonic ticket fixes the ordering: a response may only publish if no newer load has been
+   * started since it left. Stale answers are dropped rather than painted.
+   */
+  const loadSeq = useRef(0);
+
   const load = useCallback(async () => {
+    const seq = ++loadSeq.current;
     try {
       const data = await adminAdaptiveCourseService.getCourse(courseId);
+      if (seq !== loadSeq.current) return;
       setCourse(data);
+      // A refresh that worked clears the last one that did not. Without this the red banner
+      // outlives the failure and sits above a tree that has since loaded perfectly well.
+      setError(null);
     } catch (e) {
+      if (seq !== loadSeq.current) return;
       setError(getAxiosErrorDetail(e, "Failed to load course."));
     } finally {
-      setLoading(false);
+      if (seq === loadSeq.current) setLoading(false);
     }
   }, [courseId]);
 


### PR DESCRIPTION
## The report

> after seeding new article when i go to \[the course builder] there is ui glitch where whole page seems to be rendering again and again glitchy way

This is the frontend half. The [backend half](https://github.com/AI-Linc-LMS/ai-linc-backend/pull/599) was the dominant cause: the admin course-detail endpoint was issuing 392 queries and taking **15 seconds** on a 48-topic course.

## What this fixes

Every edit in the builder refreshes the **whole** course tree, and about ten call sites can fire it: rename a module or topic, delete a row, add content, `AdminArticleViewer onSaved`, `AdminCodingViewer onDeleted`, `MatchedVideoReview onChanged` (one instance per coding problem and per video companion).

They are plain GETs with nothing sequencing them, so two are easily in flight at once and **the last to arrive wins rather than the last to be asked**. At 15 seconds a request that is trivially easy to hit, and it is visible: the tree redraws with data older than what it already had, then redraws again when the newer answer lands.

A monotonic ticket fixes the ordering. A response may publish only if no newer load has started since it left; stale answers are dropped rather than painted.

No abort controller — the request is already paid for by the time it resolves, and cancelling buys nothing here. The ordering is the bug, not the traffic.

## Also

`load()` only ever *set* `error`, never cleared it, so one failed refresh left the red banner sitting permanently above a tree that had since loaded perfectly well. A successful refresh now clears it.

## What I checked and deliberately did not change

- **No refetch loop exists.** This page has exactly one `useEffect`, with stable deps (`courseId` primitive, `load` memoized on it). No polling, no `refetchOnWindowFocus`, no unstable query key — it does not use TanStack Query at all.
- **The skeleton does not flash.** `setLoading(true)` is never called after mount, so background refreshes swap data silently.
- **Unmemoized tree rows** re-render wholesale on every refresh, and the `AuthContext` / `ToastContext` provider values are fresh object literals each render. Both are real re-render costs, but they are a separate change with a wider blast radius, so they are not in this PR.

`tsc --noEmit` clean; `eslint` clean on the changed file (one pre-existing unused-var warning untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)