### PR TITLE
promote: AI Tutor track browser and agenda progress

### DIFF
--- a/app/ai-tutor/page.tsx
+++ b/app/ai-tutor/page.tsx
@@ -52,6 +52,9 @@ import {
  * account with no sessions, no notes and no suggestions still gets a full-height rail.
  */
 
+/** How many topics a track shows before the learner asks for the rest. */
+const PREVIEW_PER_TRACK = 6;
+
 const TRACK_ICON_FALLBACK = "solar:notebook-bookmark-bold-duotone";
 
 export default function AiTutorPage() {
@@ -61,6 +64,7 @@ export default function AiTutorPage() {
   const { push, prefetch } = useInstantNavigation();
   const { showToast } = useToast();
   const [activeTrack, setActiveTrack] = useState<string | null>(null);
+  const [expandedTrack, setExpandedTrack] = useState(false);
 
   const { data, isLoading, isError } = useQuery<TutorDashboard>({
     queryKey: aiTutorKeys.dashboard,
@@ -76,10 +80,23 @@ export default function AiTutorPage() {
     return seen;
   }, [data?.catalogue]);
 
-  const visibleTopics = useMemo(() => {
+  /**
+   * One track at a time, six at a time.
+   *
+   * This defaulted to "All" and painted the entire 56-topic catalogue on first load - about
+   * nineteen grid rows, roughly 2,900px, below everything else on the page. A tester's verdict
+   * was "too long, I am not sure anyone will check that", and they were right: a wall of every
+   * topic is not a browser, it is a dump.
+   *
+   * The track is DERIVED rather than defaulted, so the chips render with one selected on first
+   * paint instead of none.
+   */
+  const currentTrack = activeTrack ?? tracks[0] ?? null;
+  const trackTopics = useMemo(() => {
     const all = data?.catalogue ?? [];
-    return activeTrack ? all.filter((t) => t.track === activeTrack) : all;
-  }, [data?.catalogue, activeTrack]);
+    return currentTrack ? all.filter((t) => t.track === currentTrack) : all;
+  }, [data?.catalogue, currentTrack]);
+  const visibleTopics = expandedTrack ? trackTopics : trackTopics.slice(0, PREVIEW_PER_TRACK);
 
   const sessionHref = (input: {
     topic: string;
@@ -199,6 +216,33 @@ export default function AiTutorPage() {
                 </TutorSurface>
               ))}
             </Box>
+            {trackTopics.length > PREVIEW_PER_TRACK ? (
+              <Box
+                component="button"
+                type="button"
+                onClick={() => setExpandedTrack((open) => !open)}
+                sx={{
+                  mt: 1.5,
+                  px: 0,
+                  py: 0.5,
+                  border: "none",
+                  bgcolor: "transparent",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  fontSize: "0.88rem",
+                  fontWeight: 500,
+                  color: "var(--ai-violet)",
+                  "&:focus-visible": {
+                    outline: "none",
+                    boxShadow: "0 0 0 2px var(--canvas), 0 0 0 4px var(--ai-violet)",
+                  },
+                }}
+              >
+                {expandedTrack
+                  ? "Show fewer"
+                  : `Show all ${trackTopics.length} in ${currentTrack}`}
+              </Box>
+            ) : null}
           </Box>
         ) : null}
 
@@ -304,24 +348,19 @@ export default function AiTutorPage() {
             <TutorSectionHeading
               icon="solar:widget-4-bold-duotone"
               title="Browse by track"
-              meta={`${data?.catalogue.length ?? 0} topics`}
+              meta={currentTrack ? `${currentTrack} · ${trackTopics.length} topics` : undefined}
             />
             <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 2 }}>
-              <Box
-                component="button"
-                type="button"
-                onClick={() => setActiveTrack(null)}
-                sx={trackChipSx(activeTrack === null)}
-              >
-                All
-              </Box>
               {tracks.map((track) => (
                 <Box
                   key={track}
                   component="button"
                   type="button"
-                  onClick={() => setActiveTrack(track)}
-                  sx={trackChipSx(activeTrack === track)}
+                  onClick={() => {
+                    setActiveTrack(track);
+                    setExpandedTrack(false);
+                  }}
+                  sx={trackChipSx(currentTrack === track)}
                 >
                   {track}
                 </Box>

--- a/lib/hooks/useRealtimeTutor.ts
+++ b/lib/hooks/useRealtimeTutor.ts
@@ -135,6 +135,16 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
   const [caption, setCaption] = useState("");
   const [cards, setCards] = useState<CanvasCard[]>([]);
   const [planIndex, setPlanIndex] = useState(0);
+  /**
+   * The same value as `planIndex`, readable from the flush closure.
+   *
+   * `flush` builds its payload from refs, so the React state above is invisible to it. The
+   * result was that `plan_index` was never sent at all - the serializer accepts it and the
+   * events endpoint writes it, but every TutorSession row ever recorded has 0. That made the
+   * dashboard read "0/N covered" on every completed lesson, and made a reconnect restart the
+   * agenda at section one.
+   */
+  const planIndexRef = useRef(0);
   const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   /** True while a dropped connection is being re-established (R1). */
@@ -438,6 +448,7 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
         case "update_lesson_plan": {
           const next = Number(args.current_index ?? 0);
           setPlanIndex(next);
+          planIndexRef.current = next;
           return respondToTool(callId, { ok: true });
         }
         case "open_ide":
@@ -876,7 +887,12 @@ export function useRealtimeTutor(options: UseRealtimeTutorOptions = {}) {
     const usage = pendingUsageRef.current.splice(0);
     if (!immediate && !turns.length && !artifacts.length && !usage.length) return;
     try {
-      await aiTutorService.pushEvents(sid, { turns, artifacts, usage });
+      await aiTutorService.pushEvents(sid, {
+        turns,
+        artifacts,
+        usage,
+        plan_index: planIndexRef.current,
+      });
     } catch {
       // Put them back so a transient failure does not lose the transcript.
       pendingTurnsRef.current.unshift(...turns);


### PR DESCRIPTION
Promotes [#1379](https://github.com/AI-Linc-LMS/lms-platform-frontend/pull/1379).

- **Browse by track** opened on "All" and painted all 56 topics (~19 rows, ~2,900px). Now one track, six topics, with a "Show all" escape hatch.
- **`plan_index` was never sent.** The backend accepted and wrote it, the service type declared it, but `flush` built its payload from refs while the index lived in React state — so every session row has `plan_index = 0`. That's why the dashboard reads "0/N covered", why reconnect restarts the agenda at section one, and why nothing could measure whether the agenda prompt changes worked.

Unit CI green; `tsc` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)