### PR TITLE
feat(interview): report token usage

### DIFF
--- a/lib/hooks/useRealtimeInterview.ts
+++ b/lib/hooks/useRealtimeInterview.ts
@@ -75,6 +75,9 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
   // Turn buffer, flushed on a timer rather than per turn, so a long interview is a handful of
   // requests rather than hundreds.
   const pendingTurnsRef = useRef<InterviewTurnPayload[]>([]);
+  // Per-response usage payloads, flushed with the turns. Without these the server has only
+  // the wall clock to price a session by, and the ledger would under-count every interview.
+  const pendingUsageRef = useRef<Record<string, unknown>[]>([]);
   const seqRef = useRef(0);
   const flushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -110,13 +113,16 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
   const flushTurns = useCallback(async () => {
     const sessionId = sessionIdRef.current;
     const batch = pendingTurnsRef.current;
-    if (!sessionId || !batch.length) return;
+    const usageBatch = pendingUsageRef.current;
+    if (!sessionId || (!batch.length && !usageBatch.length)) return;
     pendingTurnsRef.current = [];
+    pendingUsageRef.current = [];
     try {
-      await interviewService.pushTurns(sessionId, batch);
+      await interviewService.pushTurns(sessionId, batch, usageBatch);
     } catch {
-      // Put them back rather than losing the record of what was said.
+      // Put both back rather than losing the record of what was said, or under-billing.
       pendingTurnsRef.current = [...batch, ...pendingTurnsRef.current];
+      pendingUsageRef.current = [...usageBatch, ...pendingUsageRef.current];
     }
   }, []);
 
@@ -198,6 +204,15 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
         case "input_audio_buffer.speech_stopped":
           setCandidateSpeaking(false);
           break;
+
+        case "response.done": {
+          // Carries this turn's token usage across all six billing axes. Collected here and
+          // flushed with the transcript; the server treats it as a floor, not a truth.
+          const usage = (event.response as { usage?: Record<string, unknown> } | undefined)
+            ?.usage;
+          if (usage) pendingUsageRef.current.push(usage);
+          break;
+        }
 
         case "response.function_call_arguments.done": {
           const name = String(event.name ?? "");

--- a/lib/services/interview.service.ts
+++ b/lib/services/interview.service.ts
@@ -107,8 +107,15 @@ export const interviewService = {
     await apiClient.post(`${BASE}/sessions/${sessionId}/answer/`, payload);
   },
 
-  pushTurns: async (sessionId: string, turns: InterviewTurnPayload[]): Promise<void> => {
-    await apiClient.post(`${BASE}/sessions/${sessionId}/events/`, { turns });
+  pushTurns: async (
+    sessionId: string,
+    turns: InterviewTurnPayload[],
+    usage: Record<string, unknown>[] = [],
+  ): Promise<void> => {
+    // Usage rides along with the transcript batch rather than getting its own request: a
+    // twenty-minute interview emits dozens of response.done events and one endpoint call per
+    // event would be noise on a single-task backend.
+    await apiClient.post(`${BASE}/sessions/${sessionId}/events/`, { turns, usage });
   },
 
   end: async (sessionId: string, reason = "closed"): Promise<void> => {


### PR DESCRIPTION
Pairs with backend PR #659. Without this the server can only price a session by wall clock, so every interview would be under-counted in the ledger.

`response.done` carries the turn's usage across all six billing axes. Collected and flushed with the transcript batch rather than sent per event: a twenty-minute interview emits dozens of responses, and one request each would be noise on a single-task backend.

A failed flush puts **both** the turns and the usage back, rather than losing the record of what was said or quietly under-billing.

The server treats these numbers as a floor, never a truth — a modified client can under-report, and the wall clock is the only thing it cannot forge.

Typecheck and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)