### PR TITLE
feat(ai-tutor): glass orb, steadier captions, and four room fixes

### DIFF
--- a/app/ai-tutor/session/[id]/loading.tsx
+++ b/app/ai-tutor/session/[id]/loading.tsx
@@ -15,7 +15,10 @@ export default function Loading() {
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: "calc(100dvh - 64px)",
+        // The full viewport. The room hides the global app bar, so subtracting its 64px left a
+        // strip of the light page background below the shimmer - a white band across the bottom
+        // of an otherwise dark screen, and the same defect the room itself had.
+        height: "100dvh",
         background:
           "radial-gradient(115% 90% at 50% 8%, #241653 0%, #170d38 42%, #0b0619 100%)",
       }}

--- a/app/ai-tutor/session/[id]/page.tsx
+++ b/app/ai-tutor/session/[id]/page.tsx
@@ -48,8 +48,16 @@ const PHASE_HINT: Record<string, string> = {
   speaking: "Cut in whenever you like",
 };
 
-// The support FAB is fixed bottom-right and otherwise sits on top of "End session".
-const FAB_CLEARANCE = 72;
+/**
+ * Room to the right of the transport bar for the fixed support FAB.
+ *
+ * Measured rather than eyeballed: `ReportIssueFAB` is a default-size MUI `Fab` (56px) at
+ * `insetInlineEnd: 24`, so it occupies 24px to 80px from the right edge. The previous 72px
+ * reserved less than that, and "End session" slid under the headset button - which is a bad
+ * pair of controls to overlap, since one ends a paid session and the other opens a support
+ * dialog. 96 clears the FAB with a 16px gap.
+ */
+const FAB_CLEARANCE = 96;
 
 export default function TutorSessionPage() {
   const router = useRouter();
@@ -190,6 +198,25 @@ export default function TutorSessionPage() {
 
   const failed = phase === "failed";
   const hasCards = cards.length > 0;
+
+  /**
+   * The caption split into sentences, newest first.
+   *
+   * The transport already trims the transcript to whole sentences, so this only has to reverse
+   * them and cap how many are shown. Capped because the block has a fixed height now: rendering
+   * more than fits would just be clipped, and clipping mid-word is the thing that made the old
+   * caption look broken.
+   */
+  const captionLines = useMemo(() => {
+    const text = (tutor.caption || "").trim();
+    if (!text) return [];
+    const parts = text.match(/[^.!?]+[.!?]*/g) ?? [text];
+    return parts
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .reverse()
+      .slice(0, hasCards ? 2 : 3);
+  }, [tutor.caption, hasCards]);
   const lowTime = remaining !== null && remaining < 120;
 
   if (!topic) {
@@ -436,8 +463,20 @@ export default function TutorSessionPage() {
                   <TutorVoice phase={phase} getLevels={tutor.getLevels} />
                 </Box>
 
-                {/* Captions. Large and centred while the ribbon owns the stage, because at
-                    that point they ARE the content. */}
+                {/* Captions.
+
+                    Two properties this block has to hold, and the old version held neither.
+
+                    FIXED height, not `minHeight`. The caption grows and shrinks with whatever the
+                    tutor happens to be saying, and with only a minimum the KEY POINTS card below
+                    it slid up and down on every sentence. A card that moves while you are reading
+                    it is worse than a caption that runs out of room.
+
+                    NEWEST FIRST. The tutor is still talking, so the interesting line is the one
+                    that just arrived. Rendering chronologically put it at the bottom and pushed
+                    the eye downward on every update. The conversation panel stays chronological,
+                    because there you are reading back through a record rather than following a
+                    voice. */}
                 <Box
                   sx={{
                     flexShrink: 0,
@@ -445,38 +484,56 @@ export default function TutorSessionPage() {
                     pt: 2.5,
                     pb: hasCards ? 2 : 3,
                     textAlign: "center",
-                    minHeight: hasCards ? 64 : 96,
+                    height: hasCards ? 92 : 132,
+                    overflow: "hidden",
+                    transition: "height 300ms ease",
                   }}
                 >
-                  <Typography
+                  <Box
                     sx={{
-                      fontSize: hasCards
-                        ? { xs: "0.95rem", md: "1rem" }
-                        : { xs: "1.1rem", md: "1.35rem" },
-                      lineHeight: 1.55,
-                      color: tutor.caption
-                        ? "rgba(255,255,255,0.95)"
-                        : "rgba(255,255,255,0.55)",
                       maxWidth: 760,
                       mx: "auto",
-                      /**
-                       * No line clamp.
-                       *
-                       * The clamp appended an ellipsis mid-sentence, so the caption read as a
-                       * broken feed: "...different outcomes all exist... When you're...". The
-                       * transport now trims the transcript to whole sentences instead, which is
-                       * the right place to decide it - the clamp could only ever cut blindly at
-                       * a pixel boundary.
-                       *
-                       * `minHeight` still reserves the space, so nothing below shifts as lines
-                       * come and go.
-                       */
-                      transition: "font-size 300ms ease",
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 0.5,
                     }}
                     aria-live="polite"
                   >
-                    {tutor.caption || PHASE_HINT[phase] || PHASE_LABEL[phase]}
-                  </Typography>
+                    {captionLines.length ? (
+                      captionLines.map((line, i) => (
+                        <Typography
+                          key={`${i}-${line.slice(0, 24)}`}
+                          sx={{
+                            fontSize: hasCards
+                              ? { xs: "0.95rem", md: "1rem" }
+                              : { xs: "1.1rem", md: "1.35rem" },
+                            lineHeight: 1.5,
+                            // The newest line is the one being spoken; older ones recede rather
+                            // than disappearing, so the eye stays at the top of the block.
+                            color:
+                              i === 0
+                                ? "rgba(255,255,255,0.95)"
+                                : "rgba(255,255,255,0.45)",
+                            transition: "font-size 300ms ease, color 300ms ease",
+                          }}
+                        >
+                          {line}
+                        </Typography>
+                      ))
+                    ) : (
+                      <Typography
+                        sx={{
+                          fontSize: hasCards
+                            ? { xs: "0.95rem", md: "1rem" }
+                            : { xs: "1.1rem", md: "1.35rem" },
+                          lineHeight: 1.5,
+                          color: "rgba(255,255,255,0.55)",
+                        }}
+                      >
+                        {PHASE_HINT[phase] || PHASE_LABEL[phase]}
+                      </Typography>
+                    )}
+                  </Box>
                 </Box>
 
                 {/* Canvas */}

--- a/components/ai-tutor/room/Strands.tsx
+++ b/components/ai-tutor/room/Strands.tsx
@@ -493,22 +493,28 @@ export default function Strands({
      * over ~400ms when the first canvas card arrives. ResizeObserver fires on every frame of that
      * animation, so the transition was paying for ~25 framebuffer reallocations and visibly
      * juddered. Two guards: ignore a callback reporting the same integer size, and touch the
-     * post-processing render target only when the glass pass is actually enabled (the room never
-     * enables it, so that was pure waste).
+     * post-processing render target only when the glass pass is actually enabled.
+     *
+     * `lastGlass` is part of the key, not just the dimensions. Without it, turning glass on
+     * without also changing size would leave the render target at its initial size forever, and
+     * the orb would sample a stale texture.
      */
     let lastW = 0;
     let lastH = 0;
+    let lastGlass: boolean | null = null;
     function resize() {
       if (!ctn) return;
       const width = ctn.offsetWidth;
       const height = ctn.offsetHeight;
       if (!width || !height) return;
-      if (width === lastW && height === lastH) return;
+      const glassOn = Boolean(propsRef.current.glass);
+      if (width === lastW && height === lastH && glassOn === lastGlass) return;
       lastW = width;
       lastH = height;
+      lastGlass = glassOn;
       renderer.setSize(width, height);
       program.uniforms.uResolution.value = [width, height];
-      if (propsRef.current.glass) {
+      if (glassOn) {
         renderTarget.setSize(width, height);
         glassProgram.uniforms.uResolution.value = [width, height];
       }

--- a/components/ai-tutor/room/TutorVoice.tsx
+++ b/components/ai-tutor/room/TutorVoice.tsx
@@ -72,83 +72,35 @@ const Strands = dynamic(() => import("./Strands"), {
  * Violet is the tutor and pink is the learner. That distinction is the only thing the colour
  * has to communicate, so the two never share their second hue.
  */
+/**
+ * Per-phase look, on the glass-orb preset.
+ *
+ * The palette is fixed - orange, violet, cyan - and deliberately NOT varied per phase. Rotating
+ * hues inside a refracting sphere reads as the glass changing material rather than as the tutor
+ * changing state, which is the opposite of informative.
+ *
+ * State is carried by MOTION instead, which is also what was asked for: the orb turns over faster
+ * when someone is talking. `count` and `waviness` shift with it so a fast orb also looks busier,
+ * and the learner is distinguished from the tutor by being quicker and more agitated rather than
+ * by being a different colour.
+ */
+const PALETTE = ["#F97316", "#7C3AED", "#06B6D4"];
+
 const PHASE_LOOK: Record<
   TutorPhase,
   { colors: string[]; count: number; speed: number; waviness: number; saturation: number }
 > = {
-  idle: {
-    colors: ["#F8FAFF", "#BFDBFE", "#7DD3FC"],
-    count: 2,
-    speed: 0.16,
-    waviness: 0.75,
-    saturation: 1.0,
-  },
-  starting: {
-    colors: ["#FFFFFF", "#DBEAFE", "#7DD3FC"],
-    count: 2,
-    speed: 0.26,
-    waviness: 0.85,
-    saturation: 1.0,
-  },
-  connecting: {
-    colors: ["#FFFFFF", "#C7D2FE", "#60A5FA"],
-    count: 3,
-    speed: 0.8,
-    waviness: 1.15,
-    saturation: 0.95,
-  },
-  listening: {
-    colors: ["#FBFDFF", "#DBEAFE", "#67E8F9", "#818CF8"],
-    count: 3,
-    speed: 0.2,
-    waviness: 0.8,
-    saturation: 1.05,
-  },
-  // The learner. Warm, so the two speakers are never mistaken for each other.
-  "student-speaking": {
-    colors: ["#FFFFFF", "#FBCFE8", "#F472B6"],
-    count: 3,
-    speed: 0.5,
-    waviness: 1.2,
-    saturation: 1.3,
-  },
-  thinking: {
-    colors: ["#FFFFFF", "#E0E7FF", "#A5B4FC"],
-    count: 4,
-    speed: 1.3,
-    waviness: 1.7,
-    saturation: 0.95,
-  },
-  // The tutor. Cool white through ice-blue into a single indigo, which is what makes it read
-  // as one clean filament rather than a bundle of coloured threads.
-  speaking: {
-    colors: ["#FFFFFF", "#E0F2FE", "#67E8F9", "#6366F1"],
-    count: 3,
-    speed: 0.5,
-    waviness: 1.0,
-    saturation: 1.2,
-  },
-  ending: {
-    colors: ["#F8FAFC", "#CBD5E1", "#94A3B8"],
-    count: 2,
-    speed: 0.14,
-    waviness: 0.55,
-    saturation: 0.5,
-  },
-  ended: {
-    colors: ["#F1F5F9", "#CBD5E1"],
-    count: 2,
-    speed: 0.1,
-    waviness: 0.5,
-    saturation: 0.32,
-  },
-  failed: {
-    colors: ["#FFFFFF", "#FCA5A5", "#DC2626"],
-    count: 2,
-    speed: 0.12,
-    waviness: 0.6,
-    saturation: 0.85,
-  },
+  idle: { colors: PALETTE, count: 3, speed: 0.18, waviness: 1.3, saturation: 1.5 },
+  starting: { colors: PALETTE, count: 3, speed: 0.34, waviness: 1.4, saturation: 1.5 },
+  connecting: { colors: PALETTE, count: 3, speed: 0.7, waviness: 1.55, saturation: 1.45 },
+  listening: { colors: PALETTE, count: 3, speed: 0.26, waviness: 1.35, saturation: 1.5 },
+  // The learner: quicker and more agitated than the tutor, same glass.
+  "student-speaking": { colors: PALETTE, count: 3, speed: 1.15, waviness: 1.95, saturation: 1.6 },
+  thinking: { colors: PALETTE, count: 3, speed: 1.5, waviness: 1.8, saturation: 1.45 },
+  speaking: { colors: PALETTE, count: 3, speed: 0.8, waviness: 1.6, saturation: 1.5 },
+  ending: { colors: PALETTE, count: 2, speed: 0.14, waviness: 1.0, saturation: 0.8 },
+  ended: { colors: PALETTE, count: 2, speed: 0.1, waviness: 0.9, saturation: 0.5 },
+  failed: { colors: ["#FCA5A5", "#DC2626", "#7C3AED"], count: 2, speed: 0.12, waviness: 1.0, saturation: 1.0 },
 };
 
 export const PHASE_LABEL: Record<TutorPhase, string> = {
@@ -224,32 +176,20 @@ export function TutorVoice({
 
       liveRef.current = {
         colors: look.colors,
-        speed: look.speed + amp * 0.35,
         /**
-         * Waviness picks up some of the expression the bounded amplitude gave up, but not all of
-         * it. Pushing it to +0.95 made the strand thrash: many short wavelengths crossing each
-         * other reads as noise, not as a voice. +0.3 keeps the wave legible as one moving line.
+         * Speed carries the voice. This was the explicit ask, and it suits the orb: a sphere of
+         * moving light reads its energy from how fast the bands turn over, far more than from how
+         * far they travel. It also cannot push anything out of frame, because the glass masks
+         * everything outside its own radius.
          */
-        waviness: look.waviness + amp * 0.3,
-        /**
-         * Bounded at 1.3, not 3.7.
-         *
-         * The shader's excursion is `(0.1 + 0.02 * e) * env * uAmplitude` in uv units against a
-         * visible half-height of `0.5 / uScaleY`. At the old range the ribbon swung 1.4x past the
-         * edge on normal speech and 2.2x on loud speech, so it left the screen precisely when it
-         * was doing the thing it exists to do.
-         */
-        amplitude: 0.5 + amp * 0.8,
-        /**
-         * Thickness and glow are what actually decide how much of the container the ribbon eats,
-         * and both were far too high. Five strands each contribute a squared falloff; summed and
-         * passed through `1 - exp(-col * uGlow)` they saturate to flat white long before the wave
-         * runs out of room. These ceilings come from a headless render sweep - the bright core
-         * lands near 50% of the height at full volume instead of filling the frame.
-         */
-        thickness: 0.24 + amp * 0.16,
-        glow: 1.15 + amp * 0.45,
-        intensity: 0.5 + amp * 0.5,
+        speed: look.speed + amp * 1.6,
+        waviness: look.waviness + amp * 0.35,
+        // Amplitude and thickness stay near the preset. Inside a refracting sphere a big swing
+        // just smears against the rim rather than reading as loudness.
+        amplitude: 0.8 + amp * 0.25,
+        thickness: 1.0,
+        glow: 2.7 + amp * 0.5,
+        intensity: 0.4 + amp * 0.25,
         saturation: look.saturation,
       };
 
@@ -267,21 +207,31 @@ export function TutorVoice({
 
   return (
     <Box sx={{ position: "relative", width: "100%", height }}>
+      {/* The glass-orb preset.
+
+          `fitSingleRibbon` is deliberately absent. It computes `uScale` from the container's
+          aspect ratio to keep a full-width ribbon from tiling, and that is the wrong problem
+          here: the orb is a circle whose radius comes from `glassSize`, so the sphere bounds the
+          visual and `scale` stays a fixed 1.2. Leaving the fit on would fight the preset and
+          stretch the bands inside the glass on a wide container. */}
       <Strands
         colors={look.colors}
         count={look.count}
         speed={look.speed}
         waviness={look.waviness}
         saturation={look.saturation}
-        amplitude={reduceMotion ? 0.7 : 1}
-        thickness={0.85}
-        glow={3.2}
-        taper={2.0}
-        spread={1}
-        intensity={0.6}
+        amplitude={reduceMotion ? 0.7 : 0.8}
+        thickness={1}
+        glow={2.7}
+        taper={6}
+        spread={1.1}
+        intensity={0.4}
         opacity={1}
-        scale={1.35}
-        fitSingleRibbon
+        scale={1.2}
+        glass
+        refraction={1.05}
+        dispersion={1.3}
+        glassSize={0.54}
         liveRef={reduceMotion ? undefined : (liveRef as { current: StrandsLive })}
         paused={reduceMotion}
       />

--- a/components/ai-tutor/room/strands-uniforms.test.ts
+++ b/components/ai-tutor/room/strands-uniforms.test.ts
@@ -84,62 +84,57 @@ describe("Strands uniform wiring", () => {
     expect(writtenPerFrame(SOURCE).has("uScaleY")).toBe(true);
   });
 
-  it("keeps room for the wave at the LOUDEST amplitude TutorVoice actually sends", () => {
+  /**
+   * The geometry invariants below moved when the room switched to the glass-orb preset.
+   *
+   * `fitSingleRibbon` is no longer passed, so `RIBBON_FILL` and `MAX_VERTICAL_SCALE` are inert for
+   * this app: `uScale` is the fixed `scale` prop and the sphere's own radius bounds the visual.
+   * Those constants stay in the vendored component because `fitSingleRibbon` is still a supported
+   * prop, but asserting them here would be guarding a code path the product does not take, which
+   * is worse than no test - it reads as coverage while protecting nothing.
+   *
+   * So these assert the configuration the room actually renders, read out of TutorVoice.
+   */
+  const VOICE = readFileSync(path.resolve(__dirname, "TutorVoice.tsx"), "utf8");
+
+  it("renders the orb, not the full-width ribbon", () => {
+    expect(VOICE).toMatch(/\n\s*glass\n/);
+    // The PROP, not the word: the comment above the element explains why the fit is absent, and
+    // that explanation is worth keeping.
+    expect(VOICE).not.toMatch(/^\s*fitSingleRibbon(\s*=|\s*$)/m);
+    // The sphere's radius is 0.46 * glassSize, and `p` spans +/-0.5 vertically, so anything at or
+    // above ~1.08 would push the orb past the top and bottom of its container.
+    const size = Number(VOICE.match(/glassSize=\{([\d.]+)\}/)![1]);
+    expect(size).toBeGreaterThan(0);
+    expect(0.46 * size).toBeLessThan(0.5);
+  });
+
+  it("keeps the wave inside the sphere at the loudest amplitude", () => {
     /**
-     * The invariant that was violated in production, and it spans two files.
-     *
-     * `Strands` caps the vertical scale; `TutorVoice` drives `amplitude` from the audio level. The
-     * cap was chosen against the RESTING wave while TutorVoice sent up to 3.7 on loud speech, so
-     * the ribbon swung 1.4x past the visible edge on normal speech and 2.2x on loud - it left the
-     * screen precisely when it was doing its job. Asserting the two together is the only way to
-     * keep them honest, because either file looks perfectly reasonable on its own.
+     * Same invariant as before, re-derived for the preset. The visible half-height is
+     * `0.5 / scale` because `uScaleY` is the plain `scale` prop without the fit, and the shader's
+     * excursion is `(0.1 + 0.02 * e) * env * uAmplitude`.
      */
-    const cap = Number(SOURCE.match(/MAX_VERTICAL_SCALE\s*=\s*([\d.]+)/)![1]);
-    const voice = readFileSync(path.resolve(__dirname, "TutorVoice.tsx"), "utf8");
-    const amp = voice.match(/amplitude:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
+    const scale = Number(VOICE.match(/scale=\{([\d.]+)\}/)![1]);
+    const amp = VOICE.match(/amplitude:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
     expect(amp).not.toBeNull();
     const maxAmplitude = Number(amp![1]) + Number(amp![2]);
-
-    // Excursion is (0.1 + 0.02 * e) * env * uAmplitude, with e and env at most 1 in the centre.
-    const maxExcursion = (0.1 + 0.02 * 1) * maxAmplitude;
-    const halfHeight = 0.5 / cap;
-    // 1.5x, so thickness and glow have somewhere to spread rather than clipping at the edge.
-    expect(halfHeight / maxExcursion).toBeGreaterThan(1.5);
+    const maxExcursion = (0.1 + 0.02) * maxAmplitude;
+    expect(0.5 / scale / maxExcursion).toBeGreaterThan(1.5);
   });
 
-  it("keeps thickness and glow below the values that saturated to flat white", () => {
-    // From a headless thickness/glow sweep: past these the bright core fills most of the container
-    // and the ribbon reads as a blown-out smear with no visible strand structure.
-    const voice = readFileSync(path.resolve(__dirname, "TutorVoice.tsx"), "utf8");
-    const th = voice.match(/thickness:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
-    const gl = voice.match(/glow:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
-    expect(th).not.toBeNull();
-    expect(gl).not.toBeNull();
-    expect(Number(th![1]) + Number(th![2])).toBeLessThanOrEqual(0.55);
-    expect(Number(gl![1]) + Number(gl![2])).toBeLessThanOrEqual(2.0);
+  it("drives the orb with speed, which is what carries the voice here", () => {
+    // The explicit product requirement: it turns over faster when someone is talking. A ceiling
+    // too, because past a point the bands strobe rather than flow.
+    const speed = VOICE.match(/speed:\s*look\.speed\s*\+\s*amp\s*\*\s*([\d.]+)/);
+    expect(speed).not.toBeNull();
+    expect(Number(speed![1])).toBeGreaterThan(0.5);
+    expect(Number(speed![1])).toBeLessThanOrEqual(2.5);
   });
 
-  it("fits the ribbon inside the frame, and cannot go so narrow that it tiles", () => {
-    /**
-     * Both bounds are derived, not chosen.
-     *
-     * `uScale = aspect * FILL / (2 * TAPER_ZERO)`, so `uv.x` peaks at `TAPER_ZERO / FILL` -
-     * independent of aspect ratio, which is the whole point of expressing it this way.
-     *
-     * Upper bound: FILL below 1 is what lets the taper reach zero before the container edge. At 1
-     * the ribbon carries luminance right up to the edge and reads as cut off, which is how it
-     * first shipped.
-     *
-     * Lower bound: the envelope's next positive lobe begins at `uv.x` 1.538. Past that the effect
-     * TILES into repeating lens shapes. `TAPER_ZERO / FILL < 1.538` gives `FILL > 0.25`, and the
-     * assertion keeps a margin over that rather than sitting on the boundary.
-     */
-    const fill = Number(SOURCE.match(/RIBBON_FILL\s*=\s*([\d.]+)/)![1]);
-    const taperZero = Number(SOURCE.match(/TAPER_ZERO\s*=\s*([\d.]+)/)![1]);
-
-    expect(fill).toBeLessThan(1);
-    const peakUvX = taperZero / fill;
-    // 1.538 is where the cosine returns positive. Require 25% headroom below it.
-    expect(peakUvX).toBeLessThan(1.538 / 1.25);
+  it("keeps glow below the value that saturates the sphere to flat white", () => {
+    const glow = VOICE.match(/glow:\s*([\d.]+)\s*\+\s*amp\s*\*\s*([\d.]+)/);
+    expect(glow).not.toBeNull();
+    expect(Number(glow![1]) + Number(glow![2])).toBeLessThanOrEqual(3.6);
   });
 });


### PR DESCRIPTION
## The tutor is a glass orb

Switches the room to the glass preset with the exact parameters requested — orange/violet/cyan, taper 6, spread 1.1, intensity 0.4, saturation 1.5, scale 1.2, refraction 1.05, dispersion 1.3, `glassSize` 0.54.

This answers **"make it small in width" structurally rather than by tuning.** The sphere's radius is `0.46 * glassSize` in units of half-*height*, so its size comes from the container's height and is completely independent of width. Rendered headlessly at 900×600 it is a **300px circle, a third of the frame**, and it stays circular at any aspect instead of stretching into a band.

`fitSingleRibbon` is deliberately not passed — it derives `uScale` from aspect to stop a full-width ribbon tiling, which is the wrong problem when the sphere bounds the visual and `scale` is fixed at 1.2.

**Speed carries the voice**, as asked. A sphere of moving light reads its energy from how fast the bands turn over, not how far they travel — and it cannot push anything out of frame, because the glass masks everything outside its radius.

## Four room fixes

- **The KEY POINTS card slid up and down.** The caption had `minHeight`, so it grew with the speech and moved everything below it. Fixed height now; it clips rather than shoving.
- **The caption read in the wrong direction.** Newest line rendered last, pushing the eye downward on every update. Sentences are reversed — newest on top, older dimmed. The conversation panel stays chronological, since there you are reading a record rather than following a voice.
- **"End session" slid under the support FAB.** That Fab is 56px at `insetInlineEnd: 24`, so it spans 24–80px from the right; the bar reserved 72. Ending a paid session and opening a support dialog is a bad pair to overlap. Now 96 with the measurement recorded in the constant.
- **White strip under the shimmer.** `loading.tsx` still had `calc(100dvh - 64px)` for an app bar the room hides — I fixed this in `page.tsx` and missed the route's other entry point.

## Verification

Glass orb rendered headlessly (both programs link, orb is circular, 101 hues at rest / 47 speaking). 7 guard tests, repointed at the glass configuration since `RIBBON_FILL`/`MAX_VERTICAL_SCALE` are inert without `fitSingleRibbon` — a test guarding an unused path reads as coverage while protecting nothing. Proven by re-adding `fitSingleRibbon`: the orb test fails by name. `tsc` clean, `next build` clean.

Backend counterpart (tutor identity): AI-Linc-LMS/ai-linc-backend#627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)