### PR TITLE
fix(live sessions): ask for the recording of the date the student clicked

### DIFF
--- a/components/live-sessions/useLiveSessions.ts
+++ b/components/live-sessions/useLiveSessions.ts
@@ -67,7 +67,13 @@ export function useLiveSessions() {
   const handleWatchRecording = async (activity: StudentLiveSession) => {
     try {
       setWatchingRecordingId(activity.id);
-      const info = await studentLiveSessionsService.getRecording(activity.id);
+      // `activity.id` stays the PARENT id for every expanded occurrence (feedback and reminders
+      // are series-level), so it cannot identify which date this row is. Without the occurrence,
+      // both 17 and 18 August asked for the same recording and got it.
+      const info = await studentLiveSessionsService.getRecording(
+        activity.id,
+        activity.occurrence_id
+      );
       if (info.playable_in_app) {
         // Watch ON platform: the backend proxy streams Zoom MP4s and Google Meet Drive
         // recordings alike - no external tabs, no share links.
@@ -75,7 +81,9 @@ export function useLiveSessions() {
         return;
       }
       // Manually pasted recording link - external is all we have.
-      const external = info.recording_link || activity.recording_link || activity.zoom_recording_url;
+      // Prefer THIS row's own recording over the series-level fallbacks, for the same reason.
+      const external =
+        activity.zoom_recording_url || info.recording_link || activity.recording_link;
       if (external?.trim()) {
         window.open(external, "_blank");
         return;

--- a/lib/services/live-sessions/student-live-sessions.service.ts
+++ b/lib/services/live-sessions/student-live-sessions.service.ts
@@ -108,11 +108,22 @@ export const studentLiveSessionsService = {
     return list.filter(isIncludedLiveSession).map(toStudentSession);
   },
 
+  /**
+   * The recording for one live session.
+   *
+   * `occurrenceId` is required for a recurring series and is the whole point of this signature: a
+   * series is ONE session row carrying N dated occurrences, each with its own recording. Asking by
+   * activityId alone gets the series-latest one, so every date played the same video - students on
+   * an 8024-E series were shown a single recording for both 17 and 18 August, and it belonged to
+   * neither date.
+   */
   getRecording: async (
-    activityId: number
+    activityId: number,
+    occurrenceId?: number | null
   ): Promise<LiveSessionRecordingResponse> => {
     const response = await apiClient.get<LiveSessionRecordingResponse>(
-      `${BASE}/live-activities/${activityId}/recording/`
+      `${BASE}/live-activities/${activityId}/recording/`,
+      occurrenceId ? { params: { occurrence_id: occurrenceId } } : undefined
     );
     return response.data;
   },


### PR DESCRIPTION
Students on the 8024-E series got **the same video for 17 and 18 August** — and it was a *third* recording belonging to neither date.

A recurring series is ONE session row carrying N dated occurrences. This page already expands it into one card per date, and deliberately keeps the **parent** id on each row because feedback and reminders are series-level. The Watch handler then called `getRecording(activity.id)` — the parent — so every date asked the same question and got the same answer: the series-latest recording, which belongs to no particular date.

Now passes `activity.occurrence_id`, and prefers this row's own `zoom_recording_url` over the series-level fallbacks for the external link.

Worth noting: **the expansion logic above it was already correct.** Each occurrence carried its own URL all along — only the click path threw that away.

## Ship order

Pairs with backend **#643**, which makes the recording / playback / stream endpoints occurrence-aware. `occurrence_id` is optional on the wire, so this is safe in either order — an older backend ignores the query param and behaves exactly as it does today.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)