### PR TITLE
release: admin Recording tab plays the right date for recurring series

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -618,7 +618,21 @@ export default function LiveSessionDetailPage() {
                 {tabKey === "recording" && (
                   <SectionCard title={t("adminLiveSessions.recording", "Recording")} icon="mdi:play-circle-outline">
                     <Box sx={{ display: "flex", gap: 1.25, flexWrap: "wrap", alignItems: "center" }}>
-                      {hasRecording ? (
+                      {/* A recurring series has one recording PER DATE, and this button can only ask
+                          for the series — which resolves to the series-level file, matching none of
+                          the dates. Sending the trainer to the Timeline is the only honest answer;
+                          each row there plays its own date. Students already get the per-date video. */}
+                      {hasRecording && isRecurring ? (
+                        <ControlButton
+                          icon="mdi:calendar-multiselect"
+                          label={t("adminLiveSessions.viewPerDateRecordings", "View recordings by date")}
+                          tone="primary"
+                          onClick={() => {
+                            const i = tabsWithFeedback.findIndex((x) => x.key === "timeline");
+                            if (i >= 0) setTab(i);
+                          }}
+                        />
+                      ) : hasRecording ? (
                         <ControlButton icon="mdi:play" label={t("adminLiveSessions.playRecording", "Play recording")} tone="primary" onClick={() => setPlayerOpen(true)} />
                       ) : (
                         <InfoCallout icon="mdi:cloud-clock-outline" color="var(--font-tertiary)">


### PR DESCRIPTION
Promotes #1377.

Follow-on to #1375, which fixed the **student** player. This closes the same hole on the **trainer's** screen: the admin detail page's Recording tab could only ask for the series, so for Agileology's recurring series it played a third video matching neither date.

For a recurring series the tab now sends the trainer to the Timeline, where each date plays its own recording. Non-recurring sessions keep the direct Play button.

Verified: `tsc --noEmit` exit 0; per-date resolution confirmed against the deployed backend and prod DB, reads only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)