### PR TITLE
fix(instructor): open the builder for a course you were allotted, not only one you built

### DIFF
--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -29,6 +29,7 @@ export default function InstructorCoursePage() {
   // instructor already loaded. Absent (deep link, hard refresh) it stays false and the builder
   // link simply is not offered — the card on /instructor/courses is the reliable route.
   const [authoredByMe, setAuthoredByMe] = useState(false);
+  const [canEdit, setCanEdit] = useState(false);
 
   useEffect(() => {
     if (!courseId) return;
@@ -39,6 +40,7 @@ export default function InstructorCoursePage() {
         if (cancelled) return;
         const mine = list.find((c) => c.kind === "adaptive" && c.id === courseId);
         setAuthoredByMe(!!mine?.authored_by_me);
+        setCanEdit(mine?.can_edit ?? !!mine?.authored_by_me);
       })
       .catch(() => {
         // A missing link is a missing convenience, not a broken page.
@@ -98,10 +100,10 @@ export default function InstructorCoursePage() {
         icon="mdi:book-education"
         action={
           <Stack direction="row" spacing={1}>
-            {/* Offered only for a course this instructor BUILT. Being assigned to teach a course
-                does not carry the right to rewrite it, and the server says so — a button that
-                403s is worse than no button. */}
-            {authoredByMe && (
+            {/* Offered for any course this instructor may EDIT — which now includes one they were
+                allotted a batch on, not only one they built. Still driven by what the server says
+                rather than by authorship, so a button that would 403 is never rendered. */}
+            {canEdit && (
               <HeaderActionButton
                 icon="mdi:hammer-wrench"
                 onClick={() => push(`/admin/adaptive-courses/${courseId}`)}

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -72,10 +72,15 @@ export default function InstructorCoursesPage() {
           //
           // Only adaptive courses have either view. Classic ids come from a different table, so
           // sending one there would open an unrelated course that happens to share the number.
+          // Open the BUILDER for any course this person may edit, not just one they authored.
+          // A trainer allotted a batch is teaching from this material; sending them to a student
+          // list instead was the whole complaint. Falls back to authorship when an older backend
+          // does not report the capability.
+          const mayEdit = c.can_edit ?? c.authored_by_me;
           const href =
             c.kind !== "adaptive"
               ? null
-              : c.authored_by_me
+              : mayEdit
                 ? `/admin/adaptive-courses/${c.id}`
                 : `/instructor/courses/${c.id}`;
           const open = () => { if (href) push(href); };

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -97,6 +97,15 @@ export interface InstructorCourse {
   updated_at: string;
   /** True when THIS instructor built it — which carries full edit rights, unlike being assigned. */
   authored_by_me: boolean;
+  /**
+   * Whether this instructor may open the course builder on this course.
+   *
+   * Server-reported, deliberately. The client used to infer it from `authored_by_me`, which was
+   * right only while editing was authorship-only. An assigned trainer now edits too, and a UI that
+   * re-derives the rule drifts from the server the moment the rule changes. Optional because an
+   * older backend will not send it.
+   */
+  can_edit?: boolean;
   /** "" for anything not instructor-authored (including every classic course). */
   review_status: "" | "draft" | "pending_review" | "approved" | "rejected";
   /** The admin's reason on a rejection, shown verbatim. */


### PR DESCRIPTION
> "the instructor could see only the learners and the progress and not able to see the course and the curriculum and the problems in it"

Both routes into the course builder were gated on `authored_by_me`:

- the course card routed to `/instructor/courses/<id>` (a student list) unless the instructor had authored it
- the detail page's "Open the builder" button rendered only for authors, with a comment explaining that assignment does not carry the right to rewrite

That comment described the server accurately **at the time**. Backend #642 reverses it — teaching the course is now the grant — so both gates read `can_edit`, which the API reports per course.

**Server-reported on purpose, not re-derived.** The client inferring the rule from authorship is exactly what drifted here: the permission model changed and the UI kept enforcing the old one. Falls back to `authored_by_me` when an older backend doesn't send the field, so this is safe to deploy in either order.

The route itself already existed — `proxy.ts` has admitted instructors to `/admin/adaptive-courses/<id>` since the authoring RBAC landed, deliberately scoped to one course by id. Nothing linked them to it.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)