### PR TITLE
fix(live sessions): admin Recording tab played a video from no session at all

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -618,7 +618,21 @@ export default function LiveSessionDetailPage() {
                 {tabKey === "recording" && (
                   <SectionCard title={t("adminLiveSessions.recording", "Recording")} icon="mdi:play-circle-outline">
                     <Box sx={{ display: "flex", gap: 1.25, flexWrap: "wrap", alignItems: "center" }}>
-                      {hasRecording ? (
+                      {/* A recurring series has one recording PER DATE, and this button can only ask
+                          for the series — which resolves to the series-level file, matching none of
+                          the dates. Sending the trainer to the Timeline is the only honest answer;
+                          each row there plays its own date. Students already get the per-date video. */}
+                      {hasRecording && isRecurring ? (
+                        <ControlButton
+                          icon="mdi:calendar-multiselect"
+                          label={t("adminLiveSessions.viewPerDateRecordings", "View recordings by date")}
+                          tone="primary"
+                          onClick={() => {
+                            const i = tabsWithFeedback.findIndex((x) => x.key === "timeline");
+                            if (i >= 0) setTab(i);
+                          }}
+                        />
+                      ) : hasRecording ? (
                         <ControlButton icon="mdi:play" label={t("adminLiveSessions.playRecording", "Play recording")} tone="primary" onClick={() => setPlayerOpen(true)} />
                       ) : (
                         <InfoCallout icon="mdi:cloud-clock-outline" color="var(--font-tertiary)">


### PR DESCRIPTION
Follow-on to #1374 / #1375, which fixed the **student** player.

## What was still wrong

A recurring series stores one recording **per date** on its occurrence rows, and *also* a series-level recording on the `LiveClass`. The admin detail page's **Recording** tab could only ask for the series.

Resolved against production for Agileology series 194 (read-only):

| Asked for | Zoom file id |
|---|---|
| no occurrence — what this tab sent | `c19fcff4-82d6-4f05-ab1c-f36949c81eba` |
| Mon 17 Aug (occ 219) | `46ad51f3-e121-493f-a1e4-10ea6116b0df` |
| Tue 18 Aug (occ 220) | `eaae4611-f170-41c7-89e7-e703117ed828` |

So the tab played a **third** video, matching neither date.

## Why it matters

This is the screen the trainer uses to check a student complaint. Students are already fixed; without this, a trainer verifying the fix sees a video that is neither session and reasonably concludes it is still broken.

## The change

For a recurring series the tab stops guessing and sends the trainer to the **Timeline**, where each date already plays its own recording (`occ.recording_url`, per occurrence). Non-recurring sessions keep the direct Play button — for them the series *is* the session.

`Sync recording` is untouched; it is legitimately series-level.

## Verification

- `tsc --noEmit` — exit 0, 0 errors (FE CI has no typecheck, so this was run locally)
- Per-date resolution confirmed against the deployed backend + prod DB, reads only
- Every other `RecordingPlayerDialog` call site audited: student page passes `occurrenceId`; the admin Timeline uses each occurrence's own URL; the admin list has no occurrence rows to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)