### PR TITLE
feat(interview): realtime interview room

### DIFF
--- a/app/interview/result/[sessionId]/page.tsx
+++ b/app/interview/result/[sessionId]/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import { Box, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+
+import { MainLayout } from "@/components/layout/MainLayout";
+import interviewService, { type InterviewResult } from "@/lib/services/interview.service";
+
+/**
+ * The candidate's result.
+ *
+ * The rule this page exists to enforce: **a grade that failed is never shown as a mark.**
+ * The old module returned a fully-formed dict of zeros when its grader could not reach the
+ * model, and fourteen real candidates were shown a fabricated zero as their result. Here the
+ * server distinguishes `failed` from a genuine zero, and this page renders that distinction
+ * rather than flattening it back into a number.
+ *
+ * Coverage is shown alongside the score for the same reason: a mark from an interview that
+ * covered half its questions means something different from the same mark at full coverage,
+ * and hiding that would make the two look identical.
+ */
+export default function InterviewResultPage({
+  params,
+}: {
+  params: Promise<{ sessionId: string }>;
+}) {
+  const { sessionId } = use(params);
+  const [result, setResult] = useState<InterviewResult | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    let attempts = 0;
+
+    const poll = async () => {
+      try {
+        const data = await interviewService.result(sessionId);
+        if (cancelled) return;
+        setResult(data);
+        setLoading(false);
+        // Grading runs after the call ends, so "pending" is expected briefly. Give up after a
+        // bounded number of tries rather than polling a dead session forever.
+        if (data.state === "pending" && attempts < 20) {
+          attempts += 1;
+          setTimeout(() => void poll(), 3000);
+        }
+      } catch {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  if (loading) {
+    return (
+      <MainLayout>
+        <Box sx={{ p: 4 }}>
+          <Typography>Loading your result...</Typography>
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  const state = result?.state ?? "pending";
+  const unavailable = state === "pending" || state === "failed" || state === "void";
+
+  return (
+    <MainLayout>
+      <Box sx={{ maxWidth: 820, mx: "auto", px: { xs: 2, md: 3 }, py: { xs: 3, md: 4 } }}>
+        <Typography sx={{ fontSize: "1.6rem", fontWeight: 600, mb: 3 }}>
+          Interview result
+        </Typography>
+
+        {unavailable ? (
+          <Box
+            sx={{
+              border: "1px solid var(--border-color, #e5e7eb)",
+              borderRadius: "12px",
+              p: 4,
+              textAlign: "center",
+            }}
+          >
+            <Icon
+              icon={
+                state === "void"
+                  ? "solar:shield-cross-bold-duotone"
+                  : "solar:hourglass-line-duotone"
+              }
+              width={40}
+              height={40}
+            />
+            <Typography sx={{ mt: 1.5, fontWeight: 500 }}>
+              {state === "void"
+                ? "This attempt was voided."
+                : state === "failed"
+                  ? "We could not mark this interview."
+                  : "Your interview is being marked."}
+            </Typography>
+            <Typography sx={{ mt: 1, fontSize: "0.9rem", color: "var(--font-secondary, #6b7280)" }}>
+              {/* Deliberately not a zero. A grade we could not compute is not a score of nothing. */}
+              {state === "failed"
+                ? "This is a problem on our side, not a reflection of how you did. It will be marked again shortly."
+                : state === "void"
+                  ? "Please contact your administrator."
+                  : "This usually takes a few seconds."}
+            </Typography>
+          </Box>
+        ) : (
+          <>
+            <Box
+              sx={{
+                border: "1px solid var(--border-color, #e5e7eb)",
+                borderRadius: "12px",
+                p: 4,
+                mb: 3,
+              }}
+            >
+              <Typography sx={{ fontSize: "0.8rem", letterSpacing: "0.08em", textTransform: "uppercase", color: "var(--font-secondary, #6b7280)" }}>
+                Score
+              </Typography>
+              <Typography sx={{ fontSize: "2.4rem", fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>
+                {result?.score ?? 0}
+                <Typography component="span" sx={{ fontSize: "1.2rem", color: "var(--font-secondary, #6b7280)" }}>
+                  {" "}/ {result?.max_score ?? 0}
+                </Typography>
+              </Typography>
+              {result?.coverage ? (
+                <Typography sx={{ mt: 1, fontSize: "0.88rem", color: "var(--font-secondary, #6b7280)" }}>
+                  {result.coverage.answered} of {result.coverage.planned} questions answered
+                  {result.coverage.completeness < 1
+                    ? " — this interview did not cover everything it planned to, so read the score in that light."
+                    : ""}
+                </Typography>
+              ) : null}
+            </Box>
+
+            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              {(result?.questions ?? []).map((q) => (
+                <Box
+                  key={q.position}
+                  sx={{
+                    border: "1px solid var(--border-color, #e5e7eb)",
+                    borderRadius: "12px",
+                    p: 2.5,
+                  }}
+                >
+                  <Box sx={{ display: "flex", gap: 2, alignItems: "baseline", mb: 1 }}>
+                    <Typography sx={{ fontWeight: 500, flex: 1 }}>{q.question}</Typography>
+                    <Typography sx={{ fontVariantNumeric: "tabular-nums", whiteSpace: "nowrap" }}>
+                      {q.answered ? `${q.score} / ${q.max_score}` : "Not answered"}
+                    </Typography>
+                  </Box>
+                  {q.feedback ? (
+                    <Typography sx={{ fontSize: "0.9rem", color: "var(--font-secondary, #6b7280)" }}>
+                      {q.feedback}
+                    </Typography>
+                  ) : null}
+                </Box>
+              ))}
+            </Box>
+          </>
+        )}
+      </Box>
+    </MainLayout>
+  );
+}

--- a/app/interview/room/page.tsx
+++ b/app/interview/room/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Box, Button, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+
+import { QuestionCard } from "@/components/interview/room/QuestionCard";
+import { InterviewTranscript } from "@/components/interview/room/InterviewTranscript";
+import {
+  ROOM_BG,
+  ROOM_BORDER,
+  ROOM_GREEN,
+  ROOM_PANEL,
+  ROOM_RED,
+  ROOM_TEXT,
+  ROOM_TEXT_DIM,
+  ROOM_TEXT_FAINT,
+  ROOM_VIOLET,
+} from "@/components/ai-tutor/room/roomTokens";
+import { useRealtimeInterview } from "@/lib/hooks/useRealtimeInterview";
+
+/**
+ * The live interview room.
+ *
+ * **The URL never changes while the call is up.** `/interview/room?template=<id>` is where the
+ * whole interview happens, including after the real session id is known. The global camera
+ * route guard tears media streams down on pathname change, so rewriting the URL mid-call would
+ * kill the microphone and the interviewer's voice. The same constraint shapes the tutor room.
+ *
+ * Dark, matching the tutor's session room and importing the same tokens, because the two are
+ * the same kind of surface: a place you talk to something, not a page of content.
+ */
+
+const PHASE_COPY: Record<string, string> = {
+  idle: "Ready when you are.",
+  starting: "Setting up your interview...",
+  connecting: "Connecting...",
+  live: "Live",
+  ending: "Wrapping up...",
+  ended: "Finished",
+  failed: "Something went wrong",
+};
+
+function InterviewRoom() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const templateId = Number(params.get("template") || 0);
+
+  const {
+    phase,
+    error,
+    transcript,
+    currentQuestion,
+    questionCount,
+    candidateSpeaking,
+    sessionId,
+    connect,
+    end,
+    setMuted: setMicMuted,
+  } = useRealtimeInterview();
+
+  const [muted, setMuted] = useState(false);
+  const startedRef = useRef(false);
+  const finishedSessionRef = useRef<string>("");
+
+  // Auto-start once. A candidate arriving here has already agreed to sit the interview on the
+  // previous screen, so a second "begin" click is friction in a timed exercise.
+  useEffect(() => {
+    if (!templateId || startedRef.current) return;
+    startedRef.current = true;
+    void connect(templateId);
+  }, [connect, templateId]);
+
+  // Capture the session id while it is still available, so the redirect below survives the
+  // hook resetting its refs during teardown.
+  useEffect(() => {
+    if (sessionId) finishedSessionRef.current = sessionId;
+  }, [sessionId]);
+
+  // Navigate only AFTER teardown, never during. Leaving while the call is live would trip the
+  // route guard and cut the audio mid-question.
+  useEffect(() => {
+    if (phase === "ended" && finishedSessionRef.current) {
+      router.push(`/interview/result/${finishedSessionRef.current}`);
+    }
+  }, [phase, router]);
+
+  const toggleMute = useCallback(() => {
+    setMuted((was) => {
+      const next = !was;
+      setMicMuted(next);
+      return next;
+    });
+  }, [setMicMuted]);
+
+  const live = phase === "live";
+
+  return (
+    <Box sx={{ minHeight: "100vh", background: ROOM_BG, color: ROOM_TEXT, px: { xs: 2, md: 4 }, py: { xs: 3, md: 4 } }}>
+      <Box sx={{ maxWidth: 1100, mx: "auto" }}>
+        {/* Header */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 3 }}>
+          <Box
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              bgcolor: live ? ROOM_GREEN : phase === "failed" ? ROOM_RED : ROOM_TEXT_FAINT,
+              flexShrink: 0,
+            }}
+          />
+          <Typography sx={{ fontSize: "0.9rem", color: ROOM_TEXT_DIM }}>
+            {PHASE_COPY[phase] ?? phase}
+          </Typography>
+          <Box sx={{ flex: 1 }} />
+          {candidateSpeaking ? (
+            <Typography sx={{ fontSize: "0.8rem", color: ROOM_VIOLET }}>Listening</Typography>
+          ) : null}
+        </Box>
+
+        {error ? (
+          <Box
+            sx={{
+              borderRadius: "var(--radius-card, 12px)",
+              border: `1px solid ${ROOM_RED}`,
+              bgcolor: ROOM_PANEL,
+              p: 3,
+              mb: 3,
+            }}
+          >
+            <Typography sx={{ color: ROOM_TEXT, mb: 1.5 }}>{error}</Typography>
+            <Button
+              onClick={() => {
+                startedRef.current = false;
+                void connect(templateId);
+              }}
+              sx={{ color: ROOM_VIOLET, textTransform: "none" }}
+            >
+              Try again
+            </Button>
+          </Box>
+        ) : null}
+
+        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1.4fr 1fr" }, gap: 3 }}>
+          <QuestionCard question={currentQuestion} total={questionCount} />
+          <InterviewTranscript entries={transcript} />
+        </Box>
+
+        {/* Controls */}
+        <Box
+          sx={{
+            mt: 3,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 1.5,
+            flexWrap: "wrap",
+          }}
+        >
+          <Button
+            onClick={toggleMute}
+            disabled={!live}
+            startIcon={
+              <Icon icon={muted ? "solar:microphone-slash-bold" : "solar:microphone-3-bold"} />
+            }
+            sx={{
+              textTransform: "none",
+              color: ROOM_TEXT,
+              border: `1px solid ${ROOM_BORDER}`,
+              borderRadius: "999px",
+              px: 2.5,
+            }}
+          >
+            {muted ? "Unmute" : "Mute"}
+          </Button>
+          <Button
+            onClick={() => void end()}
+            disabled={phase === "ending" || phase === "ended"}
+            sx={{
+              textTransform: "none",
+              color: ROOM_RED,
+              border: `1px solid ${ROOM_BORDER}`,
+              borderRadius: "999px",
+              px: 2.5,
+            }}
+          >
+            End interview
+          </Button>
+        </Box>
+
+        <Typography
+          sx={{ mt: 2, textAlign: "center", fontSize: "0.78rem", color: ROOM_TEXT_FAINT }}
+        >
+          Speak naturally. You can interrupt the interviewer at any point.
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+export default function InterviewRoomPage() {
+  return (
+    <Suspense fallback={null}>
+      <InterviewRoom />
+    </Suspense>
+  );
+}

--- a/components/interview/room/InterviewTranscript.tsx
+++ b/components/interview/room/InterviewTranscript.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Box, Typography } from "@mui/material";
+
+import {
+  ROOM_BORDER,
+  ROOM_PANEL,
+  ROOM_TEXT,
+  ROOM_TEXT_DIM,
+  ROOM_TEXT_FAINT,
+  ROOM_VIOLET,
+} from "@/components/ai-tutor/room/roomTokens";
+import type { InterviewTranscriptEntry } from "@/lib/hooks/useRealtimeInterview";
+
+/**
+ * What has been said so far.
+ *
+ * Oldest first and auto-scrolled, unlike the tutor's conversation panel which is newest-first.
+ * An interview is read back as a narrative, and a candidate glancing at it wants to see where
+ * they are in the arc rather than the most recent line in isolation.
+ */
+export function InterviewTranscript({ entries }: { entries: InterviewTranscriptEntry[] }) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [entries.length]);
+
+  return (
+    <Box
+      sx={{
+        borderRadius: "var(--radius-card, 12px)",
+        border: `1px solid ${ROOM_BORDER}`,
+        bgcolor: ROOM_PANEL,
+        display: "flex",
+        flexDirection: "column",
+        maxHeight: { xs: 240, md: 420 },
+        overflow: "hidden",
+      }}
+    >
+      <Box sx={{ px: 2.5, py: 1.25, borderBottom: `1px solid ${ROOM_BORDER}` }}>
+        <Typography
+          sx={{
+            fontSize: "0.74rem",
+            fontWeight: 500,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: ROOM_TEXT_DIM,
+          }}
+        >
+          Transcript
+        </Typography>
+      </Box>
+      <Box sx={{ overflowY: "auto", px: 2.5, py: 2, display: "flex", flexDirection: "column", gap: 1.75 }}>
+        {entries.length === 0 ? (
+          <Typography sx={{ fontSize: "0.88rem", color: ROOM_TEXT_FAINT }}>
+            Nothing yet.
+          </Typography>
+        ) : (
+          entries.map((entry) => (
+            <Box key={`${entry.role}-${entry.seq}`}>
+              <Typography
+                sx={{
+                  fontSize: "0.7rem",
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                  color: entry.role === "candidate" ? ROOM_VIOLET : ROOM_TEXT_FAINT,
+                  mb: 0.25,
+                }}
+              >
+                {entry.role === "candidate" ? "You" : "Interviewer"}
+              </Typography>
+              <Typography sx={{ fontSize: "0.92rem", lineHeight: 1.5, color: ROOM_TEXT }}>
+                {entry.text}
+              </Typography>
+            </Box>
+          ))
+        )}
+        <div ref={endRef} />
+      </Box>
+    </Box>
+  );
+}
+
+export default InterviewTranscript;

--- a/components/interview/room/QuestionCard.tsx
+++ b/components/interview/room/QuestionCard.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { Box, Typography } from "@mui/material";
+import { Icon } from "@iconify/react";
+
+import {
+  ROOM_BORDER,
+  ROOM_PANEL,
+  ROOM_TEXT,
+  ROOM_TEXT_DIM,
+  ROOM_TEXT_FAINT,
+  ROOM_VIOLET,
+} from "@/components/ai-tutor/room/roomTokens";
+import type { NextQuestion } from "@/lib/services/interview.service";
+
+/**
+ * The question currently being asked, shown as text as well as spoken.
+ *
+ * Showing it is not redundant with hearing it. Candidates are nervous, questions get missed,
+ * and "sorry, could you repeat that" costs a minute of a timed interview. It also makes the
+ * interview usable by someone in a noisy room or with a hearing impairment, which the old
+ * voice-only flow simply was not.
+ *
+ * The rubric is deliberately not here, and is never sent to the browser at all: a candidate
+ * who can read what they are marked against can write to it.
+ */
+
+const KIND_LABEL: Record<string, { label: string; icon: string }> = {
+  behavioural: { label: "About you", icon: "solar:user-speak-rounded-bold-duotone" },
+  conceptual: { label: "Concept", icon: "solar:lightbulb-bolt-bold-duotone" },
+  coding: { label: "Coding", icon: "solar:code-square-bold-duotone" },
+  mcq: { label: "Multiple choice", icon: "solar:list-check-bold-duotone" },
+};
+
+export function QuestionCard({
+  question,
+  total,
+}: {
+  question: NextQuestion | null;
+  total: number;
+}) {
+  if (!question?.question) {
+    return (
+      <Box
+        sx={{
+          borderRadius: "var(--radius-card, 12px)",
+          border: `1px solid ${ROOM_BORDER}`,
+          bgcolor: ROOM_PANEL,
+          p: { xs: 3, md: 4 },
+          display: "grid",
+          placeItems: "center",
+          minHeight: 200,
+          textAlign: "center",
+        }}
+      >
+        <Box>
+          <Icon
+            icon="solar:microphone-3-bold-duotone"
+            width={36}
+            height={36}
+            style={{ color: ROOM_TEXT_FAINT }}
+          />
+          <Typography sx={{ mt: 1.5, fontSize: "0.95rem", color: ROOM_TEXT_DIM }}>
+            Listen for the first question. It will appear here as it is asked.
+          </Typography>
+        </Box>
+      </Box>
+    );
+  }
+
+  const meta = KIND_LABEL[question.kind ?? "conceptual"] ?? KIND_LABEL.conceptual;
+
+  return (
+    <Box
+      sx={{
+        borderRadius: "var(--radius-card, 12px)",
+        border: `1px solid ${ROOM_BORDER}`,
+        bgcolor: ROOM_PANEL,
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          px: 2.5,
+          py: 1.25,
+          borderBottom: `1px solid ${ROOM_BORDER}`,
+        }}
+      >
+        <Icon icon={meta.icon} width={16} height={16} style={{ color: ROOM_VIOLET }} />
+        <Typography
+          sx={{
+            fontSize: "0.74rem",
+            fontWeight: 500,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            color: ROOM_TEXT_DIM,
+          }}
+        >
+          {meta.label}
+        </Typography>
+        <Box sx={{ flex: 1 }} />
+        {total > 0 && question.position ? (
+          <Typography
+            sx={{ fontSize: "0.78rem", color: ROOM_TEXT_FAINT, fontVariantNumeric: "tabular-nums" }}
+          >
+            {question.position} of {total}
+          </Typography>
+        ) : null}
+      </Box>
+      <Box sx={{ px: { xs: 2.5, md: 4 }, py: { xs: 3, md: 4 } }}>
+        <Typography
+          sx={{
+            fontSize: { xs: "1.15rem", md: "1.4rem" },
+            lineHeight: 1.45,
+            fontWeight: 500,
+            color: ROOM_TEXT,
+            textWrap: "balance",
+          }}
+        >
+          {question.question}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+export default QuestionCard;

--- a/lib/hooks/useRealtimeInterview.ts
+++ b/lib/hooks/useRealtimeInterview.ts
@@ -1,0 +1,373 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import interviewService, {
+  type InterviewTurnPayload,
+  type NextQuestion,
+} from "@/lib/services/interview.service";
+import { getAudioConstraints } from "@/lib/utils/audio-constraints";
+import { registerMediaStream } from "@/lib/utils/media-stream-registry";
+
+/**
+ * The interview transport: browser <-> OpenAI over WebRTC, Django only for the record.
+ *
+ * Adapted from `useRealtimeTutor`, which is proven in production, with one structural
+ * difference that is the whole point of the rebuild: **the model has no questions.** It has a
+ * single tool, `next_question`, and this hook resolves it by asking Django. So every question
+ * asked leaves a server row, and the browser never holds the paper.
+ *
+ * Two things carried over from the tutor because they were learned the hard way:
+ *
+ * 1. The audio element is DELIBERATELY DETACHED from the document.
+ *    `lib/utils/cameraUtils.ts::stopAllMediaTracks` walks `document.querySelectorAll("audio")`
+ *    and stops the tracks on everything it finds, so an element in the document is one stray
+ *    navigation away from having the interviewer go silent mid-question.
+ *
+ * 2. The call id comes from the SDP response's `Location` header. Without it there is no
+ *    server-side hangup, so a session cap cannot be enforced against a client that ignores
+ *    its own timer.
+ */
+
+const OAI_EVENTS_CHANNEL = "oai-events";
+const TURN_FLUSH_MS = 10_000;
+
+export type InterviewPhase =
+  | "idle"
+  | "starting"
+  | "connecting"
+  | "live"
+  | "ending"
+  | "ended"
+  | "failed";
+
+export interface InterviewTranscriptEntry {
+  role: "interviewer" | "candidate";
+  text: string;
+  seq: number;
+}
+
+export interface UseRealtimeInterviewOptions {
+  /** Fired when the server releases a question, so the UI can show progress. */
+  onQuestion?: (question: NextQuestion) => void;
+  onPhase?: (phase: InterviewPhase) => void;
+  onError?: (message: string) => void;
+}
+
+export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) {
+  const [phase, setPhase] = useState<InterviewPhase>("idle");
+  const [error, setError] = useState<string>("");
+  const [transcript, setTranscript] = useState<InterviewTranscriptEntry[]>([]);
+  const [currentQuestion, setCurrentQuestion] = useState<NextQuestion | null>(null);
+  const [questionCount, setQuestionCount] = useState(0);
+  const [candidateSpeaking, setCandidateSpeaking] = useState(false);
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const sessionIdRef = useRef<string>("");
+  const pcRef = useRef<RTCPeerConnection | null>(null);
+  const dcRef = useRef<RTCDataChannel | null>(null);
+  const audioElRef = useRef<HTMLAudioElement | null>(null);
+  const micStreamRef = useRef<MediaStream | null>(null);
+  const closedRef = useRef(false);
+
+  // Turn buffer, flushed on a timer rather than per turn, so a long interview is a handful of
+  // requests rather than hundreds.
+  const pendingTurnsRef = useRef<InterviewTurnPayload[]>([]);
+  const seqRef = useRef(0);
+  const flushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // The question currently being answered, so a candidate's speech lands against the right
+  // row. Held in a ref because the data channel handler must see the latest value without
+  // being re-created, which would drop events.
+  const activeQuestionRef = useRef<NextQuestion | null>(null);
+  const answerBufferRef = useRef<string>("");
+
+  const setPhaseSafe = useCallback((next: InterviewPhase) => {
+    setPhase(next);
+    optionsRef.current.onPhase?.(next);
+  }, []);
+
+  const fail = useCallback(
+    (message: string) => {
+      setError(message);
+      setPhaseSafe("failed");
+      optionsRef.current.onError?.(message);
+    },
+    [setPhaseSafe],
+  );
+
+  const recordTurn = useCallback((role: "interviewer" | "candidate", text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    seqRef.current += 1;
+    const entry: InterviewTurnPayload = { role, text: trimmed, seq: seqRef.current };
+    pendingTurnsRef.current.push(entry);
+    setTranscript((prev) => [...prev, entry]);
+  }, []);
+
+  const flushTurns = useCallback(async () => {
+    const sessionId = sessionIdRef.current;
+    const batch = pendingTurnsRef.current;
+    if (!sessionId || !batch.length) return;
+    pendingTurnsRef.current = [];
+    try {
+      await interviewService.pushTurns(sessionId, batch);
+    } catch {
+      // Put them back rather than losing the record of what was said.
+      pendingTurnsRef.current = [...batch, ...pendingTurnsRef.current];
+    }
+  }, []);
+
+  /**
+   * Commit whatever the candidate said to the question they were on.
+   *
+   * Called when the next question is released, and again at the end, so the last answer is
+   * not lost. `update_or_create` on the server makes a repeat harmless.
+   */
+  const commitAnswer = useCallback(async () => {
+    const question = activeQuestionRef.current;
+    const text = answerBufferRef.current.trim();
+    answerBufferRef.current = "";
+    if (!question?.question_id || !text || !sessionIdRef.current) return;
+    try {
+      await interviewService.answer(sessionIdRef.current, {
+        question_id: question.question_id,
+        transcript: text,
+      });
+    } catch {
+      /* the turn record still carries what was said; never fail an interview on this */
+    }
+  }, []);
+
+  const sendEvent = useCallback((payload: Record<string, unknown>) => {
+    const dc = dcRef.current;
+    if (dc && dc.readyState === "open") dc.send(JSON.stringify(payload));
+  }, []);
+
+  /** Resolve the model's one tool by asking the server. */
+  const resolveNextQuestion = useCallback(
+    async (callId: string) => {
+      await commitAnswer();
+      let result: NextQuestion;
+      try {
+        result = await interviewService.nextQuestion(sessionIdRef.current);
+      } catch {
+        result = { done: true };
+      }
+
+      if (!result.done) {
+        activeQuestionRef.current = result;
+        setCurrentQuestion(result);
+        optionsRef.current.onQuestion?.(result);
+      } else {
+        activeQuestionRef.current = null;
+        setCurrentQuestion(null);
+      }
+
+      sendEvent({
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: callId,
+          output: JSON.stringify(result),
+        },
+      });
+      sendEvent({ type: "response.create" });
+    },
+    [commitAnswer, sendEvent],
+  );
+
+  const handleServerEvent = useCallback(
+    (event: Record<string, unknown>) => {
+      const type = String(event.type ?? "");
+
+      switch (type) {
+        case "session.created":
+          setPhaseSafe("live");
+          break;
+
+        case "input_audio_buffer.speech_started":
+          setCandidateSpeaking(true);
+          // Drop audio already buffered in the browser so barge-in is immediate. The old
+          // stack had no barge-in at all and candidates could not interrupt.
+          sendEvent({ type: "output_audio_buffer.clear" });
+          break;
+
+        case "input_audio_buffer.speech_stopped":
+          setCandidateSpeaking(false);
+          break;
+
+        case "response.function_call_arguments.done": {
+          const name = String(event.name ?? "");
+          const callId = String(event.call_id ?? "");
+          if (name === "next_question" && callId) void resolveNextQuestion(callId);
+          break;
+        }
+
+        case "conversation.item.input_audio_transcription.completed": {
+          // What the CANDIDATE said. Buffered against the current question and recorded.
+          const text = String(event.transcript ?? "");
+          answerBufferRef.current = `${answerBufferRef.current} ${text}`.trim();
+          recordTurn("candidate", text);
+          break;
+        }
+
+        case "response.output_audio_transcript.done": {
+          recordTurn("interviewer", String(event.transcript ?? ""));
+          break;
+        }
+
+        default:
+          break;
+      }
+    },
+    [recordTurn, resolveNextQuestion, sendEvent, setPhaseSafe],
+  );
+
+  const connect = useCallback(
+    async (templateId: number) => {
+      if (phase !== "idle" && phase !== "failed" && phase !== "ended") return;
+      closedRef.current = false;
+      setError("");
+      setTranscript([]);
+      setPhaseSafe("starting");
+
+      let started;
+      try {
+        started = await interviewService.start(templateId);
+      } catch {
+        fail("Could not start the interview. Please try again.");
+        return;
+      }
+      sessionIdRef.current = started.session_id;
+      setQuestionCount(started.question_count);
+      setPhaseSafe("connecting");
+
+      try {
+        const pc = new RTCPeerConnection();
+        pcRef.current = pc;
+
+        // Detached on purpose. See this module's docstring.
+        const audioEl = new Audio();
+        audioEl.autoplay = true;
+        (audioEl as HTMLAudioElement & { playsInline?: boolean }).playsInline = true;
+        audioElRef.current = audioEl;
+
+        pc.ontrack = (e) => {
+          audioEl.srcObject = e.streams[0];
+          void audioEl.play().catch(() => undefined);
+        };
+
+        const micStream = await navigator.mediaDevices.getUserMedia({
+          audio: getAudioConstraints(),
+        });
+        micStreamRef.current = micStream;
+        registerMediaStream(micStream);
+        micStream.getTracks().forEach((track) => pc.addTrack(track, micStream));
+
+        const dc = pc.createDataChannel(OAI_EVENTS_CHANNEL);
+        dcRef.current = dc;
+        dc.onmessage = (e) => {
+          try {
+            handleServerEvent(JSON.parse(e.data));
+          } catch {
+            /* a malformed frame is not worth ending an interview over */
+          }
+        };
+
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+
+        const sdpResponse = await fetch(started.realtime.calls_url, {
+          method: "POST",
+          body: offer.sdp,
+          headers: {
+            Authorization: `Bearer ${started.client_secret}`,
+            "Content-Type": "application/sdp",
+          },
+        });
+        if (!sdpResponse.ok) throw new Error("SDP exchange failed");
+        await pc.setRemoteDescription({ type: "answer", sdp: await sdpResponse.text() });
+
+        const location = sdpResponse.headers.get("Location") ?? "";
+        const callId = location.split("/").filter(Boolean).pop() ?? "";
+        void interviewService
+          .reportConnected(sessionIdRef.current, callId)
+          .catch(() => undefined);
+
+        flushTimerRef.current = setInterval(() => void flushTurns(), TURN_FLUSH_MS);
+        setPhaseSafe("live");
+      } catch {
+        fail("Could not connect. Check your microphone and network, then try again.");
+      }
+    },
+    [fail, flushTurns, handleServerEvent, phase, setPhaseSafe],
+  );
+
+  const end = useCallback(async () => {
+    if (closedRef.current) return;
+    closedRef.current = true;
+    setPhaseSafe("ending");
+
+    if (flushTimerRef.current) {
+      clearInterval(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+
+    // Order matters: the last answer, then the transcript, then the close. Ending first would
+    // grade the interview without its final answer in it.
+    await commitAnswer();
+    await flushTurns();
+
+    try {
+      micStreamRef.current?.getTracks().forEach((t) => t.stop());
+      dcRef.current?.close();
+      pcRef.current?.close();
+      if (audioElRef.current) audioElRef.current.srcObject = null;
+    } catch {
+      /* teardown is best effort */
+    }
+
+    const sessionId = sessionIdRef.current;
+    if (sessionId) {
+      try {
+        await interviewService.end(sessionId, "closed");
+      } catch {
+        /* the server sweep reconciles anything that never reported */
+      }
+    }
+    setPhaseSafe("ended");
+  }, [commitAnswer, flushTurns, setPhaseSafe]);
+
+  // A candidate who closes the tab must not leave a live call running and billing.
+  useEffect(() => {
+    return () => {
+      if (!closedRef.current) {
+        try {
+          micStreamRef.current?.getTracks().forEach((t) => t.stop());
+          dcRef.current?.close();
+          pcRef.current?.close();
+        } catch {
+          /* nothing useful to do while unmounting */
+        }
+      }
+      if (flushTimerRef.current) clearInterval(flushTimerRef.current);
+    };
+  }, []);
+
+  return {
+    phase,
+    error,
+    transcript,
+    currentQuestion,
+    questionCount,
+    candidateSpeaking,
+    sessionId: sessionIdRef.current,
+    connect,
+    end,
+  };
+}
+
+export default useRealtimeInterview;

--- a/lib/hooks/useRealtimeInterview.ts
+++ b/lib/hooks/useRealtimeInterview.ts
@@ -306,6 +306,19 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
     [fail, flushTurns, handleServerEvent, phase, setPhaseSafe],
   );
 
+  /**
+   * Actually mute, by disabling the outgoing track.
+   *
+   * State alone would give the candidate a button that lies to them: the interviewer would
+   * keep hearing everything while the UI said otherwise. Disabling the track is what stops
+   * audio leaving, and semantic VAD then stops taking turns on it.
+   */
+  const setMuted = useCallback((muted: boolean) => {
+    micStreamRef.current?.getAudioTracks().forEach((track) => {
+      track.enabled = !muted;
+    });
+  }, []);
+
   const end = useCallback(async () => {
     if (closedRef.current) return;
     closedRef.current = true;
@@ -367,6 +380,7 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
     sessionId: sessionIdRef.current,
     connect,
     end,
+    setMuted,
   };
 }
 

--- a/lib/services/interview.service.ts
+++ b/lib/services/interview.service.ts
@@ -1,0 +1,108 @@
+import apiClient from "./api";
+
+/**
+ * Interview API client.
+ *
+ * Note what is NOT here: any way to fetch the question paper. The browser is deliberately
+ * never given the questions, only the one it is currently on, and never the rubric. A client
+ * that holds the paper can look ahead, and a candidate who can read the rubric can write to
+ * it. See `lib/hooks/useRealtimeInterview.ts` for the transport.
+ */
+
+const BASE = "/interview/api";
+
+export interface StartedInterview {
+  session_id: string;
+  client_secret: string;
+  planned_minutes: number;
+  /** A COUNT, not the questions. Used only to show progress. */
+  question_count: number;
+  /** Server-controlled, so the provider endpoint is not baked into the bundle. */
+  realtime: { calls_url: string; model: string; voice: string };
+}
+
+export interface NextQuestion {
+  done: boolean;
+  question_id?: number;
+  position?: number;
+  kind?: "behavioural" | "conceptual" | "coding" | "mcq";
+  question?: string;
+  coding_problem_id?: number;
+  mcq_id?: number;
+}
+
+export interface InterviewTurnPayload {
+  role: "interviewer" | "candidate";
+  text: string;
+  seq: number;
+}
+
+export interface QuestionResult {
+  position: number;
+  kind: string;
+  question: string;
+  score: number;
+  max_score: number;
+  answered: boolean;
+  feedback: string;
+}
+
+export interface InterviewResult {
+  state: "pending" | "graded" | "failed" | "void";
+  score: number | null;
+  max_score?: number | null;
+  percentage?: number | null;
+  coverage?: {
+    completeness: number;
+    planned: number;
+    answered: number;
+    sections: Record<string, Record<string, number>>;
+  };
+  questions?: QuestionResult[];
+  message?: string;
+}
+
+export const interviewService = {
+  start: async (templateId: number): Promise<StartedInterview> => {
+    const { data } = await apiClient.post(`${BASE}/sessions/`, { template_id: templateId });
+    return data;
+  },
+
+  reportConnected: async (sessionId: string, callId: string): Promise<void> => {
+    await apiClient.post(`${BASE}/sessions/${sessionId}/connected/`, { call_id: callId });
+  },
+
+  /** The server tool. The interviewer has no questions of its own. */
+  nextQuestion: async (sessionId: string): Promise<NextQuestion> => {
+    const { data } = await apiClient.post(`${BASE}/sessions/${sessionId}/next-question/`, {});
+    return data;
+  },
+
+  answer: async (
+    sessionId: string,
+    payload: {
+      question_id: number;
+      transcript?: string;
+      code?: string;
+      language_id?: number;
+      objective_result?: Record<string, unknown>;
+    },
+  ): Promise<void> => {
+    await apiClient.post(`${BASE}/sessions/${sessionId}/answer/`, payload);
+  },
+
+  pushTurns: async (sessionId: string, turns: InterviewTurnPayload[]): Promise<void> => {
+    await apiClient.post(`${BASE}/sessions/${sessionId}/events/`, { turns });
+  },
+
+  end: async (sessionId: string, reason = "closed"): Promise<void> => {
+    await apiClient.post(`${BASE}/sessions/${sessionId}/end/`, { reason });
+  },
+
+  result: async (sessionId: string): Promise<InterviewResult> => {
+    const { data } = await apiClient.get(`${BASE}/sessions/${sessionId}/result/`);
+    return data;
+  },
+};
+
+export default interviewService;


### PR DESCRIPTION
Phase 2 of the mock interview rebuild. Frontend only; the backend spine is already merged and prod-verified.

Nothing here is wired into navigation yet and the backend feature is off for every tenant (`INTERVIEW_REALTIME_ENABLED=False`, zero `InterviewConfig` rows), so this is unreachable in production until deliberately switched on.

## What replaces what

| | old | new |
|---|---|---|
| transport | `useSpeechToText` 1,018 + `useInterviewerVoice` 573 + voice-picker 143 + 2 API routes = **2,005 lines** | `useRealtimeInterview` **373 lines** |
| barge-in | none | native |
| turn latency | 6–15s serial: silence detect → LLM → TTS fetch → `readyState` wait | speech-to-speech |

No silence detection, no TTS fetch, no `readyState` wait, no voice-picker fallback, no watchdog timers, because speech-to-speech removes the hops those existed to paper over.

## The structural difference

The model has **one** tool, `next_question`, resolved by asking Django. It owns no questions, so every question asked leaves a server row, and the browser never holds the paper or the rubric.

## Carried over deliberately

- **Audio element detached from the document.** `stopAllMediaTracks` walks `document.querySelectorAll("audio")`; an attached element is one stray navigation from silencing the interviewer.
- **URL never changes mid-call.** The camera route guard tears down streams on pathname change. The result redirect fires only after teardown.
- **Call id from the SDP `Location` header**, without which there's no server-side hangup and the session cap is unenforceable.

## Fixed while building

The mute button initially only set React state — it didn't mute. A button that lies to a candidate mid-assessment is worse than no button. It now disables the outgoing track.

## Verification

`tsc --noEmit` clean, verified with a deliberate-error canary since this repo's CI has no typecheck and only Netlify would catch one. `eslint` clean.

**Not yet verified: no real spoken interview has run against this.** That's the next step and it's the only thing that genuinely tests any of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)