### PR TITLE
perf(P1): chrome hoist re-land (scroll-verified), 300s router cache, login overlap, dead-collector circuit breakers

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -149,10 +149,15 @@ export default function LoginPage() {
       // The animation now belongs to the auth provider, so this page and the Google button play
       // exactly the same one.
       setIsRedirecting(true);
-      await celebrate("signin");
 
+      // Overlap the ~950ms celebration with the destination's RSC+chunk
+      // prefetch instead of paying them serially — by the time the tick
+      // finishes, the router cache is warm and the replace() paints at once.
       const role = Cookies.get("user_role") ?? "";
       const target = resolvePostLoginPath(role, getSearchParam("redirect"));
+      router.prefetch(target);
+
+      await celebrate("signin");
       // SPA navigation, immediately.
       //
       // This used to be `setTimeout(() => { window.location.href = target }, 500)`. That was a

--- a/app/api/telemetry/alert/route.ts
+++ b/app/api/telemetry/alert/route.ts
@@ -179,13 +179,12 @@ Span ID: ${payload.spanId}
 export async function POST(req: NextRequest) {
   try {
     if (!ALERT_FROM || ALERT_TO.length === 0) {
-      return NextResponse.json(
-        {
-          error:
-            "SES_ALERT_FROM_EMAIL or SES_ALERT_TO_EMAILS missing",
-        },
-        { status: 500 }
-      );
+      // Alerting is deliberately unconfigured on this site. This is not an
+      // error: answering 500 here made every navigation that categorised a
+      // slow/failed request pay a Lambda invocation AND log noise on all ~35
+      // tenants (none of which set the SES vars). 204 = "received, nothing to
+      // do", and the client's circuit breaker stops asking.
+      return new NextResponse(null, { status: 204 });
     }
 
     const body =

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,7 @@ import { TelemetryProvider } from "@/components/providers/TelemetryProvider";
 import { ProfileActivationBlocker } from "@/components/auth/ProfileActivationBlocker";
 import { TenantSetupBlocker } from "@/components/auth/TenantSetupBlocker";
 import { TenantDeactivatedGate } from "@/components/auth/TenantDeactivatedGate";
+import { AppChrome } from "@/components/layout/AppChrome";
 import { XPGainProvider } from "@/components/community/XPGainProvider";
 import { XpCelebrationOverlay } from "@/components/common/XpCelebrationOverlay";
 import { PointsPrimer } from "@/components/common/PointsPrimer";
@@ -141,7 +142,7 @@ export default async function RootLayout({
                                     <TourProvider>
                                       <ProfileActivationBlocker />
                                       <TenantSetupBlocker />
-                                      {children}
+                                      <AppChrome>{children}</AppChrome>
                                       <PointsPrimer />
                                       <XpCelebrationOverlay />
                                     </TourProvider>

--- a/components/auth/GoogleSignIn.tsx
+++ b/components/auth/GoogleSignIn.tsx
@@ -182,12 +182,15 @@ export const GoogleSignIn: React.FC<GoogleSignInProps> = ({
         // showed a green "Login successful!" snackbar while the password path had long since
         // moved to the animation, because the tick used to be local state on the login page and
         // this is a child component that cannot reach it.
-        await celebrate("signin");
+        // Prefetch the destination DURING the tick instead of after it, so the
+        // replace() below paints from a warm router cache.
         const role = Cookies.get("user_role") ?? "";
         const redirectUrl = resolvePostLoginPath(
           role,
           getSearchParam("redirect")
         );
+        router.prefetch(redirectUrl);
+        await celebrate("signin");
         // SPA navigation, immediately — same fix as the password login path: this was a 500ms
         // setTimeout doing a full document reload, which tore down the freshly-rendered destination
         // (white flash + a second round of shimmers) on top of the router.replace the login page's

--- a/components/common/PointsPrimer.tsx
+++ b/components/common/PointsPrimer.tsx
@@ -1,16 +1,20 @@
 "use client";
 
 import { useEffect } from "react";
+import { useAuth } from "@/lib/auth/auth-context";
 import { primePointsTotal } from "@/lib/xp/pointsWatcher";
 
 /**
  * Seeds the unified points-total baseline once on load, so the learner's FIRST
  * earn of the session already animates (the watcher has a value to diff against).
- * Unauthenticated loads (e.g. the login page) just get a silently-ignored 401.
+ * Gated on auth: unauthenticated loads used to fire a guaranteed 401 on every
+ * login-page view across every tenant.
  */
 export function PointsPrimer() {
+  const { isAuthenticated } = useAuth();
   useEffect(() => {
+    if (!isAuthenticated) return;
     void primePointsTotal();
-  }, []);
+  }, [isAuthenticated]);
   return null;
 }

--- a/components/dashboard/v2/modules/JobOpeningsPanel.tsx
+++ b/components/dashboard/v2/modules/JobOpeningsPanel.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { jobsV2Service, type JobV2 } from "@/lib/services/jobs-v2.service";
+import { readProfileLock, useProfileGate } from "@/lib/contexts/ProfileGateContext";
 import { ModuleEmpty, ModuleHeader, ModulePanel, ModuleRowsSkeleton, Pill, timeUntil } from "./shared";
 
 const GRADIENT = "linear-gradient(135deg, #10b981, #0d9488)";
@@ -41,15 +42,32 @@ export function JobOpeningsPanel() {
   const router = useRouter();
   const [items, setItems] = useState<JobV2[] | null>(null);
   const [hidden, setHidden] = useState(false);
+  // The profile gate already knows when jobs are locked for this learner —
+  // fetching anyway produced a guaranteed profile_incomplete 403 on every
+  // dashboard mount for every profile-incomplete student.
+  const { lockedModules, status: gateStatus, applyServerLock } = useProfileGate();
+  const jobsLocked = lockedModules.includes("jobs");
 
   useEffect(() => {
+    if (gateStatus === "loading") return; // wait until we know
+    if (jobsLocked) {
+      setHidden(true);
+      return;
+    }
     let cancelled = false;
     jobsV2Service
       .getJobs()
       .then((res) => { if (!cancelled) setItems(selectJobs(res?.results ?? [])); })
-      .catch(() => { if (!cancelled) setHidden(true); });
+      .catch((err) => {
+        if (cancelled) return;
+        // Feed a profile_incomplete 403 back into the gate so the rest of the
+        // app locks consistently, then hide as before.
+        const lock = readProfileLock(err);
+        if (lock) applyServerLock(lock);
+        setHidden(true);
+      });
     return () => { cancelled = true; };
-  }, []);
+  }, [gateStatus, jobsLocked, applyServerLock]);
 
   if (hidden) return null;
 

--- a/components/layout/AppChrome.tsx
+++ b/components/layout/AppChrome.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box } from "@mui/material";
+import { usePathname } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import { isRtl } from "@/lib/i18n";
+import { AppBar } from "./AppBar";
+import { Sidebar, DRAWER_WIDTH } from "./Sidebar";
+import { BottomNavigation } from "./BottomNavigation";
+import { ChromeProvider } from "./ChromeContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { reportContentCompleted } from "@/lib/streak/streakCelebration";
+import { StreakCelebrationOverlay } from "@/components/common/StreakCelebrationOverlay";
+import { ReportIssueFAB } from "@/components/common/ReportIssueFAB";
+import { useHideLeaderboardView } from "@/lib/contexts/ClientInfoContext";
+
+/**
+ * Persistent app chrome, mounted ONCE in the root layout.
+ *
+ * Previously every one of the ~114 pages rendered its own <MainLayout>, and 43 of the loading.tsx
+ * files rendered a second one via PageShimmerLayout. Because those are different element positions in
+ * different route subtrees, React unmounted and remounted the ENTIRE shell on every navigation —
+ * AppBar, Sidebar, BottomNavigation, ReportIssueFAB and useTimeTracking all torn down and rebuilt,
+ * with the header refetching and the in-progress time segment dropped. It also meant the chrome
+ * visibly flashed between a route's loading.tsx and its page.
+ *
+ * Mounting it here instead means the shell survives navigation entirely; only the content column
+ * swaps. MainLayout stays in place as the per-page CONTENT wrapper (it collapses to just its content
+ * Box when it detects it is inside this chrome), so no page had to change.
+ */
+
+/**
+ * Routes that must NOT receive the shared chrome, and keep rendering exactly what they render today:
+ *  - the unauthenticated routes, which have no app shell at all;
+ *  - the first-login setup wizard, likewise;
+ *  - the legacy submodule player, the only page that passes RUNTIME-computed MainLayout props
+ *    (`hideSidebar={!isMobile} fullPage DrawerWidth={0}`), which cannot be expressed by a static
+ *    shared shell;
+ *  - the assessment runner, whose desktop-only gate mounts its own MainLayout and which must stay a
+ *    distraction-free full-page surface while proctored.
+ */
+const CHROMELESS_PREFIXES = [
+  // Unauthenticated / pre-app surfaces — no shell at all.
+  "/login",
+  "/signup",
+  "/forgot-password",
+  "/reset-password",
+  "/verify-email",
+  "/auth/handoff",
+  "/setup",
+  // Public, auth-free credential verification — must not show app navigation.
+  "/credentials",
+  // Off-screen render target captured into a PDF; any chrome would end up in the file.
+  "/user/scorecard/pdf",
+  // Standalone utilities / demos that deliberately render bare.
+  "/mock-interview/voice-sample",
+  "/proctoring-demo",
+];
+
+const CHROMELESS_PATTERNS: RegExp[] = [
+  /^\/courses\/[^/]+\/submodule\/[^/]+/, // legacy submodule player (runtime chrome props)
+  // Distraction-free, often proctored runners. These render their own full-page surface today and
+  // must not gain a sidebar/app bar.
+  /^\/assessments\/[^/]+\/take/,
+  /^\/assessments\/[^/]+\/calibration/,
+  /^\/mock-interview\/[^/]+\/take/,
+  /^\/adaptive-courses\/[^/]+\/interview\/[^/]+/,
+];
+
+function isChromeless(pathname: string | null): boolean {
+  if (!pathname) return true; // pre-hydration: render bare rather than flashing a shell
+  if (CHROMELESS_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))) return true;
+  return CHROMELESS_PATTERNS.some((re) => re.test(pathname));
+}
+
+export function AppChrome({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  if (isChromeless(pathname)) {
+    // No chrome, and no ChromeProvider — so any MainLayout on these routes behaves exactly as before.
+    return <>{children}</>;
+  }
+  return <ChromeShell>{children}</ChromeShell>;
+}
+
+function ChromeShell({ children }: { children: React.ReactNode }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const handleDrawerToggle = () => setMobileOpen((o) => !o);
+
+  // Global app time tracking — now runs once for the session instead of restarting every navigation.
+  useTimeTracking();
+
+  const hideLeaderboardView = useHideLeaderboardView();
+
+  // Any content completion (legacy or adaptive) dispatches "submodule-complete";
+  // refetch the streak and celebrate if it went up.
+  useEffect(() => {
+    if (hideLeaderboardView || typeof window === "undefined") return;
+    const handleSubmoduleComplete = () => reportContentCompleted();
+    window.addEventListener("submodule-complete", handleSubmoduleComplete);
+    return () => window.removeEventListener("submodule-complete", handleSubmoduleComplete);
+  }, [hideLeaderboardView]);
+
+  const { i18n } = useTranslation();
+  const rtl = isRtl(i18n.language || "en");
+
+  // direction: ltr so flex order stays consistent (order 1 = left, order 2 = right); with dir="rtl"
+  // on the document, flex start would be on the right and main content would sit under the sidebar.
+  return (
+    <ChromeProvider value={true}>
+      <Box
+        sx={{
+          // Scroll-container geometry copied EXACTLY from MainLayout's
+          // non-fullPage path. Omitting `overflow`/`height` here is the bug
+          // that forced the #1148 revert: no ancestor was a scroll container
+          // any more and content past the viewport was unreachable.
+          direction: "ltr",
+          display: "flex",
+          flexDirection: "row",
+          minHeight: "auto",
+          height: "auto",
+          maxHeight: "none",
+          overflow: "auto",
+          backgroundColor: "var(--background)",
+          width: "100%",
+        }}
+      >
+        <AppBar onMenuClick={handleDrawerToggle} DrawerWidth={DRAWER_WIDTH} />
+        <Box
+          sx={{
+            order: rtl ? 2 : 0,
+            flexShrink: 0,
+            width: { xs: 0, md: DRAWER_WIDTH },
+            minWidth: { md: DRAWER_WIDTH },
+            overflow: "hidden",
+          }}
+        >
+          <Sidebar mobileOpen={mobileOpen} onClose={handleDrawerToggle} />
+        </Box>
+        <Box
+          component="main"
+          sx={{
+            order: rtl ? 1 : 0,
+            direction: rtl ? "rtl" : "ltr",
+            flexGrow: 1,
+            flexShrink: 1,
+            minWidth: 0,
+            width: { xs: "100%", md: `calc(100% - ${DRAWER_WIDTH}px)` },
+            maxWidth: { md: `calc(100% - ${DRAWER_WIDTH}px)` },
+            minHeight: "auto",
+            height: "auto",
+            maxHeight: "none",
+            overflow: "auto",
+            backgroundColor: "var(--background)",
+            display: "flex",
+            flexDirection: "column",
+            marginInlineStart: { md: 0 },
+            marginInlineEnd: { md: 0 },
+            transition: "width 0.3s ease",
+          }}
+        >
+          {/* Toolbar spacer for the fixed AppBar */}
+          <Box sx={{ minHeight: { xs: "56px", sm: "64px" }, flexShrink: 0 }} />
+          {children}
+        </Box>
+        <BottomNavigation />
+        {!hideLeaderboardView && <StreakCelebrationOverlay />}
+        <ReportIssueFAB />
+      </Box>
+    </ChromeProvider>
+  );
+}

--- a/components/layout/ChromeContext.tsx
+++ b/components/layout/ChromeContext.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/**
+ * True when persistent app chrome (AppBar + Sidebar + BottomNavigation) is already mounted above the
+ * current tree by <AppChrome>, which lives in the ROOT layout.
+ *
+ * MainLayout reads this to decide whether it should render the chrome itself or just its content
+ * column. That is what lets the chrome be hoisted without editing the 114 pages that call MainLayout:
+ * inside AppChrome they collapse to the content wrapper, and the sidebar/app bar stop being torn down
+ * and rebuilt on every navigation.
+ */
+const ChromeContext = createContext(false);
+
+export const ChromeProvider = ChromeContext.Provider;
+
+export function useInsideChrome(): boolean {
+  return useContext(ChromeContext);
+}

--- a/components/layout/MainLayout.tsx
+++ b/components/layout/MainLayout.tsx
@@ -13,6 +13,7 @@ import { reportContentCompleted } from "@/lib/streak/streakCelebration";
 import { StreakCelebrationOverlay } from "@/components/common/StreakCelebrationOverlay";
 import { ReportIssueFAB } from "@/components/common/ReportIssueFAB";
 import { useHideLeaderboardView } from "@/lib/contexts/ClientInfoContext";
+import { useInsideChrome } from "./ChromeContext";
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -34,7 +35,56 @@ interface MainLayoutProps {
   DrawerWidth?: number;
 }
 
-export const MainLayout: React.FC<MainLayoutProps> = memo(({
+/**
+ * Nesting-aware: inside the hoisted <AppChrome> (root layout) the shell is
+ * already mounted and survives navigation, so this renders ONLY the per-page
+ * content column. On the chromeless routes AppChrome skips, it renders the
+ * original self-contained layout below, byte-for-byte unchanged.
+ */
+export const MainLayout: React.FC<MainLayoutProps> = memo((props) => {
+  const insideChrome = useInsideChrome();
+  return insideChrome ? (
+    <MainLayoutContent {...props} />
+  ) : (
+    <StandaloneMainLayout {...props} />
+  );
+});
+
+MainLayout.displayName = "MainLayout";
+
+/**
+ * The per-page content column — the only part that should change between
+ * routes. Geometry copied EXACTLY from StandaloneMainLayout's inner content
+ * Box (the #1148 revert was caused by dropping its height/overflow here).
+ * marginTop stays 0 in all cases: the chrome shell always renders the toolbar
+ * spacer, so the standalone fullPage marginTop would double-space.
+ */
+function MainLayoutContent({
+  children,
+  fullPage = false,
+  fullWidthContent = false,
+}: MainLayoutProps) {
+  return (
+    <Box
+      sx={{
+        flexGrow: 1,
+        p: fullPage ? 0 : { xs: 2, sm: 3, md: 4 },
+        width: "100%",
+        maxWidth: fullPage ? "100%" : fullWidthContent ? "none" : "1400px",
+        mx: fullPage ? 0 : "auto",
+        pb: fullPage ? 0 : { xs: "72px", md: 4 },
+        height: fullPage ? "100%" : "auto",
+        minHeight: fullPage ? 0 : "calc(100vh - 64px)",
+        overflow: fullPage ? "hidden" : "auto",
+        position: "relative",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+const StandaloneMainLayout: React.FC<MainLayoutProps> = memo(({
   children,
   hideSidebar = false,
   fullPage = false,
@@ -161,4 +211,4 @@ export const MainLayout: React.FC<MainLayoutProps> = memo(({
   );
 });
 
-MainLayout.displayName = "MainLayout";
+StandaloneMainLayout.displayName = "StandaloneMainLayout";

--- a/lib/contexts/ProfileGateContext.tsx
+++ b/lib/contexts/ProfileGateContext.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { profileService, type ProfileCompletion } from "@/lib/services/profile.service";
+import { useAuth } from "@/lib/auth/auth-context";
 
 /**
  * Whether this learner's profile is complete, and what stays locked until it is.
@@ -64,7 +65,20 @@ export function ProfileGateProvider({ children }: { children: React.ReactNode })
     }
   }, []);
 
+  const { isAuthenticated } = useAuth();
+
   useEffect(() => {
+    // Signed out (e.g. the login page): don't fire a guaranteed-401 fetch —
+    // report "nothing is locked" instead. Keying the effect on
+    // isAuthenticated also fixes the stale-after-login bug: this provider
+    // used to fetch exactly once on mount, so a login-page 401 left it in
+    // "error" for the whole session and the profile-completion card never
+    // appeared on the first post-login dashboard.
+    if (!isAuthenticated) {
+      setCompletion(null);
+      setStatus("ready");
+      return;
+    }
     void load();
     // Belt and braces. Nothing should depend on the gate resolving — that coupling is what broke
     // the Jobs page — but a provider stuck on "loading" forever is still a bug in its own right,
@@ -73,7 +87,7 @@ export function ProfileGateProvider({ children }: { children: React.ReactNode })
       setStatus((prev) => (prev === "loading" ? "error" : prev));
     }, 15000);
     return () => clearTimeout(failsafe);
-  }, [load]);
+  }, [load, isAuthenticated]);
 
   const applyServerLock = useCallback((body: { missing_fields?: string[] }) => {
     setCompletion((prev) => ({

--- a/lib/services/client.service.ts
+++ b/lib/services/client.service.ts
@@ -130,11 +130,11 @@ export interface ClientInfo {
 
 export const initApp = async (clientId: number): Promise<ClientInfo> => {
   try {
+    // No cache-buster: `_t: Date.now()` made every call a unique URL, which
+    // defeated the browser cache AND every CDN in front of this endpoint.
+    // The payload varies by nothing request-specific.
     const response = await apiClient.get<ClientInfo>(
-      `/api/clients/${clientId}/client-info/`,
-      {
-        params: { _t: Date.now() },
-      }
+      `/api/clients/${clientId}/client-info/`
     );
     return response.data;
   } catch (error: any) {

--- a/lib/telemetry/browser-tracer.ts
+++ b/lib/telemetry/browser-tracer.ts
@@ -69,9 +69,17 @@ function classifyFailure(
   return "other";
 }
 
+// Circuit breaker: alerting is best-effort. Once the alert route says it is
+// unconfigured (204) or fails twice, stop posting for the rest of the session —
+// this used to fire a doomed request (and a Lambda invocation) on every
+// categorised failure, on every tenant, forever.
+let alertDisabled = false;
+let alertFailures = 0;
+
 async function sendFailureAlert(payload: FailureAlertPayload): Promise<void> {
+  if (alertDisabled) return;
   try {
-    await fetch("/api/telemetry/alert", {
+    const res = await fetch("/api/telemetry/alert", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -81,8 +89,18 @@ async function sendFailureAlert(payload: FailureAlertPayload): Promise<void> {
       },
       body: JSON.stringify(payload),
     });
+    if (res.status === 204) {
+      alertDisabled = true; // explicitly unconfigured on this site
+    } else if (!res.ok) {
+      alertFailures += 1;
+      if (alertFailures >= 2) alertDisabled = true;
+    } else {
+      alertFailures = 0;
+    }
   } catch {
     // Never throw - alerting must not affect the app
+    alertFailures += 1;
+    if (alertFailures >= 2) alertDisabled = true;
   }
 }
 
@@ -136,6 +154,24 @@ export async function initBrowserTracer() {
   }
 
   const exporter = new OTLPTraceExporter({ url: traceEndpoint });
+
+  // Circuit breaker: the collector this points at has been observed returning
+  // 500 on every export (telemetry-backend.netlify.app), which added a failed
+  // 0.5-1.8s background request per navigation indefinitely. After 3
+  // consecutive failed exports, drop spans silently for the session.
+  let exportFailures = 0;
+  const rawExport = exporter.export.bind(exporter);
+  exporter.export = (spans, resultCallback) => {
+    if (exportFailures >= 3) {
+      resultCallback({ code: 0 }); // ExportResultCode.SUCCESS — drop silently
+      return;
+    }
+    rawExport(spans, (result) => {
+      exportFailures = result.code === 0 ? 0 : exportFailures + 1;
+      resultCallback(result);
+    });
+  };
+
   const batchProcessor = new BatchSpanProcessor(exporter, {
     scheduledDelayMillis: 500,
   });

--- a/next.config.ts
+++ b/next.config.ts
@@ -136,12 +136,16 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["@mui/material", "@mui/icons-material"],
     // Reuse the client Router Cache for visited routes so back/again navigation
-    // is instant instead of refetching the route on every visit. Default for
-    // dynamic routes is 0 (never reused); 30s makes revisits snappy without
-    // going stale. (Next.js experimental.staleTimes.)
+    // is instant instead of refetching the route on every visit.
+    //
+    // These can be LONG because 140/142 pages are "use client" shells: the RSC
+    // payload a navigation fetches contains no user data — freshness comes from
+    // the pages' own client-side API calls. At 30s every prefetch expired
+    // before it was used and every post-idle click re-paid a full RSC round
+    // trip (the single biggest "every click feels slow" mechanism).
     staleTimes: {
-      dynamic: 30,
-      static: 180,
+      dynamic: 300,
+      static: 1800,
     },
   },
   


### PR DESCRIPTION
## Phase 1 of the ultrafast program — make every click feel instant

1. **Chrome hoist re-landed** with the exact scroll geometry whose omission forced the #1148 revert, and with the verification #1148 asked for: production build served against the live demo tenant, Playwright confirmed window/container scrolling on 9 student routes + 5 admin routes (including every page named in the revert: assessments, resume, adaptive courses, community, cohorts), and chrome persistence proven by DOM-node identity across a SPA navigation.
2. **staleTimes 30/180 → 300/1800** — client-shell RSC payloads carry no user data; 30s guaranteed every post-idle click re-paid the full round trip and every prefetch expired unused.
3. **Login flow de-serialized** — destination prefetch overlaps the 950ms celebration tick; ProfileGate/PointsPrimer no longer fire guaranteed-401s on login views; ProfileGate reloads on auth flip (fixes the missing profile-completion card after login); `_t=Date.now()` cache-buster dropped from client-info; JobOpeningsPanel consults the profile gate instead of collecting a guaranteed 403 per dashboard mount.
4. **Telemetry circuit breakers** — the alert route returns 204 when SES is unconfigured (was a 500 + Lambda invocation per categorised failure on every tenant); the OTLP exporter stops after 3 consecutive failed exports (the collector has been 500ing on every export).

tsc clean · vitest 139/139 · `next build` 91/91 static

🤖 Generated with [Claude Code](https://claude.com/claude-code)