### PR TITLE
fix(ai-tutor): drop the on-screen captions, and stop cropping canvas images

### DIFF
--- a/app/ai-tutor/session/[id]/page.tsx
+++ b/app/ai-tutor/session/[id]/page.tsx
@@ -39,15 +39,6 @@ import type {
  * URL to the real session id mid-call would kill both the microphone and the tutor's voice.
  */
 
-const PHASE_HINT: Record<string, string> = {
-  starting: "Planning your lesson",
-  connecting: "Connecting you now",
-  listening: "Go ahead, ask anything",
-  "student-speaking": "Listening to you",
-  thinking: "Thinking about that",
-  speaking: "Cut in whenever you like",
-};
-
 /**
  * Room to the right of the transport bar for the fixed support FAB.
  *
@@ -199,24 +190,6 @@ export default function TutorSessionPage() {
   const failed = phase === "failed";
   const hasCards = cards.length > 0;
 
-  /**
-   * The caption split into sentences, newest first.
-   *
-   * The transport already trims the transcript to whole sentences, so this only has to reverse
-   * them and cap how many are shown. Capped because the block has a fixed height now: rendering
-   * more than fits would just be clipped, and clipping mid-word is the thing that made the old
-   * caption look broken.
-   */
-  const captionLines = useMemo(() => {
-    const text = (tutor.caption || "").trim();
-    if (!text) return [];
-    const parts = text.match(/[^.!?]+[.!?]*/g) ?? [text];
-    return parts
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .reverse()
-      .slice(0, hasCards ? 2 : 3);
-  }, [tutor.caption, hasCards]);
   const lowTime = remaining !== null && remaining < 120;
 
   if (!topic) {
@@ -463,103 +436,23 @@ export default function TutorSessionPage() {
                   <TutorVoice phase={phase} getLevels={tutor.getLevels} />
                 </Box>
 
-                {/* Captions.
+                {/* No on-screen captions.
 
-                    Two properties this block has to hold, and the old version held neither.
+                    They were removed on purpose. A live transcript under the orb competes with
+                    the thing it is describing: the learner reads ahead of the voice, and the
+                    canvas card below moved every time a sentence arrived. The phase pill above
+                    already says whether the tutor is listening or speaking, which is the only
+                    part of that block anyone needed at a glance.
 
-                    FIXED height, not `minHeight`. The caption grows and shrinks with whatever the
-                    tutor happens to be saying, and with only a minimum the KEY POINTS card below
-                    it slid up and down on every sentence. A card that moves while you are reading
-                    it is worse than a caption that runs out of room.
-
-                    NEWEST FIRST. The tutor is still talking, so the interesting line is the one
-                    that just arrived. Rendering chronologically put it at the bottom and pushed
-                    the eye downward on every update. The conversation panel stays chronological,
-                    because there you are reading back through a record rather than following a
-                    voice. */}
-                <Box
-                  sx={{
-                    flexShrink: 0,
-                    px: { xs: 2.5, md: 5 },
-                    py: hasCards ? 1.5 : 2,
-                    textAlign: "center",
-                    height: hasCards ? 92 : 132,
-                    overflow: "hidden",
-                    transition: "height 300ms ease",
-                    /**
-                     * Centre the lines in the slot.
-                     *
-                     * The box is a fixed height so the cards below never move, but the content was
-                     * top-aligned inside it. One short line therefore sat at the top with a large
-                     * gap beneath, three lines filled the box, and the caption appeared to jump up
-                     * and down against the orb above it on every sentence. Fixing the container
-                     * without fixing where the text sits inside it only moved the problem.
-                     */
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <Box
-                    sx={{
-                      maxWidth: 760,
-                      width: "100%",
-                      display: "flex",
-                      flexDirection: "column",
-                      // Tight, so consecutive sentences read as one caption receding rather than
-                      // as a stack of separate paragraphs.
-                      gap: 0.25,
-                    }}
-                    aria-live="polite"
-                  >
-                    {captionLines.length ? (
-                      captionLines.map((line, i) => (
-                        <Typography
-                          key={`${i}-${line.slice(0, 24)}`}
-                          sx={{
-                            // The newest line is the one being spoken. Older ones recede in BOTH
-                            // size and opacity, which is what makes the block read as one caption
-                            // trailing off rather than three lines competing for attention.
-                            fontSize:
-                              i === 0
-                                ? hasCards
-                                  ? { xs: "0.95rem", md: "1rem" }
-                                  : { xs: "1.1rem", md: "1.35rem" }
-                                : hasCards
-                                  ? { xs: "0.82rem", md: "0.86rem" }
-                                  : { xs: "0.92rem", md: "1rem" },
-                            lineHeight: 1.45,
-                            color:
-                              i === 0
-                                ? "rgba(255,255,255,0.95)"
-                                : i === 1
-                                  ? "rgba(255,255,255,0.5)"
-                                  : "rgba(255,255,255,0.3)",
-                            transition: "font-size 300ms ease, color 300ms ease",
-                          }}
-                        >
-                          {line}
-                        </Typography>
-                      ))
-                    ) : (
-                      <Typography
-                        sx={{
-                          fontSize: hasCards
-                            ? { xs: "0.95rem", md: "1rem" }
-                            : { xs: "1.1rem", md: "1.35rem" },
-                          lineHeight: 1.5,
-                          color: "rgba(255,255,255,0.55)",
-                        }}
-                      >
-                        {PHASE_HINT[phase] || PHASE_LABEL[phase]}
-                      </Typography>
-                    )}
-                  </Box>
-                </Box>
+                    The transcript is NOT lost. `tutor.caption` still feeds the conversation
+                    panel, where reading back through a record is the actual job, and the recap
+                    keeps the full transcript after the session. */}
 
                 {/* Canvas */}
                 {hasCards ? (
-                  <Box sx={{ flex: 1, overflowY: "auto", px: { xs: 2, md: 3 }, pb: 3 }}>
+                  // pt replaces the separation the caption slot used to provide, so the first
+                  // card does not butt straight up against the orb.
+                  <Box sx={{ flex: 1, overflowY: "auto", px: { xs: 2, md: 3 }, pt: 2, pb: 3 }}>
                     <CanvasStage cards={cards} />
                   </Box>
                 ) : (

--- a/components/ai-tutor/room/CanvasStage.tsx
+++ b/components/ai-tutor/room/CanvasStage.tsx
@@ -182,17 +182,42 @@ function ImageCard({ payload }: { payload: Record<string, unknown> }) {
       {/* A plain img, never next/image: these are arbitrary third-party URLs and the
           optimizer silently drops hosts it cannot handle. */}
       <Box
-        component="img"
-        src={String(payload.url ?? "")}
-        alt={String(payload.alt ?? "")}
         sx={{
-          width: "100%",
-          maxHeight: 340,
-          objectFit: "cover",
+          // The image sits on its own slab rather than being cropped to the card.
+          //
+          // `objectFit: cover` filled the box neatly and cut the picture: a set of nesting
+          // dolls lost its heads and feet, which is the whole point of showing nesting dolls
+          // to explain recursion. The tutor picks these to be LOOKED at, so losing the
+          // subject to fit a rectangle defeats the tool. `contain` keeps the whole frame,
+          // and the tinted slab behind it stops a portrait image reading as a floating
+          // fragment against the room.
+          bgcolor: "rgba(255,255,255,0.04)",
+          border: "1px solid rgba(255,255,255,0.06)",
           borderRadius: "10px",
-          display: "block",
+          overflow: "hidden",
+          display: "grid",
+          placeItems: "center",
+          // A floor as well as a ceiling: without it a very wide, short image collapses to a
+          // letterbox strip a few pixels tall.
+          minHeight: 180,
+          maxHeight: 420,
         }}
-      />
+      >
+        <Box
+          component="img"
+          src={String(payload.url ?? "")}
+          alt={String(payload.alt ?? "")}
+          loading="lazy"
+          sx={{
+            maxWidth: "100%",
+            maxHeight: 420,
+            width: "auto",
+            height: "auto",
+            objectFit: "contain",
+            display: "block",
+          }}
+        />
+      </Box>
       <Typography
         sx={{ fontSize: "0.87rem", color: "rgba(255,255,255,0.68)", mt: 1 }}
       >


### PR DESCRIPTION
Two things the session room was doing to the material it is meant to present.

### Captions removed

A live transcript under the orb competes with the thing it is describing — the learner reads ahead of the voice instead of listening to it, and the card below shifted every time a sentence landed. The phase pill already says **LISTENING / SPEAKING**, which is the only part of that block that was doing work at a glance.

The transcript is **not** lost: `tutor.caption` still feeds the conversation panel (where reading back through a record is the actual job), and the recap keeps the full transcript after the session.

Dead code goes with it — the `captionLines` memo and the `PHASE_HINT` map. The canvas picks up the freed vertical space, plus a little top padding where the caption slot used to provide separation from the orb.

### Images are no longer cropped

The canvas image card used `objectFit: cover` against a fixed 340px box, so a tall picture lost its top and bottom. A set of Matryoshka dolls shown to explain recursion arrived **with the heads and feet cut off** — precisely the part that makes it a picture of nesting.

The tutor picks these images to be looked at, so losing the subject to fit a rectangle defeats the tool. The image now sits on a tinted slab and is `contain`ed rather than cropped, with a `minHeight` so a very wide, short image cannot collapse into a letterbox strip.

The recap filmstrip keeps `cover` deliberately: those are fixed-height thumbnails in a row and should fill uniformly, and clicking one already opens a contained view.

### Verification

`tsc --noEmit` clean, `next build` compiled successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)