### PR TITLE
release(ai-tutor): a smaller ribbon

### DIFF
--- a/components/ai-tutor/room/Strands.tsx
+++ b/components/ai-tutor/room/Strands.tsx
@@ -291,10 +291,16 @@ const TAPER_ZERO = 0.3846;
 /**
  * How much of the container's half-width the ribbon is allowed to span.
  *
- * Below 1 the taper reaches zero before the edge, which is the difference between a ribbon
- * that fades out and a ribbon that looks cut off.
+ * Below 1 the taper reaches zero before the edge, which is the difference between a ribbon that
+ * fades out and a ribbon that looks cut off. Well below 1 it is also the main lever for how wide
+ * the ribbon reads: measured on the room's full stage, 0.74 spanned 68% of the width and 0.52
+ * spans 50%.
+ *
+ * It cannot go so low that the envelope's next positive lobe becomes visible, which would tile the
+ * effect. The lobe returns at uv.x 1.538 and this ratio holds uv.x at 0.74 regardless of aspect,
+ * so there is a wide margin.
  */
-const RIBBON_FILL = 0.74;
+const RIBBON_FILL = 0.52;
 
 /**
  * Ceiling on the vertical scale, so `uv.y` keeps room for the wave at its LOUDEST.
@@ -313,7 +319,7 @@ const RIBBON_FILL = 0.74;
  * pixels fully saturated. The shipped values were off the top of that grid, which is why loud
  * speech read as a blown-out white mass filling the frame.
  */
-const MAX_VERTICAL_SCALE = 1.6;
+const MAX_VERTICAL_SCALE = 1.0;
 
 const buildPalette = (colors: string[]): number[][] => {
   const filled = colors && colors.length ? colors : ["#ffffff"];


### PR DESCRIPTION
Promotes #1352.

Measured on the room's full stage rather than guessed — swept the two scale constants and read the rendered extent at a perceptible alpha:

| | width | height at rest | height at full volume |
|---|---|---|---|
| before | 68% | 19% | 66% |
| **after** | **50%** | **12%** | **52%** |

`RIBBON_FILL` (0.74 → 0.52) is the width lever, and lowering it also buys margin against the taper envelope's next positive lobe, which is what would tile the effect. uv.x now peaks at 0.74 against a lobe returning at 1.538.

`MAX_VERTICAL_SCALE` (1.6 → 1.0) is the height lever, and it works in the direction that reads as backwards, so the comment now says so: the strand's size is fixed in uv units, so a **larger** visible uv range means it covers a **smaller** fraction of the container. This also raises headroom over the loudest wave excursion from 2x to 3.2x, so the guard test asserting that invariant gets easier to satisfy, not harder.

## Verification

The edge fade still puts alpha at **exactly 0 on all four edges** at both rest and full volume, in both the full-stage and band geometries, and the palette still resolves 30–40 distinct hues so it has not flattened. `tsc` clean, `next build` clean, 6 guard tests pass.

*(Correcting my own slip: this PR was opened by a script I reused from the previous release, so it initially carried that release's title and description. The change itself is only the two scale constants — see #1352.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)