### PR TITLE
fix(ai-tutor): newest canvas card on top

### DIFF
--- a/components/ai-tutor/room/CanvasStage.tsx
+++ b/components/ai-tutor/room/CanvasStage.tsx
@@ -233,8 +233,15 @@ export function CanvasStage({ cards }: { cards: CanvasCard[] }) {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-      {cards.map((card, index) => {
-        const active = index === cards.length - 1;
+      {/* Newest first, matching the caption and the conversation panel.
+
+          The tutor puts a card up mid-sentence and then talks about it, so the one it is
+          describing right now is the one that just arrived. Appending it to the bottom meant the
+          learner had to scroll down every time a diagram or image appeared, while the thing being
+          discussed sat off-screen. Reversing it keeps the current card in the same place - the
+          top - and pushes the history down instead. */}
+      {[...cards].reverse().map((card, index) => {
+        const active = index === 0;
         switch (card.kind) {
           case "slide":
             return (


### PR DESCRIPTION
The tutor puts a diagram or image up mid-sentence and then talks about it, so the card being described is always the one that just arrived. Appending it to the **bottom** meant it landed below the fold — the learner had to scroll down every time a visual appeared, while the thing under discussion sat off-screen.

Reversed, matching the stage caption and the conversation panel: the current card stays in one place at the top, history pushes down. The active-card highlight follows, since `active` was "last index" and is now "first".

`tsc` clean, `next build` clean, 7 guard tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)