### PR TITLE
fix(ai-tutor): scale the ribbon down and stop it leaving the frame when it speaks

### DIFF
--- a/app/ai-tutor/session/[id]/page.tsx
+++ b/app/ai-tutor/session/[id]/page.tsx
@@ -420,7 +420,17 @@ export default function TutorSessionPage() {
                     height: hasCards
                       ? { xs: 150, md: 190 }
                       : { xs: 300, md: "min(52vh, 460px)" },
-                    transition: "height 420ms cubic-bezier(.175,.885,.32,1.1)",
+                    /**
+                     * A plain ease-out, not DESIGN.md's overshoot curve.
+                     *
+                     * The overshoot (the trailing 1.1) suits an element that enters and settles,
+                     * and is wrong here: this container holds a WebGL surface that re-fits on every
+                     * size change, so the bounce made the ribbon visibly rescale twice. Together
+                     * with the framebuffer reallocation that used to happen on every frame of this
+                     * animation, the transition juddered.
+                     */
+                    transition: "height 380ms cubic-bezier(0.22, 0.61, 0.36, 1)",
+                    willChange: "height",
                   }}
                 >
                   <TutorVoice phase={phase} getLevels={tutor.getLevels} />

--- a/components/ai-tutor/room/Strands.tsx
+++ b/components/ai-tutor/room/Strands.tsx
@@ -275,16 +275,26 @@ const TAPER_ZERO = 0.3846;
  * Below 1 the taper reaches zero before the edge, which is the difference between a ribbon
  * that fades out and a ribbon that looks cut off.
  */
-const RIBBON_FILL = 0.82;
+const RIBBON_FILL = 0.74;
 
 /**
- * Ceiling on the vertical scale, so `uv.y` never shrinks below the wave's own excursion.
+ * Ceiling on the vertical scale, so `uv.y` keeps room for the wave at its LOUDEST.
  *
- * The wave peaks at roughly +/-0.1125 uv units at these settings. A cap of 3 gives +/-0.167, so
- * about 1.5x headroom at any aspect ratio. Without it a 10:1 band had +/-0.047 - the wave swung
- * more than twice the visible height, off the top and bottom of the container.
+ * The first version sized this against the RESTING wave and was wrong by a factor of two, because
+ * `TutorVoice` drives `amplitude` from the audio level: it sent 0.7 while silent and up to 3.7 on
+ * loud speech. Measured against the shader's own `(0.1 + 0.02 * e) * env * uAmplitude`, normal
+ * speech swung 1.4x past the visible edge and loud speech 2.2x - so the ribbon left the screen
+ * exactly when it was doing the one thing it exists to do.
+ *
+ * A cap of 1.6 gives `uv.y` +/-0.3125. With the amplitude range now bounded at 1.3 the loudest
+ * excursion is ~0.156, leaving 2x headroom for thickness and glow to spread into.
+ *
+ * Verified by rendering the real shader headlessly over a thickness/glow/cap grid: at these values
+ * the bright core is ~9% of the container height at rest and ~50% at full volume, with under 8% of
+ * pixels fully saturated. The shipped values were off the top of that grid, which is why loud
+ * speech read as a blown-out white mass filling the frame.
  */
-const MAX_VERTICAL_SCALE = 3.0;
+const MAX_VERTICAL_SCALE = 1.6;
 
 const buildPalette = (colors: string[]): number[][] => {
   const filled = colors && colors.length ? colors : ["#ffffff"];
@@ -451,15 +461,32 @@ export default function Strands({
     // Upstream listens on window resize only, which misses the case that actually happens
     // here: the transport bar and the IDE panel change this element's size without the
     // window changing at all.
+    /**
+     * Re-fit the effect to the container.
+     *
+     * Both `setSize` calls reallocate GPU storage, and the room animates this container's height
+     * over ~400ms when the first canvas card arrives. ResizeObserver fires on every frame of that
+     * animation, so the transition was paying for ~25 framebuffer reallocations and visibly
+     * juddered. Two guards: ignore a callback reporting the same integer size, and touch the
+     * post-processing render target only when the glass pass is actually enabled (the room never
+     * enables it, so that was pure waste).
+     */
+    let lastW = 0;
+    let lastH = 0;
     function resize() {
       if (!ctn) return;
       const width = ctn.offsetWidth;
       const height = ctn.offsetHeight;
       if (!width || !height) return;
+      if (width === lastW && height === lastH) return;
+      lastW = width;
+      lastH = height;
       renderer.setSize(width, height);
       program.uniforms.uResolution.value = [width, height];
-      renderTarget.setSize(width, height);
-      glassProgram.uniforms.uResolution.value = [width, height];
+      if (propsRef.current.glass) {
+        renderTarget.setSize(width, height);
+        glassProgram.uniforms.uResolution.value = [width, height];
+      }
       // TAPER_ZERO is where cos(x * PI * 1.3) first reaches zero, i.e. the outer edge of the
       // envelope's single lobe. Mapping that edge to RIBBON_FILL of the half-width puts the
       // ribbon's own fade comfortably inside the frame: no tiling, and no crop either.

--- a/components/ai-tutor/room/TutorVoice.tsx
+++ b/components/ai-tutor/room/TutorVoice.tsx
@@ -223,12 +223,28 @@ export function TutorVoice({
       liveRef.current = {
         colors: look.colors,
         speed: look.speed + amp * 0.6,
-        waviness: look.waviness + amp * 0.75,
-        // A wide amplitude range is what makes speech legible in the ribbon rather than a
-        // constant shimmer: quiet is nearly flat, loud genuinely swells.
-        amplitude: 0.7 + amp * 3.0,
-        thickness: 0.6 + amp * 0.7,
-        glow: 2.4 + amp * 2.0,
+        // Waviness and speed now carry most of the expression. They change the SHAPE of the
+        // strand without moving it further from the centre line, so they can swing hard without
+        // pushing the ribbon out of its container.
+        waviness: look.waviness + amp * 0.95,
+        /**
+         * Bounded at 1.3, not 3.7.
+         *
+         * The shader's excursion is `(0.1 + 0.02 * e) * env * uAmplitude` in uv units against a
+         * visible half-height of `0.5 / uScaleY`. At the old range the ribbon swung 1.4x past the
+         * edge on normal speech and 2.2x on loud speech, so it left the screen precisely when it
+         * was doing the thing it exists to do.
+         */
+        amplitude: 0.5 + amp * 0.8,
+        /**
+         * Thickness and glow are what actually decide how much of the container the ribbon eats,
+         * and both were far too high. Five strands each contribute a squared falloff; summed and
+         * passed through `1 - exp(-col * uGlow)` they saturate to flat white long before the wave
+         * runs out of room. These ceilings come from a headless render sweep - the bright core
+         * lands near 50% of the height at full volume instead of filling the frame.
+         */
+        thickness: 0.28 + amp * 0.22,
+        glow: 1.25 + amp * 0.55,
         intensity: 0.5 + amp * 0.5,
         saturation: look.saturation,
       };

--- a/components/ai-tutor/room/strands-uniforms.test.ts
+++ b/components/ai-tutor/room/strands-uniforms.test.ts
@@ -84,15 +84,39 @@ describe("Strands uniform wiring", () => {
     expect(writtenPerFrame(SOURCE).has("uScaleY")).toBe(true);
   });
 
-  it("keeps the vertical scale capped, or a wide band clips the wave", () => {
-    // The wave peaks near ±0.113 uv units. Without a cap, a 10:1 band gives uv.y ±0.047 and the
-    // motion happens off-screen, so amplitude stops tracking the voice.
-    const cap = SOURCE.match(/MAX_VERTICAL_SCALE\s*=\s*([\d.]+)/);
-    expect(cap).not.toBeNull();
-    const value = Number(cap![1]);
-    expect(value).toBeGreaterThan(0);
-    // 0.5 / cap is the visible half-height; it must exceed the wave's own excursion.
-    expect(0.5 / value).toBeGreaterThan(0.113);
+  it("keeps room for the wave at the LOUDEST amplitude TutorVoice actually sends", () => {
+    /**
+     * The invariant that was violated in production, and it spans two files.
+     *
+     * `Strands` caps the vertical scale; `TutorVoice` drives `amplitude` from the audio level. The
+     * cap was chosen against the RESTING wave while TutorVoice sent up to 3.7 on loud speech, so
+     * the ribbon swung 1.4x past the visible edge on normal speech and 2.2x on loud - it left the
+     * screen precisely when it was doing its job. Asserting the two together is the only way to
+     * keep them honest, because either file looks perfectly reasonable on its own.
+     */
+    const cap = Number(SOURCE.match(/MAX_VERTICAL_SCALE\s*=\s*([\d.]+)/)![1]);
+    const voice = readFileSync(path.resolve(__dirname, "TutorVoice.tsx"), "utf8");
+    const amp = voice.match(/amplitude:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
+    expect(amp).not.toBeNull();
+    const maxAmplitude = Number(amp![1]) + Number(amp![2]);
+
+    // Excursion is (0.1 + 0.02 * e) * env * uAmplitude, with e and env at most 1 in the centre.
+    const maxExcursion = (0.1 + 0.02 * 1) * maxAmplitude;
+    const halfHeight = 0.5 / cap;
+    // 1.5x, so thickness and glow have somewhere to spread rather than clipping at the edge.
+    expect(halfHeight / maxExcursion).toBeGreaterThan(1.5);
+  });
+
+  it("keeps thickness and glow below the values that saturated to flat white", () => {
+    // From a headless thickness/glow sweep: past these the bright core fills most of the container
+    // and the ribbon reads as a blown-out smear with no visible strand structure.
+    const voice = readFileSync(path.resolve(__dirname, "TutorVoice.tsx"), "utf8");
+    const th = voice.match(/thickness:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
+    const gl = voice.match(/glow:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
+    expect(th).not.toBeNull();
+    expect(gl).not.toBeNull();
+    expect(Number(th![1]) + Number(th![2])).toBeLessThanOrEqual(0.55);
+    expect(Number(gl![1]) + Number(gl![2])).toBeLessThanOrEqual(2.0);
   });
 
   it("fits the ribbon inside the frame rather than cropping it", () => {


### PR DESCRIPTION
The ribbon renders now, which exposed the next problem: too large, and speaking pushed it off the
top and bottom.

## RCA — a factor-of-two error in my own sizing

I set `MAX_VERTICAL_SCALE` against the **resting** wave. But `TutorVoice` drives `amplitude` from
the audio level and was sending `0.7 + amp * 3.0` — up to **3.7** on loud speech. Measured against
the shader's excursion `(0.1 + 0.02 * e) * env * uAmplitude` versus a visible half-height of
`0.5 / uScaleY`:

| state | uAmplitude | excursion | visible half | verdict |
|---|---|---|---|---|
| silent | 0.70 | 0.077 | 0.202 | inside |
| normal speech | 2.50 | 0.291 | 0.202 | **1.4× off-screen** |
| loud speech | 3.70 | 0.444 | 0.202 | **2.2× off-screen** |

Amplitude is now bounded at 1.3 with the cap at 1.6, giving 2× headroom. Waviness absorbs the lost
expression, since it reshapes the strand without moving it off the centre line.

**Thickness and glow mattered more than amplitude.** Five strands each contribute a squared
falloff; summed and passed through `1 - exp(-col * uGlow)` they saturate to flat white. I rendered
the real shader headlessly over a thickness/glow/cap grid and picked values where the bright core is
~9% of container height at rest and ~50% at full volume, under 8% saturated.

## Transition judder — two causes

- `ResizeObserver` fires every frame of the 400ms height animation, and each call reallocated GPU
  storage **twice**. Now ignores same-size callbacks, and only touches the post-processing render
  target when the glass pass is enabled — which the room never enables, so that was pure waste.
- The height used DESIGN.md's overshoot curve. Right for something that enters and settles; wrong
  for a container whose contents re-fit on resize, since the bounce rescaled the ribbon twice.

## Verification

The guard test now asserts the **cross-file** invariant instead of a hardcoded number, because the
cap and the amplitude live in different files and each looks fine alone. **Proven by reintroducing
the old amplitude** — headroom drops to 0.70× against a required 1.5× and the test fails by name.
6 tests pass, `tsc` clean, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)