### PR TITLE
fix(assessments): the detector's opinion no longer decides who sits the exam

### DIFF
--- a/app/assessments/[slug]/device-check/page.tsx
+++ b/app/assessments/[slug]/device-check/page.tsx
@@ -579,18 +579,51 @@ export default function DeviceCheckPage({
     deviceStatus.microphone &&
     deviceStatus.browserSupported;
 
-  // `!faceCheckError` is load-bearing, not belt-and-braces. Until this change the forced
-  // `faceCount = 0` in the detection catch was — by accident — the only thing holding this gate
-  // shut when the detector died: 0 faces meant faceValidationPassed stayed false. Removing that
-  // (so a dead detector stops being reported as "no face detected") also removed the accidental
-  // fail-closed, which would have let a student into a graded proctored exam behind a detector
-  // that had already stopped looking. The gate is now closed explicitly, by the same signal that
-  // produces the honest message.
+  /**
+   * The line here is between a DEVICE and a DETECTOR, and it is the whole fix.
+   *
+   * A proctored assessment genuinely requires a camera and a microphone: if the hardware is not
+   * there and permitted, there is nothing to proctor, and that is a real precondition the
+   * institution is entitled to enforce. So `deviceStatus.camera` and `deviceStatus.microphone`
+   * remain gates when `proctoring_enabled` is on.
+   *
+   * What must NEVER gate entry is our detector's OPINION about that working camera. The gate used
+   * to also require `faceValidationPassed && !faceCheckError` — our BlazeFace pipeline saying it
+   * could presently see exactly one face. That is a wholly different claim from "a camera exists",
+   * and it is the one that failed: weights fetched from a third-party CDN at exam time, a CPU
+   * fallback that froze the tab, a detection loop that gave up silently, an error the page never
+   * rendered. Each produced a student sitting in front of a working, permitted camera being told
+   * "No face detected" with no way forward. 126 support tickets, ~38% of everything ever filed
+   * (docs/audits/ticket-module-rca.md in ai-linc-backend).
+   *
+   * Fixing those causes made it rarer. Only removing the detector from the gate makes the OUTCOME
+   * impossible — and the next unforeseen detector bug is then a degraded signal, not a cohort that
+   * cannot sit its paper. Network speed comes out for the same reason: a slow link is a warning,
+   * not grounds for refusal.
+   *
+   * So: hardware is required, judgement about the hardware is advisory. Violations are still
+   * recorded against the attempt throughout; this changes who gets through the door, not what is
+   * logged once they are.
+   */
+  const proctoringRequired = assessment?.proctoring_enabled !== false;
+
   const canProceed =
-    devicesAndBrowserReady &&
-    faceValidationPassed &&
-    !faceCheckError &&
-    networkAllowsProceed;
+    deviceStatus.browserSupported &&
+    (!proctoringRequired || (deviceStatus.camera && deviceStatus.microphone));
+
+  /**
+   * The advisory signals: things that are not right but must not stop the student.
+   *
+   * Deliberately excludes camera and microphone — for a proctored assessment those are real
+   * preconditions and appear as blocking errors elsewhere on this page, with their own retry. What
+   * lands here is our JUDGEMENT about a camera that is present and permitted, plus link speed.
+   * Surfaced honestly so nobody discovers mid-exam that face monitoring was never running.
+   */
+  const degradedSignals: string[] = [];
+  if (faceCheckError) degradedSignals.push("the camera check could not run");
+  else if (deviceStatus.camera && !faceValidationPassed)
+    degradedSignals.push("we cannot see your face clearly");
+  if (!networkAllowsProceed) degradedSignals.push("your connection is very slow");
 
   if (deviceAccessDenied && deniedAssessment) {
     return (
@@ -1242,6 +1275,23 @@ export default function DeviceCheckPage({
               alignItems: "stretch",
             }}
           >
+            {/* Advisory, never a barrier. The student is told what is degraded and then given the
+                same button as everyone else. Before this, each of these conditions silently
+                removed the button and left them with nothing to click. */}
+            {canProceed && degradedSignals.length > 0 && (
+              <Alert
+                severity="warning"
+                sx={{ borderRadius: "var(--radius-card)" }}
+              >
+                <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                  You can still start your assessment
+                </Typography>
+                <Typography variant="body2">
+                  {`We noticed ${degradedSignals.join(", and ")}. You do not need to fix this to begin — your assessment will not be blocked. If your institution requires camera monitoring, tell your supervisor before you start.`}
+                </Typography>
+              </Alert>
+            )}
+
             {canProceed ? (
               <Button
                 fullWidth

--- a/app/assessments/[slug]/take/page.tsx
+++ b/app/assessments/[slug]/take/page.tsx
@@ -17,6 +17,7 @@ import type { RefObject, Dispatch, SetStateAction } from "react";
 import { flushSync } from "react-dom";
 import { useRouter } from "next/navigation";
 import {
+  Alert,
   Box,
   Typography,
   Button,
@@ -210,6 +211,12 @@ export default function TakeAssessmentPage({
   const [showFullscreenExitConfirm, setShowFullscreenExitConfirm] =
     useState(false);
   const [mediaInterrupted, setMediaInterrupted] = useState(false);
+  /** The camera-dropped notice is dismissible. It informs; it must never trap. */
+  const [mediaNoticeDismissed, setMediaNoticeDismissed] = useState(false);
+  /** Face analysis could not start. The exam runs; the UI says so rather than pretending. */
+  const [proctoringUnavailable, setProctoringUnavailable] = useState(false);
+  /** Camera/mic missing on a proctored attempt: a real precondition, shown in place with a retry. */
+  const [mediaRequiredButMissing, setMediaRequiredButMissing] = useState(false);
   const [responses, setResponses] = useState<
     Record<string, Record<string, any>>
   >({});
@@ -934,7 +941,9 @@ export default function TakeAssessmentPage({
 
     if (hasLiveVideo && hasLiveAudio) return;
 
-    // Attempt to get a fresh stream before falling back to device-check
+    // Try for a fresh stream. If it does not come, proctoring is simply unavailable — this used to
+    // `router.replace` the student to device check on arrival, which is a lock-out before they have
+    // even seen the paper.
     navigator.mediaDevices
       .getUserMedia({
         video: { width: { ideal: 640 }, height: { ideal: 480 }, facingMode: "user" },
@@ -945,8 +954,9 @@ export default function TakeAssessmentPage({
           (window as any).__assessmentStream = freshStream;
         }
       })
-      .catch(() => {
-        router.replace(`/assessments/${slug}/device-check`);
+      .catch((err) => {
+        setProctoringUnavailable(true);
+        console.warn("[assessment] no media on take-page mount:", String(err));
       });
   }, [assessment, loading, slug, router]);
 
@@ -1388,26 +1398,57 @@ export default function TakeAssessmentPage({
   const handleRetryProctoringMedia = useCallback(() => {
     setMediaInterrupted(false);
     mediaGraceUntilRef.current = Date.now() + 10000;
-    startProctoring().catch(() => {
+    startProctoring().catch((err) => {
+      // Retrying and failing must never cost the student their place. This used to
+      // `router.replace` to device check — navigating someone AWAY from the paper they are
+      // mid-way through, with the clock running, because their webcam did not come back.
+      setProctoringUnavailable(true);
       showToast(
-        "Could not restore camera or microphone. Please use device check again.",
-        "error"
+        "Camera could not be restored. Your assessment continues without it.",
+        "info",
       );
-      router.replace(`/assessments/${slug}/device-check`);
+      console.warn("[assessment] retry proctoring failed:", String(err));
     });
-  }, [startProctoring, showToast, router, slug]);
+  }, [startProctoring, showToast]);
 
-  // Start assessment - require live camera + mic before timer (proctored)
+  // Start assessment. Proctoring is attempted, never required.
   const handleStartAssessment = useCallback(async () => {
     if (isInitializingRef.current) return;
     isInitializingRef.current = true;
     setShowStartButton(false);
 
-    const failProctoredStart = (toastMessage: string) => {
+    /**
+     * The DETECTOR could not start — the model would not load, WebGL is blocked, inference failed.
+     * The exam proceeds without camera analysis.
+     *
+     * This used to unwind the whole start: reset `assessmentStarted`, re-show the start button,
+     * toast an error. A student whose GPU is locked down could not begin at all, with a clock
+     * running, over a failure that says nothing about whether they have a camera.
+     *
+     * Note what this is NOT: it is not a missing camera. Camera and microphone remain required for
+     * a proctored assessment and are handled separately below. This is only our analysis of a
+     * camera we already have.
+     */
+    const continueWithoutFaceAnalysis = (reason: string) => {
+      setProctoringUnavailable(true);
+      showToast(
+        "Camera monitoring is unavailable, but your assessment is not blocked.",
+        "info",
+      );
+      console.warn("[assessment] face analysis unavailable, continuing:", reason);
+    };
+
+    /**
+     * The camera or microphone itself is missing. A proctored assessment genuinely requires them,
+     * so this does NOT start — but it also does not `router.replace` the student to the device
+     * check they just came from, which is how the old `failProctoredStart` produced a loop minutes
+     * before a deadline. They stay here, are told plainly, and can retry in place.
+     */
+    const blockOnMissingMedia = () => {
       flushSync(() => setAssessmentStarted(false));
       isInitializingRef.current = false;
-      showToast(toastMessage, "error");
-      router.replace(`/assessments/${slug}/device-check`);
+      setShowStartButton(true);
+      setMediaRequiredButMissing(true);
     };
 
     try {
@@ -1430,13 +1471,15 @@ export default function TakeAssessmentPage({
             if (typeof window !== "undefined") {
               (window as any).__assessmentStream = stream;
             }
-          } catch {
-            failProctoredStart(
-              "Camera and microphone are required.\nPlease allow access and complete device check."
-            );
+          } catch (err) {
+            // No camera or microphone at all. A proctored assessment requires them, so this stops
+            // the start — in place, with a retry, never by navigating away.
+            console.warn("[assessment] media unavailable at start:", String(err));
+            blockOnMissingMedia();
             return;
           }
         }
+        setMediaRequiredButMissing(false);
 
         // Mount UI so <video ref={videoRef}> in timer bar is available
         flushSync(() => setAssessmentStarted(true));
@@ -1464,16 +1507,12 @@ export default function TakeAssessmentPage({
         try {
           await startProctoring();
         } catch (proctorErr) {
-          isInitializingRef.current = false;
-          setShowStartButton(true);
-          flushSync(() => setAssessmentStarted(false));
-          showToast(
-            proctorErr instanceof Error
-              ? proctorErr.message
-              : "Face detection could not start. Please try again or refresh the page.",
-            "error"
+          // The detector, not the device. Previously this unwound the entire start, so a blocked
+          // GPU or an unreachable model meant a student could not begin at all — over a failure
+          // that says nothing about whether they have a camera. They do; we just cannot analyse it.
+          continueWithoutFaceAnalysis(
+            proctorErr instanceof Error ? proctorErr.message : String(proctorErr),
           );
-          return;
         }
       } else {
         setAssessmentStarted(true);
@@ -2304,70 +2343,97 @@ export default function TakeAssessmentPage({
         return false;
       }}
     >
+      {/* Camera or microphone missing on a proctored attempt. Rendered OUTSIDE the
+          `assessmentStarted` gate on purpose: everything below is inside it, so without this the
+          student would get a blank page — the exact dead end the old redirect-to-device-check was
+          papering over. They stay on their assessment, are told what is wrong, and retry here. */}
+      {mediaRequiredButMissing && !assessmentStarted && (
+        <Box sx={{ display: "flex", justifyContent: "center", p: 3 }}>
+          <Paper elevation={0} sx={{ maxWidth: 480, p: 3, borderRadius: 2 }}>
+            <Typography variant="h6" sx={{ fontWeight: 700, mb: 1 }}>
+              Camera and microphone needed to begin
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ color: "var(--font-secondary)", mb: 2, lineHeight: 1.6 }}
+            >
+              This is a proctored assessment, so it cannot start until your
+              camera and microphone are available. Allow access in your browser
+              (check the icon in the address bar), close any other app using the
+              camera, then try again. You have not lost your place.
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+              <Button
+                variant="contained"
+                onClick={() => void handleStartAssessment()}
+                sx={{ textTransform: "none", fontWeight: 600 }}
+              >
+                Try again
+              </Button>
+              <Button
+                variant="outlined"
+                onClick={() => router.push(`/assessments/${slug}/device-check`)}
+                sx={{ textTransform: "none", fontWeight: 600 }}
+              >
+                Open device check
+              </Button>
+            </Box>
+          </Paper>
+        </Box>
+      )}
+
       {assessmentStarted && (
         <>
-          {mediaInterrupted &&
+          {/* Face analysis is not running, but the paper is. Say so rather than let a student
+              assume they are being monitored when they are not. */}
+          {proctoringUnavailable &&
             !submitting &&
             assessment?.proctoring_enabled !== false && (
-              <Box
-                sx={{
-                  position: "fixed",
-                  inset: 0,
-                  zIndex: 1999,
-                  bgcolor:
-                    "color-mix(in srgb, var(--font-primary) 78%, transparent)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  p: 2,
-                }}
+              <Alert severity="info" sx={{ borderRadius: 0 }}>
+                <Typography variant="body2">
+                  Camera monitoring is unavailable on this device. Your
+                  assessment is recorded and graded normally.
+                </Typography>
+              </Alert>
+            )}
+
+          {/* Camera dropped MID-EXAM.
+           *
+           * This was a full-viewport overlay (position:fixed, inset:0, z-index 1999) sitting on top
+           * of the paper with the clock still running. A student whose camera was grabbed by
+           * another app, or whose USB webcam blinked, could not read or answer a single question
+           * until they fixed it - and one of the two buttons offered to navigate them AWAY from
+           * their in-progress exam, back to the device check.
+           *
+           * It is now a banner: same information, same Retry, but it sits above the paper instead
+           * of over it, and it can be dismissed. Nothing here stops a student answering. */}
+          {mediaInterrupted &&
+            !mediaNoticeDismissed &&
+            !submitting &&
+            assessment?.proctoring_enabled !== false && (
+              <Alert
+                severity="warning"
+                onClose={() => setMediaNoticeDismissed(true)}
+                action={
+                  <Button
+                    size="small"
+                    onClick={handleRetryProctoringMedia}
+                    sx={{ textTransform: "none", fontWeight: 600 }}
+                  >
+                    Retry camera
+                  </Button>
+                }
+                sx={{ borderRadius: 0 }}
               >
-                <Paper
-                  elevation={4}
-                  sx={{
-                    maxWidth: 440,
-                    p: 3,
-                    textAlign: "center",
-                    borderRadius: 2,
-                  }}
-                >
-                  <Typography variant="h6" sx={{ fontWeight: 700, mb: 1 }}>
-                    Camera or microphone unavailable
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    sx={{ color: "var(--font-secondary)", mb: 2, lineHeight: 1.6 }}
-                  >
-                    Your session requires an active camera and microphone.
-                    Restore permissions or reconnect your devices to continue.
-                  </Typography>
-                  <Box
-                    sx={{
-                      display: "flex",
-                      gap: 1.5,
-                      justifyContent: "center",
-                      flexWrap: "wrap",
-                    }}
-                  >
-                    <Button
-                      variant="contained"
-                      onClick={handleRetryProctoringMedia}
-                      sx={{ textTransform: "none", fontWeight: 600 }}
-                    >
-                      Retry
-                    </Button>
-                    <Button
-                      variant="outlined"
-                      onClick={() =>
-                        router.push(`/assessments/${slug}/device-check`)
-                      }
-                      sx={{ textTransform: "none", fontWeight: 600 }}
-                    >
-                      Back to device check
-                    </Button>
-                  </Box>
-                </Paper>
-              </Box>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  Camera or microphone unavailable
+                </Typography>
+                <Typography variant="body2">
+                  Camera monitoring has stopped, but your assessment is not
+                  affected. Keep answering — you can retry the camera at any
+                  time.
+                </Typography>
+              </Alert>
             )}
 
           <LiveAssessmentTimerBar

--- a/app/assessments/never-block-the-student.test.ts
+++ b/app/assessments/never-block-the-student.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A device problem must never stop a student sitting their assessment.
+ *
+ * This is the single largest source of support tickets this platform has: 126 of them, ~38% of
+ * everything ever filed, from students in front of a working camera being told "No face detected"
+ * with no way forward. The causes were fixed one at a time — third-party weights, a CPU fallback
+ * that froze the tab, a silent retry exhaustion, an error the page never rendered — and each fix
+ * made the failure rarer without making the OUTCOME impossible.
+ *
+ * The outcome became impossible only when the signals stopped gating the door. These tests defend
+ * that property, because it is the kind of thing a well-meaning change reintroduces: adding
+ * `&& cameraOk` to a start condition looks like tightening security, and is in fact how a cohort
+ * loses an exam.
+ *
+ * Source-text assertions rather than rendering the pages: both are ~2,700-line client components
+ * with routers, media streams, fullscreen and tf.js in their import graph. Standing that up in
+ * jsdom would test the mocks. What is worth protecting is the RULE, and the rule is visible in the
+ * source.
+ */
+
+const ROOT = path.join(__dirname, "..", "..");
+const read = (rel: string) => readFileSync(path.join(ROOT, rel), "utf8");
+
+const DEVICE_CHECK = "app/assessments/[slug]/device-check/page.tsx";
+const TAKE = "app/assessments/[slug]/take/page.tsx";
+
+/**
+ * The detector's JUDGEMENT about a working camera. None of these may gate entry — this is the
+ * class that produced the 126 tickets.
+ *
+ * Note what is deliberately absent: `deviceStatus.camera` and `deviceStatus.microphone`. A
+ * proctored assessment genuinely requires the hardware, and that precondition is enforced. The bug
+ * was never "we required a camera"; it was "we required our ML to be happy about one".
+ */
+const DETECTOR_SIGNALS = [
+  "faceValidationPassed",
+  "faceCheckError",
+  "faceCount",
+  "faceStatus",
+  "latestViolation",
+  "networkAllowsProceed",
+];
+
+describe("the device check cannot lock a student out", () => {
+  it("never gates entry on the detector's opinion", () => {
+    const src = read(DEVICE_CHECK);
+    const match = src.match(/const canProceed =([\s\S]*?);/);
+    expect(match, "canProceed should still exist").toBeTruthy();
+
+    const expression = match![1];
+    for (const signal of DETECTOR_SIGNALS) {
+      expect(
+        expression.includes(signal),
+        `canProceed must not depend on "${signal}". That is our analysis of the camera, not ` +
+          `whether a camera exists, and making it load-bearing is what produced 126 tickets.`,
+      ).toBe(false);
+    }
+  });
+
+  it("still requires camera and mic for a proctored assessment", () => {
+    // The precondition the institution is entitled to enforce, and which the owner asked to keep:
+    // no camera or mic means nothing to proctor.
+    const expression = read(DEVICE_CHECK).match(/const canProceed =([\s\S]*?);/)![1];
+    expect(expression).toContain("browserSupported");
+    expect(expression).toContain("proctoringRequired");
+    expect(expression).toContain("deviceStatus.camera");
+    expect(expression).toContain("deviceStatus.microphone");
+  });
+
+  it("still tells the student what is degraded", () => {
+    // De-gating must not become hiding. If entry is allowed while something is broken, the student
+    // is told plainly — otherwise they discover mid-exam that nothing was being recorded.
+    const src = read(DEVICE_CHECK);
+    expect(src).toContain("degradedSignals");
+    expect(src).toMatch(/You can still start your assessment/);
+  });
+});
+
+describe("the take page cannot bounce a student out", () => {
+  it("never AUTOMATICALLY redirects to device check", () => {
+    // The distinction that matters is who decided. `router.replace` is the app moving a student
+    // against their will, with no history entry to come back by — that is the bounce that ran on
+    // mount, on a failed proctoring start, and on a failed camera retry, each of them a lock-out
+    // behind the first. A `router.push` inside an onClick is a button the student chose to press,
+    // and offering "open device check" to someone who wants it is help, not a trap.
+    const src = read(TAKE);
+    const autoRedirects = [
+      ...src.matchAll(/router\.replace\(`\/assessments\/\$\{slug\}\/device-check`\)/g),
+    ];
+    expect(
+      autoRedirects.length,
+      "A student on the take page is mid-assessment with a running clock; nothing may move them " +
+        "off it automatically.",
+    ).toBe(0);
+  });
+
+  it("degrades instead of unwinding the start when the DETECTOR fails", () => {
+    const src = read(TAKE);
+    expect(src).toContain("continueWithoutFaceAnalysis");
+    expect(
+      src.includes("failProctoredStart("),
+      "failProctoredStart reset assessmentStarted and redirected; it must not come back.",
+    ).toBe(false);
+  });
+
+  it("blocks in place, not by navigating away, when camera/mic are missing", () => {
+    const src = read(TAKE);
+    expect(src).toContain("blockOnMissingMedia");
+    // Rendered outside the assessmentStarted gate, or the student gets a blank page — everything
+    // else on this route lives inside that conditional.
+    expect(src).toMatch(/mediaRequiredButMissing && !assessmentStarted/);
+    expect(src).toContain("Camera and microphone needed to begin");
+  });
+
+  it("does not cover the paper with a blocking media overlay", () => {
+    const src = read(TAKE);
+    // The old overlay was position:fixed / inset:0 / zIndex:1999 over the whole exam, with the
+    // clock running and no way to answer a question underneath it.
+    const overlay = src.match(/mediaInterrupted &&[\s\S]{0,400}?zIndex:\s*1999/);
+    expect(
+      overlay,
+      "The camera-dropped notice must be a dismissible banner, not a full-viewport overlay.",
+    ).toBeNull();
+    expect(src).toContain("mediaNoticeDismissed");
+  });
+});


### PR DESCRIPTION
The line this draws is between a **device** and a **detector**, and it is the whole fix.

A proctored assessment genuinely requires a camera and a microphone — no hardware means nothing to proctor. **That precondition stays enforced.**

What must never gate entry is our *judgement* about a camera that is present and working. `canProceed` also required `faceValidationPassed && !faceCheckError` — our BlazeFace pipeline saying it could presently see exactly one face. That is a wholly different claim from "a camera exists", and it is the one that kept failing:

- weights fetched from a third-party CDN at exam time
- a CPU fallback that froze the tab
- a detection loop that gave up silently after 10s
- an error the page never rendered

Each produced a student in front of a working, permitted camera being told *"No face detected"* with no way forward. **126 tickets, ~38% of everything ever filed.**

Fixing those causes made it rarer. Only removing the detector from the gate makes the *outcome* impossible — so the next unforeseen detector bug is a degraded signal, not a cohort that cannot sit its paper.

## Four lock-outs removed, in the order a student hits them

| # | Was | Now |
|---|---|---|
| 1 | `canProceed` required `faceValidationPassed && !faceCheckError && networkAllowsProceed` | camera + mic + browser support only |
| 2 | take-page mount `router.replace`d to device check on failed `getUserMedia` — before the student saw the paper | records that analysis is unavailable |
| 3 | `startProctoring()` failure unwound the entire start, so a blocked GPU meant no exam at all | continue without face analysis |
| 4 | mid-exam camera drop = full-viewport overlay (`inset:0`, `zIndex:1999`) over the paper, clock running, with a button that navigated **away** from the in-progress attempt | dismissible banner |

## Missing camera/mic still stops the start — in place

A screen rendered **outside** the `assessmentStarted` gate (everything else on the route is inside it, so without that the student gets a blank page) with *Try again* and an optional link to device check. No automatic redirect anywhere — the old bounce could loop minutes before a deadline.

## Degradation is stated, never hidden

The device check lists what is not working *above an enabled button*, and the exam shows a banner when face analysis is not running, so nobody assumes they are being monitored when they are not. Violations are still recorded throughout — this changes who gets through the door, not what is logged once they are.

## Tests

7 regression tests assert the rule *as a rule*: detector signals must not appear in `canProceed`, camera/mic must, no `router.replace` to device check, no full-viewport media overlay. **All 7 fail on the pre-change code** (verified by reverting both pages and re-running).

128 tests pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)