### PR TITLE
fix(live sessions): the PLAYER has to know the date too

### DIFF
--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -550,7 +550,10 @@ export default function LiveSessionsPage() {
         </>
       )}
 
+      {/* occurrenceId is what makes this play the DATE the student clicked. `id` is the series for
+          every expanded row, so passing it alone streams the series-latest recording. */}
       <RecordingPlayerDialog open={Boolean(playerSession)} liveClassId={playerSession?.id ?? null}
+        occurrenceId={playerSession?.occurrence_id ?? null}
         title={playerSession?.topic_name} onClose={() => setPlayerSession(null)} />
       {summarySession && (
         <StudentSessionSummaryDialog activityId={summarySession.id} topicName={summarySession.topic_name || ""} open onClose={() => setSummarySession(null)} />

--- a/components/live-sessions/RecordingPlayerDialog.tsx
+++ b/components/live-sessions/RecordingPlayerDialog.tsx
@@ -18,6 +18,16 @@ import { config } from "@/lib/config";
 
 interface RecordingPlayerDialogProps {
   liveClassId: number | null;
+  /**
+   * Which DATE of a recurring series to play.
+   *
+   * A series is ONE session row carrying N dated occurrences, each with its own recording, so
+   * `liveClassId` alone cannot identify the video. Without this the player asked for the series and
+   * Zoom answered with the series-latest file, so every date played the same recording — the exact
+   * bug this dialog looked innocent of, because the availability check one layer up had already
+   * been made occurrence-aware.
+   */
+  occurrenceId?: number | null;
   title?: string;
   open: boolean;
   onClose: () => void;
@@ -41,6 +51,7 @@ interface RecordingPlayerDialogProps {
  */
 export function RecordingPlayerDialog({
   liveClassId,
+  occurrenceId,
   title,
   open,
   onClose,
@@ -62,8 +73,11 @@ export function RecordingPlayerDialog({
       setLoading(true);
       setError(null);
       try {
+        // The token the server mints is bound to the occurrence, and the stream proxy serves what
+        // that token authorised — so the id has to be on BOTH calls or they disagree.
+        const occQs = occurrenceId ? `?occurrence_id=${occurrenceId}` : "";
         const res = await apiClient.get<{ token?: string }>(
-          `/live-class/api/clients/${config.clientId}/live-activities/${liveClassId}/recording/playback/`
+          `/live-class/api/clients/${config.clientId}/live-activities/${liveClassId}/recording/playback/${occQs}`
         );
         if (cancelled) return;
         const token = res.data?.token;
@@ -83,7 +97,7 @@ export function RecordingPlayerDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, liveClassId, t]);
+  }, [open, liveClassId, occurrenceId, t]);
 
   return (
     <Dialog


### PR DESCRIPTION
Both recordings still played the 17 August video after #1370. **My fix was incomplete**, and it's worth being precise about how.

The Watch handler asks `.../recording/` whether there is something to play. I made *that* call occurrence-aware, so availability was correct. But when it answers `playable_in_app`, the flow hands off to `RecordingPlayerDialog` — and the dialog is what actually fetches the video, from two endpoints I never touched:

```
.../live-activities/<liveClassId>/recording/playback/   -> signed token
.../live-activities/<liveClassId>/recording/stream/?t=  -> the bytes
```

`liveClassId` is `playerSession?.id`, which for every expanded occurrence is the **series** id. So the availability check said *"the 18th has a recording"* and the player then streamed the series-latest file. The symptom never changed because the path that plays the video was never on the route I fixed.

## The fix

The dialog now takes `occurrenceId` and puts it on the playback call. The **stream** call needs no id — the token the server mints is already bound to the occurrence and the proxy serves exactly what that token authorised, which is why the backend was built that way.

The **admin** live-sessions page is deliberately unchanged: it lists series rows and never expands occurrences, so it has no date to pass.

## Verified on the deployed backend

Through the playback resolver the player actually uses, against production series 194:

```
no occurrence (old)  -> …vB-jR6tJZ_NSf0xIN.8QZQjhzVkB4GDtxk
Mon 17 Aug           -> …iUw_ik3QT8K3gVp2g.gXSIuHMTqs3y3kyN
Tue 18 Aug           -> …WgVcjzmphTZHPjktd.pGCJT6KhJHZhCsQf
```

Three distinct files, and neither date is the series-latest one both were being served.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)