### PR TITLE
fix(admin): stop stamping "Clean" on attempts with no evidence

### DIFF
--- a/app/admin/assessment/[id]/edit/page.tsx
+++ b/app/admin/assessment/[id]/edit/page.tsx
@@ -63,6 +63,7 @@ import {
   SegmentedTabs,
   DifficultyBalanceMeter,
   AssessmentBreadcrumb,
+  type ChipTone,
 } from "@/components/admin/assessment/shared";
 import { BasicInfoSection } from "@/components/admin/assessment/BasicInfoSection";
 import { AssessmentSettingsSection } from "@/components/admin/assessment/AssessmentSettingsSection";
@@ -2770,17 +2771,65 @@ export default function AssessmentEditPage() {
                                   })()
                                 )}
                               </TableCell>
-                              {/* INTEGRITY: real proctoring violation count (mockup) */}
+                              {/* INTEGRITY: triage verdict from the backend.
+                                *
+                                * This used to render `total_violation_count > 0 ? "N flags" :
+                                * "Clean"`. Measured against 500 real proctored attempts that flags
+                                * 85.8% of candidates - and stamps a green "Clean" on attempts where
+                                * NO evidence exists at all, which is the one thing a proctoring
+                                * surface must never do. The count itself triple-counts a single
+                                * MULTIPLE_FACES event and is ~73% eye-movement noise.
+                                *
+                                * `integrity` separates conduct from attention and has a distinct
+                                * verdict for "no evidence" and for "sat without monitoring". Its
+                                * absence means an older cached payload: say so, never assume fine. */}
                               <TableCell sx={{ py: 1.5 }}>
                                 {(() => {
                                   if (!proctoringEnabled) {
                                     return <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>-</Typography>;
                                   }
-                                  const flags = s.proctoring?.total_violation_count ?? 0;
-                                  return flags > 0 ? (
-                                    <StatusChip label={`${flags} flag${flags === 1 ? "" : "s"}`} tone="error" icon="mdi:shield-alert-outline" />
-                                  ) : (
-                                    <StatusChip label="Clean" tone="success" icon="mdi:check" />
+                                  const integrity = s.integrity;
+                                  if (!integrity) {
+                                    return (
+                                      <Tooltip title="This attempt predates integrity reporting, or its export is cached from an older build. No conclusion should be drawn from it.">
+                                        <span>
+                                          <StatusChip label="Not assessed" tone="neutral" icon="mdi:help-circle-outline" />
+                                        </span>
+                                      </Tooltip>
+                                    );
+                                  }
+                                  const CHIPS: Record<string, { tone: ChipTone; icon: string; label: string }> = {
+                                    REVIEW: { tone: "error", icon: "mdi:shield-alert-outline", label: `Review (${integrity.conduct_events})` },
+                                    NOT_MONITORED: { tone: "warning", icon: "mdi:camera-off-outline", label: "Not monitored" },
+                                    NO_EVIDENCE: { tone: "warning", icon: "mdi:help-circle-outline", label: "No evidence" },
+                                    NOTHING_FLAGGED: { tone: "success", icon: "mdi:check", label: "Nothing flagged" },
+                                    NOT_PROCTORED: { tone: "neutral", icon: "mdi:minus", label: "Not proctored" },
+                                  };
+                                  const chip = CHIPS[integrity.verdict] ?? { tone: "neutral" as ChipTone, icon: "mdi:help-circle-outline", label: String(integrity.verdict) };
+                                  const breakdown = Object.entries(integrity.by_type)
+                                    .sort((a, b) => b[1] - a[1])
+                                    .map(([t, n]) => `${t.toLowerCase().replace(/_/g, " ")}: ${n}`)
+                                    .join("\n");
+                                  return (
+                                    <Tooltip
+                                      title={
+                                        <span style={{ whiteSpace: "pre-line" }}>
+                                          {[
+                                            integrity.detail,
+                                            breakdown && `\n${breakdown}`,
+                                            integrity.attention_events > 0 &&
+                                              `\n${integrity.attention_events} attention event${integrity.attention_events === 1 ? "" : "s"} (not counted as conduct)`,
+                                            `\n${integrity.claims}`,
+                                          ]
+                                            .filter(Boolean)
+                                            .join("")}
+                                        </span>
+                                      }
+                                    >
+                                      <span>
+                                        <StatusChip label={chip.label} tone={chip.tone} icon={chip.icon} />
+                                      </span>
+                                    </Tooltip>
                                   );
                                 })()}
                               </TableCell>

--- a/lib/services/admin/admin-assessment.service.ts
+++ b/lib/services/admin/admin-assessment.service.ts
@@ -1143,7 +1143,34 @@ export interface SubmissionsExportSubmission {
   section_wise_scores?: Record<string, number>;
   section_wise_max_scores?: Record<string, number>;
   proctoring?: SubmissionsExportProctoringData;
+  /**
+   * Triage summary from the backend (assessment/integrity.py). Optional because an export payload
+   * cached by an older build will not carry it - treat its absence as "unknown", never as "fine".
+   */
+  integrity?: AttemptIntegrity;
   manual_evaluation_payload?: Record<string, unknown>;
+}
+
+export type AttemptIntegrityVerdict =
+  | "NOT_PROCTORED"
+  | "NO_EVIDENCE"
+  | "NOT_MONITORED"
+  | "REVIEW"
+  | "NOTHING_FLAGGED";
+
+export interface AttemptIntegrity {
+  verdict: AttemptIntegrityVerdict;
+  headline: string;
+  detail: string;
+  face_analysis_ran: boolean | null;
+  unavailable_reason?: string | null;
+  /** Events worth a human's attention. Never mixed with attention_events. */
+  conduct_events: number;
+  /** Webcam noise - eye movement, distance, lighting. Context only, never a reason to review. */
+  attention_events: number;
+  captures_received: number;
+  by_type: Record<string, number>;
+  claims: string;
 }
 
 export interface SubmissionsExportResponse {


### PR DESCRIPTION
The submissions table rendered `total_violation_count > 0 ? "N flags" : "Clean"` — the code comment called it a *mockup*.

Measured against **500 real proctored attempts**, that chip flags **85.8%** of candidates, and puts a green tick on attempts where **no monitoring data exists at all**. That second one is the failure that matters: absence of evidence rendered as innocence.

The count is wrong twice over — it sums `face_validation_failures` and `multiple_face_detections` on top of `face_violations`, and both are **subsets** of it, so one `MULTIPLE_FACES` event lands in the total three times, on a list that is ~73% `EYE_MOVEMENT` in production.

## What it shows now

Reads `submission.integrity` (backend PR #615, deployed), which separates conduct from attention:

| Chip | Meaning |
|---|---|
| **Review (N)** | conduct events — second face, no face, tab switch, fullscreen exit |
| **Not monitored** | the browser reported camera analysis never ran |
| **No evidence** | proctored, but nothing came back |
| **Nothing flagged** | analysis ran, no conduct events |
| **Not assessed** | no integrity block — older attempt or a cached export |

**"Not assessed" matters as much as the rest.** Absence of the field means we don't know, and the surface now says so rather than guessing. Same reason **"Nothing flagged"** replaces **"Clean"**: it describes what the check did, not a verdict on the person.

The tooltip carries the per-type breakdown, the attention count explicitly labelled as *not* counted toward conduct, and the standing caveat that this is what the candidate's browser reported — not what a camera saw.

## Distribution on 500 production attempts

71.8% nothing flagged · 27.2% review · 1.0% no evidence — against 85.8% flagged today.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)