### PR TITLE
release(ai-tutor): review fixes for the voice tutor

### DIFF
--- a/app/ai-tutor/page.tsx
+++ b/app/ai-tutor/page.tsx
@@ -387,7 +387,9 @@ export default function AiTutorPage() {
 
         {/* An honest floor for the content column. Everything above self-hides, so a brand
             new learner would otherwise see the composer and then nothing until the rail. */}
-        {!isLoading && !recent.length && !suggestions.length ? (
+        {/* `data` rather than `!isLoading`: on a failed fetch isLoading is also false, and this
+            would tell a learner with a full history that they have never had a lesson. */}
+        {data && !recent.length && !suggestions.length ? (
           <TutorTintSurface tint="violet" sx={{ textAlign: "center", py: { xs: 3.5, md: 5 } }}>
             <Icon
               icon="solar:microphone-3-bold-duotone"
@@ -417,7 +419,7 @@ export default function AiTutorPage() {
         {/* ---------- The rail ---------- */}
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5, minWidth: 0 }}>
           <MinutesPanel quota={quota} />
-          <CapabilityPanel />
+          <CapabilityPanel codingEnabled={quota?.coding_enabled !== false} />
           <ProgressPanel stats={stats} />
           {notes.length > 0 ? (
             <Box>

--- a/app/ai-tutor/session/[id]/page.tsx
+++ b/app/ai-tutor/session/[id]/page.tsx
@@ -65,34 +65,68 @@ export default function TutorSessionPage() {
 
   const [plan, setPlan] = useState<LessonPlanSection[]>([]);
   const [quiz, setQuiz] = useState<PooledQuestion | null>(null);
-  const [showConversation, setShowConversation] = useState(false);
+  /**
+   * Which panel the side dock is showing. One slot, so this is a selector rather than two
+   * independent booleans - two 470px panels plus the canvas does not fit on a laptop.
+   */
+  const [dock, setDock] = useState<"editor" | "conversation" | null>(null);
   const [ide, setIde] = useState<{
-    open: boolean;
+    /** Whether the editor EXISTS. Distinct from whether the dock is currently showing it. */
+    opened: boolean;
     language: string;
     task: string;
     starter?: string;
-  }>({ open: false, language: "python", task: "" });
-  const [runNonce, setRunNonce] = useState(0);
+  }>({ opened: false, language: "python", task: "" });
+  /**
+   * The learner's code, owned here rather than by IdePanel.
+   *
+   * IdePanel unmounts whenever the dock switches to the conversation, and it used to own this in
+   * local state, so reading back what the tutor said destroyed whatever the learner had typed.
+   * The tutor could cause it too, since `close_ide` is a tool the model calls on its own.
+   */
+  const [codeBuffer, setCodeBuffer] = useState("");
+  const [runRequest, setRunRequest] = useState<{ nonce: number; stdin: string }>({
+    nonce: 0,
+    stdin: "",
+  });
   const [planOpen, setPlanOpen] = useState(false);
 
-  const codeReaderRef = useRef<(() => { language: string; code: string } | null) | null>(
-    null
-  );
+  const codeBufferRef = useRef("");
+  codeBufferRef.current = codeBuffer;
+  const ideRef = useRef(ide);
+  ideRef.current = ide;
   const launchedRef = useRef(false);
 
   const tutor = useRealtimeTutor({
     onQuiz: setQuiz,
-    onOpenIde: ({ language, task, starter_code }) =>
-      setIde({ open: true, language, task, starter: starter_code }),
-    // The learner can say "close the editor" and the tutor calls close_ide. Keep the
-    // language and buffer around so reopening does not wipe what they wrote.
-    onCloseIde: () => setIde((prev) => ({ ...prev, open: false })),
-    onRunCode: () => setRunNonce((n) => n + 1),
-    readStudentCode: () => codeReaderRef.current?.() ?? null,
+    onOpenIde: ({ language, task, starter_code }) => {
+      setIde({ opened: true, language, task, starter: starter_code });
+      // Show it. Without this the model could "open" an editor that stayed behind the
+      // conversation panel, and then talk about code the learner could not see.
+      setDock("editor");
+    },
+    // The learner can say "close the editor" and the tutor calls close_ide. The buffer lives in
+    // this component, so closing hides the panel and never discards their work.
+    onCloseIde: () => setDock((prev) => (prev === "editor" ? null : prev)),
+    onRunCode: (stdin) => setRunRequest((prev) => ({ nonce: prev.nonce + 1, stdin })),
+    // Read from the buffer directly. This used to go through a ref that IdePanel registered on
+    // mount and never cleared, so after the panel unmounted the model was served the code of an
+    // editor that was no longer on screen.
+    readStudentCode: () =>
+      ideRef.current.opened
+        ? { language: ideRef.current.language, code: codeBufferRef.current }
+        : null,
     onError: (message) => showToast(message, "error"),
   });
 
   const { start, end, phase, sessionId, cards } = tutor;
+
+  // A quiz is deliberately silent - the tutor says one line and waits while the learner reads -
+  // so the idle watchdog must not read that as an abandoned tab and hang up mid-question.
+  useEffect(() => {
+    tutor.setIdleSuspended(Boolean(quiz));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [quiz]);
 
   // Start once, on mount, off the click that navigated here. The microphone prompt and the
   // audio element are both created inside `start`, in the same task, which is what iOS needs
@@ -112,21 +146,14 @@ export default function TutorSessionPage() {
     })();
   }, [level, minutes, slug, source, start, topic]);
 
-  /**
-   * The dock holds one panel at a time, so each opener closes the other.
-   *
-   * Toggling both independently let a learner open the editor over the conversation and then
-   * close the editor back to a conversation they had forgotten was there, which reads as the
-   * room having lost track of its own state.
-   */
+  /** The dock holds one panel, so each toggle both selects and deselects. */
   const openEditor = useCallback(() => {
-    setShowConversation(false);
-    setIde((prev) => ({ ...prev, open: !prev.open }));
+    setIde((prev) => (prev.opened ? prev : { ...prev, opened: true }));
+    setDock((prev) => (prev === "editor" ? null : "editor"));
   }, []);
 
   const openConversation = useCallback(() => {
-    setIde((prev) => ({ ...prev, open: false }));
-    setShowConversation((prev) => !prev);
+    setDock((prev) => (prev === "conversation" ? null : "conversation"));
   }, []);
 
   const leave = useCallback(async () => {
@@ -456,13 +483,17 @@ export default function TutorSessionPage() {
             )}
           </Box>
 
-          {/* The side dock. Editor and conversation share it: two 470px panels plus the
-              canvas does not fit on a laptop, and stacking them would make both cramped.
-              Opening one closes the other, which also matches how they are used - you read
-              back what was said, or you write code, not both at once. */}
-          {ide.open || showConversation ? (
+          {/* The side dock. Editor and conversation share one 470px slot: both plus the canvas
+              does not fit on a laptop, and stacking them would make both cramped.
+
+              IdePanel stays MOUNTED once opened, hidden with `display` rather than unmounted,
+              because Monaco is expensive to re-create and because unmounting it used to be how
+              the learner's code got destroyed. The buffer now lives in this component, so the
+              mount is about editor state (cursor, undo history, scroll) rather than the text. */}
+          {ide.opened || dock ? (
             <Box
               sx={{
+                display: dock ? "block" : "none",
                 width: { xs: "100%", md: 470 },
                 flexShrink: 0,
                 position: { xs: "absolute", md: "static" },
@@ -470,28 +501,33 @@ export default function TutorSessionPage() {
                 zIndex: { xs: 10, md: "auto" },
               }}
             >
-              {ide.open ? (
-                <IdePanel
-                  open={ide.open}
-                  sessionId={sessionId}
-                  language={ide.language}
-                  task={ide.task}
-                  starterCode={ide.starter}
-                  onClose={() => setIde((prev) => ({ ...prev, open: false }))}
-                  onShareCode={tutor.shareCode}
-                  onRunResult={tutor.reportRunResult}
-                  registerReader={(reader) => {
-                    codeReaderRef.current = reader;
-                  }}
-                  runRequestNonce={runNonce}
-                />
-              ) : (
+              {ide.opened ? (
+                <Box
+                  sx={{ display: dock === "editor" ? "block" : "none", height: "100%" }}
+                >
+                  <IdePanel
+                    open
+                    sessionId={sessionId}
+                    language={ide.language}
+                    task={ide.task}
+                    starterCode={ide.starter}
+                    onClose={() => setDock(null)}
+                    onShareCode={tutor.shareCode}
+                    onRunResult={tutor.reportRunResult}
+                    runRequestNonce={runRequest.nonce}
+                    runStdin={runRequest.stdin}
+                    value={codeBuffer}
+                    onValueChange={setCodeBuffer}
+                  />
+                </Box>
+              ) : null}
+              {dock === "conversation" ? (
                 <ConversationPanel
                   entries={tutor.transcript}
                   liveCaption={tutor.phase === "speaking" ? tutor.caption : ""}
-                  onClose={() => setShowConversation(false)}
+                  onClose={() => setDock(null)}
                 />
-              )}
+              ) : null}
             </Box>
           ) : null}
         </Box>
@@ -517,12 +553,12 @@ export default function TutorSessionPage() {
               component="button"
               type="button"
               onClick={openEditor}
-              aria-pressed={ide.open}
-              sx={{ ...dockBtn, ...(ide.open ? dockBtnOn : null) }}
+              aria-pressed={dock === "editor"}
+              sx={{ ...dockBtn, ...(dock === "editor" ? dockBtnOn : null) }}
             >
               <Icon icon="solar:code-square-bold-duotone" width={17} />
               <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
-                {ide.open ? "Hide editor" : "Editor"}
+                {dock === "editor" ? "Hide editor" : "Editor"}
               </Box>
             </Box>
 
@@ -530,12 +566,12 @@ export default function TutorSessionPage() {
               component="button"
               type="button"
               onClick={openConversation}
-              aria-pressed={showConversation}
-              sx={{ ...dockBtn, ...(showConversation ? dockBtnOn : null) }}
+              aria-pressed={dock === "conversation"}
+              sx={{ ...dockBtn, ...(dock === "conversation" ? dockBtnOn : null) }}
             >
               <Icon icon="solar:chat-round-line-bold-duotone" width={17} />
               <Box component="span" sx={{ display: { xs: "none", sm: "inline" } }}>
-                {showConversation ? "Hide conversation" : "Conversation"}
+                {dock === "conversation" ? "Hide conversation" : "Conversation"}
               </Box>
             </Box>
 
@@ -555,6 +591,7 @@ export default function TutorSessionPage() {
         onClose={() => setQuiz(null)}
         tutorCaption={tutor.caption}
         tutorSpeaking={tutor.phase === "speaking"}
+        tutorTurnId={tutor.tutorTurnId}
       />
     </MainLayout>
   );

--- a/app/ai-tutor/session/[id]/recap/page.tsx
+++ b/app/ai-tutor/session/[id]/recap/page.tsx
@@ -35,6 +35,9 @@ import { aiTutorKeys, aiTutorService } from "@/lib/services/ai-tutor.service";
  * is still running rather than showing a spinner over the whole thing.
  */
 
+/** How many times to poll for a recap that is still being written before giving up. */
+const POLL_LIMIT = 40;
+
 const STATUS_TONE: Record<string, { icon: string; colour: string; label: string }> = {
   solid: { icon: "solar:check-circle-bold", colour: "#16a34a", label: "Solid" },
   shaky: { icon: "solar:minus-circle-bold", colour: "#d97706", label: "Needs another pass" },
@@ -51,11 +54,24 @@ export default function TutorRecapPage() {
     queryKey: aiTutorKeys.recap(sessionId),
     queryFn: () => aiTutorService.recap(sessionId),
     enabled: Boolean(sessionId),
-    // The recap is written by a Celery task after the session ends, so poll briefly
-    // rather than making the learner refresh.
+    /**
+     * The recap is written by a Celery task after the session ends, so poll briefly rather than
+     * making the learner refresh.
+     *
+     * Bounded at POLL_LIMIT. An unbounded poll meant a recap task that died left the tab
+     * requesting every four seconds indefinitely, which is a request every four seconds against
+     * a backend served from four gunicorn slots, for a page nobody is watching any more.
+     */
     refetchInterval: (query) =>
-      query.state.data?.recap_status === "pending" ? 4000 : false,
+      query.state.data?.recap_status === "pending" &&
+      query.state.dataUpdateCount < POLL_LIMIT
+        ? 4000
+        : false,
   });
+
+  // A poll failure is transient and must not throw away a recap we already have. `isError` alone
+  // replaced the entire page with "We could not find that session" on one dropped request.
+  const failedOutright = isError && !data;
 
   // Landing here means a session just ended, whichever route got us here (including a tab
   // restored from history). Marking the dashboard stale once is cheap and removes the "my
@@ -69,7 +85,7 @@ export default function TutorRecapPage() {
     prefetch("/ai-tutor");
   }, [prefetch]);
 
-  if (isError) {
+  if (failedOutright) {
     return (
       <PageShell>
         <ModulePageHeader
@@ -91,12 +107,16 @@ export default function TutorRecapPage() {
   }
 
   const recap = data?.recap ?? {};
+  const recapText = (recap.summary ?? "").trim();
   const concepts = recap.concepts ?? [];
   const notes = data?.notes ?? [];
   const artifacts = data?.artifacts ?? [];
   const quiz = data?.quiz ?? [];
   const pending = data?.recap_status === "pending";
   const skipped = data?.recap_status === "skipped";
+  // Anything that is not pending, skipped or a written recap. Previously this rendered a tinted
+  // card containing nothing at all, which reads as the page being broken rather than the recap.
+  const unwritten = Boolean(data) && !pending && !skipped && !recapText;
 
   const cardCount = notes.filter((n) => n.prompt?.trim() && n.answer?.trim()).length;
   const quizRight = quiz.filter((q) => q.is_correct).length;
@@ -200,6 +220,18 @@ export default function TutorRecapPage() {
               That session was too short to write up. Start another and talk for a few minutes
               to get a recap.
             </Typography>
+          ) : unwritten ? (
+            <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5 }}>
+              <Icon
+                icon="solar:danger-triangle-bold-duotone"
+                width={18}
+                style={{ color: "#d97706", marginTop: 2, flexShrink: 0 }}
+              />
+              <Typography sx={{ fontSize: "0.95rem", color: "var(--font-secondary)", lineHeight: 1.6 }}>
+                We could not write up this session. Everything below is still yours: the
+                transcript, anything that went on the canvas, and any flashcards it saved.
+              </Typography>
+            </Box>
           ) : (
             <Typography sx={{ fontSize: { xs: "1rem", md: "1.05rem" }, lineHeight: 1.7 }}>
               {recap.summary}
@@ -341,7 +373,7 @@ export default function TutorRecapPage() {
                           mt: 0.35,
                         }}
                       >
-                        You picked {attempt.selected.join(", ")}
+                        You picked {describePicked(attempt)}
                       </Typography>
                     ) : null}
                   </Box>
@@ -417,6 +449,24 @@ export default function TutorRecapPage() {
       </Box>
     </PageShell>
   );
+}
+
+/**
+ * What the learner actually chose, in words.
+ *
+ * A bare "You picked B" is useless a day later: the letter means nothing without the option list,
+ * and this is the one place the recap is meant to be readable on its own.
+ */
+function describePicked(attempt: {
+  selected?: string[];
+  question?: { options?: { id: string; label: string }[] };
+}): string {
+  const options = attempt.question?.options ?? [];
+  const labels = (attempt.selected ?? []).map((id) => {
+    const match = options.find((o) => o.id === id);
+    return match?.label ? `${id}. ${match.label}` : id;
+  });
+  return labels.join("; ");
 }
 
 const LEVEL_LABEL: Record<string, string> = {

--- a/components/ai-tutor/dashboard/CapabilityPanel.tsx
+++ b/components/ai-tutor/dashboard/CapabilityPanel.tsx
@@ -18,7 +18,15 @@ import { TutorTintSurface } from "../shared/surfaces";
  * page fell back to the white-on-white column this replaced.
  */
 
-const CAPABILITIES = [
+interface Capability {
+  icon: string;
+  title: string;
+  detail: string;
+  /** Only shown when the tenant has the code editor switched on. */
+  needsCoding?: boolean;
+}
+
+const CAPABILITIES: Capability[] = [
   {
     icon: "solar:hand-stars-bold-duotone",
     title: "Cut in whenever",
@@ -33,6 +41,10 @@ const CAPABILITIES = [
     icon: "solar:code-square-bold-duotone",
     title: "Code with it watching",
     detail: 'Say "open the editor". It reads what you write and asks why.',
+    // The tool is not even offered to the model on a tenant with coding disabled, so promising
+    // it here produced the one outcome this panel exists to prevent: a learner asking for
+    // something and the tutor not doing it.
+    needsCoding: true,
   },
   {
     icon: "solar:gallery-bold-duotone",
@@ -41,7 +53,8 @@ const CAPABILITIES = [
   },
 ];
 
-export function CapabilityPanel() {
+export function CapabilityPanel({ codingEnabled = true }: { codingEnabled?: boolean }) {
+  const items = CAPABILITIES.filter((c) => !c.needsCoding || codingEnabled);
   return (
     <TutorTintSurface tint="indigo" padded={false}>
       <Box
@@ -74,7 +87,7 @@ export function CapabilityPanel() {
       </Box>
 
       <Box sx={{ px: { xs: 2, md: 2.5 }, py: 1.75, display: "grid", gap: 1.75 }}>
-        {CAPABILITIES.map((item) => (
+        {items.map((item) => (
           <Box key={item.title} sx={{ display: "flex", gap: 1.25, alignItems: "flex-start" }}>
             <Box
               sx={{

--- a/components/ai-tutor/dashboard/MinutesPanel.tsx
+++ b/components/ai-tutor/dashboard/MinutesPanel.tsx
@@ -24,9 +24,51 @@ const RADIUS = (RING - STROKE) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 export function MinutesPanel({ quota }: { quota?: TutorQuota }) {
+  /**
+   * Nothing to report yet.
+   *
+   * Without this the panel defaulted every figure to zero and stated "0 of 0 minutes left" for
+   * the whole first paint, which is not a slow number arriving late: it is a confident claim that
+   * the learner has no allowance. Some of them would have closed the tab.
+   */
+  if (!quota) {
+    return (
+      <TutorTintSurface tint="deep">
+        <Typography
+          sx={{
+            fontSize: "0.7rem",
+            fontWeight: 600,
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            color: "rgba(255,255,255,0.6)",
+            mb: 2,
+            '[dir="rtl"] &': { letterSpacing: "normal", textTransform: "none" },
+          }}
+        >
+          This month
+        </Typography>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 2.25 }}>
+          <Box
+            sx={{
+              width: RING,
+              height: RING,
+              borderRadius: 9999,
+              flexShrink: 0,
+              border: `${STROKE}px solid rgba(255,255,255,0.14)`,
+            }}
+          />
+          <Box sx={{ flex: 1, display: "grid", gap: 1 }}>
+            <Box sx={{ height: 13, width: "78%", borderRadius: 9999, bgcolor: "rgba(255,255,255,0.14)" }} />
+            <Box sx={{ height: 11, width: "56%", borderRadius: 9999, bgcolor: "rgba(255,255,255,0.1)" }} />
+          </Box>
+        </Box>
+      </TutorTintSurface>
+    );
+  }
+
   // Staff bypass the reservation, so their number never moves. Rendering "30 of 30 left" is
   // indistinguishable from a broken meter, which is exactly how it was first reported.
-  if (quota?.unmetered) {
+  if (quota.unmetered) {
     return (
       <TutorTintSurface tint="deep">
         <Box sx={{ display: "flex", alignItems: "center", gap: 1.75 }}>
@@ -56,9 +98,9 @@ export function MinutesPanel({ quota }: { quota?: TutorQuota }) {
     );
   }
 
-  const limit = quota?.minutes_limit ?? 0;
-  const used = quota?.minutes_used ?? 0;
-  const remaining = quota?.minutes_remaining ?? 0;
+  const limit = quota.minutes_limit ?? 0;
+  const used = quota.minutes_used ?? 0;
+  const remaining = quota.minutes_remaining ?? 0;
   const fraction = limit > 0 ? Math.min(1, Math.max(0, remaining / limit)) : 0;
   const low = limit > 0 && remaining <= 5;
   const out = limit > 0 && remaining < 2;
@@ -147,7 +189,7 @@ export function MinutesPanel({ quota }: { quota?: TutorQuota }) {
           >
             {used} used so far. Resets at the start of next month.
           </Typography>
-          {quota?.max_session_minutes ? (
+          {quota.max_session_minutes ? (
             <Typography
               sx={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.52)", mt: 0.75 }}
             >

--- a/components/ai-tutor/recap/RecapFlashcards.tsx
+++ b/components/ai-tutor/recap/RecapFlashcards.tsx
@@ -24,29 +24,37 @@ type Grade = "got" | "missed";
 
 export function RecapFlashcards({ notes }: { notes: TutorNote[] }) {
   const cards = useMemo(() => notes.filter((n) => n.prompt?.trim() && n.answer?.trim()), [notes]);
-  const [index, setIndex] = useState(0);
   const [revealed, setRevealed] = useState(false);
   const [grades, setGrades] = useState<Record<number, Grade>>({});
 
+  /**
+   * Position is DERIVED from what has been graded, not held in a separate index.
+   *
+   * The recap polls while the summary is still being written, so `notes` can grow underneath this
+   * component. A manual index plus a `graded >= cards.length` completion test went inconsistent
+   * the moment that happened: the index clamped to the old last card, re-grading it did not move
+   * the count because grades are keyed by id, and the deck could never complete. Deriving both
+   * from the same source makes the deck simply absorb new cards.
+   *
+   * Counting only ids still present also stops a card that has left the deck from keeping the
+   * completion count above the deck size.
+   */
+  const graded = cards.filter((c) => grades[c.id]).length;
+  const got = cards.filter((c) => grades[c.id] === "got").length;
+  const card = cards.find((c) => !grades[c.id]);
+  const done = cards.length > 0 && !card;
+
   if (!cards.length) return null;
 
-  const card = cards[Math.min(index, cards.length - 1)];
-  const graded = Object.keys(grades).length;
-  const got = Object.values(grades).filter((g) => g === "got").length;
-  const done = graded >= cards.length;
-
   const advance = (grade: Grade) => {
+    if (!card) return;
     setGrades((prev) => ({ ...prev, [card.id]: grade }));
     setRevealed(false);
-    // Stop at the end rather than wrapping: wrapping to card 1 after the last card reads
-    // as the widget having lost your place.
-    setIndex((i) => Math.min(i + 1, cards.length - 1));
   };
 
   const restart = () => {
     setGrades({});
     setRevealed(false);
-    setIndex(0);
   };
 
   return (
@@ -63,7 +71,7 @@ export function RecapFlashcards({ notes }: { notes: TutorNote[] }) {
       >
         <Icon icon="solar:cards-bold-duotone" width={18} style={{ color: "var(--ai-violet)" }} />
         <Typography sx={{ fontSize: "0.88rem", fontWeight: 600 }}>
-          Card {Math.min(index + 1, cards.length)} of {cards.length}
+          Card {Math.min(graded + 1, cards.length)} of {cards.length}
         </Typography>
         <Box sx={{ flex: 1 }} />
         {graded > 0 ? (
@@ -124,7 +132,7 @@ export function RecapFlashcards({ notes }: { notes: TutorNote[] }) {
               Run the deck again
             </Box>
           </Box>
-        ) : (
+        ) : card ? (
           <>
             <Typography
               sx={{
@@ -215,7 +223,7 @@ export function RecapFlashcards({ notes }: { notes: TutorNote[] }) {
               </Box>
             ) : null}
           </>
-        )}
+        ) : null}
       </Box>
     </TutorSurface>
   );

--- a/components/ai-tutor/room/IdePanel.tsx
+++ b/components/ai-tutor/room/IdePanel.tsx
@@ -27,6 +27,12 @@ import {
  * paused for a couple of seconds, and the buffer has actually changed materially since the
  * last push. There is a visible toggle, because some people want to think in silence.
  *
+ * The buffer is NOT owned here. It lives in the room page and arrives as `value`/`onChange`,
+ * because this panel unmounts whenever the learner opens the conversation beside it, and local
+ * state would take their code with it. Losing typed code in a metered voice session is the worst
+ * thing this panel could do, and it also let the tutor cause it: `close_ide` is a tool the model
+ * can call on its own.
+ *
  * Running code is NOT a model-callable backend tool. Judge0 is a synchronous call with a
  * long timeout, and the platform serves every request from four gunicorn slots; a
  * model-triggered run in the tool path would mean up to thirty seconds of silence AND a
@@ -55,8 +61,10 @@ export function IdePanel({
   onClose,
   onShareCode,
   onRunResult,
-  registerReader,
   runRequestNonce,
+  runStdin = "",
+  value,
+  onValueChange,
 }: {
   open: boolean;
   /** Runs are scoped to the session server-side; without it there is nothing to run against. */
@@ -67,10 +75,15 @@ export function IdePanel({
   onClose: () => void;
   onShareCode: (language: string, code: string) => void;
   onRunResult: (summary: string) => void;
-  registerReader: (reader: () => { language: string; code: string } | null) => void;
   runRequestNonce: number;
+  /** Input the model asked to feed the program, from request_code_run. */
+  runStdin?: string;
+  /** The buffer, owned by the room so it survives this panel unmounting. */
+  value: string;
+  onValueChange: (next: string) => void;
 }) {
-  const [code, setCode] = useState(starterCode ?? "");
+  const code = value;
+  const setCode = onValueChange;
   const [watching, setWatching] = useState(true);
   const [running, setRunning] = useState(false);
   const [output, setOutput] = useState<string>("");
@@ -80,16 +93,14 @@ export function IdePanel({
   const lastPushedRef = useRef("");
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Seed from the scaffold only while the buffer is empty. A second `open_ide` mid-lesson used
+  // to overwrite whatever the learner had written with the new exercise's starter code.
   useEffect(() => {
-    if (starterCode !== undefined) setCode(starterCode);
+    if (starterCode && !codeRef.current.trim()) setCode(starterCode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [starterCode]);
 
-  // Let the hook read the buffer when the model calls read_student_code.
-  useEffect(() => {
-    registerReader(() => ({ language, code: codeRef.current }));
-  }, [language, registerReader]);
-
-  const runCode = useCallback(async () => {
+  const runCode = useCallback(async (stdin = "") => {
     if (running || !codeRef.current.trim() || !sessionId) return;
     setRunning(true);
     setOutput("");
@@ -97,6 +108,9 @@ export function IdePanel({
       const result = await aiTutorService.runCode(sessionId, {
         source: codeRef.current,
         language,
+        // The model can pass input with request_code_run. Dropping it meant a program that
+        // reads stdin ran against nothing and the tutor read back a confusing result.
+        ...(stdin ? { stdin } : {}),
       });
       // A refusal is a normal 200 carrying a learner-facing sentence. Show it as-is
       // rather than turning "add a main() method" into "something went wrong".
@@ -119,9 +133,19 @@ export function IdePanel({
     }
   }, [language, onRunResult, running, sessionId]);
 
-  // The model can ask for a run; the browser performs it on its own timeline.
+  /**
+   * The model can ask for a run; the browser performs it on its own timeline.
+   *
+   * `seenNonceRef` starts at the nonce's current value rather than at zero, so mounting the panel
+   * when the model has already requested runs earlier in the lesson does not immediately fire one.
+   * That mattered when this panel remounted on every dock switch, and is still the correct
+   * behaviour for a fresh mount.
+   */
+  const seenNonceRef = useRef(runRequestNonce);
   useEffect(() => {
-    if (runRequestNonce > 0) void runCode();
+    if (runRequestNonce === seenNonceRef.current) return;
+    seenNonceRef.current = runRequestNonce;
+    void runCode(runStdin);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runRequestNonce]);
 
@@ -224,7 +248,7 @@ export function IdePanel({
         <Box
           component="button"
           type="button"
-          onClick={runCode}
+          onClick={() => void runCode()}
           disabled={running}
           sx={{
             px: 1.75,

--- a/components/ai-tutor/room/QuizOverlay.tsx
+++ b/components/ai-tutor/room/QuizOverlay.tsx
@@ -44,6 +44,7 @@ export function QuizOverlay({
   onClose,
   tutorCaption = "",
   tutorSpeaking = false,
+  tutorTurnId = 0,
 }: {
   question: PooledQuestion | null;
   onAnswer: (questionId: number, selected: string[]) => Promise<QuizGradeResult | null>;
@@ -51,13 +52,29 @@ export function QuizOverlay({
   /** The tutor's live transcript, so its reaction shows up here rather than only in audio. */
   tutorCaption?: string;
   tutorSpeaking?: boolean;
+  /** Increments per spoken turn. Used to tell "has it spoken SINCE I answered". */
+  tutorTurnId?: number;
 }) {
   const [selected, setSelected] = useState<string[]>([]);
   const [result, setResult] = useState<QuizGradeResult | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  // Captured at submit time so the echo only shows what the tutor said about THIS answer,
-  // not whatever it happened to be mid-sentence about when the quiz opened.
-  const [captionAtSubmit, setCaptionAtSubmit] = useState("");
+  /**
+   * Set when grading could not complete.
+   *
+   * Without this the dialog was a trap: `onAnswer` returns null on a network failure, `result`
+   * stayed null, and with `onClose` wired to `result ? close : undefined` there was no backdrop
+   * click, no Escape, and no visible explanation. The learner was stuck looking at a question
+   * inside a paid session.
+   */
+  const [gradeError, setGradeError] = useState(false);
+  /**
+   * The tutor's turn number at the moment the answer was sent.
+   *
+   * The echo below only renders once the counter has moved past this, which is the only reliable
+   * way to know the tutor is talking about THIS answer. Diffing the caption string could not
+   * work, because `caption` is a sliding window and scrolls past any snapshot.
+   */
+  const [turnAtSubmit, setTurnAtSubmit] = useState(0);
 
   const multi = question?.style === "multiple";
 
@@ -67,7 +84,8 @@ export function QuizOverlay({
     setSelected([]);
     setResult(null);
     setSubmitting(false);
-    setCaptionAtSubmit("");
+    setTurnAtSubmit(0);
+    setGradeError(false);
   }, [question?.id]);
 
   const toggle = (id: string) => {
@@ -80,33 +98,34 @@ export function QuizOverlay({
   const submit = async () => {
     if (!question || !selected.length || submitting) return;
     setSubmitting(true);
-    setCaptionAtSubmit(tutorCaption);
+    setGradeError(false);
+    setTurnAtSubmit(tutorTurnId);
     const graded = await onAnswer(question.id, selected);
-    setResult(graded);
+    // A null grade is a failed round trip, not a wrong answer. Never render it as one.
+    if (graded && graded.ok !== false) setResult(graded);
+    else setGradeError(true);
     setSubmitting(false);
   };
 
   const close = () => {
     setSelected([]);
     setResult(null);
-    setCaptionAtSubmit("");
+    setTurnAtSubmit(0);
+    setGradeError(false);
     onClose();
   };
 
   if (!question) return null;
 
-  // Anything the tutor has said since the answer went in. Empty until it starts reacting.
-  const reaction =
-    result && tutorCaption !== captionAtSubmit
-      ? tutorCaption.startsWith(captionAtSubmit)
-        ? tutorCaption.slice(captionAtSubmit.length).trim()
-        : tutorCaption.trim()
-      : "";
+  // What the tutor has said in a turn that STARTED after the answer went in.
+  const reaction = result && tutorTurnId > turnAtSubmit ? tutorCaption.trim() : "";
 
   return (
     <Dialog
       open
-      onClose={result ? close : undefined}
+      // Always closable. A quiz the learner cannot leave is worse than a quiz they skip, and
+      // they are paying by the minute while they look at it.
+      onClose={close}
       maxWidth="sm"
       fullWidth
       slotProps={{
@@ -240,6 +259,32 @@ export function QuizOverlay({
             })}
         </Box>
 
+        {gradeError ? (
+          <Box
+            sx={{
+              mt: 2.5,
+              p: 2,
+              borderRadius: "10px",
+              bgcolor: ROOM_INK,
+              border: "1px solid rgba(251,191,36,0.34)",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.85, mb: 0.5 }}>
+              <Icon
+                icon="solar:danger-triangle-bold"
+                width={17}
+                style={{ color: "#fbbf24" }}
+              />
+              <Typography sx={{ fontSize: "0.92rem", fontWeight: 600, color: "#fbbf24" }}>
+                Could not check that
+              </Typography>
+            </Box>
+            <Typography sx={{ fontSize: "0.88rem", color: ROOM_TEXT_DIM, lineHeight: 1.55 }}>
+              Your answer did not reach us. Try again, or skip it and carry on with the lesson.
+            </Typography>
+          </Box>
+        ) : null}
+
         {result ? (
           <Box
             sx={{
@@ -299,15 +344,41 @@ export function QuizOverlay({
                 }}
               >
                 {reaction ||
-                  (tutorSpeaking
-                    ? "Your tutor is picking this up…"
-                    : "Your tutor has your answer and will pick it up.")}
+                  (result?.delivered === false
+                    ? "Your tutor did not receive this one, so it will not comment on it."
+                    : tutorSpeaking
+                      ? "Your tutor is picking this up…"
+                      : "Your tutor has your answer and will pick it up.")}
               </Typography>
             </Box>
           </Box>
         ) : null}
 
         <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 1, mt: 2.5 }}>
+          {!result ? (
+            <Box
+              component="button"
+              type="button"
+              onClick={close}
+              sx={{
+                px: 2,
+                py: 1.15,
+                borderRadius: "8px",
+                border: `1px solid ${ROOM_BORDER}`,
+                bgcolor: "transparent",
+                fontFamily: "inherit",
+                fontSize: "0.9rem",
+                fontWeight: 500,
+                color: ROOM_TEXT_DIM,
+                cursor: "pointer",
+                transition: "color 160ms ease, border-color 160ms ease",
+                "&:hover": { color: ROOM_TEXT, borderColor: ROOM_TEXT_DIM },
+                "&:focus-visible": roomFocusRing,
+              }}
+            >
+              Skip
+            </Box>
+          ) : null}
           <Box
             component="button"
             type="button"
@@ -330,7 +401,13 @@ export function QuizOverlay({
               "&:focus-visible": roomFocusRing,
             }}
           >
-            {result ? "Back to the lesson" : submitting ? "Checking…" : "Check my answer"}
+            {result
+              ? "Back to the lesson"
+              : submitting
+                ? "Checking…"
+                : gradeError
+                  ? "Try again"
+                  : "Check my answer"}
           </Box>
         </Box>
       </Box>

--- a/components/ai-tutor/room/Strands.tsx
+++ b/components/ai-tutor/room/Strands.tsx
@@ -52,6 +52,7 @@ uniform float uHueShift;
 uniform float uIntensity;
 uniform float uOpacity;
 uniform float uScale;
+uniform float uScaleY;
 uniform float uSaturation;
 
 out vec4 fragColor;
@@ -79,7 +80,13 @@ vec3 strandColor(float t) {
 
 void main() {
   vec2 uv = (gl_FragCoord.xy - 0.5 * uResolution) / uResolution.y;
-  uv /= max(uScale, 0.0001);
+  // Anisotropic on purpose. A single isotropic scale has to serve two jobs at once: fit the
+  // taper envelope horizontally, and leave the wave somewhere to move vertically. In a wide band
+  // those conflict, and the horizontal fit wins, squeezing uv.y until the wave's own excursion is
+  // several times the visible height. The ribbon then reads as a flat line whose amplitude does
+  // not respond to the voice, because the movement is happening off-screen.
+  uv.x /= max(uScale, 0.0001);
+  uv.y /= max(uScaleY, 0.0001);
 
   float e = 0.06 + uIntensity * 0.94;
   float env = pow(max(cos(uv.x * PI * 1.3), 0.0), uTaper);
@@ -270,6 +277,15 @@ const TAPER_ZERO = 0.3846;
  */
 const RIBBON_FILL = 0.82;
 
+/**
+ * Ceiling on the vertical scale, so `uv.y` never shrinks below the wave's own excursion.
+ *
+ * The wave peaks at roughly +/-0.1125 uv units at these settings. A cap of 3 gives +/-0.167, so
+ * about 1.5x headroom at any aspect ratio. Without it a 10:1 band had +/-0.047 - the wave swung
+ * more than twice the visible height, off the top and bottom of the container.
+ */
+const MAX_VERTICAL_SCALE = 3.0;
+
 const buildPalette = (colors: string[]): number[][] => {
   const filled = colors && colors.length ? colors : ["#ffffff"];
   const padded: number[][] = [];
@@ -359,6 +375,7 @@ export default function Strands({
   fitRef.current = fitSingleRibbon;
   /** Minimum uScale that keeps the taper envelope to one lobe at the current aspect. */
   const minScaleRef = useRef(0);
+  const minScaleYRef = useRef(0);
 
   const ctnDom = useRef<HTMLDivElement>(null);
 
@@ -445,6 +462,9 @@ export default function Strands({
       // ribbon's own fade comfortably inside the frame: no tiling, and no crop either.
       minScaleRef.current =
         ((width / Math.max(height, 1)) * RIBBON_FILL) / (2 * TAPER_ZERO);
+      // Vertical scale is capped, so a short wide band keeps room for the wave. Below the cap
+      // the two are equal and the effect is exactly as isotropic as it always was.
+      minScaleYRef.current = Math.min(minScaleRef.current, MAX_VERTICAL_SCALE);
     }
     window.addEventListener("resize", resize);
     const observer =
@@ -486,6 +506,9 @@ export default function Strands({
       program.uniforms.uOpacity.value = current.opacity;
       program.uniforms.uScale.value = fitRef.current
         ? minScaleRef.current
+        : current.scale;
+      program.uniforms.uScaleY.value = fitRef.current
+        ? minScaleYRef.current
         : current.scale;
       program.uniforms.uSaturation.value = current.saturation;
 

--- a/docs/modules/ai-tutor-client.md
+++ b/docs/modules/ai-tutor-client.md
@@ -137,6 +137,14 @@ that had been cropped. It is now `(aspect * RIBBON_FILL) / (2 * TAPER_ZERO)` wit
 is also an absolute rather than a floor: `Math.max` against the caller's `scale` re-introduced
 the crop in any container narrower than about 4:3.
 
+`uScale` is **anisotropic** (`uScale` for x, `uScaleY` for y, capped at `MAX_VERTICAL_SCALE`). One
+isotropic scale had to serve two conflicting jobs — fit the taper horizontally, and leave the wave
+room to move vertically — and in a wide band the horizontal fit won. At the room's band aspect
+(~5.6:1) `uv.y` spanned ±0.084 while the wave's own excursion is ±0.113, and at 10:1 it was ±0.047:
+the ribbon read as a flat line whose amplitude did not respond to the voice, because the movement
+was happening off-screen. The cap keeps ~1.5x headroom at any aspect and leaves tall or square
+containers exactly as isotropic as they were.
+
 The palettes in `TutorVoice.tsx` each lead with a near-white and fall through lavender to a
 cooler indigo or cyan. A single-hue palette renders flat no matter how much glow is applied,
 because the shader distributes a palette *along* the strand (`uv.x * 0.30` plus a per-strand
@@ -220,12 +228,31 @@ So nothing sends `response.create` directly. `requestResponse()` sends it only w
 drains on `response.done` / `response.cancelled`. One deep on purpose: three tool results
 arriving during one long answer should produce one reaction, not three consecutive monologues.
 
-Two details that matter. The gate is set optimistically *before* sending, or two results landing
-in the same tick both see `false` and both send. And the `error` handler re-queues on an
-"active response" message rather than surfacing it, because OpenAI can start a response we were
-never told about, which leaves the gate stale no matter how careful the local bookkeeping is.
+The gate is set optimistically *before* sending, or two results landing in the same tick both see
+`false` and both send. That optimism is the dangerous part, because a gate held on nothing means a
+**permanently mute tutor**, which is far worse than the duplicate-response error the gate exists
+to prevent. Three things make it fail open:
+
+- `send` returns whether the payload actually left the browser. It no-ops when the data channel is
+  not open, and the gate is released immediately if so — nothing was requested, so no
+  `response.created` or `response.done` will ever arrive to release it.
+- an `error` that is *not* an "active response" message releases the gate before being surfaced.
+  (An "active response" message re-queues instead: OpenAI can start a response we were never told
+  about, which leaves local bookkeeping stale however careful it is.)
+- `armResponseWatchdog` releases the gate after `RESPONSE_ACK_TIMEOUT_MS` if no
+  `response.created` arrives, covering rejection modes we have not enumerated.
+
+`releaseResponseGate(false)` is barge-in. On `response.cancelled` the queue is **dropped, not
+drained**: the response was cancelled because the learner started talking, so firing what had
+queued behind it would make the tutor answer over the top of them — the exact behaviour this
+feature exists to prevent. Whatever they are about to say is more current than a queued reaction.
+
 The gate is also cleared in `teardownTransport`, since a stuck `true` across a reconnect would
 mean the tutor never spoke again after one.
+
+`tellTutor` returns whether its message was delivered, and `submitQuizAnswer` passes that through
+as `delivered` on the grade. The quiz overlay tells the learner "your tutor has your answer", and
+it must not say that when the channel was closed and the message was dropped.
 
 ### Tool dispatch
 
@@ -292,8 +319,36 @@ Consequences worth knowing:
   lesson. It also echoes the tutor's live caption under the verdict, because otherwise the
   learner is being spoken to while looking at a modal that shows no sign of having heard them.
 - The side dock holds **one** panel: the editor or the conversation, never both. Two 470px
-  panels plus the canvas does not fit on a laptop, and letting them toggle independently meant
-  closing the editor could reveal a conversation panel the learner had forgotten was open.
+  panels plus the canvas does not fit on a laptop. `dock` is a `"editor" | "conversation" | null`
+  selector rather than two booleans, because independent toggles meant closing the editor could
+  reveal a conversation panel the learner had forgotten was open.
+- **The learner's code lives in the room page, not in `IdePanel`.** This is the most important
+  invariant in the room. `IdePanel` owned it in local state, and since the dock rendered one child
+  at a time, opening the conversation unmounted the panel and destroyed the buffer — with no
+  recovery anywhere, because Monaco disposes its model on unmount (`keepCurrentModel` defaults to
+  false) so even the undo stack went. The tutor could trigger it too, since `close_ide` is a tool
+  the model calls on its own. `IdePanel` now also stays **mounted** once opened, hidden with
+  `display`, which keeps cursor, undo history and scroll position across a dock switch.
+- `read_student_code` reads the buffer directly. It used to go through a ref that `IdePanel`
+  registered on mount and never cleared, so after unmount the model was served the code of an
+  editor that was no longer on screen.
+- `starterCode` seeds only an **empty** buffer. A second `open_ide` mid-lesson used to overwrite
+  whatever the learner had written with the new exercise's scaffold.
+- `request_code_run` returns `ok: false` when no editor is open or the buffer is empty. Answering
+  `status: "running"` made the tutor announce it was running code and then wait forever for output
+  that could never arrive.
+- The idle watchdog is **suspended while the quiz modal is open**. It measures silence, and a quiz
+  is deliberately silent — the tutor says one line and waits while the learner reads. Learners were
+  being hung up on mid-question, and the "still there?" prompt that would have saved them renders
+  behind the modal.
+- The quiz overlay is always closable and has a Skip button. `onAnswer` returns null on a failed
+  round trip, which left `result` null, `onClose` wired to `undefined`, and the learner trapped in
+  a dialog inside a metered session. An ungraded answer (`ok: false`) is also never rendered as
+  "Not quite." or reported to the tutor as wrong.
+- The overlay's "tutor is reacting" echo keys off `tutorTurnId`, a counter that increments on
+  `response.created`. It used to diff the caption against a snapshot, which cannot work: `caption`
+  is a 320-character sliding window, so once it scrolled past the snapshot the overlay fell back to
+  showing the whole window — including what the tutor was saying *before* the answer was sent.
 - The transport bar reserves right-hand padding for the fixed support FAB, which otherwise sits
   on top of "End session".
 - **Strands appears only here.** It was briefly on the dashboard composer and was removed: the
@@ -327,9 +382,9 @@ cards in a row is not colour, it is noise.
 | Pick up where you left off | Content | **Self-hides.** |
 | Because of what you're studying | Content | Falls through enrolled courses → weak skills → roadmap next-steps → hides. |
 | Browse by track | Content | Always present. 56 seeded topics across 7 tracks, with track filters. |
-| "You have not had a lesson yet" | Content | **Only** on a first visit, so the column has a floor once everything above it hides. |
-| Minutes ring | Rail | Complete, from the quota call. Shows "Unlimited" for staff, who bypass the reservation. |
-| Things you can say | Rail | **Always present, never hides.** This is what keeps the rail full for an account with no history. |
+| "You have not had a lesson yet" | Content | **Only** on a first visit, so the column has a floor once everything above it hides. Gated on `data`, not `!isLoading`: on a failed fetch `isLoading` is also false, which would tell a learner with a full history they had never had a lesson. |
+| Minutes ring | Rail | Skeleton until the quota arrives — it used to default every figure to zero and state "0 of 0 minutes left", which is not a slow number but a confident claim that the learner has no allowance. Shows "Unlimited" for staff, who bypass the reservation. |
+| Things you can say | Rail | **Always present, never hides.** This is what keeps the rail full for an account with no history. The editor row is withheld when the tenant has coding off, since promising a tool the model was never given produces the exact failure the panel exists to prevent. |
 | Your progress | Rail | Always present. Zeros are honest. |
 | Things you kept | Rail | **Self-hides.** |
 
@@ -358,6 +413,21 @@ Two things worth keeping:
   the same data and is deliberately a different component.
 - `RecapTranscript` opens **closed**, behind a turn count, with a filter. The most common reason
   to open a transcript is to find one specific thing that was said.
+
+Three failure modes this page had to be hardened against, all of them consequences of polling
+while the recap task is still writing:
+
+- **A transient poll failure must not discard the page.** `isError` alone replaced everything with
+  "We could not find that session" on one dropped request. The error state is now `isError && !data`.
+- **The poll is bounded** (`POLL_LIMIT`). A recap task that died left the tab requesting every four
+  seconds forever, against a backend served from four gunicorn slots, for a page nobody is watching.
+- **`RecapFlashcards` derives its position from what has been graded**, not from a separate index.
+  `notes` can grow underneath it mid-poll, and an index plus a `graded >= cards.length` test went
+  inconsistent the moment it did: the index clamped to the old last card, re-grading it did not move
+  the count (grades are keyed by id), and the deck could never complete.
+
+A `recap_status` that is none of pending/skipped/written now says so. It used to render a tinted
+card containing nothing, which reads as the page being broken rather than the recap.
 
 ---
 

--- a/lib/hooks/useRealtimeTutor.ts
+++ b/lib/hooks/useRealtimeTutor.ts
@@ -53,6 +53,14 @@ const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000];
 /** How many turns the in-room conversation view keeps. Older ones live in the recap. */
 const TRANSCRIPT_LIMIT = 200;
 
+/**
+ * How long to wait for OpenAI to acknowledge a `response.create` before assuming it will not.
+ *
+ * `response.created` normally lands in well under a second. This is the backstop that stops a
+ * dropped or rejected request from muting the tutor for the rest of the lesson.
+ */
+const RESPONSE_ACK_TIMEOUT_MS = 8_000;
+
 export type TutorPhase =
   | "idle"
   | "starting"
@@ -117,6 +125,16 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
    * Capped, because a thirty-minute lesson is a lot of DOM for something usually closed.
    */
   const [transcript, setTranscript] = useState<TranscriptEntry[]>([]);
+  /**
+   * Increments every time the tutor starts a new spoken turn.
+   *
+   * The quiz overlay needs to know "has the tutor said anything since I submitted", and it was
+   * answering that by diffing the caption string against a snapshot. That could not work:
+   * `caption` is a 320-character sliding window, so once the window scrolls past the snapshot the
+   * prefix no longer matches and the overlay fell back to showing the whole window - including
+   * the sentence the tutor was saying BEFORE the answer was sent. A counter is unambiguous.
+   */
+  const [tutorTurnId, setTutorTurnId] = useState(0);
 
   // Everything below is deliberately a ref: it changes at audio rate or is needed inside
   // callbacks that must not be re-created on every render.
@@ -161,6 +179,18 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
   const lastVoiceAtRef = useRef(0);
   const idleTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   /**
+   * Suspends the idle watchdog while something has the learner's attention on screen.
+   *
+   * The watchdog measures silence, and a quiz is deliberately silent: the tutor is instructed to
+   * say one line and go quiet because the learner is reading. So a learner working through a
+   * question got hung up on mid-question, and the "still there?" prompt that would have saved
+   * them renders behind the modal where they cannot reach it.
+   *
+   * A ref, not state: the watchdog reads it from inside a setInterval that must not be
+   * re-created, and nothing renders from it.
+   */
+  const idleSuspendedRef = useRef(false);
+  /**
    * Whether OpenAI is currently generating a response.
    *
    * `response.create` on a conversation that already has one in flight is rejected outright
@@ -176,6 +206,7 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
    */
   const responseActiveRef = useRef(false);
   const responseQueuedRef = useRef(false);
+  const responseWatchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptRef = useRef(0);
   const reconnectingRef = useRef(false);
   const connectRef = useRef<((secret: string, callsUrl: string) => Promise<void>) | null>(null);
@@ -185,24 +216,65 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
 
   // --- outbound helpers ------------------------------------------------------
 
+  /**
+   * Returns whether the payload actually left the browser.
+   *
+   * The caller usually does not care, but `requestResponse` does: it sets the response gate
+   * before sending, and a silent drop here would leave the gate set with nothing in flight to
+   * ever clear it.
+   */
   const send = useCallback((payload: unknown) => {
     const dc = dcRef.current;
-    if (dc && dc.readyState === "open") {
-      dc.send(JSON.stringify(payload));
-    }
+    if (!dc || dc.readyState !== "open") return false;
+    dc.send(JSON.stringify(payload));
+    return true;
   }, []);
 
-  /** Ask for a spoken turn, waiting out any turn already in progress. */
+  /**
+   * Ask for a spoken turn, waiting out any turn already in progress.
+   *
+   * The gate is set BEFORE the send, because two tool results landing in the same tick would
+   * otherwise both see `false` and both send. But an optimistic gate has to be able to fail
+   * open, and there are two ways it can be left holding a lock on nothing:
+   *
+   *  - `send` drops the payload because the data channel is not open. Nothing was requested, so
+   *    no `response.created` or `response.done` will ever arrive to release it.
+   *  - the request reaches OpenAI and is rejected for a reason we do not recognise, which comes
+   *    back as an `error` event and not as a response lifecycle event.
+   *
+   * Either one used to mean the tutor went permanently silent for the rest of the lesson, which
+   * is a far worse failure than the duplicate-response error the gate exists to prevent. So the
+   * send result is checked, and a watchdog releases the gate if no response materialises.
+   */
+  const armResponseWatchdog = useCallback(() => {
+    if (responseWatchdogRef.current) clearTimeout(responseWatchdogRef.current);
+    responseWatchdogRef.current = setTimeout(() => {
+      if (!responseActiveRef.current) return;
+      // Nothing acknowledged the request. Fail open: a spurious duplicate is recoverable, a
+      // mute tutor is not.
+      responseActiveRef.current = false;
+      if (responseQueuedRef.current) {
+        responseQueuedRef.current = false;
+        if (send({ type: "response.create" })) {
+          responseActiveRef.current = true;
+          armResponseWatchdog();
+        }
+      }
+    }, RESPONSE_ACK_TIMEOUT_MS);
+  }, [send]);
+
   const requestResponse = useCallback(() => {
     if (responseActiveRef.current) {
       responseQueuedRef.current = true;
       return;
     }
-    // Optimistic: set before sending, because two tool results landing in the same tick
-    // would otherwise both see `false` and both send.
     responseActiveRef.current = true;
-    send({ type: "response.create" });
-  }, [send]);
+    if (!send({ type: "response.create" })) {
+      responseActiveRef.current = false;
+      return;
+    }
+    armResponseWatchdog();
+  }, [send, armResponseWatchdog]);
 
   /**
    * A turn finished. Let anything that queued behind it go now.
@@ -210,13 +282,29 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
    * The queue is one deep on purpose. Three tool results arriving during one long answer
    * should produce one reaction, not three consecutive monologues.
    */
-  const releaseResponseGate = useCallback(() => {
-    responseActiveRef.current = false;
-    if (!responseQueuedRef.current) return;
-    responseQueuedRef.current = false;
-    responseActiveRef.current = true;
-    send({ type: "response.create" });
-  }, [send]);
+  const releaseResponseGate = useCallback(
+    (drainQueue = true) => {
+      responseActiveRef.current = false;
+      if (responseWatchdogRef.current) {
+        clearTimeout(responseWatchdogRef.current);
+        responseWatchdogRef.current = null;
+      }
+      // `drainQueue: false` is barge-in. The response was cancelled because the learner started
+      // talking, so firing whatever had queued behind it would make the tutor answer over the
+      // top of them - the exact behaviour this feature exists to avoid. Drop it instead: the
+      // learner is about to say what they want, and that is more current than a queued reaction.
+      if (!drainQueue) {
+        responseQueuedRef.current = false;
+        return;
+      }
+      if (!responseQueuedRef.current) return;
+      responseQueuedRef.current = false;
+      if (!send({ type: "response.create" })) return;
+      responseActiveRef.current = true;
+      armResponseWatchdog();
+    },
+    [send, armResponseWatchdog]
+  );
 
   const respondToTool = useCallback(
     (callId: string, output: unknown) => {
@@ -233,10 +321,16 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
     [send, requestResponse]
   );
 
-  /** Inject a fact into the conversation and ask the tutor to react to it out loud. */
+  /**
+   * Inject a fact into the conversation and ask the tutor to react to it out loud.
+   *
+   * Returns whether it actually reached OpenAI. Callers that promise the learner "your tutor has
+   * this" need to know, because `send` drops silently when the data channel is not open and the
+   * quiz overlay was asserting the tutor had an answer it had never received.
+   */
   const tellTutor = useCallback(
     (text: string) => {
-      send({
+      const delivered = send({
         type: "conversation.item.create",
         item: {
           type: "message",
@@ -244,7 +338,9 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
           content: [{ type: "input_text", text }],
         },
       });
+      if (!delivered) return false;
       requestResponse();
+      return true;
     },
     [send, requestResponse]
   );
@@ -315,11 +411,23 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
             buffer ? { ok: true, ...buffer } : { ok: false, reason: "editor_closed" }
           );
         }
-        case "request_code_run":
+        case "request_code_run": {
           // Returns immediately; the output is injected as a message when it lands, so a
           // three-second Judge0 round trip never becomes three seconds of dead air.
+          //
+          // But "running" has to be true. With no editor open there is nothing to run, and
+          // answering `ok: true, status: "running"` made the tutor announce it was running the
+          // code and then wait for output that could never arrive.
+          const buffer = optionsRef.current.readStudentCode?.();
+          if (!buffer) {
+            return respondToTool(callId, { ok: false, reason: "editor_closed" });
+          }
+          if (!buffer.code.trim()) {
+            return respondToTool(callId, { ok: false, reason: "editor_empty" });
+          }
           optionsRef.current.onRunCode?.(String(args.stdin ?? ""));
           return respondToTool(callId, { ok: true, status: "running" });
+        }
         case "show_quiz": {
           const next = questionPoolRef.current.find(
             (q) => !usedQuestionsRef.current.has(q.id)
@@ -381,14 +489,20 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
     async (questionId: number, selected: string[]) => {
       const sid = sessionIdRef.current;
       if (!sid) return null;
+      lastVoiceAtRef.current = Date.now();
+      setIdleWarning(false);
       try {
         const result = await aiTutorService.gradeQuiz(sid, questionId, selected);
-        tellTutor(
+        // `ok: false` means the server could not grade it (unknown question id, for instance).
+        // Telling the tutor the learner got it wrong would be a lie, and it was also being
+        // rendered to the learner as "Not quite."
+        if (result?.ok === false) return result;
+        const delivered = tellTutor(
           result.is_correct
             ? "I answered that quiz question correctly."
             : `I got that quiz question wrong. I picked ${selected.join(", ")}, the answer was ${(result.correct ?? []).join(", ")}.`
         );
-        return result;
+        return { ...result, delivered };
       } catch {
         return null;
       }
@@ -459,7 +573,13 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
           break;
 
         case "response.created":
+          setTutorTurnId((n) => n + 1);
           responseActiveRef.current = true;
+          // Acknowledged, so the watchdog is no longer needed; `response.done` releases it.
+          if (responseWatchdogRef.current) {
+            clearTimeout(responseWatchdogRef.current);
+            responseWatchdogRef.current = null;
+          }
           break;
 
         case "response.output_audio_transcript.delta": {
@@ -568,7 +688,7 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
         case "response.cancelled":
           tutorTranscriptRef.current = "";
           setPhase("listening");
-          releaseResponseGate();
+          releaseResponseGate(false);
           break;
 
         case "error": {
@@ -582,8 +702,12 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
           if (/active response/i.test(message)) {
             responseActiveRef.current = true;
             responseQueuedRef.current = true;
+            armResponseWatchdog();
             break;
           }
+          // Some other rejection. If we were holding the gate for a request that has now failed,
+          // release it, or the tutor stays silent for the rest of the lesson.
+          releaseResponseGate();
           optionsRef.current.onError?.(message);
           break;
         }
@@ -591,7 +715,7 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
           break;
       }
     },
-    [handleToolCall, send, releaseResponseGate]
+    [handleToolCall, send, releaseResponseGate, armResponseWatchdog]
   );
 
   // --- flushing --------------------------------------------------------------
@@ -633,6 +757,10 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
     // across a reconnect would mean the tutor never spoke again after one.
     responseActiveRef.current = false;
     responseQueuedRef.current = false;
+    if (responseWatchdogRef.current) {
+      clearTimeout(responseWatchdogRef.current);
+      responseWatchdogRef.current = null;
+    }
 
     // Detach the handlers first, or closing the connection fires the very drop detection that
     // would start another reconnect.
@@ -976,6 +1104,13 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
         lastVoiceAtRef.current = Date.now();
         idleTimerRef.current = setInterval(() => {
           if (closedRef.current || reconnectingRef.current) return;
+          if (idleSuspendedRef.current) {
+            // Reading a quiz is engagement, not idleness. Keep the clock at zero so dismissing
+            // the modal does not immediately trip the warning either.
+            lastVoiceAtRef.current = Date.now();
+            setIdleWarning(false);
+            return;
+          }
           const silent = Date.now() - lastVoiceAtRef.current;
           if (silent >= IDLE_END_MS) {
             void end("idle");
@@ -1016,6 +1151,12 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
     caption,
     cards,
     transcript,
+    tutorTurnId,
+    /** Pause the idle watchdog while a modal owns the screen. */
+    setIdleSuspended: (suspended: boolean) => {
+      idleSuspendedRef.current = suspended;
+      if (suspended) lastVoiceAtRef.current = Date.now();
+    },
     planIndex,
     remainingSeconds,
     error,

--- a/lib/services/ai-tutor.service.ts
+++ b/lib/services/ai-tutor.service.ts
@@ -201,6 +201,13 @@ export interface QuizGradeResult {
   selected?: string[];
   explanation?: string;
   reason?: string;
+  /**
+   * Whether the grade actually reached the tutor over the data channel.
+   *
+   * Set client-side, not by the server. The overlay claims "your tutor has your answer", and it
+   * must not claim that when the channel was closed and the message was dropped.
+   */
+  delivered?: boolean;
 }
 
 export const aiTutorService = {


### PR DESCRIPTION
Promotes #1344 to production.

## What is in this

Fixes for 27 findings from a 60-agent adversarial review of the AI Tutor work shipped earlier
today. Each finding had to survive two independent skeptics prompted to refute it; 16 verdicts came
back refuted and were not acted on.

**Two would have hurt a real learner in a paid session:**

- **Silent loss of the learner's code.** The side dock rendered one panel at a time, so opening the
  conversation panel unmounted `IdePanel` and destroyed its buffer — with no recovery, since Monaco
  disposes its model on unmount. `close_ide` is a model-callable tool, so the tutor could trigger it
  too. The buffer now lives in the room page and the panel stays mounted.
- **A permanently mute tutor.** The response gate added earlier today is set optimistically before
  sending, and `send` no-ops when the data channel is closed, so the gate could hold a lock on
  nothing and the tutor would never speak again for the rest of the lesson. It now fails open three
  ways, and barge-in drops the queued turn instead of draining it (which was making the tutor answer
  over the top of the learner).

Plus: the quiz dialog was inescapable on a failed grade; the reaction echo showed pre-submit speech;
one dropped recap poll wiped the page; the flashcard deck could never complete if it grew mid-poll;
`MinutesPanel` claimed "0 of 0 minutes left" before the quota arrived; `CapabilityPanel` promised the
editor to tenants with coding off; the idle watchdog hung up mid-quiz; and Strands' isotropic scale
clipped the ribbon's wave vertically in band mode so amplitude stopped tracking the voice.

## Verification

`tsc` clean, `next build` clean, all #1344 checks passed with zero failures. Backend counterpart:
AI-Linc-LMS/ai-linc-backend#617 (165 tests, 20 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)