### PR TITLE
Live sessions: the Agileology hardening train (FE waves 1-6)

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -52,6 +52,7 @@ import { LiveSessionNoticeDialog } from "@/components/admin/live-sessions/LiveSe
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import { StudyMaterialManager } from "@/components/live-sessions/StudyMaterialManager";
 import { EditWebinarDialog } from "@/components/admin/live-sessions/EditWebinarDialog";
+import { EditSessionDialog } from "@/components/admin/live-sessions/EditSessionDialog";
 import { formatSessionTime } from "@/lib/utils/session-time";
 
 function formatDateTime(s?: string | null, timezone?: string | null) {
@@ -90,6 +91,7 @@ export default function LiveSessionDetailPage() {
   const [syncingRecording, setSyncingRecording] = useState(false);
   const [playerOpen, setPlayerOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
+  const [editSessionOpen, setEditSessionOpen] = useState(false);
   const [creatingGoogle, setCreatingGoogle] = useState(false);
   const [updatingGoogle, setUpdatingGoogle] = useState(false);
   const [cancellingGoogle, setCancellingGoogle] = useState(false);
@@ -397,8 +399,25 @@ export default function LiveSessionDetailPage() {
         : t("adminLiveSessions.cancelOrReschedule", "Cancel / Reschedule")}
     </ButtonBase>
   );
+  // Always available, for every provider and state - before this, only webinars-while-scheduled
+  // had any Edit, so a plain meeting's typo'd topic or wrong trainer was stuck until recreation.
+  const editSessionButton = (
+    <ButtonBase
+      onClick={() => setEditSessionOpen(true)}
+      sx={{
+        px: 2.25, py: 1, borderRadius: 999, fontWeight: 700, fontSize: "0.82rem",
+        color: "var(--accent-indigo)", display: "inline-flex", alignItems: "center", gap: 0.5,
+        border: "1px solid color-mix(in srgb, var(--accent-indigo) 35%, transparent)",
+        "&:hover": { background: "color-mix(in srgb, var(--accent-indigo) 8%, transparent)" },
+      }}
+    >
+      <IconWrapper icon="mdi:pencil-outline" size={16} />
+      {t("adminLiveSessions.editSession", "Edit session")}
+    </ButtonBase>
+  );
   const headerActions = (
     <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+      {editSessionButton}
       {noticeButton}
       {deleteSessionButton}
       {backButton}
@@ -601,7 +620,10 @@ export default function LiveSessionDetailPage() {
                   <SectionCard>
                     <LiveSessionOccurrenceTimeline
                       liveClassId={activity.id}
+                      seriesTitle={activity.topic_name}
+                      timezone={activity.timezone}
                       onOpenRecording={(url) => window.open(url, "_blank", "noopener,noreferrer")}
+                      onChanged={() => void load()}
                     />
                   </SectionCard>
                 )}
@@ -740,6 +762,15 @@ export default function LiveSessionDetailPage() {
           activity={activity}
           open={editOpen}
           onClose={() => setEditOpen(false)}
+          onSaved={load}
+        />
+      )}
+
+      {activity && (
+        <EditSessionDialog
+          activity={activity}
+          open={editSessionOpen}
+          onClose={() => setEditSessionOpen(false)}
           onSaved={load}
         />
       )}

--- a/app/admin/tickets/[id]/page.tsx
+++ b/app/admin/tickets/[id]/page.tsx
@@ -68,6 +68,7 @@ export default function AdminTicketDetailPage() {
   const [uploading, setUploading] = useState(false);
   const [resolving, setResolving] = useState(false);
   const [updatingStatus, setUpdatingStatus] = useState(false);
+  const [reminding, setReminding] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
@@ -156,6 +157,23 @@ export default function AdminTicketDetailPage() {
       );
     } finally {
       setUpdatingStatus(false);
+    }
+  };
+
+  const handleRemind = async () => {
+    if (!ticket?.assigned_to_user) return;
+    setReminding(true);
+    try {
+      await ticketService.remindAssignee(clientId, ticket.id);
+      showToast(`Reminder sent to ${ticket.assigned_to_user.full_name}`, "success");
+    } catch (err) {
+      // The 400 reasons (unassigned / already resolved) arrive verbatim from unwrapError.
+      showToast(
+        err instanceof Error ? err.message : "Failed to send the reminder",
+        "error",
+      );
+    } finally {
+      setReminding(false);
     }
   };
 
@@ -328,6 +346,30 @@ export default function AdminTicketDetailPage() {
                   sx={{ flexShrink: 0 }}
                 >
                   <TicketStatusChip status={ticket.status} />
+                  {/* Nudge whoever owns it - the queue notified nobody, so an assigned ticket
+                      could sit untouched with no follow-up short of a side-channel ping. */}
+                  {ticket.assigned_to_user && ticket.status !== "RESOLVED" && (
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={handleRemind}
+                      disabled={reminding}
+                      startIcon={
+                        reminding ? (
+                          <CircularProgress size={14} color="inherit" />
+                        ) : (
+                          <IconWrapper icon="mdi:bell-ring-outline" size={15} />
+                        )
+                      }
+                      sx={{
+                        textTransform: "none",
+                        fontWeight: 600,
+                        borderRadius: 999,
+                      }}
+                    >
+                      Remind assignee
+                    </Button>
+                  )}
                   {ticket.status === "OPEN" && (
                     <Button
                       size="small"

--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -100,6 +100,14 @@ export default function InstructorCoursePage() {
         icon="mdi:book-education"
         action={
           <Stack direction="row" spacing={1}>
+            {/* The material itself, as a learner sees it. Staff preview works end-to-end on
+                locked courses now, so this needs neither an enrollment nor edit rights. */}
+            <HeaderActionButton
+              icon="mdi:book-open-page-variant-outline"
+              onClick={() => push(`/adaptive-courses/${courseId}`)}
+            >
+              View course content
+            </HeaderActionButton>
             {/* Offered for any course this instructor may EDIT — which now includes one they were
                 allotted a batch on, not only one they built. Still driven by what the server says
                 rather than by authorship, so a button that would 403 is never rendered. */}

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -132,6 +132,27 @@ export default function InstructorCoursesPage() {
                     <Icon icon="mdi:arrow-right" width={15} />
                   </Stack>
                 )}
+                {/* See the material as a learner does. Staff preview now works end-to-end on
+                    locked courses, so a trainer can read what they'll teach without a builder
+                    role or an enrollment. Adaptive only - classic ids live in another table. */}
+                {c.kind === "adaptive" && (
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={0.5}
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => { e.stopPropagation(); push(`/adaptive-courses/${c.id}`); }}
+                    onKeyDown={(e) => { if (e.key === "Enter") { e.stopPropagation(); push(`/adaptive-courses/${c.id}`); } }}
+                    onMouseEnter={() => prefetch(`/adaptive-courses/${c.id}`)}
+                    sx={{ mt: 0.75, fontSize: "0.82rem", fontWeight: 800, color: "#10b981", width: "fit-content",
+                      "&:hover": { textDecoration: "underline" } }}
+                  >
+                    <Icon icon="mdi:eye-outline" width={16} />
+                    View content
+                    <Icon icon="mdi:arrow-right" width={15} />
+                  </Stack>
+                )}
               </Box>
             </Reveal>
           );

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -110,7 +110,10 @@ export default function InstructorLiveSessionsPage() {
   const [tab, setTab] = useState<SessionStatus | "all">("all");
   const [now, setNow] = useState(() => Date.now());
   const [hostingId, setHostingId] = useState<number | null>(null);
-  const [toast, setToast] = useState<{ text: string; sev: "success" | "error" | "info" } | null>(null);
+  const [toast, setToast] = useState<{ text: string; sev: "success" | "error" | "info" | "warning" } | null>(null);
+  // Webinar panelist links, keyed by session id, remembered from the host-link fetch so the row
+  // can offer "Copy panelist link" for co-presenters (the row's plain copy is the ATTENDEE link).
+  const [panelistUrls, setPanelistUrls] = useState<Record<number, string>>({});
 
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<InstructorLiveSession | null>(null);
@@ -155,10 +158,10 @@ export default function InstructorLiveSessionsPage() {
   const endedShown = useMemo(() => withStatus.filter((x) => x.status === "ended").length, [withStatus]);
   const showTruncation = (tab === "all" || tab === "ended") && pastTotal > endedShown;
 
-  const copyLink = async (link: string) => {
+  const copyLink = async (link: string, what = "Join link") => {
     try {
       await navigator.clipboard.writeText(link);
-      setToast({ text: "Join link copied to clipboard.", sev: "success" });
+      setToast({ text: `${what} copied to clipboard.`, sev: "success" });
     } catch {
       setToast({ text: "Couldn't copy the link.", sev: "error" });
     }
@@ -168,8 +171,20 @@ export default function InstructorLiveSessionsPage() {
     try {
       const link = await instructorService.getHostLink(s.id);
       if (!link.url) { setToast({ text: "No host link is available for this session yet.", sev: "error" }); return; }
+      if (link.kind === "host" && link.panelist_url) {
+        setPanelistUrls((cur) => ({ ...cur, [s.id]: link.panelist_url! }));
+      }
+      // A stale link is still opened - Zoom often accepts it, and refusing outright would strand
+      // the trainer. The warning tells them what to do if it bounces.
       window.open(link.url, "_blank", "noopener");
-      setToast({ text: link.kind === "panelist" ? "Opening your panelist link. You'll join as a presenter." : "Opening your host link.", sev: "info" });
+      if (link.stale) {
+        setToast({
+          text: "This start link was issued a while ago and may have expired. If Zoom rejects it, try again closer to the session start for a fresh link.",
+          sev: "warning",
+        });
+      } else {
+        setToast({ text: link.kind === "panelist" ? "Opening your panelist link. You'll join as a presenter." : "Opening your host link.", sev: "info" });
+      }
     } catch {
       setToast({ text: "Couldn't get your host link right now.", sev: "error" });
     } finally {
@@ -253,8 +268,10 @@ export default function InstructorLiveSessionsPage() {
             status={status}
             now={now}
             hosting={hostingId === s.id}
+            panelistUrl={panelistUrls[s.id]}
             onHost={() => startHosting(s)}
-            onCopy={() => copyLink(s.join_link)}
+            onCopy={() => copyLink(s.join_link, "Attendee join link")}
+            onCopyPanelist={() => copyLink(panelistUrls[s.id], "Panelist link")}
             onEdit={() => setEditing(s)}
             onAttendance={() => setAttendanceFor(s)}
             onMaterials={() => setMaterialsFor(s)}
@@ -323,9 +340,9 @@ function TurnoutBlock({ label, attendance, registered, turnout, unidentified = 0
   );
 }
 
-function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttendance, onMaterials, onRecording, onDelete }: {
-  s: InstructorLiveSession; status: SessionStatus; now: number; hosting: boolean;
-  onHost: () => void; onCopy: () => void; onEdit: () => void; onAttendance: () => void; onMaterials: () => void; onRecording: () => void; onDelete: () => void;
+function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCopyPanelist, onEdit, onAttendance, onMaterials, onRecording, onDelete }: {
+  s: InstructorLiveSession; status: SessionStatus; now: number; hosting: boolean; panelistUrl?: string;
+  onHost: () => void; onCopy: () => void; onCopyPanelist: () => void; onEdit: () => void; onAttendance: () => void; onMaterials: () => void; onRecording: () => void; onDelete: () => void;
 }) {
   const m = STATUS_META[status];
   const p = PROVIDER_META[s.provider] ?? PROVIDER_META.manual;
@@ -404,17 +421,28 @@ function SessionRow({ s, status, now, hosting, onHost, onCopy, onEdit, onAttenda
               {status === "live" ? "Start hosting" : "Start early"}
             </Button>
           )}
+          {/* Only known after a host-link fetch. The panelist link is for CO-PRESENTERS — handing
+              out the attendee link put trainers in the audience with no screen share. */}
+          {panelistUrl && status !== "ended" && (
+            <Tooltip title="Share this with a co-presenter so they join on stage, not in the audience.">
+              <Button onClick={onCopyPanelist} startIcon={<Icon icon="mdi:account-star-outline" width={16} />} sx={outlineBtn}>
+                Copy panelist link
+              </Button>
+            </Tooltip>
+          )}
           {status === "scheduled" && (
             <>
               {s.editable && (
                 <Button onClick={onEdit} startIcon={<Icon icon="mdi:pencil-outline" width={16} />} sx={outlineBtn}>Edit</Button>
               )}
               {s.join_link && (
-                <Button onClick={onCopy} startIcon={<Icon icon="mdi:tray-arrow-up" width={16} />}
-                  sx={{ textTransform: "none", fontWeight: 700, color: "#7c3aed", px: 1.75, py: 0.9, borderRadius: 2,
-                    bgcolor: "color-mix(in srgb,#7c3aed 10%,transparent)" }}>
-                  Copy link
-                </Button>
+                <Tooltip title="The link students use to join. Presenters need the panelist link instead - this one seats them in the audience.">
+                  <Button onClick={onCopy} startIcon={<Icon icon="mdi:tray-arrow-up" width={16} />}
+                    sx={{ textTransform: "none", fontWeight: 700, color: "#7c3aed", px: 1.75, py: 0.9, borderRadius: 2,
+                      bgcolor: "color-mix(in srgb,#7c3aed 10%,transparent)" }}>
+                    Copy attendee link
+                  </Button>
+                </Tooltip>
               )}
             </>
           )}

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -35,6 +35,7 @@ import {
   type UnidentifiedParticipant,
 } from "@/lib/services/instructor.service";
 import { adminLiveActivitiesService } from "@/lib/services/admin/admin-live-activities.service";
+import { RoleChip } from "@/components/live-sessions/ui/LiveSessionUI";
 import { viewerTimeZone, timezoneOptions, sessionTimeParts } from "@/lib/utils/session-time";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
@@ -784,7 +785,11 @@ function AttendanceDialog({ session, onClose }: { session: InstructorLiveSession
                     {(r.name || "?").slice(0, 1).toUpperCase()}
                   </Box>
                   <Box sx={{ minWidth: 0, flex: 1 }}>
-                    <Typography sx={{ fontWeight: 700, fontSize: "0.86rem" }} noWrap>{r.name}</Typography>
+                    <Stack direction="row" spacing={0.6} alignItems="center" sx={{ minWidth: 0 }}>
+                      <Typography sx={{ fontWeight: 700, fontSize: "0.86rem" }} noWrap>{r.name}</Typography>
+                      {/* Who ran the room vs who attended it - display only on this surface. */}
+                      <RoleChip role={r.role} />
+                    </Stack>
                     {r.email && <Typography sx={{ fontSize: "0.74rem", color: "text.secondary" }} noWrap>{r.email}</Typography>}
                   </Box>
                   {r.duration_minutes != null && <Typography sx={{ fontSize: "0.74rem", color: "text.secondary" }}>{r.duration_minutes}m</Typography>}

--- a/app/instructor/tickets/page.tsx
+++ b/app/instructor/tickets/page.tsx
@@ -1,14 +1,34 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { Box, Chip, Stack, Typography } from "@mui/material";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { ModulePageHeader } from "@/components/common/ModulePageHeader";
 import { Reveal } from "@/components/scorecard/shared";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
+import { useAuth } from "@/lib/auth/auth-context";
+import { useToast } from "@/components/common/Toast";
 import { config } from "@/lib/config";
-import { ticketService, type Ticket, type TicketStatus } from "@/lib/services/ticket.service";
+import {
+  ticketService,
+  TICKET_CATEGORY_OPTIONS,
+  type Ticket,
+  type TicketCategory,
+  type TicketStatus,
+} from "@/lib/services/ticket.service";
 
 /**
  * An instructor's ticket queue: the doubts raised by students in the cohorts they staff.
@@ -38,19 +58,26 @@ const FILTERS = [
 
 export default function InstructorTicketsPage() {
   const { push } = useInstantNavigation();
+  const { user } = useAuth();
+  const { showToast } = useToast();
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState("");
+  const [category, setCategory] = useState<TicketCategory | "">("");
+  // Resolve-from-here: contract change - a ticket's ASSIGNEE may resolve it, not only admins.
+  const [resolveFor, setResolveFor] = useState<Ticket | null>(null);
+  const [notes, setNotes] = useState("");
+  const [resolving, setResolving] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       setLoading(true);
       try {
-        const rows = await ticketService.listInstructor(
-          config.clientId,
-          status ? { status: status as TicketStatus } : undefined
-        );
+        const rows = await ticketService.listInstructor(config.clientId, {
+          ...(status ? { status: status as TicketStatus } : {}),
+          ...(category ? { category } : {}),
+        });
         if (!cancelled) setTickets(rows);
       } catch {
         if (!cancelled) setTickets([]);
@@ -61,12 +88,46 @@ export default function InstructorTicketsPage() {
     return () => {
       cancelled = true;
     };
-  }, [status]);
+  }, [status, category]);
 
   const counts = useMemo(() => {
     const open = tickets.filter((t) => t.status === "OPEN").length;
     return { total: tickets.length, open };
   }, [tickets]);
+
+  /**
+   * Whether THIS teacher owns the ticket. TicketUserMini carries both the profile id (`id`) and
+   * the User id (`user_id`), and the auth context's id space isn't guaranteed to be either, so
+   * match on both plus the email - a false negative only hides a convenience button.
+   */
+  const isAssignedToMe = useCallback(
+    (t: Ticket): boolean => {
+      const a = t.assigned_to_user;
+      if (!a || !user) return false;
+      if (a.id === user.id || a.user_id === user.id) return true;
+      return Boolean(a.email && user.email && a.email.toLowerCase() === user.email.toLowerCase());
+    },
+    [user],
+  );
+
+  const submitResolve = async () => {
+    if (!resolveFor || !notes.trim() || resolving) return;
+    setResolving(true);
+    try {
+      const updated = await ticketService.resolve(Number(config.clientId), resolveFor.id, {
+        admin_resolution_notes: notes.trim(),
+      });
+      setTickets((cur) => cur.map((t) => (t.id === updated.id ? updated : t)));
+      setResolveFor(null);
+      setNotes("");
+      showToast("Ticket resolved. The student has been notified.", "success");
+    } catch (err) {
+      // unwrapError already put the server's own reason in the message.
+      showToast(err instanceof Error ? err.message : "Couldn't resolve the ticket.", "error");
+    } finally {
+      setResolving(false);
+    }
+  };
 
   return (
     <PageShell>
@@ -78,7 +139,7 @@ export default function InstructorTicketsPage() {
       />
 
       <Reveal>
-        <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: "wrap", gap: 1 }}>
+        <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", gap: 1 }}>
           {FILTERS.map((f) => (
             <Chip
               key={f.key || "all"}
@@ -89,6 +150,37 @@ export default function InstructorTicketsPage() {
                 cursor: "pointer",
                 bgcolor: status === f.key ? "var(--primary-500)" : "var(--card-bg)",
                 color: status === f.key ? "#fff" : "var(--font-secondary)",
+                border: "1px solid var(--border-default)",
+              }}
+            />
+          ))}
+        </Stack>
+        {/* Category filter — passed straight through as ?category=; the backend still scopes what
+            a teacher may see (assigned to them: any category; their cohorts: teaching categories). */}
+        <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: "wrap", gap: 1 }}>
+          <Chip
+            label="All categories"
+            size="small"
+            onClick={() => setCategory("")}
+            sx={{
+              fontWeight: 700,
+              cursor: "pointer",
+              bgcolor: category === "" ? "var(--primary-500)" : "var(--card-bg)",
+              color: category === "" ? "#fff" : "var(--font-secondary)",
+              border: "1px solid var(--border-default)",
+            }}
+          />
+          {TICKET_CATEGORY_OPTIONS.map((c) => (
+            <Chip
+              key={c.value}
+              label={c.label}
+              size="small"
+              onClick={() => setCategory(category === c.value ? "" : c.value)}
+              sx={{
+                fontWeight: 700,
+                cursor: "pointer",
+                bgcolor: category === c.value ? "var(--primary-500)" : "var(--card-bg)",
+                color: category === c.value ? "#fff" : "var(--font-secondary)",
                 border: "1px solid var(--border-default)",
               }}
             />
@@ -164,21 +256,93 @@ export default function InstructorTicketsPage() {
                     </Box>
                   </Stack>
                   {/* Assigned vs unassigned is the triage signal a teacher scans for. */}
-                  {t.assigned_to_user && (
-                    <Typography
-                      sx={{ color: "var(--font-secondary)", fontSize: "0.72rem", mt: 0.6 }}
-                    >
-                      <Icon icon="mdi:account-check-outline" width={13} style={{ verticalAlign: -2 }} />{" "}
-                      {t.assigned_to_user.full_name}
-                      {t.assigned_by_user === null ? " (auto-routed)" : ""}
-                    </Typography>
-                  )}
+                  <Stack direction="row" alignItems="center" spacing={1} sx={{ mt: 0.6 }}>
+                    {t.assigned_to_user && (
+                      <Typography
+                        sx={{ color: "var(--font-secondary)", fontSize: "0.72rem", flex: 1, minWidth: 0 }}
+                      >
+                        <Icon icon="mdi:account-check-outline" width={13} style={{ verticalAlign: -2 }} />{" "}
+                        {t.assigned_to_user.full_name}
+                        {isAssignedToMe(t) ? " (you)" : ""}
+                        {t.assigned_by_user === null ? " (auto-routed)" : ""}
+                      </Typography>
+                    )}
+                    {/* The assignee may resolve their own ticket (not only admins) - offer it
+                        right here instead of sending the teacher hunting for an admin. */}
+                    {isAssignedToMe(t) && t.status !== "RESOLVED" && (
+                      <Chip
+                        size="small"
+                        label="Resolve"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setNotes(t.admin_resolution_notes || "");
+                          setResolveFor(t);
+                        }}
+                        sx={{
+                          fontWeight: 800,
+                          cursor: "pointer",
+                          ml: "auto",
+                          color: "#047857",
+                          bgcolor: "color-mix(in srgb,#10b981 14%,transparent)",
+                        }}
+                      />
+                    )}
+                  </Stack>
                 </Box>
               </Reveal>
             );
           })}
         </Stack>
       )}
+
+      {/* Assignee resolve dialog - a lighter sibling of the admin resolve form (that one is
+          inline in the admin detail page, not a reusable component). Notes are required; the
+          endpoint notifies the student on success. */}
+      <Dialog
+        open={Boolean(resolveFor)}
+        onClose={resolving ? undefined : () => setResolveFor(null)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle sx={{ fontWeight: 800 }}>
+          Resolve ticket{resolveFor ? ` · ${resolveFor.subject}` : ""}
+        </DialogTitle>
+        <DialogContent>
+          <Typography sx={{ color: "var(--font-secondary)", fontSize: "0.85rem", mb: 1.5 }}>
+            The student is notified by email and in-app with what you write here.
+          </Typography>
+          <TextField
+            label="Resolution notes *"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            multiline
+            rows={4}
+            fullWidth
+            placeholder="Explain how you resolved the doubt, and any follow-up steps."
+            disabled={resolving}
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            onClick={() => setResolveFor(null)}
+            disabled={resolving}
+            sx={{ textTransform: "none", fontWeight: 700 }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            onClick={() => void submitResolve()}
+            disabled={resolving || !notes.trim()}
+            startIcon={
+              resolving ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:check" width={16} />
+            }
+            sx={{ textTransform: "none", fontWeight: 800, borderRadius: 999, px: 2.5, bgcolor: "#047857", "&:hover": { bgcolor: "#065f46" } }}
+          >
+            {resolving ? "Resolving…" : "Resolve & notify"}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </PageShell>
   );
 }

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -241,6 +241,9 @@ export default function LiveSessionsPage() {
           ...s,
           // Keep the parent id for API calls (feedback, reminders) but make the key unique per date.
           occurrence_id: o.id,
+          // Per-date title where one exists (AI-titled after transcript sync, or admin-renamed);
+          // blank inherits the series title.
+          topic_name: o.topic_name || s.topic_name,
           class_datetime: o.occurrence_datetime ?? s.class_datetime,
           duration_minutes: o.duration_minutes ?? s.duration_minutes,
           // `live` has already excluded cancelled occurrences, but .filter() does not narrow the

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -49,6 +49,19 @@ function joinUrlOf(s: StudentLiveSession): string {
 function initials(name: string): string {
   return (name || "?").trim().slice(0, 2).toUpperCase();
 }
+/** Key for anything stored per CARD: expanded occurrences of one series share `s.id`, so state
+ *  keyed by id alone ticks every date of the series at once. `0` = the single-session case. */
+function prepKeyOf(s: StudentLiveSession): string {
+  return `${s.id}:${s.occurrence_id ?? 0}`;
+}
+/** The backend's ticks for THIS card: the per-occurrence list for an expanded instance (when the
+ *  backend sends the map), the series-level list otherwise. */
+function seededPrep(s: StudentLiveSession): number[] {
+  if (s.occurrence_id != null && s.my_prep_by_occurrence) {
+    return s.my_prep_by_occurrence[String(s.occurrence_id)] ?? [];
+  }
+  return s.my_prep ?? [];
+}
 function fmtDay(dt?: string | null, tz?: string | null) {
   if (!dt) return { d: "", mon: "", wd: "" };
   const x = new Date(dt);
@@ -151,7 +164,9 @@ export default function LiveSessionsPage() {
   const [tab, setTab] = useState<Tab>("upcoming");
   const [stats, setStats] = useState<MyLiveStats | null>(null);
   const [reminders, setReminders] = useState<Record<number, boolean>>({});
-  const [prep, setPrep] = useState<Record<number, number[]>>({});
+  // Keyed by prepKeyOf(s) (`id:occurrence`), NOT by id: a series' expanded dates each carry their
+  // own checklist, and an id-keyed map ticked all of them together.
+  const [prep, setPrep] = useState<Record<string, number[]>>({});
   const [toast, setToast] = useState<string | null>(null);
   const [feedbackFor, setFeedbackFor] = useState<StudentLiveSession | null>(null);
   const { enabled: communityEnabled } = useClientFeature(COMMUNITY_FEATURE);
@@ -166,15 +181,10 @@ export default function LiveSessionsPage() {
     mockInterviewService.listInterviews().then(setInterviews).catch(() => undefined);
   }, []);
   useEffect(() => {
-    // seed reminder + prep state from the payload
+    // seed reminder state from the payload (reminders stay series-level)
     setReminders((cur) => {
       const next = { ...cur };
       for (const s of sessions) if (next[s.id] === undefined) next[s.id] = Boolean(s.reminder_enabled);
-      return next;
-    });
-    setPrep((cur) => {
-      const next = { ...cur };
-      for (const s of sessions) if (next[s.id] === undefined) next[s.id] = s.my_prep ?? [];
       return next;
     });
   }, [sessions]);
@@ -242,11 +252,27 @@ export default function LiveSessionsPage() {
           has_recording: Boolean(o.has_recording || (inherits && s.has_recording)),
           zoom_recording_url:
             o.zoom_recording_url ?? (inherits ? s.zoom_recording_url : undefined),
+          // Same rule as the recording: the series-level summary is the series-LATEST one, so it
+          // may only surface on the occurrence that inherits the series artifacts — otherwise
+          // every date would advertise notes that belong to one sitting.
+          zoom_ai_summary: o.zoom_ai_summary ?? (inherits ? s.zoom_ai_summary : null),
         });
       });
     }
     return out;
   }, [sessions]);
+
+  useEffect(() => {
+    // Seed prep state per CARD (instance), so each date of a series keeps its own checklist.
+    setPrep((cur) => {
+      const next = { ...cur };
+      for (const s of instances) {
+        const k = prepKeyOf(s);
+        if (next[k] === undefined) next[k] = seededPrep(s);
+      }
+      return next;
+    });
+  }, [instances]);
 
   const live = useMemo(
     // A cancelled session must never drive the LIVE hero: the meeting still exists and is
@@ -344,15 +370,16 @@ export default function LiveSessionsPage() {
     }
   }, [reminders]);
   const togglePrep = useCallback(async (s: StudentLiveSession, index: number) => {
-    const current = prep[s.id] ?? s.my_prep ?? [];
+    const key = prepKeyOf(s);
+    const current = prep[key] ?? seededPrep(s);
     const done = !current.includes(index);
     const optimistic = done ? [...current, index].sort((a, b) => a - b) : current.filter((i) => i !== index);
-    setPrep((c) => ({ ...c, [s.id]: optimistic }));
+    setPrep((c) => ({ ...c, [key]: optimistic }));
     try {
-      const r = await studentLiveSessionsService.togglePrep(s.id, index, done);
-      setPrep((c) => ({ ...c, [s.id]: r.completed }));
+      const r = await studentLiveSessionsService.togglePrep(s.id, index, done, s.occurrence_id);
+      setPrep((c) => ({ ...c, [key]: r.completed }));
     } catch {
-      setPrep((c) => ({ ...c, [s.id]: current })); // revert
+      setPrep((c) => ({ ...c, [key]: current })); // revert
       setToast("Couldn't update your checklist.");
     }
   }, [prep]);
@@ -514,7 +541,7 @@ export default function LiveSessionsPage() {
                     {upcoming.map((s, i) => (
                       <UpcomingCard key={s.occurrence_id ?? s.id} s={s} isNext={i === 0}
                         reminderOn={reminders[s.id] ?? Boolean(s.reminder_enabled)}
-                        prepDone={prep[s.id] ?? s.my_prep ?? []}
+                        prepDone={prep[prepKeyOf(s)] ?? seededPrep(s)}
                         onAddCalendar={() => addToCalendar(s)} onRemind={() => toggleReminder(s)}
                         onTogglePrep={(idx) => togglePrep(s, idx)} />
                     ))}
@@ -555,8 +582,11 @@ export default function LiveSessionsPage() {
       <RecordingPlayerDialog open={Boolean(playerSession)} liveClassId={playerSession?.id ?? null}
         occurrenceId={playerSession?.occurrence_id ?? null}
         title={playerSession?.topic_name} onClose={() => setPlayerSession(null)} />
+      {/* Same occurrence rule as the recording player above: `id` is the series for every
+          expanded row, so the occurrence is what makes this show the clicked DATE's notes. */}
       {summarySession && (
-        <StudentSessionSummaryDialog activityId={summarySession.id} topicName={summarySession.topic_name || ""} open onClose={() => setSummarySession(null)} />
+        <StudentSessionSummaryDialog activityId={summarySession.id} occurrenceId={summarySession.occurrence_id ?? null}
+          topicName={summarySession.topic_name || ""} open onClose={() => setSummarySession(null)} />
       )}
 
       <LiveSessionFeedbackDialog

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -17,7 +17,7 @@ import { COMMUNITY_FEATURE, HIDE_PARTICIPANT_COUNTS, useClientFeature, useClient
 import { studentLiveSessionsService } from "@/lib/services/live-sessions";
 import type { StudentLiveSession, StudentLiveOccurrence, MyLiveStats } from "@/lib/services/live-sessions";
 import { formatSessionClock, formatSessionTime } from "@/lib/utils/session-time";
-import { ScheduleCalendar, type CalendarEvent } from "@/components/live-sessions/ScheduleCalendar";
+import { ScheduleCalendar, dayKey, type CalendarEvent } from "@/components/live-sessions/ScheduleCalendar";
 import { assessmentService, type Assessment } from "@/lib/services/assessment.service";
 import mockInterviewService, { type MockInterview } from "@/lib/services/mock-interview.service";
 
@@ -169,6 +169,8 @@ export default function LiveSessionsPage() {
   const [prep, setPrep] = useState<Record<string, number[]>>({});
   const [toast, setToast] = useState<string | null>(null);
   const [feedbackFor, setFeedbackFor] = useState<StudentLiveSession | null>(null);
+  // Calendar day filter (local YYYY-MM-DD from dayKey); null = show everything.
+  const [selectedDay, setSelectedDay] = useState<string | null>(null);
   const { enabled: communityEnabled } = useClientFeature(COMMUNITY_FEATURE);
   const hideCounts = useClientOptIn(HIDE_PARTICIPANT_COUNTS);
   // Extra calendar sources (best-effort — a failure just leaves those dots off the calendar).
@@ -303,13 +305,15 @@ export default function LiveSessionsPage() {
   }, [instances]);
 
   // Unified calendar feed: live sessions + assessment windows (start=assessment, end=deadline) +
-  // scheduled mock interviews.
+  // scheduled mock interviews. Built from the occurrence-expanded `instances`, not the raw
+  // sessions - a recurring series is one row whose class_datetime is frozen at occurrence #1, so
+  // feeding sessions gave the whole series a single dot on its first date and none on the rest.
   const calendarEvents = useMemo<CalendarEvent[]>(() => {
     const evs: CalendarEvent[] = [];
-    for (const s of sessions) {
+    for (const s of instances) {
       if (!s.class_datetime) continue;
       evs.push({
-        id: `live-${s.id}`,
+        id: `live-${s.id}-${s.occurrence_id ?? 0}`,
         date: s.class_datetime,
         title: s.topic_name || "Live session",
         type: "live",
@@ -325,7 +329,7 @@ export default function LiveSessionsPage() {
       if (iv.scheduled_date_time) evs.push({ id: `iv-${iv.id}`, date: iv.scheduled_date_time, title: iv.title || iv.topic || "Mock interview", type: "interview", subtitle: iv.topic });
     }
     return evs;
-  }, [sessions, assessments, interviews]);
+  }, [instances, assessments, interviews]);
 
   // While a session is live, poll Zoom for the CURRENT participant count (the stored
   // attendance_count only lands after the meeting ends — that's why it read '0 joined').
@@ -370,16 +374,35 @@ export default function LiveSessionsPage() {
   }, [liveId, liveKey, loadSessions]);
 
 
+  // Calendar day filter, applied to all three tabs (and therefore the tab counts).
+  const matchesSelectedDay = useCallback(
+    (s: StudentLiveSession) => {
+      if (!selectedDay) return true;
+      if (!s.class_datetime) return false;
+      const d = new Date(s.class_datetime);
+      return !isNaN(d.getTime()) && dayKey(d) === selectedDay;
+    },
+    [selectedDay],
+  );
+  const selectedDayLabel = useMemo(() => {
+    if (!selectedDay) return "";
+    const [y, m, d] = selectedDay.split("-").map(Number);
+    return new Date(y, m - 1, d).toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+  }, [selectedDay]);
+
   const upcoming = useMemo(
     // `s !== live` matters only for a clock-promoted hero (still "scheduled" in the payload):
     // a session shown as LIVE NOW must not also be listed as upcoming.
-    () => instances.filter((s) => s.meeting_status === "scheduled" && s !== live).sort((a, b) => (a.class_datetime || "").localeCompare(b.class_datetime || "")),
-    [instances, live],
+    () => instances.filter((s) => s.meeting_status === "scheduled" && s !== live && matchesSelectedDay(s)).sort((a, b) => (a.class_datetime || "").localeCompare(b.class_datetime || "")),
+    [instances, live, matchesSelectedDay],
   );
-  const recordings = useMemo(() => instances.filter((s) => s.has_recording), [instances]);
+  const recordings = useMemo(
+    () => instances.filter((s) => s.has_recording && matchesSelectedDay(s)),
+    [instances, matchesSelectedDay],
+  );
   const history = useMemo(
-    () => instances.filter((s) => PAST.has(s.meeting_status ?? "")).sort((a, b) => (b.class_datetime || "").localeCompare(a.class_datetime || "")),
-    [instances],
+    () => instances.filter((s) => PAST.has(s.meeting_status ?? "") && matchesSelectedDay(s)).sort((a, b) => (b.class_datetime || "").localeCompare(a.class_datetime || "")),
+    [instances, matchesSelectedDay],
   );
 
   const syncAll = useCallback(() => {
@@ -557,6 +580,27 @@ export default function LiveSessionsPage() {
           {/* Main grid */}
           <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 320px" }, gap: 2.5, alignItems: "start" }}>
             <Box>
+              {/* Calendar day filter chip - dismissible; clicking the same day on the calendar
+                  also clears it. */}
+              {selectedDay && (
+                <Stack direction="row" sx={{ mb: 1.5 }}>
+                  <Box
+                    onClick={() => setSelectedDay(null)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setSelectedDay(null); }}
+                    sx={{ display: "inline-flex", alignItems: "center", gap: 0.6, px: 1.5, py: 0.6, borderRadius: 999,
+                      cursor: "pointer", fontSize: "0.8rem", fontWeight: 700, color: "#6d28d9",
+                      bgcolor: "color-mix(in srgb,#8b5cf6 12%,transparent)",
+                      border: "1px solid color-mix(in srgb,#8b5cf6 30%,transparent)",
+                      "&:hover": { bgcolor: "color-mix(in srgb,#8b5cf6 18%,transparent)" } }}
+                  >
+                    <Icon icon="mdi:calendar-search" width={15} />
+                    Showing {selectedDayLabel}
+                    <Icon icon="mdi:close-circle" width={16} />
+                  </Box>
+                </Stack>
+              )}
               {/* Tabs */}
               <Stack direction="row" spacing={0.75} sx={{ mb: 2, flexWrap: "wrap", gap: 0.75 }}>
                 {TABS.map((tb) => {
@@ -608,7 +652,7 @@ export default function LiveSessionsPage() {
 
             {/* Right rail */}
             <Stack spacing={2.5}>
-              <ScheduleCalendar events={calendarEvents} />
+              <ScheduleCalendar events={calendarEvents} selectedKey={selectedDay} onSelectDay={setSelectedDay} />
               {stats && <AttendanceRail stats={stats} />}
             </Stack>
           </Box>

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
@@ -158,7 +158,7 @@ export default function LiveSessionsPage() {
   const {
     loadingClientInfo, hasLiveSessionsFeature, loading, sessions,
     watchingRecordingId, playerSession, setPlayerSession, summarySession, setSummarySession,
-    handleWatchRecording,
+    handleWatchRecording, loadSessions,
   } = useLiveSessions();
 
   const [tab, setTab] = useState<Tab>("upcoming");
@@ -310,6 +310,11 @@ export default function LiveSessionsPage() {
   // attendance_count only lands after the meeting ends — that's why it read '0 joined').
   const [liveJoined, setLiveJoined] = useState<number | null>(null);
   const liveId = live?.id;
+  // id:occurrence of the hero session - `id` alone can't tell two dates of one series apart.
+  const liveKey = live ? `${live.id}:${live.occurrence_id ?? 0}` : null;
+  // Which hero we already refreshed the list for after Zoom reported it over - the poll keeps
+  // returning live:false every 25s afterwards, and only the TRANSITION should refetch.
+  const endedRefreshedForRef = useRef<string | null>(null);
   useEffect(() => {
     if (!liveId) {
       setLiveJoined(null);
@@ -319,7 +324,18 @@ export default function LiveSessionsPage() {
     const poll = async () => {
       try {
         const r = await studentLiveSessionsService.getLiveCount(liveId);
-        if (!cancelled) setLiveJoined(r.live && r.count != null ? r.count : null);
+        if (cancelled) return;
+        setLiveJoined(r.live && r.count != null ? r.count : null);
+        if (r.live) {
+          // Back live (or live after a flap): a later end may refetch again.
+          endedRefreshedForRef.current = null;
+        } else if (endedRefreshedForRef.current !== liveKey) {
+          // Zoom says the meeting is over while the hero still shows LIVE. One silent list
+          // refresh so the hero clears as soon as the backend stamps the end, instead of
+          // lingering until the student reloads by hand.
+          endedRefreshedForRef.current = liveKey;
+          void loadSessions({ background: true });
+        }
       } catch {
         /* keep the attendance-count fallback */
       }
@@ -330,7 +346,7 @@ export default function LiveSessionsPage() {
       cancelled = true;
       clearInterval(timer);
     };
-  }, [liveId]);
+  }, [liveId, liveKey, loadSessions]);
 
 
   const upcoming = useMemo(

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -508,11 +508,10 @@ export default function LiveSessionsPage() {
 
           {/* KPI cards */}
           {stats && (
-            <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr 1fr", md: "repeat(4,1fr)" }, gap: 2, mb: 3 }}>
+            <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr 1fr", md: "repeat(3,1fr)" }, gap: 2, mb: 3 }}>
               <StatCard icon="mdi:check-circle-outline" tint="#7c3aed" value={stats.sessions_attended} label="Sessions attended" sub={`of ${stats.sessions_held} held`} />
               <StatCard icon="mdi:calendar-check-outline" tint="#10b981" value={`${stats.attendance_rate}%`} label="Attendance rate" sub={`cohort avg ${stats.cohort_avg_rate}%`} />
               <StatCard icon="mdi:clock-outline" tint="#ec4899" value={stats.live_hours} label="Live hours" sub="attended" />
-              <StatCard icon="mdi:play-circle-outline" tint="#f59e0b" value={stats.recordings_left} label="Recordings left" sub="to catch up" />
             </Box>
           )}
 

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -43,6 +43,36 @@ function providerOf(s: StudentLiveSession): { label: string; icon: string; color
 function courseOf(s: StudentLiveSession): string {
   return s.cohort_detail?.name || s.adaptive_course_detail?.title || s.course_detail?.title || "";
 }
+/** Course title only - for cards that already show the batch as its own chip, so the batch name
+ *  isn't printed twice. */
+function courseTextOf(s: StudentLiveSession): string {
+  return s.adaptive_course_detail?.title || s.course_detail?.title || "";
+}
+/** Stable per-batch accent so the same cohort always wears the same color across cards. */
+const COHORT_CHIP_COLORS = ["#6366f1", "#0ea5e9", "#f59e0b", "#10b981", "#ec4899", "#8b5cf6", "#14b8a6", "#f43f5e"];
+function cohortColorOf(id: number): string {
+  return COHORT_CHIP_COLORS[Math.abs(id) % COHORT_CHIP_COLORS.length];
+}
+/** The batch a session belongs to, as a prominent colored chip. Null-safe: renders nothing when
+ *  the session has no cohort (course-targeted sessions). */
+function CohortChip({ s, small }: { s: StudentLiveSession; small?: boolean }) {
+  const id = s.cohort_detail?.id;
+  const name = s.cohort_detail?.name;
+  if (id == null || !name) return null;
+  const c = cohortColorOf(id);
+  return (
+    <Box
+      title={name}
+      sx={{ display: "inline-flex", alignItems: "center", gap: 0.4, px: small ? 0.8 : 1, py: 0.2, borderRadius: 999,
+        fontSize: small ? "0.64rem" : "0.68rem", fontWeight: 800, color: c, flexShrink: 0,
+        bgcolor: `color-mix(in srgb, ${c} 13%, transparent)`,
+        border: `1px solid color-mix(in srgb, ${c} 30%, transparent)`, maxWidth: 170 }}
+    >
+      <Icon icon="mdi:account-group" width={small ? 11 : 12} style={{ flexShrink: 0 }} />
+      <Box component="span" sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{name}</Box>
+    </Box>
+  );
+}
 function joinUrlOf(s: StudentLiveSession): string {
   return (s.is_google_meet ? s.join_link : s.zoom_join_url) || s.join_link || "";
 }
@@ -171,6 +201,8 @@ export default function LiveSessionsPage() {
   const [feedbackFor, setFeedbackFor] = useState<StudentLiveSession | null>(null);
   // Calendar day filter (local YYYY-MM-DD from dayKey); null = show everything.
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  // Batch filter (cohort id); null = all batches. Only rendered when >= 2 batches exist.
+  const [batchFilter, setBatchFilter] = useState<number | null>(null);
   const { enabled: communityEnabled } = useClientFeature(COMMUNITY_FEATURE);
   const hideCounts = useClientOptIn(HIDE_PARTICIPANT_COUNTS);
   // Extra calendar sources (best-effort — a failure just leaves those dots off the calendar).
@@ -374,16 +406,28 @@ export default function LiveSessionsPage() {
   }, [liveId, liveKey, loadSessions]);
 
 
-  // Calendar day filter, applied to all three tabs (and therefore the tab counts).
+  // Calendar day + batch filters, applied to all three tabs (and therefore the tab counts).
   const matchesSelectedDay = useCallback(
     (s: StudentLiveSession) => {
+      if (batchFilter != null && s.cohort_detail?.id !== batchFilter) return false;
       if (!selectedDay) return true;
       if (!s.class_datetime) return false;
       const d = new Date(s.class_datetime);
       return !isNaN(d.getTime()) && dayKey(d) === selectedDay;
     },
-    [selectedDay],
+    [selectedDay, batchFilter],
   );
+  // The distinct batches across this student's sessions - a filter is only worth its pixels when
+  // there are at least two.
+  const batchOptions = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const s of sessions) {
+      const id = s.cohort_detail?.id;
+      const name = s.cohort_detail?.name;
+      if (id != null && name && !map.has(id)) map.set(id, name);
+    }
+    return Array.from(map, ([id, name]) => ({ id, name }));
+  }, [sessions]);
   const selectedDayLabel = useMemo(() => {
     if (!selectedDay) return "";
     const [y, m, d] = selectedDay.split("-").map(Number);
@@ -580,6 +624,45 @@ export default function LiveSessionsPage() {
           {/* Main grid */}
           <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 320px" }, gap: 2.5, alignItems: "start" }}>
             <Box>
+              {/* Batch filter - only when this student actually spans several batches. */}
+              {batchOptions.length >= 2 && (
+                <Stack direction="row" spacing={0.75} sx={{ mb: 1.5, flexWrap: "wrap", gap: 0.75, alignItems: "center" }}>
+                  <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "text.secondary" }}>BATCH</Typography>
+                  <Box
+                    onClick={() => setBatchFilter(null)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setBatchFilter(null); }}
+                    sx={{ px: 1.25, py: 0.4, borderRadius: 999, cursor: "pointer", fontSize: "0.74rem", fontWeight: 700,
+                      color: batchFilter === null ? "#fff" : "text.secondary",
+                      background: batchFilter === null ? "linear-gradient(135deg,#7c3aed,#a855f7)" : "var(--card-bg)",
+                      border: batchFilter === null ? "1px solid transparent" : "1px solid var(--border-default)" }}
+                  >
+                    All
+                  </Box>
+                  {batchOptions.map((b) => {
+                    const active = batchFilter === b.id;
+                    const c = cohortColorOf(b.id);
+                    return (
+                      <Box
+                        key={b.id}
+                        onClick={() => setBatchFilter(active ? null : b.id)}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setBatchFilter(active ? null : b.id); }}
+                        sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.25, py: 0.4, borderRadius: 999,
+                          cursor: "pointer", fontSize: "0.74rem", fontWeight: 700,
+                          color: active ? "#fff" : c,
+                          bgcolor: active ? c : `color-mix(in srgb, ${c} 12%, transparent)`,
+                          border: `1px solid color-mix(in srgb, ${c} ${active ? "100%" : "30%"}, transparent)` }}
+                      >
+                        <Box sx={{ width: 7, height: 7, borderRadius: "50%", bgcolor: active ? "#fff" : c }} />
+                        {b.name}
+                      </Box>
+                    );
+                  })}
+                </Stack>
+              )}
               {/* Calendar day filter chip - dismissible; clicking the same day on the calendar
                   also clears it. */}
               {selectedDay && (
@@ -823,6 +906,7 @@ function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind
   const doneCount = prepItems.filter((_, i) => prepDone.includes(i)).length;
   const countdown = useCountdown(isNext ? s.class_datetime : null);
   const recurring = Boolean(s.zoom_is_recurring && (s.occurrences?.length ?? 0) > 0);
+  const courseText = s.cohort_detail?.name ? courseTextOf(s) : courseOf(s);
   const [open, setOpen] = useState(false);
 
   return (
@@ -840,13 +924,15 @@ function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind
           <Stack direction="row" spacing={0.75} alignItems="center" sx={{ mb: 0.5, flexWrap: "wrap", gap: 0.5 }}>
             <Box sx={{ px: 0.9, py: 0.2, borderRadius: 999, bgcolor: "color-mix(in srgb,#8b5cf6 14%,transparent)", color: "#6d28d9", fontSize: "0.66rem", fontWeight: 800 }}>Scheduled</Box>
             <Stack direction="row" spacing={0.35} alignItems="center" sx={{ color: p.color }}><Icon icon={p.icon} width={14} /><Typography sx={{ fontSize: "0.72rem", fontWeight: 700 }}>{p.label}</Typography></Stack>
+            <CohortChip s={s} />
             <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>{formatSessionClock(s.class_datetime, s.timezone)} · {s.duration_minutes || 0}m</Typography>
             {recurring && <Box sx={{ px: 0.8, py: 0.2, borderRadius: 999, bgcolor: "color-mix(in srgb,#6366f1 12%,transparent)", color: "#4f46e5", fontSize: "0.64rem", fontWeight: 800 }}>Recurring</Box>}
           </Stack>
           <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.2 }}>{s.topic_name}</Typography>
           <Stack direction="row" spacing={1.25} alignItems="center" sx={{ mt: 0.4, color: "text.secondary", flexWrap: "wrap", gap: 0.5 }}>
             {s.instructor && <Stack direction="row" spacing={0.4} alignItems="center"><Icon icon="mdi:account-outline" width={13} /><Typography sx={{ fontSize: "0.8rem" }}>{s.instructor}</Typography></Stack>}
-            {courseOf(s) && <Stack direction="row" spacing={0.4} alignItems="center"><Icon icon="mdi:bookmark-outline" width={13} /><Typography sx={{ fontSize: "0.8rem" }} noWrap>{courseOf(s)}</Typography></Stack>}
+            {/* The batch already has its chip above, so this line is course-only when one exists. */}
+            {courseText && <Stack direction="row" spacing={0.4} alignItems="center"><Icon icon="mdi:bookmark-outline" width={13} /><Typography sx={{ fontSize: "0.8rem" }} noWrap>{courseText}</Typography></Stack>}
           </Stack>
           {recurring && (
             <Box sx={{ mt: 1 }}>
@@ -928,8 +1014,13 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
     <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 2, display: "flex", gap: 1.75, alignItems: "center", flexWrap: "wrap" }}>
       <DateBadge dt={s.class_datetime} tz={s.timezone} />
       <Box sx={{ flex: 1, minWidth: 180 }}>
-        <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{s.topic_name}</Typography>
-        <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>{courseOf(s) || "Recording available"}</Typography>
+        <Stack direction="row" spacing={0.75} alignItems="center" sx={{ minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{s.topic_name}</Typography>
+          <CohortChip s={s} small />
+        </Stack>
+        <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>
+          {(s.cohort_detail?.name ? courseTextOf(s) : courseOf(s)) || "Recording available"}
+        </Typography>
       </Box>
       <Stack direction="row" spacing={1}>
         {hasSummary && (
@@ -950,6 +1041,8 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
 
 function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedback?: () => void }) {
   const attended = Boolean(s.my_attendance?.attended);
+  // The batch gets its own chip, so the text line is course-only when a batch exists.
+  const courseText = s.cohort_detail?.name ? courseTextOf(s) : courseOf(s);
   return (
     <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 1.75 }}>
     <Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
@@ -958,9 +1051,10 @@ function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedba
         <Typography sx={{ fontWeight: 700, fontSize: "0.92rem" }} noWrap>{s.topic_name}</Typography>
         <Typography sx={{ fontSize: "0.78rem", color: "text.secondary" }}>
           {s.class_datetime ? formatSessionTime(s.class_datetime, s.timezone, { format: { month: "short", day: "numeric" }, dual: false, showZone: false }) : ""}
-          {courseOf(s) ? ` · ${courseOf(s)}` : ""}
+          {courseText ? ` · ${courseText}` : ""}
         </Typography>
       </Box>
+      <CohortChip s={s} small />
       <Box sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.68rem", fontWeight: 800,
         color: attended ? "#059669" : "#64748b", bgcolor: attended ? "color-mix(in srgb,#10b981 12%,transparent)" : "color-mix(in srgb,#64748b 12%,transparent)" }}>
         {attended ? "Attended" : "Missed"}

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -274,12 +274,30 @@ export default function LiveSessionsPage() {
     });
   }, [instances]);
 
-  const live = useMemo(
+  const live = useMemo(() => {
     // A cancelled session must never drive the LIVE hero: the meeting still exists and is
     // joinable, so without this the student is offered "Join now" for a class that is off.
-    () => instances.find((s) => s.meeting_status === "live" && s.notice_type !== "cancelled"),
-    [instances],
-  );
+    const reallyLive = instances.find((s) => s.meeting_status === "live" && s.notice_type !== "cancelled");
+    if (reallyLive) return reallyLive;
+    // Belt and braces: the wall clock is inside a session's window but this snapshot of the list
+    // still says "scheduled" (it was fetched before the flip). Promote it to the hero so Join
+    // appears without waiting for the next refresh - but ONLY where the join gate already allows
+    // joining (ungated, or the host has started). A gated session whose trainer hasn't opened the
+    // room stays out: the gate remains authoritative, the refetch handles that case.
+    // Deliberate clock snapshot: this re-evaluates on every (self-)refresh of the list, and the
+    // hook's boundary timer lands one just after each start, so a stale `now` only delays
+    // promotion until that reload.
+    // eslint-disable-next-line react-hooks/purity -- see above
+    const now = Date.now();
+    return instances.find((s) => {
+      if (s.meeting_status !== "scheduled" || s.notice_type === "cancelled") return false;
+      if (s.join_gated && !s.host_started) return false;
+      if (!s.class_datetime) return false;
+      const start = new Date(s.class_datetime).getTime();
+      if (Number.isNaN(start)) return false;
+      return start <= now && now <= start + (s.duration_minutes || 60) * 60_000;
+    });
+  }, [instances]);
 
   // Unified calendar feed: live sessions + assessment windows (start=assessment, end=deadline) +
   // scheduled mock interviews.
@@ -350,8 +368,10 @@ export default function LiveSessionsPage() {
 
 
   const upcoming = useMemo(
-    () => instances.filter((s) => s.meeting_status === "scheduled").sort((a, b) => (a.class_datetime || "").localeCompare(b.class_datetime || "")),
-    [instances],
+    // `s !== live` matters only for a clock-promoted hero (still "scheduled" in the payload):
+    // a session shown as LIVE NOW must not also be listed as upcoming.
+    () => instances.filter((s) => s.meeting_status === "scheduled" && s !== live).sort((a, b) => (a.class_datetime || "").localeCompare(b.class_datetime || "")),
+    [instances, live],
   );
   const recordings = useMemo(() => instances.filter((s) => s.has_recording), [instances]);
   const history = useMemo(

--- a/components/admin/live-sessions/AssignParticipantDialog.tsx
+++ b/components/admin/live-sessions/AssignParticipantDialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useToast } from "@/components/common/Toast";
+import {
+  adminLiveActivitiesService,
+  RosterStudent,
+  UnmatchedParticipant,
+} from "@/lib/services/admin/admin-live-activities.service";
+import { formatDurationSeconds } from "@/lib/utils/date-utils";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+
+interface Props {
+  liveClassId: number;
+  /** The unmatched Zoom row being attached. Must carry participant_id (guarded by the caller). */
+  participant: UnmatchedParticipant;
+  /** The roster students already in the payload - the only people this row may be attached to. */
+  students: RosterStudent[];
+  /** One sitting of a recurring series; omit for a single session. */
+  occurrenceId?: number | null;
+  onClose: () => void;
+  /** Called after a successful identify so the caller can refresh its payload. */
+  onDone: () => void | Promise<void>;
+}
+
+/**
+ * Attach an unmatched Zoom participant ("Rahul's iPad", a personal-account name) to a roster
+ * student via the identify endpoint. The student keeps the REAL Zoom duration - unlike a manual
+ * present-mark - and the backend records a name alias so the same display name auto-matches next
+ * week instead of landing back in this list.
+ */
+export function AssignParticipantDialog({ liveClassId, participant, students, occurrenceId, onClose, onDone }: Props) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [studentId, setStudentId] = useState<number | "">("");
+  const [saving, setSaving] = useState(false);
+
+  const submit = async () => {
+    if (studentId === "" || saving || participant.participant_id == null) return;
+    try {
+      setSaving(true);
+      await adminLiveActivitiesService.identifyParticipant(liveClassId, {
+        participant_id: participant.participant_id,
+        student_id: studentId,
+        ...(occurrenceId ? { occurrence_id: occurrenceId } : {}),
+      });
+      const student = students.find((s) => s.user_profile_id === studentId);
+      showToast(
+        t(
+          "adminLiveSessions.participantIdentified",
+          "Attendance recorded for {{name}}. This Zoom name will auto-match next time.",
+          { name: student?.name || "the student" }
+        ),
+        "success"
+      );
+      await onDone();
+      onClose();
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, t("adminLiveSessions.identifyFailed", "Couldn't assign this participant.")), "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
+      <DialogTitle sx={{ fontWeight: 700, fontSize: "1.02rem", color: "var(--font-primary)" }}>
+        {t("adminLiveSessions.assignToStudent", "Assign to student")}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+            <strong>{participant.name || t("adminLiveSessions.noName", "(no name)")}</strong>
+            {" · "}
+            {formatDurationSeconds(participant.duration_seconds)}
+            {participant.email ? ` · ${participant.email}` : ""}
+          </Typography>
+          <TextField
+            select
+            label={t("adminLiveSessions.student", "Student")}
+            value={studentId === "" ? "" : String(studentId)}
+            onChange={(e) => setStudentId(e.target.value === "" ? "" : Number(e.target.value))}
+            fullWidth
+            size="small"
+            helperText={t(
+              "adminLiveSessions.identifyHelp",
+              "They keep the real Zoom duration, and this name auto-matches to them next session."
+            )}
+          >
+            {students.map((s) => (
+              <MenuItem key={s.user_profile_id} value={String(s.user_profile_id)}>
+                {s.name || s.email}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={saving} sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}>
+          {t("adminLiveSessions.cancel", "Cancel")}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void submit()}
+          disabled={studentId === "" || saving}
+          sx={{
+            borderRadius: "12px",
+            textTransform: "none",
+            fontWeight: 700,
+            background: "var(--accent-indigo)",
+            color: "#fff",
+            "&:hover": { background: "var(--accent-indigo-dark)" },
+          }}
+        >
+          {saving ? <CircularProgress size={20} color="inherit" /> : t("adminLiveSessions.assign", "Assign")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/live-sessions/EditSessionDialog.tsx
+++ b/components/admin/live-sessions/EditSessionDialog.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useTenantTimezone } from "@/lib/hooks/useTenantTimezone";
+import {
+  Box,
+  Typography,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  MenuItem,
+  IconButton,
+  CircularProgress,
+} from "@mui/material";
+import { IconWrapper } from "@/components/common/IconWrapper";
+import { useToast } from "@/components/common/Toast";
+import { LiveActivity } from "@/lib/services/admin/admin-live-activities.service";
+import { liveClassService, UpdateLiveClassSessionPayload } from "@/lib/services/live-class.service";
+import { instructorService } from "@/lib/services/instructor.service";
+import { adminCohortsService } from "@/lib/services/admin/admin-cohorts.service";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+import { InfoCallout } from "@/components/live-sessions/ui/LiveSessionUI";
+import { timezoneOptions, toLocalInputInZone } from "@/lib/utils/session-time";
+
+interface Props {
+  activity: LiveActivity;
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+/** The serializer sends `instructor` as an id or a nested object depending on the endpoint. */
+function currentInstructorId(a: LiveActivity): number | null {
+  const ins = a.instructor;
+  if (typeof ins === "number") return ins;
+  if (ins && typeof ins === "object" && "id" in ins && typeof (ins as { id: unknown }).id === "number") {
+    return (ins as { id: number }).id;
+  }
+  return null;
+}
+
+/**
+ * Edit the platform session itself - topic, schedule, duration, trainer, cohort - for EVERY
+ * provider and state. Before this dialog only webinars-while-scheduled had an Edit at all; a
+ * plain Zoom meeting or a Meet session could only be deleted and recreated. PATCHes the
+ * sessions/<id>/update/ endpoint, which mirrors schedule changes to the provider server-side.
+ */
+export function EditSessionDialog({ activity, open, onClose, onSaved }: Props) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const tenantTz = useTenantTimezone();
+
+  const [topic, setTopic] = useState("");
+  const [datetime, setDatetime] = useState("");
+  const [sessionTz, setSessionTz] = useState("");
+  const [duration, setDuration] = useState(60);
+  const [instructorSel, setInstructorSel] = useState<number | "">("");
+  const [cohortSel, setCohortSel] = useState<number | "">("");
+  const [saving, setSaving] = useState(false);
+
+  const [instructors, setInstructors] = useState<{ profile_id: number; name: string; email: string }[]>([]);
+  // The directory endpoint is admin-only and can fail independently of this page - fall back to
+  // the same raw numeric field the create page uses rather than losing the ability to assign.
+  const [directoryFailed, setDirectoryFailed] = useState(false);
+  const [cohorts, setCohorts] = useState<{ id: number; name: string }[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    const tz = activity.timezone || tenantTz;
+    setTopic(activity.topic_name ?? "");
+    setSessionTz(tz);
+    // Show the wall-clock in the session's OWN zone so editing from another zone doesn't shift it.
+    setDatetime(toLocalInputInZone(activity.class_datetime, tz));
+    setDuration(activity.duration_minutes ?? 60);
+    setInstructorSel(currentInstructorId(activity) ?? "");
+    setCohortSel(activity.cohort ?? activity.cohort_detail?.id ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- prefill on open only
+  }, [open, activity]);
+
+  useEffect(() => {
+    if (!open) return;
+    instructorService
+      .getInstructorDirectory()
+      .then((rows) => {
+        setInstructors(rows.map((r) => ({ profile_id: r.profile_id, name: r.name, email: r.email })));
+        setDirectoryFailed(false);
+      })
+      .catch(() => setDirectoryFailed(true));
+    adminCohortsService
+      .listCohorts()
+      .then((list) => setCohorts(list.map((c) => ({ id: c.id, name: c.name }))))
+      .catch(() => undefined);
+  }, [open]);
+
+  const initialInstructorId = currentInstructorId(activity);
+  const initialCohortId = activity.cohort ?? activity.cohort_detail?.id ?? "";
+  const valid = topic.trim().length >= 2 && Boolean(datetime) && duration >= 1 && duration <= 480;
+
+  const handleSave = async () => {
+    if (!valid || saving) return;
+    const payload: UpdateLiveClassSessionPayload = {
+      topic_name: topic.trim(),
+      // Naive wall-clock + the zone it's in; the backend converts (contract of sessions/update/).
+      class_datetime: datetime,
+      ...(sessionTz ? { timezone: sessionTz } : {}),
+      duration_minutes: duration,
+    };
+    if (instructorSel === "" && initialInstructorId != null) {
+      payload.instructor_id = ""; // explicit clear, distinct from "not sent"
+    } else if (typeof instructorSel === "number" && instructorSel !== initialInstructorId) {
+      payload.instructor_id = instructorSel;
+    }
+    if (cohortSel !== initialCohortId) {
+      payload.cohort = cohortSel === "" ? null : cohortSel;
+    }
+    try {
+      setSaving(true);
+      await liveClassService.updateSession(activity.id, payload);
+      showToast(t("adminLiveSessions.sessionUpdated", "Session updated."), "success");
+      onSaved();
+      onClose();
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, t("adminLiveSessions.sessionUpdateFailed", "Couldn't update the session.")), "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Keep a vanished trainer selectable: the current assignee may not be in the directory (role
+  // changed, endpoint filtered) and the Select would otherwise silently render as "No trainer".
+  const showSyntheticCurrent =
+    initialInstructorId != null && !instructors.some((i) => i.profile_id === initialInstructorId);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={saving ? undefined : onClose}
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
+      <DialogTitle>
+        <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "1.05rem", color: "var(--font-primary)" }}>
+            {t("adminLiveSessions.editSession", "Edit session")}
+          </Typography>
+          <IconButton onClick={onClose} size="small" sx={{ color: "var(--font-secondary)" }}>
+            <IconWrapper icon="mdi:close" size={20} />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          {activity.zoom_is_recurring && (
+            <InfoCallout icon="mdi:calendar-multiselect">
+              {t(
+                "adminLiveSessions.editSessionRecurringHint",
+                "This is a recurring series - changing the schedule here moves the WHOLE series. To move, rename or cancel a single date, use the Timeline tab."
+              )}
+            </InfoCallout>
+          )}
+          <TextField
+            label={t("adminLiveSessions.topicName", "Topic")}
+            value={topic}
+            onChange={(e) => setTopic(e.target.value)}
+            fullWidth
+            size="small"
+          />
+          <TextField
+            label={t("adminLiveSessions.classDateAndTime", "Date and time")}
+            type="datetime-local"
+            value={datetime}
+            onChange={(e) => setDatetime(e.target.value)}
+            fullWidth
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            helperText={t("adminLiveSessions.timeInSelectedZone", "The wall-clock time, in the timezone below")}
+          />
+          <TextField
+            select
+            label={t("adminLiveSessions.timezone", "Timezone")}
+            value={sessionTz}
+            onChange={(e) => setSessionTz(e.target.value)}
+            fullWidth
+            size="small"
+          >
+            {timezoneOptions(sessionTz).map((z) => (
+              <MenuItem key={z.value} value={z.value}>{z.label}</MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label={t("adminLiveSessions.durationMinutes", "Duration (minutes)")}
+            type="number"
+            value={duration}
+            onChange={(e) => setDuration(Math.min(480, Math.max(1, Number(e.target.value) || 60)))}
+            fullWidth
+            size="small"
+            inputProps={{ min: 1, max: 480 }}
+          />
+          {directoryFailed ? (
+            <TextField
+              label={t("adminLiveSessions.instructorIdOptional", "Instructor ID (optional)")}
+              value={instructorSel === "" ? "" : String(instructorSel)}
+              onChange={(e) => {
+                const n = parseInt(e.target.value, 10);
+                setInstructorSel(Number.isNaN(n) || n < 1 ? "" : n);
+              }}
+              fullWidth
+              size="small"
+              helperText={t("adminLiveSessions.instructorDirectoryUnavailable", "Couldn't load the trainer list - enter the profile id directly, or leave blank for none.")}
+            />
+          ) : (
+            <TextField
+              select
+              label={t("adminLiveSessions.trainer", "Trainer")}
+              value={instructorSel === "" ? "" : String(instructorSel)}
+              onChange={(e) => setInstructorSel(e.target.value === "" ? "" : Number(e.target.value))}
+              fullWidth
+              size="small"
+              helperText={t("adminLiveSessions.trainerHelp", "Shown to students by their trainer code.")}
+            >
+              <MenuItem value="">{t("adminLiveSessions.noTrainer", "No trainer")}</MenuItem>
+              {showSyntheticCurrent && (
+                <MenuItem value={String(initialInstructorId)}>
+                  {t("adminLiveSessions.currentTrainer", "Current trainer")} (#{initialInstructorId})
+                </MenuItem>
+              )}
+              {instructors.map((i) => (
+                <MenuItem key={i.profile_id} value={String(i.profile_id)}>
+                  {i.name || i.email}{i.name && i.email ? ` · ${i.email}` : ""}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+          <TextField
+            select
+            label={t("adminLiveSessions.cohort", "Cohort")}
+            value={cohortSel === "" ? "" : String(cohortSel)}
+            onChange={(e) => setCohortSel(e.target.value === "" ? "" : Number(e.target.value))}
+            fullWidth
+            size="small"
+          >
+            <MenuItem value="">{t("adminLiveSessions.noCohort", "No cohort")}</MenuItem>
+            {cohorts.map((c) => (
+              <MenuItem key={c.id} value={String(c.id)}>{c.name}</MenuItem>
+            ))}
+          </TextField>
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button
+          onClick={onClose}
+          disabled={saving}
+          sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}
+        >
+          {t("adminLiveSessions.cancel", "Cancel")}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={!valid || saving}
+          sx={{
+            borderRadius: "12px",
+            textTransform: "none",
+            fontWeight: 700,
+            background: "var(--accent-indigo)",
+            color: "#fff",
+            "&:hover": { background: "var(--accent-indigo-dark)" },
+          }}
+        >
+          {saving ? <CircularProgress size={20} color="inherit" /> : t("adminLiveSessions.save", "Save")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -9,6 +9,11 @@ import {
   Button,
   Collapse,
   CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
   Table,
   TableBody,
   TableCell,
@@ -18,14 +23,17 @@ import {
   Paper,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { MeetingStatusChip } from "@/components/live-sessions/ui/LiveSessionUI";
 import {
   adminLiveActivitiesService,
   OccurrenceTimelineResponse,
+  TimelineOccurrence,
   RosterStudent,
 } from "@/lib/services/admin/admin-live-activities.service";
 import { formatDurationSeconds } from "@/lib/utils/date-utils";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
+import { toLocalInputInZone } from "@/lib/utils/session-time";
 import { useToast } from "@/components/common/Toast";
 
 function fmtDate(s: string | null) {
@@ -52,7 +60,13 @@ function studentStatus(s: RosterStudent, occStatus: string, t: (k: string, d: st
 
 interface Props {
   liveClassId: number;
+  /** Series title, the fallback when a date has no per-date topic_name of its own. */
+  seriesTitle?: string;
+  /** The series' scheduling zone - reschedules are entered and sent in this zone. */
+  timezone?: string | null;
   onOpenRecording?: (url: string) => void;
+  /** Called after a date was renamed/rescheduled/cancelled, so the parent can refresh. */
+  onChanged?: () => void;
 }
 
 /**
@@ -60,13 +74,16 @@ interface Props {
  * specific date (per-occurrence roster) vs missed, and whether its own recording / transcript is
  * ready. Renders nothing for a single (non-recurring) session - the series roster covers those.
  */
-export function LiveSessionOccurrenceTimeline({ liveClassId, onOpenRecording }: Props) {
+export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezone, onOpenRecording, onChanged }: Props) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [data, setData] = useState<OccurrenceTimelineResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [openId, setOpenId] = useState<number | null>(null);
   const [syncingId, setSyncingId] = useState<number | null>(null);
+  const [editing, setEditing] = useState<{ occ: TimelineOccurrence; mode: "rename" | "reschedule" } | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<TimelineOccurrence | null>(null);
+  const [cancelling, setCancelling] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -95,6 +112,29 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, onOpenRecording }: 
       showToast(getAxiosErrorDetail(e, "Couldn't sync attendance for this session."), "error");
     } finally {
       setSyncingId(null);
+    }
+  };
+
+  const cancelOne = async () => {
+    if (!cancelTarget) return;
+    try {
+      setCancelling(true);
+      const res = await adminLiveActivitiesService.cancelOccurrence(liveClassId, cancelTarget.id);
+      const warnings = res.data?.warnings ?? [];
+      showToast(
+        warnings.length
+          ? `${t("adminLiveSessions.occurrenceCancelled", "This date was cancelled.")} ${warnings.join(" ")}`
+          : t("adminLiveSessions.occurrenceCancelled", "This date was cancelled."),
+        warnings.length ? "warning" : "success"
+      );
+      setCancelTarget(null);
+      await load();
+      onChanged?.();
+    } catch (e) {
+      // 409 = "can't be edited safely", 502 = Zoom refused; both carry their reason in the body.
+      showToast(getAxiosErrorDetail(e, t("adminLiveSessions.occurrenceCancelFailed", "Couldn't cancel this date.")), "error");
+    } finally {
+      setCancelling(false);
     }
   };
 
@@ -187,6 +227,21 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, onOpenRecording }: 
                   <Typography sx={{ fontWeight: 700, fontSize: "0.82rem", color: "var(--font-primary)" }}>
                     {fmtDate(occ.date)}
                   </Typography>
+                  {/* Per-date title (AI-titled after transcript sync, or renamed by an admin);
+                      blank inherits the series title. */}
+                  {(occ.topic_name || seriesTitle) && (
+                    <Typography
+                      noWrap
+                      sx={{
+                        fontWeight: 600,
+                        fontSize: "0.78rem",
+                        maxWidth: 280,
+                        color: occ.topic_name ? "var(--font-primary)" : "var(--font-secondary)",
+                      }}
+                    >
+                      {occ.topic_name || seriesTitle}
+                    </Typography>
+                  )}
                   <MeetingStatusChip status={occ.status} />
                   <Box sx={{ flex: 1 }} />
                   <Chip
@@ -285,6 +340,39 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, onOpenRecording }: 
                     )}
 
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mt: 1.25, flexWrap: "wrap" }}>
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => setEditing({ occ, mode: "rename" })}
+                        startIcon={<IconWrapper icon="mdi:form-textbox" size={15} />}
+                        sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700, borderRadius: 999 }}
+                      >
+                        {t("adminLiveSessions.renameOccurrence", "Rename")}
+                      </Button>
+                      {/* Moving or cancelling only makes sense for a date that hasn't happened. */}
+                      {occ.status === "scheduled" && (
+                        <>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            onClick={() => setEditing({ occ, mode: "reschedule" })}
+                            startIcon={<IconWrapper icon="mdi:calendar-clock" size={15} />}
+                            sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700, borderRadius: 999 }}
+                          >
+                            {t("adminLiveSessions.rescheduleOccurrence", "Reschedule")}
+                          </Button>
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="error"
+                            onClick={() => setCancelTarget(occ)}
+                            startIcon={<IconWrapper icon="mdi:calendar-remove" size={15} />}
+                            sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700, borderRadius: 999 }}
+                          >
+                            {t("adminLiveSessions.cancelOccurrence", "Cancel this date")}
+                          </Button>
+                        </>
+                      )}
                       {ended && (
                         <Button
                           size="small"
@@ -331,6 +419,185 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, onOpenRecording }: 
       <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontStyle: "italic", display: "block", mt: 1.5 }}>
         {data.reliability_note}
       </Typography>
+
+      {editing && (
+        <EditOccurrenceDialog
+          liveClassId={liveClassId}
+          occ={editing.occ}
+          mode={editing.mode}
+          seriesTitle={seriesTitle}
+          timezone={timezone}
+          onClose={() => setEditing(null)}
+          onSaved={async () => {
+            setEditing(null);
+            await load();
+            onChanged?.();
+          }}
+        />
+      )}
+
+      <ConfirmDialog
+        open={Boolean(cancelTarget)}
+        title={t("adminLiveSessions.cancelOccurrenceTitle", "Cancel this date?")}
+        message={t(
+          "adminLiveSessions.cancelOccurrenceDesc",
+          "Only this date is cancelled - the series and its other dates stay. Zoom is updated and students stop seeing this sitting. This can't be undone."
+        )}
+        confirmText={cancelling ? t("adminLiveSessions.cancelling", "Cancelling…") : t("adminLiveSessions.cancelOccurrence", "Cancel this date")}
+        cancelText={t("adminLiveSessions.keepIt", "Keep it")}
+        confirmColor="error"
+        onConfirm={() => void cancelOne()}
+        onCancel={() => setCancelTarget(null)}
+      />
     </Box>
+  );
+}
+
+/**
+ * Edit ONE date of a recurring series. Two modes so each action stays a one-field decision:
+ * "rename" edits the per-date title (blank inherits the series title), "reschedule" moves the
+ * date and/or its duration. Time is entered as a wall-clock in the SERIES' own zone and sent
+ * naive+timezone, matching the sessions/update contract.
+ */
+function EditOccurrenceDialog({ liveClassId, occ, mode, seriesTitle, timezone, onClose, onSaved }: {
+  liveClassId: number;
+  occ: TimelineOccurrence;
+  mode: "rename" | "reschedule";
+  seriesTitle?: string;
+  timezone?: string | null;
+  onClose: () => void;
+  onSaved: () => void | Promise<void>;
+}) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [topic, setTopic] = useState(occ.topic_name ?? "");
+  const [datetime, setDatetime] = useState(() => (occ.date ? toLocalInputInZone(occ.date, timezone || undefined) : ""));
+  const [duration, setDuration] = useState(occ.duration_minutes || 60);
+  const [saving, setSaving] = useState(false);
+
+  const rename = mode === "rename";
+  const valid = rename ? true : Boolean(datetime) && duration >= 1 && duration <= 480;
+
+  const handleSave = async () => {
+    if (!valid || saving) return;
+    try {
+      setSaving(true);
+      await adminLiveActivitiesService.updateOccurrence(
+        liveClassId,
+        occ.id,
+        rename
+          ? { topic_name: topic.trim() } // "" clears the override back to the series title
+          : {
+              occurrence_datetime: datetime,
+              ...(timezone ? { timezone } : {}),
+              duration_minutes: duration,
+            }
+      );
+      showToast(
+        rename
+          ? t("adminLiveSessions.occurrenceRenamed", "Date renamed.")
+          : t("adminLiveSessions.occurrenceRescheduled", "Date rescheduled."),
+        "success"
+      );
+      await onSaved();
+    } catch (e) {
+      // 502 carries Zoom's own refusal, 409 the safety reason - show the server's words.
+      showToast(
+        getAxiosErrorDetail(
+          e,
+          rename
+            ? t("adminLiveSessions.occurrenceRenameFailed", "Couldn't rename this date.")
+            : t("adminLiveSessions.occurrenceRescheduleFailed", "Couldn't reschedule this date.")
+        ),
+        "error"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onClose={saving ? undefined : onClose}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: "18px",
+          border: "1px solid var(--border-default)",
+          backgroundColor: "var(--card-bg)",
+          backgroundImage: "none",
+        },
+      }}
+    >
+      <DialogTitle sx={{ fontWeight: 700, fontSize: "1.02rem", color: "var(--font-primary)" }}>
+        {rename
+          ? t("adminLiveSessions.renameOccurrenceTitle", "Rename this date")
+          : t("adminLiveSessions.rescheduleOccurrenceTitle", "Reschedule this date")}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
+          <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+            {fmtDate(occ.date)}
+          </Typography>
+          {rename ? (
+            <TextField
+              label={t("adminLiveSessions.occurrenceTopic", "Title for this date")}
+              value={topic}
+              onChange={(e) => setTopic(e.target.value)}
+              placeholder={seriesTitle}
+              fullWidth
+              size="small"
+              helperText={t("adminLiveSessions.occurrenceTopicHelp", "Leave blank to use the series title.")}
+            />
+          ) : (
+            <>
+              <TextField
+                label={t("adminLiveSessions.classDateAndTime", "Date and time")}
+                type="datetime-local"
+                value={datetime}
+                onChange={(e) => setDatetime(e.target.value)}
+                fullWidth
+                size="small"
+                InputLabelProps={{ shrink: true }}
+                helperText={t("adminLiveSessions.occurrenceTimeInZone", "Wall-clock time in {{zone}}. Zoom and students are updated.", {
+                  zone: timezone || t("adminLiveSessions.theSessionZone", "the session's timezone"),
+                })}
+              />
+              <TextField
+                label={t("adminLiveSessions.durationMinutes", "Duration (minutes)")}
+                type="number"
+                value={duration}
+                onChange={(e) => setDuration(Math.min(480, Math.max(1, Number(e.target.value) || 60)))}
+                fullWidth
+                size="small"
+                inputProps={{ min: 1, max: 480 }}
+              />
+            </>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={saving} sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}>
+          {t("adminLiveSessions.cancel", "Cancel")}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleSave()}
+          disabled={!valid || saving}
+          sx={{
+            borderRadius: "12px",
+            textTransform: "none",
+            fontWeight: 700,
+            background: "var(--accent-indigo)",
+            color: "#fff",
+            "&:hover": { background: "var(--accent-indigo-dark)" },
+          }}
+        >
+          {saving ? <CircularProgress size={20} color="inherit" /> : t("adminLiveSessions.save", "Save")}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }

--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -24,12 +24,14 @@ import {
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
-import { MeetingStatusChip } from "@/components/live-sessions/ui/LiveSessionUI";
+import { MeetingStatusChip, RoleChip } from "@/components/live-sessions/ui/LiveSessionUI";
+import { AssignParticipantDialog } from "./AssignParticipantDialog";
 import {
   adminLiveActivitiesService,
   OccurrenceTimelineResponse,
   TimelineOccurrence,
   RosterStudent,
+  UnmatchedParticipant,
 } from "@/lib/services/admin/admin-live-activities.service";
 import { formatDurationSeconds } from "@/lib/utils/date-utils";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
@@ -48,9 +50,18 @@ function fmtDate(s: string | null) {
   });
 }
 
-/** Per-student status for one occurrence - "Missed" only once THAT occurrence has ended. */
+/** Per-student status for one occurrence - "Missed" only once THAT occurrence has ended, and
+ *  never for someone who joined the batch after this sitting happened. */
 function studentStatus(s: RosterStudent, occStatus: string, t: (k: string, d: string) => string) {
-  if (s.attended) return { label: t("adminLiveSessions.attended", "Joined"), color: "var(--success-500)" };
+  if (s.attended)
+    return {
+      label: s.manual
+        ? t("adminLiveSessions.presentManual", "Present (manual)")
+        : t("adminLiveSessions.attended", "Joined"),
+      color: "var(--success-500)",
+    };
+  if (s.enrolled_after_session)
+    return { label: t("adminLiveSessions.notYetEnrolled", "Not yet enrolled"), color: "var(--font-secondary)" };
   if (occStatus === "ended" || occStatus === "expired")
     return { label: t("adminLiveSessions.missed", "Missed"), color: "var(--warning-500)" };
   if (occStatus === "live")
@@ -84,6 +95,10 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
   const [editing, setEditing] = useState<{ occ: TimelineOccurrence; mode: "rename" | "reschedule" } | null>(null);
   const [cancelTarget, setCancelTarget] = useState<TimelineOccurrence | null>(null);
   const [cancelling, setCancelling] = useState(false);
+  // Roll-call state: which `${occId}:${studentId}` mark is in flight, and which unmatched row is
+  // being attached to a student (dialog carries its occurrence for occurrence_id).
+  const [markingKey, setMarkingKey] = useState<string | null>(null);
+  const [assign, setAssign] = useState<{ occ: TimelineOccurrence; participant: UnmatchedParticipant } | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -112,6 +127,25 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
       showToast(getAxiosErrorDetail(e, "Couldn't sync attendance for this session."), "error");
     } finally {
       setSyncingId(null);
+    }
+  };
+
+  /** Manual mark for one student on ONE date - this is the week-by-week roll-call. */
+  const markOne = async (occ: TimelineOccurrence, studentId: number, input: { present?: boolean; clear?: boolean }) => {
+    const key = `${occ.id}:${studentId}`;
+    try {
+      setMarkingKey(key);
+      await adminLiveActivitiesService.markAttendance(liveClassId, {
+        student_id: studentId,
+        occurrence_id: occ.id,
+        ...input,
+      });
+      await load();
+      setOpenId(occ.id);
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, "Couldn't update attendance for this date."), "error");
+    } finally {
+      setMarkingKey(null);
     }
   };
 
@@ -280,13 +314,13 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                         <Table size="small" sx={{ tableLayout: "fixed", width: "100%" }}>
                           <TableHead>
                             <TableRow sx={{ bgcolor: "var(--surface)" }}>
-                              <TableCell sx={{ fontWeight: 700, ...tableCellSx, width: "40%" }}>
+                              <TableCell sx={{ fontWeight: 700, ...tableCellSx, width: "27%" }}>
                                 {t("adminLiveSessions.name", "Name")}
                               </TableCell>
-                              <TableCell sx={{ fontWeight: 700, ...tableCellSx, width: "36%" }}>
+                              <TableCell sx={{ fontWeight: 700, ...tableCellSx, width: "26%" }}>
                                 {t("adminLiveSessions.email", "Email")}
                               </TableCell>
-                              <TableCell sx={{ fontWeight: 700, ...tableCellSx, width: "12%" }}>
+                              <TableCell sx={{ fontWeight: 700, ...tableCellSx, width: "35%" }}>
                                 {t("adminLiveSessions.status", "Status")}
                               </TableCell>
                               <TableCell sx={{ fontWeight: 700, ...tableCellSx, width: "12%" }}>
@@ -299,6 +333,7 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                               .sort((a, b) => Number(b.attended) - Number(a.attended))
                               .map((s) => {
                                 const st = studentStatus(s, occ.status, t);
+                                const busy = markingKey === `${occ.id}:${s.user_profile_id}`;
                                 return (
                                   <TableRow key={s.user_profile_id}>
                                     <TableCell sx={{ ...tableCellSx, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={s.name}>
@@ -308,17 +343,65 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                                       {s.email}
                                     </TableCell>
                                     <TableCell sx={tableCellSx}>
-                                      <Chip
-                                        label={st.label}
-                                        size="small"
-                                        sx={{
-                                          height: 20,
-                                          fontSize: "0.68rem",
-                                          fontWeight: 600,
-                                          bgcolor: `color-mix(in srgb, ${st.color} 16%, transparent)`,
-                                          color: st.color,
-                                        }}
-                                      />
+                                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
+                                        <Chip
+                                          label={st.label}
+                                          size="small"
+                                          sx={{
+                                            height: 20,
+                                            fontSize: "0.68rem",
+                                            fontWeight: 600,
+                                            bgcolor: `color-mix(in srgb, ${st.color} 16%, transparent)`,
+                                            color: st.color,
+                                          }}
+                                        />
+                                        <RoleChip role={s.role} />
+                                        {s.overridden && (
+                                          <Chip
+                                            label={t("adminLiveSessions.overridden", "Overridden")}
+                                            size="small"
+                                            sx={{
+                                              height: 20, fontSize: "0.66rem", fontWeight: 700,
+                                              bgcolor: "color-mix(in srgb, var(--error-500) 14%, transparent)",
+                                              color: "var(--error-500)",
+                                            }}
+                                          />
+                                        )}
+                                        {/* The week-by-week roll-call: mark THIS date once it has
+                                            ended - present, absent-override, or clear the mark. */}
+                                        {ended && !s.attended && !s.overridden && (
+                                          <Button
+                                            size="small"
+                                            disabled={busy}
+                                            onClick={() => void markOne(occ, s.user_profile_id, { present: true })}
+                                            sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.64rem", textTransform: "none", fontWeight: 700 }}
+                                          >
+                                            {t("adminLiveSessions.markPresent", "Mark present")}
+                                          </Button>
+                                        )}
+                                        {ended && s.attended && !s.manual && (
+                                          <Button
+                                            size="small"
+                                            color="inherit"
+                                            disabled={busy}
+                                            onClick={() => void markOne(occ, s.user_profile_id, { present: false })}
+                                            sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.64rem", textTransform: "none", fontWeight: 700, color: "var(--error-500)" }}
+                                          >
+                                            {t("adminLiveSessions.markAbsent", "Mark absent")}
+                                          </Button>
+                                        )}
+                                        {ended && ((s.attended && s.manual) || s.overridden) && (
+                                          <Button
+                                            size="small"
+                                            color="inherit"
+                                            disabled={busy}
+                                            onClick={() => void markOne(occ, s.user_profile_id, { clear: true })}
+                                            sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.64rem", textTransform: "none", color: "var(--font-secondary)" }}
+                                          >
+                                            {t("adminLiveSessions.undo", "Undo")}
+                                          </Button>
+                                        )}
+                                      </Box>
                                     </TableCell>
                                     <TableCell sx={tableCellSx}>
                                       {s.attended ? formatDurationSeconds(s.duration_seconds) : "-"}
@@ -331,12 +414,52 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                       </TableContainer>
                     )}
 
+                    {/* Staff & hosts who were in THIS sitting (not counted as students). */}
+                    {(occ.staff_participants?.length ?? 0) > 0 && (
+                      <Box sx={{ mt: 1, display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+                        <Typography variant="caption" sx={{ fontWeight: 700, color: "var(--font-secondary)" }}>
+                          {t("adminLiveSessions.staffAndHostsInline", "Staff & hosts:")}
+                        </Typography>
+                        {occ.staff_participants!.map((p, i) => (
+                          <Box key={i} sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}>
+                            <RoleChip role={p.role} />
+                            <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                              {p.name || p.email}
+                              {p.duration_seconds ? ` · ${formatDurationSeconds(p.duration_seconds)}` : ""}
+                            </Typography>
+                          </Box>
+                        ))}
+                      </Box>
+                    )}
+
                     {occ.unmatched_participants.length > 0 && (
-                      <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontStyle: "italic", display: "block", mt: 1 }}>
-                        {t("adminLiveSessions.rosterUnmatched", "Unmatched participants ({{count}})", {
-                          count: occ.unmatched_participants.length,
-                        })}
-                      </Typography>
+                      <Box sx={{ mt: 1 }}>
+                        <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontStyle: "italic", display: "block" }}>
+                          {t("adminLiveSessions.rosterUnmatched", "Unmatched participants ({{count}})", {
+                            count: occ.unmatched_participants.length,
+                          })}
+                        </Typography>
+                        {occ.unmatched_participants.map((p, idx) => (
+                          <Box key={p.participant_id ?? idx} sx={{ display: "flex", alignItems: "center", gap: 1, mt: 0.4 }}>
+                            <Typography variant="caption" sx={{ color: "var(--font-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                              {p.name || t("adminLiveSessions.noName", "(no name)")}
+                              {" · "}
+                              {formatDurationSeconds(p.duration_seconds)}
+                            </Typography>
+                            {/* Attach THIS date's join to a student - keeps the real duration and
+                                auto-matches the name on later dates. */}
+                            {p.participant_id != null && occ.students.length > 0 && (
+                              <Button
+                                size="small"
+                                onClick={() => setAssign({ occ, participant: p })}
+                                sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.64rem", textTransform: "none", fontWeight: 700 }}
+                              >
+                                {t("adminLiveSessions.assignToStudent", "Assign to student")}
+                              </Button>
+                            )}
+                          </Box>
+                        ))}
+                      </Box>
                     )}
 
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mt: 1.25, flexWrap: "wrap" }}>
@@ -419,6 +542,21 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
       <Typography variant="caption" sx={{ color: "var(--font-secondary)", fontStyle: "italic", display: "block", mt: 1.5 }}>
         {data.reliability_note}
       </Typography>
+
+      {assign && (
+        <AssignParticipantDialog
+          liveClassId={liveClassId}
+          participant={assign.participant}
+          students={assign.occ.students}
+          occurrenceId={assign.occ.id}
+          onClose={() => setAssign(null)}
+          onDone={async () => {
+            await load();
+            setOpenId(assign.occ.id);
+            onChanged?.();
+          }}
+        />
+      )}
 
       {editing && (
         <EditOccurrenceDialog

--- a/components/admin/live-sessions/LiveSessionRosterSection.tsx
+++ b/components/admin/live-sessions/LiveSessionRosterSection.tsx
@@ -19,11 +19,15 @@ import {
 import {
   adminLiveActivitiesService,
   LiveSessionRosterResponse,
+  UnmatchedParticipant,
 } from "@/lib/services/admin/admin-live-activities.service";
 import { formatDurationSeconds } from "@/lib/utils/date-utils";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { RoleChip } from "@/components/live-sessions/ui/LiveSessionUI";
 import { InviteEditorDialog } from "./InviteEditorDialog";
+import { AssignParticipantDialog } from "./AssignParticipantDialog";
 import { useToast } from "@/components/common/Toast";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 interface LiveSessionRosterSectionProps {
   liveClassId: number;
@@ -49,6 +53,7 @@ export function LiveSessionRosterSection({
   const [loading, setLoading] = useState(true);
   const [inviteEditorOpen, setInviteEditorOpen] = useState(false);
   const [markingId, setMarkingId] = useState<number | null>(null);
+  const [assignFor, setAssignFor] = useState<UnmatchedParticipant | null>(null);
 
   const fetchRoster = useCallback(async () => {
     try {
@@ -74,13 +79,15 @@ export function LiveSessionRosterSection({
     setTimeout(() => { void fetchRoster(); }, 2500);
   }, [showToast, fetchRoster]);
 
-  const handleMark = useCallback(async (studentId: number, present: boolean) => {
+  /** present:true = manual present · present:false = absent override (negates a Zoom join) ·
+   *  clear:true = remove the manual mark entirely (back to whatever Zoom recorded). */
+  const handleMark = useCallback(async (studentId: number, input: { present?: boolean; clear?: boolean }) => {
     try {
       setMarkingId(studentId);
-      await adminLiveActivitiesService.markAttendance(liveClassId, { student_id: studentId, present });
+      await adminLiveActivitiesService.markAttendance(liveClassId, { student_id: studentId, ...input });
       await fetchRoster();
-    } catch {
-      showToast("Could not update attendance", "error");
+    } catch (e) {
+      showToast(getAxiosErrorDetail(e, "Could not update attendance"), "error");
     } finally {
       setMarkingId(null);
     }
@@ -221,7 +228,9 @@ export function LiveSessionRosterSection({
                     <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap" }}>
                       {(() => {
                         // "Missed" only once the session has actually ended. Before that a non-attendee
-                        // is Upcoming (not started) or Not joined yet (live) - never "missed".
+                        // is Upcoming (not started) or Not joined yet (live) - never "missed". Someone
+                        // who joined the batch AFTER this sitting is neither: they could not have been
+                        // there, and the backend already excludes them from missed_count.
                         const st = s.attended
                           ? {
                               label: s.manual
@@ -229,11 +238,13 @@ export function LiveSessionRosterSection({
                                 : t("adminLiveSessions.attended", "Joined"),
                               color: "var(--success-500)",
                             }
-                          : data.session_ended
-                            ? { label: t("adminLiveSessions.missed", "Missed"), color: "var(--warning-500)" }
-                            : data.session_started
-                              ? { label: t("adminLiveSessions.notJoinedYet", "Not joined yet"), color: "var(--font-secondary)" }
-                              : { label: t("adminLiveSessions.upcoming", "Not started"), color: "var(--font-secondary)" };
+                          : s.enrolled_after_session
+                            ? { label: t("adminLiveSessions.notYetEnrolled", "Not yet enrolled"), color: "var(--font-secondary)" }
+                            : data.session_ended
+                              ? { label: t("adminLiveSessions.missed", "Missed"), color: "var(--warning-500)" }
+                              : data.session_started
+                                ? { label: t("adminLiveSessions.notJoinedYet", "Not joined yet"), color: "var(--font-secondary)" }
+                                : { label: t("adminLiveSessions.upcoming", "Not started"), color: "var(--font-secondary)" };
                         return (
                           <Chip
                             label={st.label}
@@ -248,23 +259,49 @@ export function LiveSessionRosterSection({
                           />
                         );
                       })()}
-                      {/* After the session ends, staff can mark a non-attendee present, or undo a manual mark. */}
-                      {sessionEnded && !s.attended && (
+                      <RoleChip role={s.role} />
+                      {/* Staff negated a Zoom-recorded join - say so, don't leave it looking like
+                          Zoom never saw them. */}
+                      {s.overridden && (
+                        <Chip
+                          label={t("adminLiveSessions.overridden", "Overridden")}
+                          size="small"
+                          sx={{
+                            height: 20, fontSize: "0.68rem", fontWeight: 700,
+                            bgcolor: "color-mix(in srgb, var(--error-500) 14%, transparent)",
+                            color: "var(--error-500)",
+                          }}
+                        />
+                      )}
+                      {/* After the session ends, staff can mark a non-attendee present, negate a
+                          Zoom join, or clear either manual mark (back to what Zoom recorded). */}
+                      {sessionEnded && !s.attended && !s.overridden && (
                         <Button
                           size="small"
                           disabled={markingId === s.user_profile_id}
-                          onClick={() => void handleMark(s.user_profile_id, true)}
+                          onClick={() => void handleMark(s.user_profile_id, { present: true })}
                           sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.65rem", textTransform: "none", fontWeight: 700 }}
                         >
                           {t("adminLiveSessions.markPresent", "Mark present")}
                         </Button>
                       )}
-                      {sessionEnded && s.attended && s.manual && (
+                      {sessionEnded && s.attended && !s.manual && (
                         <Button
                           size="small"
                           color="inherit"
                           disabled={markingId === s.user_profile_id}
-                          onClick={() => void handleMark(s.user_profile_id, false)}
+                          onClick={() => void handleMark(s.user_profile_id, { present: false })}
+                          sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.65rem", textTransform: "none", fontWeight: 700, color: "var(--error-500)" }}
+                        >
+                          {t("adminLiveSessions.markAbsent", "Mark absent")}
+                        </Button>
+                      )}
+                      {sessionEnded && ((s.attended && s.manual) || s.overridden) && (
+                        <Button
+                          size="small"
+                          color="inherit"
+                          disabled={markingId === s.user_profile_id}
+                          onClick={() => void handleMark(s.user_profile_id, { clear: true })}
                           sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.65rem", textTransform: "none", color: "var(--font-secondary)" }}
                         >
                           {t("adminLiveSessions.undo", "Undo")}
@@ -282,6 +319,55 @@ export function LiveSessionRosterSection({
         </TableContainer>
       )}
 
+      {/* Matched-but-not-enrolled people (the host, trainers, panelists). Previously these were
+          silently dropped, so the host's own join looked like nobody hosting. Never counted in
+          the joined/missed numbers. */}
+      {(data.staff_participants?.length ?? 0) > 0 && (
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="caption" sx={{ fontWeight: 600, color: "var(--font-primary)", display: "block", mb: 0.5 }}>
+            {t("adminLiveSessions.staffAndHosts", "Staff & hosts ({{count}})", {
+              count: data.staff_participants!.length,
+            })}
+          </Typography>
+          <TableContainer component={Paper} variant="outlined" sx={{ overflow: "hidden" }}>
+            <Table size="small" sx={{ tableLayout: "fixed", width: "100%" }}>
+              <TableHead>
+                <TableRow sx={{ bgcolor: "var(--surface)" }}>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "34%" }}>{t("adminLiveSessions.name", "Name")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "34%" }}>{t("adminLiveSessions.email", "Email")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "18%" }}>{t("adminLiveSessions.role", "Role")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "14%" }}>{t("adminLiveSessions.duration", "Duration")}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.staff_participants!.map((p, idx) => (
+                  <TableRow key={idx}>
+                    <TableCell
+                      sx={{ ...tableCellSx, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                      title={p.name}
+                    >
+                      {p.name || "-"}
+                    </TableCell>
+                    <TableCell
+                      sx={{ ...tableCellSx, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                      title={p.email}
+                    >
+                      {p.email || "-"}
+                    </TableCell>
+                    <TableCell sx={{ ...tableCellSx }}>
+                      <RoleChip role={p.role} />
+                    </TableCell>
+                    <TableCell sx={{ ...tableCellSx }}>
+                      {formatDurationSeconds(p.duration_seconds)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Box>
+      )}
+
       {data.unmatched_participants.length > 0 && (
         <Box sx={{ mt: 2 }}>
           <Typography variant="caption" sx={{ fontWeight: 600, color: "var(--font-primary)", display: "block", mb: 0.5 }}>
@@ -296,14 +382,15 @@ export function LiveSessionRosterSection({
             <Table size="small" sx={{ tableLayout: "fixed", width: "100%" }}>
               <TableHead>
                 <TableRow sx={{ bgcolor: "var(--surface)" }}>
-                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "40%" }}>{t("adminLiveSessions.name", "Name")}</TableCell>
-                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "44%" }}>{t("adminLiveSessions.email", "Email")}</TableCell>
-                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "16%" }}>{t("adminLiveSessions.duration", "Duration")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "30%" }}>{t("adminLiveSessions.name", "Name")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "32%" }}>{t("adminLiveSessions.email", "Email")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "14%" }}>{t("adminLiveSessions.duration", "Duration")}</TableCell>
+                  <TableCell sx={{ fontWeight: 600, ...tableCellSx, width: "24%" }} />
                 </TableRow>
               </TableHead>
               <TableBody>
                 {data.unmatched_participants.map((p, idx) => (
-                  <TableRow key={idx}>
+                  <TableRow key={p.participant_id ?? idx}>
                     <TableCell
                       sx={{ ...tableCellSx, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
                       title={p.name}
@@ -319,12 +406,36 @@ export function LiveSessionRosterSection({
                     <TableCell sx={{ ...tableCellSx }}>
                       {formatDurationSeconds(p.duration_seconds)}
                     </TableCell>
+                    <TableCell sx={{ ...tableCellSx }}>
+                      {/* Attach this row to a roster student (identify endpoint): keeps the real
+                          Zoom duration and auto-matches this display name next week. Needs the
+                          participant_id, which an older backend payload does not carry. */}
+                      {p.participant_id != null && data.students.length > 0 && (
+                        <Button
+                          size="small"
+                          onClick={() => setAssignFor(p)}
+                          sx={{ minWidth: 0, px: 0.75, py: 0, fontSize: "0.65rem", textTransform: "none", fontWeight: 700 }}
+                        >
+                          {t("adminLiveSessions.assignToStudent", "Assign to student")}
+                        </Button>
+                      )}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
           </TableContainer>
         </Box>
+      )}
+
+      {assignFor && (
+        <AssignParticipantDialog
+          liveClassId={liveClassId}
+          participant={assignFor}
+          students={data.students}
+          onClose={() => setAssignFor(null)}
+          onDone={fetchRoster}
+        />
       )}
 
       <InviteEditorDialog

--- a/components/admin/live-sessions/ZoomAttendanceSection.tsx
+++ b/components/admin/live-sessions/ZoomAttendanceSection.tsx
@@ -16,6 +16,7 @@ import {
   CircularProgress,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { RoleChip } from "@/components/live-sessions/ui/LiveSessionUI";
 import { useToast } from "@/components/common/Toast";
 import {
   adminLiveActivitiesService,
@@ -104,7 +105,13 @@ export function ZoomAttendanceSection({ liveClassId }: ZoomAttendanceSectionProp
   }
 
   const rawParticipants = data?.participants ?? [];
-  const participants = aggregateParticipants(rawParticipants);
+  // Staff first (host, then trainer, then panelists), students after - the person running the
+  // room shouldn't be buried alphabetically among forty attendees. Stable sort keeps the
+  // aggregation order within each group.
+  const ROLE_ORDER: Record<string, number> = { host: 0, instructor: 1, panelist: 2 };
+  const participants = [...aggregateParticipants(rawParticipants)].sort(
+    (a, b) => (ROLE_ORDER[a.role ?? ""] ?? 3) - (ROLE_ORDER[b.role ?? ""] ?? 3)
+  );
   const count = participants.length;
   const syncedAt = data?.synced_at;
   const syncAvailable = data?.sync_available ?? false;
@@ -187,10 +194,15 @@ export function ZoomAttendanceSection({ liveClassId }: ZoomAttendanceSectionProp
               {participants.map((p, idx) => (
                 <TableRow key={p.id ?? idx}>
                   <TableCell
-                    sx={{ ...tableCellSx, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+                    sx={{ ...tableCellSx, overflow: "hidden" }}
                     title={p.name !== "-" ? p.name : undefined}
                   >
-                    {p.name}
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, minWidth: 0 }}>
+                      <Box component="span" sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {p.name}
+                      </Box>
+                      <RoleChip role={p.role} />
+                    </Box>
                   </TableCell>
                   <TableCell
                     sx={{ ...tableCellSx, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}

--- a/components/live-sessions/ScheduleCalendar.tsx
+++ b/components/live-sessions/ScheduleCalendar.tsx
@@ -31,8 +31,9 @@ export const CALENDAR_TYPE_META: Record<CalendarEventType, { label: string; colo
 const WEEKDAYS = ["M", "T", "W", "T", "F", "S", "S"];
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-/** Local YYYY-MM-DD key (avoids UTC off-by-one that toISOString would cause). */
-function dayKey(d: Date): string {
+/** Local YYYY-MM-DD key (avoids UTC off-by-one that toISOString would cause). Exported so pages
+ *  driving the calendar in controlled mode bucket their lists with the SAME day boundaries. */
+export function dayKey(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 function clock(ev: CalendarEvent): string {
@@ -51,13 +52,26 @@ function clock(ev: CalendarEvent): string {
 export function ScheduleCalendar({
   events,
   title = "Your calendar",
+  selectedKey: controlledKey,
+  onSelectDay,
 }: {
   events: CalendarEvent[];
   title?: string;
+  /** Controlled selection (pass with onSelectDay): the parent owns the selected day; null = no
+   *  day selected. Omit for the original self-contained behavior (admin page is untouched). */
+  selectedKey?: string | null;
+  onSelectDay?: (key: string | null) => void;
 }) {
   const today = useMemo(() => new Date(), []);
   const [cursor, setCursor] = useState(() => new Date(today.getFullYear(), today.getMonth(), 1));
-  const [selectedKey, setSelectedKey] = useState(() => dayKey(today));
+  const [internalKey, setInternalKey] = useState(() => dayKey(today));
+  const isControlled = controlledKey !== undefined;
+  const selectedKey = isControlled ? controlledKey : internalKey;
+  const selectDay = (key: string) => {
+    // Controlled mode doubles as a filter: clicking the selected day again clears it.
+    if (isControlled) onSelectDay?.(key === selectedKey ? null : key);
+    else setInternalKey(key);
+  };
 
   // Bucket events by local day key.
   const byDay = useMemo(() => {
@@ -86,8 +100,9 @@ export function ScheduleCalendar({
     return out;
   }, [cursor]);
 
-  const selectedEvents = byDay.get(selectedKey) ?? [];
+  const selectedEvents = (selectedKey ? byDay.get(selectedKey) : undefined) ?? [];
   const selectedDate = useMemo(() => {
+    if (!selectedKey) return null;
     const [y, m, d] = selectedKey.split("-").map(Number);
     return new Date(y, m - 1, d);
   }, [selectedKey]);
@@ -142,10 +157,10 @@ export function ScheduleCalendar({
           const dotTypes = Array.from(new Set(dayEvents.map((e) => e.type))).slice(0, 3);
           const cell = (
             <Box
-              onClick={() => setSelectedKey(key)}
+              onClick={() => selectDay(key)}
               role="button"
               tabIndex={0}
-              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setSelectedKey(key); }}
+              onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") selectDay(key); }}
               sx={{
                 aspectRatio: "1 / 1",
                 display: "flex",
@@ -207,6 +222,12 @@ export function ScheduleCalendar({
 
       {/* Selected-day agenda */}
       <Box sx={{ borderTop: "1px solid var(--border-default)", pt: 1.5, mt: 0.5 }}>
+        {!selectedDate ? (
+          <Typography sx={{ fontSize: "0.82rem", color: "var(--font-tertiary)", py: 0.5 }}>
+            Pick a date to see its schedule.
+          </Typography>
+        ) : (
+        <>
         <Typography sx={{ fontSize: "0.72rem", fontWeight: 800, letterSpacing: "0.06em", color: "var(--font-secondary)", mb: 1 }}>
           {MONTHS[selectedDate.getMonth()].toUpperCase()} {selectedDate.getDate()}
           {selectedIsToday ? " · TODAY" : ""}
@@ -248,6 +269,8 @@ export function ScheduleCalendar({
               );
             })}
           </Box>
+        )}
+        </>
         )}
       </Box>
 

--- a/components/live-sessions/StudentSessionSummaryDialog.tsx
+++ b/components/live-sessions/StudentSessionSummaryDialog.tsx
@@ -19,6 +19,10 @@ import type { StudentLiveSessionTranscript } from "@/lib/services/live-sessions/
 
 interface StudentSessionSummaryDialogProps {
   activityId: number;
+  /** Which sitting of a recurring series. `activityId` is the SERIES for every expanded
+   *  occurrence, so without this the dialog shows the series-latest summary/transcript,
+   *  whichever date was clicked. Omit for single sessions. */
+  occurrenceId?: number | null;
   topicName: string;
   /** Controlled mode: the parent owns visibility (no trigger button is rendered). */
   open?: boolean;
@@ -29,7 +33,7 @@ interface StudentSessionSummaryDialogProps {
  *  Two modes: self-contained trigger-button + dialog (default), or CONTROLLED via open/onClose
  *  so a list can render one instance for whichever card's "View summary" was clicked. Lazily
  *  fetches the transcript only when opened, so it adds no cost to the sessions list. */
-export function StudentSessionSummaryDialog({ activityId, topicName, open: controlledOpen, onClose }: StudentSessionSummaryDialogProps) {
+export function StudentSessionSummaryDialog({ activityId, occurrenceId, topicName, open: controlledOpen, onClose }: StudentSessionSummaryDialogProps) {
   const { t } = useTranslation("common");
   const isControlled = controlledOpen !== undefined;
   const [internalOpen, setInternalOpen] = useState(false);
@@ -37,18 +41,20 @@ export function StudentSessionSummaryDialog({ activityId, topicName, open: contr
   const [data, setData] = useState<StudentLiveSessionTranscript | null>(null);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
-  const [loadedFor, setLoadedFor] = useState<number | null>(null);
+  // Occurrences of one series share activityId, so the cache key has to carry both.
+  const cacheKey = `${activityId}:${occurrenceId ?? 0}`;
+  const [loadedFor, setLoadedFor] = useState<string | null>(null);
 
   const fetchData = async () => {
-    if (loadedFor === activityId && data) return;
+    if (loadedFor === cacheKey && data) return;
     try {
       setLoading(true);
-      const res = await studentLiveSessionsService.getTranscript(activityId);
+      const res = await studentLiveSessionsService.getTranscript(activityId, occurrenceId);
       setData(res);
-      setLoadedFor(activityId);
+      setLoadedFor(cacheKey);
     } catch {
       setData(null);
-      setLoadedFor(activityId);
+      setLoadedFor(cacheKey);
     } finally {
       setLoading(false);
     }
@@ -59,11 +65,11 @@ export function StudentSessionSummaryDialog({ activityId, topicName, open: contr
     await fetchData();
   };
 
-  // Controlled mode: fetch when the parent opens us (or switches the target session).
+  // Controlled mode: fetch when the parent opens us (or switches the target session/occurrence).
   useEffect(() => {
     if (isControlled && open) void fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isControlled, open, activityId]);
+  }, [isControlled, open, activityId, occurrenceId]);
 
   const handleClose = () => {
     if (isControlled) onClose?.();

--- a/components/live-sessions/ui/LiveSessionUI.tsx
+++ b/components/live-sessions/ui/LiveSessionUI.tsx
@@ -210,6 +210,44 @@ export function MeetingStatusChip({ status, cancelled }: { status?: string | nul
   );
 }
 
+const ROLE_META: Record<string, { key: string; fallback: string; color: string; icon: string }> = {
+  host: { key: "liveSessions.roleHost", fallback: "Host", color: "var(--ai-violet, #7c3aed)", icon: "mdi:crown-outline" },
+  instructor: { key: "liveSessions.roleTrainer", fallback: "Trainer", color: "var(--accent-indigo)", icon: "mdi:school-outline" },
+  panelist: { key: "liveSessions.rolePanelist", fallback: "Panelist", color: "var(--warning-500)", icon: "mdi:presentation" },
+};
+
+/** Pill badge for a participant's Zoom-side role (Host / Trainer / Panelist). Renders nothing for
+ *  an ordinary attendee, so it can be dropped next to any name unconditionally. */
+export function RoleChip({ role, size = 13 }: { role?: string | null; size?: number }) {
+  const { t } = useTranslation("common");
+  const meta = role ? ROLE_META[role] : undefined;
+  if (!meta) return null;
+  return (
+    <Box
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.4,
+        px: 0.8,
+        py: 0.25,
+        borderRadius: 999,
+        fontSize: "0.62rem",
+        fontWeight: 800,
+        letterSpacing: "0.06em",
+        textTransform: "uppercase",
+        color: meta.color,
+        bgcolor: `color-mix(in srgb, ${meta.color} 13%, transparent)`,
+        border: `1px solid color-mix(in srgb, ${meta.color} 26%, transparent)`,
+        lineHeight: 1,
+        flexShrink: 0,
+      }}
+    >
+      <IconWrapper icon={meta.icon} size={size - 2} color={meta.color} />
+      {t(meta.key, meta.fallback)}
+    </Box>
+  );
+}
+
 /** Adaptive pill badge for the meeting platform (Zoom / Zoom Webinar / Google Meet). */
 export function PlatformChip({
   isZoom,

--- a/components/live-sessions/useLiveSessions.ts
+++ b/components/live-sessions/useLiveSessions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useToast } from "@/components/common/Toast";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
@@ -11,6 +11,54 @@ import {
 import { getLiveSessionErrorMessage, copyToClipboard } from "@/lib/utils/live-session-errors";
 
 const LIVE_SESSIONS_FEATURE = "live_sessions";
+/** How close (ms) to a status boundary the coarse 60s safety-net poll runs. */
+const NEAR_BOUNDARY_MS = 15 * 60 * 1000;
+const SAFETY_POLL_MS = 60_000;
+/** A tab returning to view refetches only if its snapshot is older than this. */
+const STALE_ON_FOCUS_MS = 60_000;
+/** setTimeout overflows (and fires IMMEDIATELY) past ~24.8 days; clamp far boundaries well below
+ *  that. A clamped timer just reloads early and reschedules - an overflowed one fetch-loops. */
+const MAX_TIMER_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * The instants at which some session's status flips, from the list we already have: every future
+ * start, and the scheduled end of anything currently running. `next` is the earliest one still
+ * ahead (null when none). `near` means something is within ±15 min of a boundary - about to
+ * start, currently live, or just ended - which is when polling is worth its requests.
+ */
+function statusBoundaries(
+  sessions: StudentLiveSession[],
+  now: number,
+): { next: number | null; near: boolean } {
+  let next = Infinity;
+  let near = false;
+  const consider = (startIso?: string | null, durationMin?: number | null) => {
+    if (!startIso) return;
+    const start = new Date(startIso).getTime();
+    if (Number.isNaN(start)) return;
+    const end = start + (durationMin || 60) * 60_000;
+    if (start > now) next = Math.min(next, start);
+    else if (now <= end) next = Math.min(next, end);
+    if (Math.abs(start - now) <= NEAR_BOUNDARY_MS || (start <= now && now <= end + NEAR_BOUNDARY_MS)) {
+      near = true;
+    }
+  };
+  for (const s of sessions) {
+    if (s.notice_type === "cancelled") continue;
+    const occs = s.occurrences ?? [];
+    if (s.zoom_is_recurring && occs.length > 0) {
+      // A recurring series' own class_datetime is frozen at occurrence #1; the dates that can
+      // actually flip status are the occurrences'.
+      for (const o of occs) {
+        if (o.status === "cancelled" || o.meeting_status === "cancelled") continue;
+        consider(o.occurrence_datetime, o.duration_minutes ?? s.duration_minutes);
+      }
+    } else {
+      consider(s.class_datetime, s.duration_minutes);
+    }
+  }
+  return { next: Number.isFinite(next) ? next : null, near };
+}
 
 function formatCompactMinutes(totalMinutes: number): string {
   if (totalMinutes <= 0) return "";
@@ -43,22 +91,113 @@ export function useLiveSessions() {
     enabledFeatureNames.size === 0 ||
     enabledFeatureNames.has(LIVE_SESSIONS_FEATURE);
 
-  const loadSessions = async () => {
+  // Self-refresh machinery. The page used to fetch exactly once on mount, so "Join now" never
+  // appeared without a manual refresh and the LIVE hero lingered after a session ended.
+  const inFlightRef = useRef(false);
+  const lastLoadAtRef = useRef(0);
+  // Bumped after every COMPLETED load so the scheduler re-evaluates with a fresh clock even when
+  // the payload (and therefore the digest) did not change.
+  const [loadStamp, setLoadStamp] = useState(0);
+  const sessionsRef = useRef<StudentLiveSession[]>([]);
+
+  const loadSessionsImpl = async (opts?: { background?: boolean }) => {
+    if (inFlightRef.current) return; // never more than one in flight; triggers while loading are dropped
+    inFlightRef.current = true;
+    const background = Boolean(opts?.background);
     try {
-      setLoading(true);
+      if (!background) setLoading(true);
       const data = await studentLiveSessionsService.getSessions();
+      sessionsRef.current = data;
       setSessions(data);
     } catch (error: unknown) {
-      showToast(getLiveSessionErrorMessage(error), "error");
+      // A failed background refresh keeps the current snapshot and stays silent - it must not
+      // toast over whatever the student is doing every 60s while a poll is active.
+      if (!background) showToast(getLiveSessionErrorMessage(error), "error");
     } finally {
-      setLoading(false);
+      if (!background) setLoading(false);
+      inFlightRef.current = false;
+      lastLoadAtRef.current = Date.now();
+      setLoadStamp((n) => n + 1);
     }
   };
+  // Stable identity so consumers (and the effects below) can list it as a dependency without
+  // re-arming - and re-firing - their fetches on every render.
+  const loadImplRef = useRef(loadSessionsImpl);
+  loadImplRef.current = loadSessionsImpl;
+  const loadSessions = useCallback(
+    (opts?: { background?: boolean }) => loadImplRef.current(opts),
+    [],
+  );
 
   useEffect(() => {
     if (loadingClientInfo || !hasLiveSessionsFeature) return;
     loadSessions();
-  }, [loadingClientInfo, hasLiveSessionsFeature]);
+  }, [loadingClientInfo, hasLiveSessionsFeature, loadSessions]);
+
+  /**
+   * Content digest of the list. The scheduler must key off DATA changes, not array identity:
+   * every reload builds a new array even when nothing changed, and an effect that re-arms on
+   * identity after a load IT caused is the classic self-sustaining refetch loop.
+   */
+  const sessionsDigest = useMemo(
+    () =>
+      sessions
+        .map((s) =>
+          [
+            s.id,
+            s.meeting_status,
+            s.class_datetime,
+            s.duration_minutes,
+            s.notice_type,
+            ...(s.occurrences ?? []).map(
+              (o) => `${o.id}.${o.meeting_status}.${o.occurrence_datetime}.${o.duration_minutes}`,
+            ),
+          ].join(":"),
+        )
+        .join("|"),
+    [sessions],
+  );
+
+  // Boundary-aware self-refresh: one silent reload just after the next status flip, plus a coarse
+  // 60s poll only while a flip is near (the backend stamps ends within ~3 min; the poll is the
+  // net under a boundary timer that fired before the stamp landed).
+  useEffect(() => {
+    if (loadingClientInfo || !hasLiveSessionsFeature) return;
+    if (!sessionsDigest && loadStamp === 0) return; // nothing loaded yet - the initial load owns the first fetch
+    const { next, near } = statusBoundaries(sessionsRef.current, Date.now());
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    if (next != null) {
+      // +5s so the backend has computed the flip by the time we ask. Never arm a past/immediate
+      // fire from inside the scheduler - that is what breaks the load->reschedule->load cycle:
+      // this effect only ever arms FUTURE work, and a boundary already behind us belongs to the
+      // safety-net interval.
+      const delay = Math.min(next + 5_000 - Date.now(), MAX_TIMER_MS);
+      if (delay >= 1_000) {
+        timer = setTimeout(() => void loadSessions({ background: true }), delay);
+      }
+    }
+    let interval: ReturnType<typeof setInterval> | null = null;
+    if (near) {
+      interval = setInterval(() => void loadSessions({ background: true }), SAFETY_POLL_MS);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+      if (interval) clearInterval(interval);
+    };
+  }, [loadingClientInfo, hasLiveSessionsFeature, sessionsDigest, loadStamp, loadSessions]);
+
+  // A tab that sat hidden through a boundary (background timers are throttled) catches up the
+  // moment it returns - but only when its snapshot is actually stale, so tab-flipping is free.
+  useEffect(() => {
+    if (loadingClientInfo || !hasLiveSessionsFeature) return;
+    const onVisibility = () => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - lastLoadAtRef.current < STALE_ON_FOCUS_MS) return;
+      void loadSessions({ background: true });
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [loadingClientInfo, hasLiveSessionsFeature, loadSessions]);
 
   const handleCopyPassword = (password: string) => {
     copyToClipboard(password, showToast, t("liveSessions.passwordCopied"));

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -39,10 +39,22 @@ export interface LiveClassOccurrence {
   duration_minutes: number;
   status: "scheduled" | "started" | "ended" | "cancelled";
   meeting_status: "scheduled" | "live" | "ended" | "expired" | "cancelled";
+  /** Per-date title; blank means "inherit the series title". */
+  topic_name?: string | null;
   zoom_recording_url?: string | null;
   zoom_recording_duration_seconds?: number | null;
   has_recording: boolean;
   zoom_ai_summary?: string | null;
+}
+
+/** PATCH body for one date of a recurring series. All fields optional (send what changed). */
+export interface UpdateOccurrencePayload {
+  /** Per-date title; empty string clears the override back to the series title. */
+  topic_name?: string;
+  /** Naive wall-clock ISO ("YYYY-MM-DDTHH:mm"); interpreted in `timezone` when sent. */
+  occurrence_datetime?: string;
+  timezone?: string;
+  duration_minutes?: number;
 }
 
 export interface LiveActivity {
@@ -176,6 +188,8 @@ export interface SendInvitesResponse {
 export interface TimelineOccurrence {
   id: number;
   zoom_occurrence_id: string;
+  /** Per-date title; blank means "inherit the series title". */
+  topic_name?: string | null;
   date: string | null;
   duration_minutes: number;
   status: "scheduled" | "live" | "ended" | "expired" | "cancelled";
@@ -605,6 +619,34 @@ export const adminLiveActivitiesService = {
   ): Promise<OccurrenceTimelineResponse> => {
     const response = await apiClient.get<OccurrenceTimelineResponse>(
       `${BASE}/live-activities/${liveClassId}/zoom/occurrences/`
+    );
+    return response.data;
+  },
+
+  /**
+   * Edit ONE date of a recurring series (rename / reschedule / re-time). Errors carry the reason:
+   * 502 when Zoom refused a time change (its message is in the body), 409 when this date can't be
+   * edited safely - surface both via getAxiosErrorDetail rather than a generic failure.
+   */
+  updateOccurrence: async (
+    liveClassId: number,
+    occurrenceId: number,
+    payload: UpdateOccurrencePayload
+  ): Promise<{ data: LiveClassOccurrence }> => {
+    const response = await apiClient.patch<{ data: LiveClassOccurrence }>(
+      `${BASE}/live-activities/${liveClassId}/occurrences/${occurrenceId}/`,
+      payload
+    );
+    return response.data;
+  },
+
+  /** Cancel just ONE date of a recurring series (the series and its other dates stay). */
+  cancelOccurrence: async (
+    liveClassId: number,
+    occurrenceId: number
+  ): Promise<{ data: { occurrence_id: number; warnings: string[] } }> => {
+    const response = await apiClient.delete<{ data: { occurrence_id: number; warnings: string[] } }>(
+      `${BASE}/live-activities/${liveClassId}/occurrences/${occurrenceId}/`
     );
     return response.data;
   },

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -124,6 +124,9 @@ export interface LiveActivity {
   my_attendance?: { attended: boolean; duration_seconds: number } | null;
 }
 
+/** Zoom-side role of a participant; null for an ordinary attendee. */
+export type LiveParticipantRole = "host" | "instructor" | "panelist" | null;
+
 export interface RosterStudent {
   user_profile_id: number;
   name: string;
@@ -131,17 +134,38 @@ export interface RosterStudent {
   attended: boolean;
   /** True when attendance came ONLY from an admin's manual "present" mark (no Zoom join). */
   manual?: boolean;
+  /** A staff mark NEGATED a Zoom-recorded join - shown absent with an "Overridden" chip. */
+  overridden?: boolean;
+  /** Joined the batch after this sitting happened - excluded from missed_count server-side. */
+  enrolled_after_session?: boolean;
+  role?: LiveParticipantRole;
   duration_seconds: number;
   join_time: string | null;
   leave_time: string | null;
 }
 
 export interface UnmatchedParticipant {
+  /** Id for the identify endpoint; absent on payloads from an older backend. */
+  participant_id?: number;
   name: string;
   email: string;
   duration_seconds: number;
   join_time: string | null;
   leave_time: string | null;
+  role?: LiveParticipantRole;
+}
+
+/** Matched-but-NOT-enrolled people (the host, trainers, panelists) - previously silently dropped
+ *  from the roster payload because they matched a profile that wasn't on the roster. */
+export interface StaffParticipant {
+  user_profile_id?: number | null;
+  name: string;
+  email: string;
+  duration_seconds: number;
+  join_time?: string | null;
+  leave_time?: string | null;
+  off_roster?: boolean;
+  role?: LiveParticipantRole;
 }
 
 export interface LiveSessionRosterResponse {
@@ -164,6 +188,7 @@ export interface LiveSessionRosterResponse {
   reliability_note: string;
   students: RosterStudent[];
   unmatched_participants: UnmatchedParticipant[];
+  staff_participants?: StaffParticipant[];
 }
 
 export interface InviteTemplateResponse {
@@ -207,6 +232,7 @@ export interface TimelineOccurrence {
   has_transcript: boolean;
   has_summary: boolean;
   ai_summary: string | null;
+  staff_participants?: StaffParticipant[];
 }
 
 export interface OccurrenceTimelineResponse {
@@ -283,6 +309,7 @@ export interface ZoomAttendanceParticipant {
   zoom_participant_id: string;
   user_profile: number | null;
   user_profile_detail: { id: number; email: string; role: string } | null;
+  role?: LiveParticipantRole;
 }
 
 export interface ZoomAttendanceResponse {
@@ -673,12 +700,33 @@ export const adminLiveActivitiesService = {
 
   /** Staff manually mark a roster student present (or clear it) for the session,
    *  or one occurrence of a recurring series. */
+  /**
+   * Manual attendance mark for one student (optionally scoped to one occurrence):
+   * `{present: true}` marks present, `{present: false}` is an ABSENT override that negates a
+   * Zoom-recorded join, `{clear: true}` removes the manual mark entirely (back to what Zoom saw).
+   */
   markAttendance: async (
     liveClassId: number,
-    input: { student_id: number; occurrence_id?: number; present: boolean }
+    input: { student_id: number; occurrence_id?: number; present?: boolean; clear?: boolean }
   ): Promise<ZoomApiResponse<unknown>> => {
     const response = await apiClient.post<ZoomApiResponse<unknown>>(
       `${BASE}/live-activities/${liveClassId}/attendance/mark/`,
+      input
+    );
+    return response.data;
+  },
+
+  /**
+   * Attach an unmatched Zoom participant row to a student: the real Zoom duration is kept, and a
+   * name alias is recorded so the same display name auto-matches next week. Same staff gate as
+   * markAttendance.
+   */
+  identifyParticipant: async (
+    liveClassId: number,
+    input: { participant_id: number; student_id: number; occurrence_id?: number }
+  ): Promise<unknown> => {
+    const response = await apiClient.post<unknown>(
+      `${BASE}/live-activities/${liveClassId}/attendance/identify/`,
       input
     );
     return response.data;

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -301,6 +301,8 @@ export interface AttendeeRow {
   email: string;
   duration_minutes: number | null;
   source: "zoom" | "meet" | "manual";
+  /** Zoom-side role (host/trainer/panelist); null/absent for an ordinary attendee. */
+  role?: "host" | "instructor" | "panelist" | null;
 }
 
 /** A roster student this participant might be. Advisory only - a human confirms. */

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -341,6 +341,12 @@ export interface InstructorLiveSessions {
 export interface HostLink {
   kind: "panelist" | "host" | "join";
   url: string;
+  /** The start_url was minted long ago and Zoom may reject it (they expire ~2h after issue). */
+  stale?: boolean;
+  /** How long Zoom start links stay valid from mint, when the backend knows it. */
+  expires_in_minutes?: number | null;
+  /** Webinar hosts also get the panelist link to hand to co-presenters. */
+  panelist_url?: string | null;
 }
 
 export interface CreateLiveSessionPayload {

--- a/lib/services/live-class.service.ts
+++ b/lib/services/live-class.service.ts
@@ -53,6 +53,8 @@ export interface UpdateLiveClassSessionPayload {
   class_datetime?: string;
   timezone?: string;
   duration_minutes?: number;
+  /** UserProfile id of the trainer; empty string clears the assignment. */
+  instructor_id?: number | "";
   meeting_link?: string;
   status?: string;
   course?: number | null;

--- a/lib/services/live-sessions/student-live-sessions.service.ts
+++ b/lib/services/live-sessions/student-live-sessions.service.ts
@@ -83,6 +83,8 @@ function toStudentSession(item: LiveActivityListItem): StudentLiveSession {
     prep_items: (item.prep_items as string[]) ?? [],
     agenda_generated_at: (item.agenda_generated_at as string) ?? null,
     my_prep: (item.my_prep as number[]) ?? [],
+    my_prep_by_occurrence:
+      (item.my_prep_by_occurrence as StudentLiveSession["my_prep_by_occurrence"]) ?? undefined,
   };
 }
 
@@ -128,11 +130,15 @@ export const studentLiveSessionsService = {
     return response.data;
   },
 
+  /** Same occurrence rule as getRecording: without `occurrenceId` a recurring series returns the
+   *  series-latest transcript, whichever date the student actually clicked. */
   getTranscript: async (
-    activityId: number
+    activityId: number,
+    occurrenceId?: number | null
   ): Promise<StudentLiveSessionTranscript> => {
     const response = await apiClient.get<StudentLiveSessionTranscript>(
-      `${BASE}/live-activities/${activityId}/transcript/`
+      `${BASE}/live-activities/${activityId}/transcript/`,
+      occurrenceId ? { params: { occurrence_id: occurrenceId } } : undefined
     );
     return response.data;
   },
@@ -162,14 +168,17 @@ export const studentLiveSessionsService = {
     return response.data;
   },
 
+  /** `occurrenceId` scopes the tick to one sitting of a recurring series; omit it for single
+   *  sessions (the backend then reads/writes the series-level list). */
   togglePrep: async (
     activityId: number,
     index: number,
-    done: boolean
+    done: boolean,
+    occurrenceId?: number | null
   ): Promise<{ completed: number[] }> => {
     const response = await apiClient.post(
       `${BASE}/live-activities/${activityId}/prep/`,
-      { index, done }
+      { index, done, ...(occurrenceId ? { occurrence_id: occurrenceId } : {}) }
     );
     return response.data;
   },

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -54,7 +54,8 @@ export interface StudentLiveSession {
   /** Provider-neutral flag from the serializer: something is watchable for this session. */
   has_recording?: boolean;
   course_detail?: { title?: string } | null;
-  cohort_detail?: { name?: string } | null;
+  /** The batch this session belongs to; `id` drives the batch filter + stable chip color. */
+  cohort_detail?: { id?: number; name?: string } | null;
   adaptive_course_detail?: { title?: string } | null;
   /** Instructor as shown to a student: their public CODE (real name hidden server-side). */
   instructor?: string | null;

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -112,7 +112,6 @@ export interface MyLiveStats {
   attendance_rate: number;
   cohort_avg_rate: number;
   live_hours: number;
-  recordings_left: number;
   week: { day: string; date: string; state: "none" | "attended" | "missed" | "live" | "upcoming" }[];
 }
 

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -87,6 +87,8 @@ export interface StudentLiveSession {
 /** One dated instance of a recurring series (from the live-activities serializer). */
 export interface StudentLiveOccurrence {
   id: number;
+  /** Per-date title (AI-titled after transcript sync, or admin-renamed); blank = series title. */
+  topic_name?: string | null;
   occurrence_datetime?: string | null;
   duration_minutes?: number | null;
   status?: string | null;

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -76,6 +76,12 @@ export interface StudentLiveSession {
   prep_items?: string[];
   agenda_generated_at?: string | null;
   my_prep?: number[];
+  /**
+   * Recurring series: the student's ticks PER OCCURRENCE, keyed by occurrence id (as a string —
+   * JSON object keys). `my_prep` stays the series-level list for single sessions and as the
+   * fallback when a backend predates this field.
+   */
+  my_prep_by_occurrence?: Record<string, number[]>;
 }
 
 /** One dated instance of a recurring series (from the live-activities serializer). */
@@ -87,6 +93,8 @@ export interface StudentLiveOccurrence {
   meeting_status?: "scheduled" | "live" | "ended" | "expired" | "cancelled" | null;
   has_recording?: boolean;
   zoom_recording_url?: string | null;
+  /** Per-occurrence AI summary (the series-level one is only the series-latest). */
+  zoom_ai_summary?: string | null;
 }
 
 /** GET .../live-activities/<id>/live-count/ — how many are in the Zoom session right now. */

--- a/lib/services/ticket.service.ts
+++ b/lib/services/ticket.service.ts
@@ -293,6 +293,25 @@ export const ticketService = {
     }
   },
 
+  /**
+   * Admin: nudge the assignee about this ticket (in-app notification + email).
+   * The backend 400s when the ticket is unassigned or already resolved - the reason is
+   * surfaced verbatim via unwrapError.
+   */
+  async remindAssignee(
+    clientId: number,
+    ticketId: number,
+  ): Promise<{ reminded: boolean; assignee_id: number }> {
+    try {
+      const { data } = await apiClient.post<{ reminded: boolean; assignee_id: number }>(
+        `/api/clients/${clientId}/tickets/${ticketId}/remind/`,
+      );
+      return data;
+    } catch (e) {
+      throw unwrapError(e, "Failed to send the reminder");
+    }
+  },
+
   async reopen(
     clientId: number,
     ticketId: number,

--- a/lib/utils/attendance-utils.ts
+++ b/lib/utils/attendance-utils.ts
@@ -27,6 +27,9 @@ export function aggregateParticipants(participants: ZoomAttendanceParticipant[])
       join_time: firstJoin,
       leave_time: lastLeave,
       duration_seconds: totalSeconds,
+      // A person's role rides along from whichever of their rows carries it (re-joins may not
+      // all be stamped).
+      role: rows.find((r) => r.role)?.role ?? null,
     };
   });
 }


### PR DESCRIPTION
Frontend counterpart of ai-linc-backend#665 — 14 commits, `npx tsc --noEmit` clean after every one (this repo's CI has no typecheck; verified manually throughout).

## Student
- Prep checklist per date (one tick no longer fans across every card of a series; each week starts 0/N)
- Summary/transcript dialog fetches the clicked date's transcript (per-date cache key)
- Self-refreshing page: boundary-aware silent refetch + visibilitychange + live-count ended-transition trigger; clock-window hero promotion respecting the join gate — Join now appears without F5
- Calendar day click filters the list (dots from occurrence-expanded instances); dismissible day chip
- Batch chips + batch filter when a learner is in ≥2 cohorts; per-date titles on cards
- "Recordings left" tile removed

## Instructor
- Stale host-link warning + "Copy panelist link"; row copy labeled as the attendee link
- Ticket queue: category chips + resolve dialog for assigned tickets; "View content" links to the adaptive courses they teach; role chips in the attendance dialog

## Admin
- Always-available "Edit session" dialog (topic/time/timezone/duration/trainer/cohort — trainer picker from the instructor directory)
- Per-date Rename / Reschedule / Cancel on the series timeline (Zoom-refusal errors surfaced verbatim)
- Editable roll-call: Mark present / Mark absent (negates a Zoom join, with Overridden chip) / Undo, per session and per date; "Assign to student" on unmatched joiners (records the auto-match alias); "Not yet enrolled" instead of "Missed" for late joiners; Host/Trainer/Panelist chips + "Staff & hosts" section
- "Remind assignee" button on ticket detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)