### PR TITLE
release(ai-tutor): invisible ribbon, white footer, greeting, card contrast, placeholder

### DIFF
--- a/app/ai-tutor/session/[id]/page.tsx
+++ b/app/ai-tutor/session/[id]/page.tsx
@@ -611,8 +611,17 @@ const bannerSx = {
 const roomShellSx = {
   display: "flex",
   flexDirection: "column",
-  // dvh, never vh: 100vh collides with the iOS Safari address bar (DESIGN.md §5).
-  height: "calc(100dvh - 64px)",
+  /**
+   * The FULL viewport, not viewport-minus-64.
+   *
+   * The 64px was reserving space for the global app bar. The room now hides that bar
+   * (`hideAppBar`), so the subtraction left a 64px strip of the light page background below the
+   * transport bar - a white band across the bottom of an otherwise black screen, which is the
+   * same class of defect hiding the app bar was meant to fix.
+   *
+   * dvh, never vh: 100vh collides with the iOS Safari address bar (DESIGN.md §5).
+   */
+  height: "100dvh",
   background:
     "radial-gradient(115% 90% at 50% 8%, #241653 0%, #170d38 42%, #0b0619 100%)",
   color: "#fff",

--- a/components/ai-tutor/dashboard/TopicComposer.tsx
+++ b/components/ai-tutor/dashboard/TopicComposer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
+import { AnimatePresence, motion } from "framer-motion";
 import type { TutorLevel, TutorQuota } from "@/lib/services/ai-tutor.service";
 
 /**
@@ -39,6 +40,12 @@ const QUICK_STARTS = [
  *
  * Rotation pauses the moment the field is focused or has any text: animation behind a cursor is
  * a distraction, not a hint.
+ *
+ * The rotating text is a real element rendered BEHIND the input, which keeps its own `placeholder`
+ * empty. That is not decoration: **a `placeholder` attribute cannot animate.** The first version
+ * swapped the attribute's value and put a `transition` on `::placeholder`, which does exactly
+ * nothing - the string changes instantly and the opacity it was transitioning never moves. Same
+ * approach as `components/roadmaps/CreateCourseBar.tsx`, whose comment says the same thing.
  */
 const PLACEHOLDER_EXAMPLES = [
   "how do B-trees actually stay balanced",
@@ -120,6 +127,8 @@ export function TopicComposer({
           boxShadow: "0 0 0 1px rgba(255,255,255,0.18)",
           px: 2,
           maxWidth: 720,
+          // Positioning context for the animated placeholder overlay.
+          position: "relative",
           transition: "box-shadow 160ms ease, background-color 160ms ease",
           "&:focus-within": {
             bgcolor: "rgba(255,255,255,0.13)",
@@ -142,7 +151,8 @@ export function TopicComposer({
           }}
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
-          placeholder={`e.g. ${PLACEHOLDER_EXAMPLES[exampleIndex]}`}
+          // Empty on purpose: the animated element below is the placeholder.
+          placeholder=""
           aria-label="What do you want to learn"
           sx={{
             flex: 1,
@@ -154,13 +164,47 @@ export function TopicComposer({
             fontSize: { xs: "1rem", md: "1.05rem" },
             py: 1.6,
             color: "#ffffff",
-            "&::placeholder": {
-              color: "rgba(255,255,255,0.5)",
-              // Cross-fade, so a swap reads as one hint replacing another rather than a flicker.
-              transition: "opacity 260ms ease",
-            },
           }}
         />
+
+        {/* The animated placeholder. Slides up and fades, so a swap reads as one hint replacing
+            another rather than as text glitching in place. */}
+        {idle ? (
+          <Box
+            aria-hidden
+            sx={{
+              position: "absolute",
+              left: { xs: 46, md: 48 },
+              right: 16,
+              pointerEvents: "none",
+              overflow: "hidden",
+              height: 26,
+            }}
+          >
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={exampleIndex}
+                initial={{ y: 14, opacity: 0 }}
+                animate={{ y: 0, opacity: 1 }}
+                exit={{ y: -14, opacity: 0 }}
+                transition={{ duration: 0.28, ease: "easeOut" }}
+              >
+                <Typography
+                  sx={{
+                    fontSize: { xs: "1rem", md: "1.05rem" },
+                    lineHeight: "26px",
+                    color: "rgba(255,255,255,0.52)",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                  }}
+                >
+                  e.g. {PLACEHOLDER_EXAMPLES[exampleIndex]}
+                </Typography>
+              </motion.div>
+            </AnimatePresence>
+          </Box>
+        ) : null}
       </Box>
 
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1.75 }}>

--- a/components/ai-tutor/room/Strands.tsx
+++ b/components/ai-tutor/room/Strands.tsx
@@ -419,6 +419,9 @@ export default function Strands({
         uIntensity: { value: intensity },
         uOpacity: { value: opacity },
         uScale: { value: scale },
+        // Declared here or the render loop's `program.uniforms.uScaleY.value = ...` throws on
+        // the first frame, which kills the rAF loop and the ribbon never draws at all.
+        uScaleY: { value: scale },
         uSaturation: { value: saturation },
       },
     });

--- a/components/ai-tutor/room/strands-uniforms.test.ts
+++ b/components/ai-tutor/room/strands-uniforms.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The ribbon shipped to production **completely invisible**, twice-reviewed and twice-built.
+ *
+ * Making `uScale` anisotropic meant adding `uniform float uScaleY` to the fragment shader and a
+ * per-frame write to `program.uniforms.uScaleY.value`. The edit that was supposed to DECLARE that
+ * uniform in the `uniforms` object did not match the source and silently did nothing. So the first
+ * animation frame threw reading `.value` of `undefined`, the requestAnimationFrame loop died, and
+ * the ribbon never drew at all.
+ *
+ * Nothing in the toolchain can catch that. `uniforms` is an untyped object literal, so `tsc` sees
+ * no error; the write is inside a callback, so `next build` never executes it. It is only
+ * observable by looking at the running page, which is exactly the check that is easiest to skip.
+ *
+ * So it is asserted here instead, by parsing the file. Three invariants, each of which was
+ * violated by the bug:
+ *
+ *  1. every uniform written per-frame is declared in a `uniforms` object,
+ *  2. every uniform the GLSL declares is supplied from JS, and
+ *  3. the specific uniform whose absence caused this is present.
+ *
+ * A parse-based test is unusual and worth it here: the alternative is a WebGL context in jsdom,
+ * which does not exist, and the failure mode is total.
+ */
+
+const SOURCE = readFileSync(
+  path.resolve(__dirname, "Strands.tsx"),
+  "utf8"
+);
+
+/** Uniform names declared in any `uniforms: { ... }` object literal. */
+function declaredInJs(source: string): Set<string> {
+  const names = new Set<string>();
+  const blocks = source.match(/uniforms:\s*\{[\s\S]*?\n {6}\},/g) ?? [];
+  for (const block of blocks) {
+    for (const match of block.matchAll(/(\bu[A-Z]\w*)\s*:/g)) names.add(match[1]);
+  }
+  return names;
+}
+
+/** Uniform names written per-frame, e.g. `program.uniforms.uScale.value = x`. */
+function writtenPerFrame(source: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of source.matchAll(/\.uniforms\.(u\w+)\.value/g)) names.add(match[1]);
+  return names;
+}
+
+/** Uniform names the GLSL itself declares. */
+function declaredInGlsl(source: string): Set<string> {
+  const names = new Set<string>();
+  for (const match of source.matchAll(/^\s*uniform\s+\w+\s+(u\w+)/gm)) names.add(match[1]);
+  return names;
+}
+
+describe("Strands uniform wiring", () => {
+  it("declares every uniform it writes per-frame", () => {
+    const declared = declaredInJs(SOURCE);
+    const written = writtenPerFrame(SOURCE);
+
+    expect(declared.size).toBeGreaterThan(10);
+    expect(written.size).toBeGreaterThan(10);
+
+    const undeclared = [...written].filter((name) => !declared.has(name)).sort();
+    // Each of these would throw on the first frame and kill the animation loop.
+    expect(undeclared).toEqual([]);
+  });
+
+  it("supplies every uniform the shader declares", () => {
+    const declared = declaredInJs(SOURCE);
+    const glsl = declaredInGlsl(SOURCE);
+
+    expect(glsl.size).toBeGreaterThan(10);
+    const unsupplied = [...glsl].filter((name) => !declared.has(name)).sort();
+    expect(unsupplied).toEqual([]);
+  });
+
+  it("still has the uScaleY uniform whose absence made the ribbon invisible", () => {
+    // Named explicitly, so deleting it fails a test that says why rather than a generic one.
+    expect(declaredInGlsl(SOURCE).has("uScaleY")).toBe(true);
+    expect(declaredInJs(SOURCE).has("uScaleY")).toBe(true);
+    expect(writtenPerFrame(SOURCE).has("uScaleY")).toBe(true);
+  });
+
+  it("keeps the vertical scale capped, or a wide band clips the wave", () => {
+    // The wave peaks near ±0.113 uv units. Without a cap, a 10:1 band gives uv.y ±0.047 and the
+    // motion happens off-screen, so amplitude stops tracking the voice.
+    const cap = SOURCE.match(/MAX_VERTICAL_SCALE\s*=\s*([\d.]+)/);
+    expect(cap).not.toBeNull();
+    const value = Number(cap![1]);
+    expect(value).toBeGreaterThan(0);
+    // 0.5 / cap is the visible half-height; it must exceed the wave's own excursion.
+    expect(0.5 / value).toBeGreaterThan(0.113);
+  });
+
+  it("fits the ribbon inside the frame rather than cropping it", () => {
+    // RIBBON_FILL < 1 is what lets the taper reach zero before the container edge. At 1.0 the
+    // ribbon carries luminance right up to the edge and reads as cut off, which is how it shipped.
+    const fill = SOURCE.match(/RIBBON_FILL\s*=\s*([\d.]+)/);
+    expect(fill).not.toBeNull();
+    expect(Number(fill![1])).toBeLessThan(1);
+    expect(Number(fill![1])).toBeGreaterThan(0.5);
+  });
+});

--- a/components/ai-tutor/shared/surfaces.tsx
+++ b/components/ai-tutor/shared/surfaces.tsx
@@ -64,15 +64,39 @@ export function TutorSurface({
         borderRadius: "var(--radius-card)",
         border: "1px solid var(--border-default)",
         bgcolor: "var(--card-bg)",
+        /**
+         * Depth from the surface ladder, never from shadow (DESIGN.md).
+         *
+         * A 1px hairline on a card the same white as the canvas gives the eye nothing to read,
+         * and a grid of them looks like a field of empty boxes. Two flat devices fix that with
+         * no shadow and no hover glow:
+         *
+         *  1. a violet rail down the leading edge, which is what actually separates one card
+         *     from the next when you scan a grid, and
+         *  2. the faintest violet wash at the top, so the card reads as tinted paper rather
+         *     than as a white rectangle on white.
+         *
+         * The rail is an `inset` box-shadow. That is not decoration-by-shadow: inset casts
+         * nothing outside the element, and it is the only way to lay a 2px fill inside the
+         * border without disturbing the box model the way a thicker `border-left` would.
+         */
+        backgroundImage:
+          "linear-gradient(180deg, color-mix(in srgb, var(--ai-violet) 4%, transparent) 0%, transparent 46%)",
+        boxShadow: "inset 2px 0 0 color-mix(in srgb, var(--ai-violet) 20%, transparent)",
         p: padded ? { xs: 2, md: 2.5 } : 0,
         ...(interactive
           ? {
               cursor: "pointer",
-              transition: "border-color 160ms ease",
-              "&:hover": { borderColor: "var(--ai-violet)" },
+              transition: "border-color 160ms ease, box-shadow 160ms ease",
+              // Hover moves the border and thickens the rail. Movement on the edge, no lift.
+              "&:hover": {
+                borderColor: "var(--ai-violet)",
+                boxShadow: "inset 3px 0 0 var(--ai-violet)",
+              },
               "&:focus-visible": {
                 outline: "none",
-                boxShadow: "0 0 0 2px var(--canvas), 0 0 0 4px var(--ai-violet)",
+                boxShadow:
+                  "inset 3px 0 0 var(--ai-violet), 0 0 0 2px var(--canvas), 0 0 0 4px var(--ai-violet)",
               },
             }
           : null),

--- a/lib/hooks/useRealtimeTutor.ts
+++ b/lib/hooks/useRealtimeTutor.ts
@@ -543,6 +543,25 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
       switch (type) {
         case "session.created":
           setPhase("listening");
+          /**
+           * Ask for the opening turn explicitly.
+           *
+           * The instructions tell the tutor to greet the learner and name the plan, but an
+           * instruction is not a trigger: with `semantic_vad` the model waits for input, and
+           * whether it volunteers a first turn is not something we controlled. So the greeting
+           * was arriving *sometimes*, and when it did not the room sat on "listening" with the
+           * learner waiting for a voice that never came - the single worst first impression this
+           * feature can make.
+           *
+           * Requested through the gate, so it cannot collide with a turn OpenAI did start on its
+           * own; if one is already live this queues behind it rather than duplicating it.
+           *
+           * Deliberately on EVERY `session.created`, not just the first. A reconnect mints a new
+           * realtime session and fires this again, and the server-built primer tells the tutor to
+           * acknowledge the reconnection and carry on - which also needs a turn to exist. A
+           * one-shot guard here left the tutor mute for the rest of any lesson that dropped.
+           */
+          requestResponse();
           break;
 
         case "input_audio_buffer.speech_started":
@@ -715,7 +734,7 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
           break;
       }
     },
-    [handleToolCall, send, releaseResponseGate, armResponseWatchdog]
+    [handleToolCall, send, releaseResponseGate, armResponseWatchdog, requestResponse]
   );
 
   // --- flushing --------------------------------------------------------------


### PR DESCRIPTION
Promotes #1346 to production. Five user-reported issues; **three were regressions from my own
earlier PRs today**, stated plainly below.

## The ribbon was rendering nothing at all

Making `uScale` anisotropic required `uniform float uScaleY` in the shader plus a per-frame write to
`program.uniforms.uScaleY.value` — but the edit meant to **declare** that uniform in the `uniforms`
object silently didn't match the source. The first frame threw on `.value` of `undefined`, the rAF
loop died, and the ribbon never drew.

Neither `tsc` (untyped object literal) nor `next build` (write lives in a callback) can catch it.
Now guarded by `strands-uniforms.test.ts`, which parses the file and asserts every uniform written
is declared, every GLSL uniform is supplied, and `uScaleY` specifically exists in all three places.
**Verified the guard by reintroducing the exact bug — 3 of 5 tests fail, naming `uScaleY`.**

## White footer strip

Room shell was `height: calc(100dvh - 64px)`, reserving space for the app bar the room now hides —
leaving 64px of light page background under the transport bar. The same defect hiding the bar fixed.

## Greeting was unreliable

An instruction is not a trigger: with `semantic_vad` the model waits for input, so whether it
volunteered a first turn was never under our control. When it didn't, the room sat on "listening"
while the learner waited for a voice. `session.created` now requests the turn through the gate — on
every connection, since a reconnect fires it again and the primer needs a turn to exist.

## Plain white cards

A 1px hairline on a card the same white as the canvas gives the eye nothing. Fixed with a violet
leading rail and the faintest top wash — **no shadow, no hover glow**; hover thickens the rail
rather than lifting the card, per DESIGN.md. The rail is an `inset` box-shadow, which casts nothing
outside the element.

## The placeholder never animated

I set the `placeholder` attribute from a rotating index and put `transition: opacity 260ms` on
`::placeholder`. That does nothing — the string swaps instantly and the eased opacity never moves.
A placeholder attribute isn't animatable. The roadmaps bar already solved this and says so in a
comment; I'd copied its state and skipped its mechanism. Now an `aria-hidden` overlay behind an
empty-placeholder input, sliding and fading via `AnimatePresence`.

## Verification

`tsc` clean, `next build` clean, #1346 settled with **0 failures**. Backend counterpart merged as
AI-Linc-LMS/ai-linc-backend#621 (186 tests; image lookup measured against live APIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)