### PR TITLE
release: cache proctoring model weights (immutable)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,19 @@ publish = ".next"
 
 [[plugins]]
 package = "@netlify/plugin-nextjs"
+
+# Proctoring model weights: immutable, and on the critical path of a graded exam.
+#
+# Netlify's default for these is `public,max-age=0,must-revalidate` (verified against
+# careerxp.ailinc.com and assessment.ailinc.com), so every student revalidates 455 KB on every
+# page load that touches the device check. On the morning of a campus drive that is a few thousand
+# conditional requests arriving in the same few minutes, against files whose bytes cannot change:
+# the content is pinned by the SHA-256 digests recorded in
+# public/assets/models/blazeface/README.md, and updating the model means committing new files.
+#
+# A year of immutable caching means a student who has sat one assessment pays zero bytes for the
+# next, and a cold cohort pays exactly once.
+[[headers]]
+  for = "/assets/models/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
Promotes #1332 from `stagging`.

Netlify serves `/assets/models/*` with `public,max-age=0,must-revalidate` by default — verified against both production sites after today's deploy. Every student revalidates 455 KB on every page load that touches the device check.

The bytes cannot change: content is pinned by the SHA-256 digests in `public/assets/models/blazeface/README.md`, and updating the model means committing different files.

At 2000-3000 concurrent, the current setting means a few thousand conditional requests inside the same few minutes on the morning of a campus drive. Immutable caching means a cold cohort pays once and a returning student pays nothing — and it removes a revalidation round-trip from the critical path of starting a graded exam, on exactly the constrained campus networks where this class of failure lives.

## Verifying after deploy

```bash
curl -sSI https://careerxp.ailinc.com/assets/models/blazeface/group1-shard1of1.bin | grep -i cache-control
# expect: cache-control: public, max-age=31536000, immutable
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)