### PR TITLE
release(ai-tutor): caption alignment, newest-first conversation, working diagram cards

### DIFF
--- a/app/ai-tutor/session/[id]/page.tsx
+++ b/app/ai-tutor/session/[id]/page.tsx
@@ -481,21 +481,34 @@ export default function TutorSessionPage() {
                   sx={{
                     flexShrink: 0,
                     px: { xs: 2.5, md: 5 },
-                    pt: 2.5,
-                    pb: hasCards ? 2 : 3,
+                    py: hasCards ? 1.5 : 2,
                     textAlign: "center",
                     height: hasCards ? 92 : 132,
                     overflow: "hidden",
                     transition: "height 300ms ease",
+                    /**
+                     * Centre the lines in the slot.
+                     *
+                     * The box is a fixed height so the cards below never move, but the content was
+                     * top-aligned inside it. One short line therefore sat at the top with a large
+                     * gap beneath, three lines filled the box, and the caption appeared to jump up
+                     * and down against the orb above it on every sentence. Fixing the container
+                     * without fixing where the text sits inside it only moved the problem.
+                     */
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
                   }}
                 >
                   <Box
                     sx={{
                       maxWidth: 760,
-                      mx: "auto",
+                      width: "100%",
                       display: "flex",
                       flexDirection: "column",
-                      gap: 0.5,
+                      // Tight, so consecutive sentences read as one caption receding rather than
+                      // as a stack of separate paragraphs.
+                      gap: 0.25,
                     }}
                     aria-live="polite"
                   >
@@ -504,16 +517,24 @@ export default function TutorSessionPage() {
                         <Typography
                           key={`${i}-${line.slice(0, 24)}`}
                           sx={{
-                            fontSize: hasCards
-                              ? { xs: "0.95rem", md: "1rem" }
-                              : { xs: "1.1rem", md: "1.35rem" },
-                            lineHeight: 1.5,
-                            // The newest line is the one being spoken; older ones recede rather
-                            // than disappearing, so the eye stays at the top of the block.
+                            // The newest line is the one being spoken. Older ones recede in BOTH
+                            // size and opacity, which is what makes the block read as one caption
+                            // trailing off rather than three lines competing for attention.
+                            fontSize:
+                              i === 0
+                                ? hasCards
+                                  ? { xs: "0.95rem", md: "1rem" }
+                                  : { xs: "1.1rem", md: "1.35rem" }
+                                : hasCards
+                                  ? { xs: "0.82rem", md: "0.86rem" }
+                                  : { xs: "0.92rem", md: "1rem" },
+                            lineHeight: 1.45,
                             color:
                               i === 0
                                 ? "rgba(255,255,255,0.95)"
-                                : "rgba(255,255,255,0.45)",
+                                : i === 1
+                                  ? "rgba(255,255,255,0.5)"
+                                  : "rgba(255,255,255,0.3)",
                             transition: "font-size 300ms ease, color 300ms ease",
                           }}
                         >

--- a/components/ai-tutor/recap/RecapArtifacts.tsx
+++ b/components/ai-tutor/recap/RecapArtifacts.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Box, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { TutorSurface } from "../shared/surfaces";
+import { TutorDiagram, type DiagramSpec } from "../room/TutorDiagram";
 
 /**
  * What went on the canvas, as a filmstrip.
@@ -162,12 +163,42 @@ function ArtifactDetail({ artifact }: { artifact: Artifact }) {
   const bullets = Array.isArray(p.bullets) ? (p.bullets as string[]) : [];
   const code = p.code ? String(p.code) : "";
   const url = p.url ? String(p.url) : "";
+  const isDiagram = artifact.kind === "diagram" && Boolean(p.kind);
 
   return (
     <TutorSurface sx={{ mt: 1.5 }}>
-      <Typography sx={{ fontSize: "1rem", fontWeight: 500, mb: bullets.length || code ? 1.25 : 0 }}>
+      <Typography
+        sx={{
+          fontSize: "1rem",
+          fontWeight: 500,
+          mb: bullets.length || code || isDiagram ? 1.25 : 0,
+        }}
+      >
         {titleOf(artifact)}
       </Typography>
+
+      {/* A diagram, on its own dark ground.
+
+          Clicking a diagram card used to expand a panel containing only the title, which read as
+          the card being broken. A diagram artifact's payload is the spec itself - a `kind` and its
+          nodes - so it has none of the bullets, code or url this panel knew how to render.
+
+          `TutorDiagram` is hard-coded for the room's dark surface (white text, white hairlines), so
+          it is given one here rather than being rewritten to be theme-aware. That also matches how
+          the recap already shows code, and reads correctly: this is a picture of what was on the
+          canvas during the lesson. */}
+      {isDiagram ? (
+        <Box
+          sx={{
+            p: { xs: 1.5, md: 2 },
+            borderRadius: "10px",
+            bgcolor: "#140b2b",
+            overflowX: "auto",
+          }}
+        >
+          <TutorDiagram spec={p as unknown as DiagramSpec} />
+        </Box>
+      ) : null}
 
       {bullets.length ? (
         <Box component="ul" sx={{ m: 0, pl: 2.5, display: "grid", gap: 0.6 }}>

--- a/components/ai-tutor/room/ConversationPanel.tsx
+++ b/components/ai-tutor/room/ConversationPanel.tsx
@@ -26,9 +26,13 @@ import {
  *
  * Two design choices worth keeping:
  *
- * It autoscrolls to the newest turn, but only while the learner is already at the bottom.
- * Yanking the view down while somebody is reading back through what was said is worse than
- * not scrolling at all.
+ * NEWEST FIRST, matching the stage caption. During a live lesson the interesting turn is the one
+ * that just happened, and chronological order buried it at the bottom of a growing list: the
+ * learner had to scroll down every time the tutor spoke. Reversing it means the thing you want is
+ * always in the same place, at the top.
+ *
+ * It autoscrolls to the newest turn, but only while the learner is already at the top. Yanking the
+ * view while somebody is reading back through what was said is worse than not scrolling at all.
  *
  * The tutor's turn only appears here once it has finished speaking it, because that is when
  * the transport commits the turn. Streaming it in word by word would duplicate the caption
@@ -51,14 +55,15 @@ export function ConversationPanel({
   useEffect(() => {
     const el = scrollRef.current;
     if (!el || !pinnedRef.current) return;
-    el.scrollTop = el.scrollHeight;
+    // Newest is at the top now, so "follow the conversation" means scrolling UP.
+    el.scrollTop = 0;
   }, [entries.length, liveCaption]);
 
   const onScroll = () => {
     const el = scrollRef.current;
     if (!el) return;
     // 40px of slack, so a stray touch does not unpin the view.
-    pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    pinnedRef.current = el.scrollTop < 40;
   };
 
   return (
@@ -155,11 +160,13 @@ export function ConversationPanel({
           </Box>
         ) : null}
 
-        {entries.map((entry) => (
+        {/* The sentence being spoken right now sits above everything, because it is the newest
+            thing there is. */}
+        {liveCaption ? <Turn role="tutor" text={liveCaption} pending /> : null}
+
+        {[...entries].reverse().map((entry) => (
           <Turn key={entry.id} role={entry.role} text={entry.text} />
         ))}
-
-        {liveCaption ? <Turn role="tutor" text={liveCaption} pending /> : null}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Promotes #1358.

**Caption alignment.** The fixed height stopped the KEY POINTS card sliding, but the text was still top-aligned inside it — one short line sat at the top of a 132px box with a gap beneath, three lines filled it. The card stopped moving and the caption started: the same defect one level down. Centred now, with older lines receding in size as well as opacity.

**Newest turn on top.** The conversation panel was chronological, burying the turn you just heard at the bottom of a growing list. Matches the stage caption now; autoscroll follows upward, and only while you are already at the top.

**Diagram cards opened to nothing.** `ArtifactDetail` handled bullets, code and images; a diagram artifact's payload *is* the spec, so it matched none and expanded to a bare title. Renders `TutorDiagram` on its own dark ground now — that component is hard-coded for the room's dark surface, so giving it one is smaller than making it theme-aware and truer to what the card is.

`tsc` clean, `next build` clean, 7 guard tests, #1358 merged with 0 failures and verified on stagging by content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)