### PR TITLE
release(ai-tutor): whole-sentence captions and a ribbon that blends into the room

### DIFF
--- a/app/ai-tutor/session/[id]/page.tsx
+++ b/app/ai-tutor/session/[id]/page.tsx
@@ -459,10 +459,18 @@ export default function TutorSessionPage() {
                         : "rgba(255,255,255,0.55)",
                       maxWidth: 760,
                       mx: "auto",
-                      display: "-webkit-box",
-                      WebkitLineClamp: hasCards ? 2 : 3,
-                      WebkitBoxOrient: "vertical",
-                      overflow: "hidden",
+                      /**
+                       * No line clamp.
+                       *
+                       * The clamp appended an ellipsis mid-sentence, so the caption read as a
+                       * broken feed: "...different outcomes all exist... When you're...". The
+                       * transport now trims the transcript to whole sentences instead, which is
+                       * the right place to decide it - the clamp could only ever cut blindly at
+                       * a pixel boundary.
+                       *
+                       * `minHeight` still reserves the space, so nothing below shifts as lines
+                       * come and go.
+                       */
                       transition: "font-size 300ms ease",
                     }}
                     aria-live="polite"

--- a/components/ai-tutor/room/Strands.tsx
+++ b/components/ai-tutor/room/Strands.tsx
@@ -126,6 +126,25 @@ void main() {
   float lum = max(max(col.r, col.g), col.b);
   float alpha = clamp(lum, 0.0, 1.0) * uOpacity;
 
+  /**
+   * Fade to nothing before the canvas edge, so the container has no visible boundary.
+   *
+   * The strand's glow is a reciprocal falloff: it decays but never reaches zero, so faint light
+   * was still present at the top and bottom rows of the canvas. Where the canvas stopped, that
+   * light stopped too - a straight horizontal edge across the room, which made the effect read as
+   * a rectangle pasted on the background rather than as light in the room.
+   *
+   * Measured in normalised screen space rather than in uv, because that is where the visible
+   * boundary actually is; uv is scaled by uScale/uScaleY and would drift with aspect ratio.
+   * The horizontal pass is belt-and-braces: the taper envelope already zeroes the ends, but a
+   * future taper change should not be able to reintroduce a hard vertical seam.
+   */
+  vec2 ndc = abs(gl_FragCoord.xy / uResolution - 0.5) * 2.0;
+  float edgeFade = (1.0 - smoothstep(0.35, 0.98, ndc.y))
+                 * (1.0 - smoothstep(0.80, 1.00, ndc.x));
+  alpha *= edgeFade;
+  col *= edgeFade;
+
   fragColor = vec4(col * uOpacity, alpha);
 }
 `;

--- a/components/ai-tutor/room/TutorVoice.tsx
+++ b/components/ai-tutor/room/TutorVoice.tsx
@@ -222,11 +222,13 @@ export function TutorVoice({
 
       liveRef.current = {
         colors: look.colors,
-        speed: look.speed + amp * 0.6,
-        // Waviness and speed now carry most of the expression. They change the SHAPE of the
-        // strand without moving it further from the centre line, so they can swing hard without
-        // pushing the ribbon out of its container.
-        waviness: look.waviness + amp * 0.95,
+        speed: look.speed + amp * 0.35,
+        /**
+         * Waviness picks up some of the expression the bounded amplitude gave up, but not all of
+         * it. Pushing it to +0.95 made the strand thrash: many short wavelengths crossing each
+         * other reads as noise, not as a voice. +0.3 keeps the wave legible as one moving line.
+         */
+        waviness: look.waviness + amp * 0.3,
         /**
          * Bounded at 1.3, not 3.7.
          *

--- a/lib/hooks/useRealtimeTutor.ts
+++ b/lib/hooks/useRealtimeTutor.ts
@@ -61,6 +61,33 @@ const TRANSCRIPT_LIMIT = 200;
  */
 const RESPONSE_ACK_TIMEOUT_MS = 8_000;
 
+/** How much spoken text the caption keeps. Roughly three lines at the room's type size. */
+const CAPTION_CHARS = 260;
+
+/**
+ * The tail of what the tutor is saying, trimmed to whole sentences.
+ *
+ * This used to be `transcript.slice(-320)`, which cut the head mid-word, and the room then clamped
+ * the tail with `-webkit-line-clamp`, which appended an ellipsis mid-sentence. The result read as
+ * a broken feed rather than as speech: "...Worlds, different outcomes all exist... When you're..."
+ *
+ * So the window is aligned to sentence boundaries instead. The trailing fragment is kept as-is,
+ * because that is the part currently being spoken and it is genuinely incomplete - what was wrong
+ * was implying a cut where the speech had not actually stopped.
+ */
+function captionFrom(transcript: string): string {
+  const text = transcript.replace(/\s+/g, " ").trim();
+  if (text.length <= CAPTION_CHARS) return text;
+
+  const window = text.slice(-CAPTION_CHARS);
+  // Advance to just after the first sentence end, so the caption opens on a capital rather than
+  // halfway through a word. Fall back to a word boundary when there is no sentence break.
+  const sentence = window.search(/(?<=[.!?])\s+\S/);
+  if (sentence !== -1) return window.slice(sentence).trimStart();
+  const space = window.indexOf(" ");
+  return space === -1 ? window : window.slice(space + 1);
+}
+
 export type TutorPhase =
   | "idle"
   | "starting"
@@ -604,7 +631,7 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
         case "response.output_audio_transcript.delta": {
           const delta = String(event.delta ?? "");
           tutorTranscriptRef.current += delta;
-          setCaption(tutorTranscriptRef.current.slice(-320));
+          setCaption(captionFrom(tutorTranscriptRef.current));
           setPhase("speaking");
           break;
         }


### PR DESCRIPTION
Promotes #1350.

**Captions** were being cut at both ends by code that did not know where the sentences were: `slice(-320)` started mid-word and `-webkit-line-clamp` appended an ellipsis at a pixel boundary. Now trimmed to sentence boundaries in the transport, clamp removed. The in-progress trailing fragment is kept, because that is genuinely still being spoken.

**The ribbon had a visible rectangle.** Its glow is a reciprocal falloff that never reaches zero, so faint light sat on the canvas's top and bottom rows and stopped in a straight line where the canvas did. A smoothstep fade in screen space takes alpha to zero before the edge — measured at exactly 0 on all four edges at rest and full volume.

**The wave thrashed while speaking**, which was my own over-correction from bounding the amplitude last round. Waviness +0.3 and speed +0.35 keep it legible as one moving line.

Verified by rendering the real shader headlessly at both container sizes and both volumes. tsc clean, next build clean, 6 guard tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)