### PR TITLE
fix(proctoring): make a broken device-check model fail the BUILD, not the exam

### DIFF
--- a/lib/public-asset-prefixes.ts
+++ b/lib/public-asset-prefixes.ts
@@ -1,0 +1,19 @@
+/**
+ * URL prefixes that bypass the auth gate in `proxy.ts`.
+ *
+ * Its own module, with no `next/server` import, so that three places can share ONE definition:
+ * the proxy itself, tests, and the build-time gate in `next.config.ts` (which runs before the
+ * webpack alias exists and so cannot import app code that pulls in Next internals).
+ *
+ * Why this is not just inlined in proxy.ts: getting it wrong is silent and expensive. The
+ * proctoring model weights were served from `/models/...`, which is not on this list, so every
+ * request for them 307'd to `/login` and tfjs received an HTML page where it expected JSON. The
+ * device check then reported "No face detected" to students whose cameras were working fine.
+ * Nothing failed loudly; it just fell back to a third-party CDN and looked like a camera problem.
+ *
+ * The copy-a-rule-into-a-test pattern is already known to drift in this repo: `proxy.test.ts`
+ * instructs "keep the two literally identical", and they are not — `proxy.ts` gained a
+ * "/roadmaps" entry that the test's copy never got, so that test passes while guarding a rule the
+ * app no longer has. One exported constant, imported everywhere, cannot drift.
+ */
+export const PUBLIC_ASSET_PREFIXES = ["/images/", "/videos/", "/assets/"] as const;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,99 @@
 import type { NextConfig } from "next";
+import fs from "node:fs";
 import path from "node:path";
+
+/**
+ * Build-time gate: the proctored device check must be able to load its face model.
+ *
+ * WHY THIS LIVES HERE, of all places. The failure it guards against cost ~38% of every support
+ * ticket this platform has ever received: the device check told students "No face detected" while
+ * their cameras worked, because the model weights were fetched from a third-party CDN at exam time
+ * and, later, because they were served from a path the auth proxy 307s to /login (tfjs then fails
+ * on a JSON parse and silently falls back to that same CDN). Both failures were invisible in
+ * production. The only detector was students filing tickets, 91% of which went unread for an
+ * average of 105 days.
+ *
+ * So this has to BLOCK A DEPLOY, and module scope in next.config.ts is the only place in this repo
+ * that can. netlify.toml runs `yarn next build`, which bypasses the `build` script in package.json
+ * entirely, so a prebuild hook there protects nothing. The unit suite cannot do it either: both
+ * .github/workflows/test.yml and vitest.config.mts state, deliberately, that they must never block
+ * a merge or a deploy.
+ *
+ * Text-based rather than importing the modules it checks: next.config.ts is evaluated before
+ * webpack, so the "@/" alias does not resolve here. Every extraction below throws when its pattern
+ * stops matching, so a refactor that outruns this gate fails the build rather than silently
+ * disabling it.
+ */
+function assertProctoringModelShippable(): void {
+  const root = process.cwd();
+  const read = (rel: string) => fs.readFileSync(path.join(root, rel), "utf8");
+  const die = (msg: string): never => {
+    throw new Error(`[proctoring-asset-gate] ${msg}`);
+  };
+
+  const prefixes = [
+    ...read("lib/public-asset-prefixes.ts").matchAll(/"(\/[^"]+\/)"/g),
+  ].map((m) => m[1]);
+  if (prefixes.length === 0) die("could not read PUBLIC_ASSET_PREFIXES");
+
+  const loaderSrc = read("lib/services/face-model-loader.ts");
+
+  // The weights must come from us, not from tfhub.dev.
+  if (!/blazeface\.load\(\s*\{\s*modelUrl/.test(loaderSrc)) {
+    die(
+      "blazeface.load() is not being passed a modelUrl, so the weights would be fetched from " +
+        "tfhub.dev at exam time (a 3-hop redirect through hosts we do not control).",
+    );
+  }
+
+  const urlMatch = loaderSrc.match(/LOCAL_MODEL_URL\s*=\s*"([^"]+)"/);
+  if (!urlMatch) die("could not find LOCAL_MODEL_URL in lib/services/face-model-loader.ts");
+  const localUrl = urlMatch![1];
+
+  // ...and from a path the auth proxy actually lets through.
+  if (!prefixes.some((p) => localUrl.startsWith(p))) {
+    die(
+      `LOCAL_MODEL_URL "${localUrl}" is not under an auth-bypass prefix ` +
+        `(${prefixes.join(", ")}). It would 307 to /login, tfjs would fail on a JSON parse, and ` +
+        "the device check would silently fall back to the CDN. See proxy.ts.",
+    );
+  }
+
+  // ...and the bytes have to actually be here, and be whole.
+  const modelRel = path.join("public", localUrl.replace(/^\//, ""));
+  if (!fs.existsSync(path.join(root, modelRel))) die(`${modelRel} is missing`);
+  const manifest = JSON.parse(read(modelRel));
+
+  // Derived, not hand-pinned. A SHA-256 table would fail on a LEGITIMATE model bump, and the
+  // cheapest way out of that failure is to regenerate the constant — which turns the guard into a
+  // tautology that always passes. This invariant survives a legitimate bump and only breaks when
+  // the weights are genuinely truncated or mismatched.
+  const DTYPE_BYTES: Record<string, number> = {
+    float32: 4, int32: 4, bool: 1, uint8: 1, float16: 2, complex64: 8,
+  };
+  let declared = 0;
+  const shards = new Set<string>();
+  for (const group of manifest.weightsManifest ?? []) {
+    for (const p of group.paths ?? []) shards.add(p);
+    for (const w of group.weights ?? []) {
+      const elements = (w.shape ?? []).reduce((a: number, b: number) => a * b, 1);
+      declared += elements * (DTYPE_BYTES[w.dtype] ?? 4);
+    }
+  }
+  if (shards.size === 0) die("model.json declares no weight shards");
+
+  let onDisk = 0;
+  for (const shard of shards) {
+    const shardPath = path.join(root, path.dirname(modelRel), shard);
+    if (!fs.existsSync(shardPath)) die(`weight shard "${shard}" is declared but missing`);
+    onDisk += fs.statSync(shardPath).size;
+  }
+  if (declared !== onDisk) {
+    die(`weights are truncated: manifest declares ${declared} bytes, shards total ${onDisk}`);
+  }
+}
+
+assertProctoringModelShippable();
 
 /**
  * Force browser build: package "node" export pulls jspdf.node.min.js → fflate Worker

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+import { PUBLIC_ASSET_PREFIXES } from "@/lib/public-asset-prefixes";
+
 // Instructors live entirely inside /instructor/*. Confining them here (server-side, no flash) is the
 // real guard that keeps the instructor role out of the student learner view and the full-admin area.
 const INSTRUCTOR_HOME = "/instructor/dashboard";
@@ -62,11 +64,9 @@ export function proxy(request: NextRequest) {
 
   // Files under /public are requested by URL (e.g. CSS background-image, <img src>).
   // They must bypass auth — otherwise unauthenticated users get 307 → /login and assets never load.
-  if (
-    pathname.startsWith("/images/") ||
-    pathname.startsWith("/videos/") ||
-    pathname.startsWith("/assets/")
-  ) {
+  // The list lives in its own module so the build gate in next.config.ts can check the proctoring
+  // model URL against the same source of truth rather than a copy that drifts.
+  if (PUBLIC_ASSET_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
Both defects that produced ~38% of all support tickets were **invisible in production**. The weights were fetched from tfhub.dev at exam time; later they were served from a path the auth proxy 307s to `/login`, where tfjs fails on a JSON parse and silently falls back to that same CDN. Nothing errored. The only detector was students filing tickets, 91% of which went unread for an average of 105 days.

So the guard has to block a deploy — and module scope in `next.config.ts` is the only place in this repo that can:

- `netlify.toml:2` runs `yarn next build`, which **bypasses the `build` script in `package.json`**. A prebuild hook there protects nothing on the deploy path.
- `.github/workflows/test.yml:4-5` states the unit job is *"deliberately NOT a required check"*, and `vitest.config.mts:12-14` states the suite is *"deliberately NOT wired into `next build`"*. Both are reasonable calls; neither can stop a bad ship.

## What the gate asserts

1. `blazeface.load()` is passed a `modelUrl` — no third-party fetch at exam time.
2. That URL is under an auth-bypass prefix from `lib/public-asset-prefixes.ts`.
3. The weights exist and are whole — manifest-declared bytes equal shard bytes on disk.

**(3) is derived, not a pinned SHA-256, on purpose.** A hash table fails on a *legitimate* model bump, and the cheapest way out of that failure is to regenerate the constant — which turns the guard into a tautology that always passes. The derived invariant survives a legitimate bump and breaks only on genuinely truncated or mismatched weights.

## `PUBLIC_ASSET_PREFIXES` moves to its own module

So `proxy.ts` and the gate share one definition. The copy-a-rule-into-a-test pattern is already known to drift here: `proxy.test.ts:5-11` says *"keep the two literally identical"* and they are not — `proxy.ts:23` gained `"/roadmaps"` and the test's copy never did, so that test passes while guarding a rule the app no longer has.

## Verification — each defect reintroduced, real `next build` run

| Reintroduced defect | Result |
|---|---|
| `LOCAL_MODEL_URL = "/models/..."` | **blocked** — names the prefix list and the 307 |
| `blazeface.load()` with no `modelUrl` | **blocked** — names tfhub.dev |
| shard truncated by 1,768 bytes | **blocked** — *"declares 401768, shards total 400000"* |
| clean tree | gate passes |

This is layer 1 of 4. It catches the two defects that actually shipped. Still to come: a post-deploy smoke check per tenant domain (the only layer that tests deployed infrastructure), runtime telemetry, and the structural de-gate so a detector failure cannot lock a student out at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)