### PR TITLE
Live sessions wave 7 FE: Wise-parity filters and per-date controls

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -5,9 +5,16 @@ import { useParams, useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import {
   Box,
+  Button,
   Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
   Tabs,
   Tab,
+  TextField,
   ButtonBase,
   CircularProgress,
   IconButton,
@@ -52,7 +59,8 @@ import { LiveSessionNoticeDialog } from "@/components/admin/live-sessions/LiveSe
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import { StudyMaterialManager } from "@/components/live-sessions/StudyMaterialManager";
 import { EditWebinarDialog } from "@/components/admin/live-sessions/EditWebinarDialog";
-import { EditSessionDialog } from "@/components/admin/live-sessions/EditSessionDialog";
+import { EditSessionDialog, currentInstructorId } from "@/components/admin/live-sessions/EditSessionDialog";
+import { liveClassService } from "@/lib/services/live-class.service";
 import { formatSessionTime } from "@/lib/utils/session-time";
 
 function formatDateTime(s?: string | null, timezone?: string | null) {
@@ -92,6 +100,7 @@ export default function LiveSessionDetailPage() {
   const [playerOpen, setPlayerOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [editSessionOpen, setEditSessionOpen] = useState(false);
+  const [addDateOpen, setAddDateOpen] = useState(false);
   const [creatingGoogle, setCreatingGoogle] = useState(false);
   const [updatingGoogle, setUpdatingGoogle] = useState(false);
   const [cancellingGoogle, setCancellingGoogle] = useState(false);
@@ -415,8 +424,25 @@ export default function LiveSessionDetailPage() {
       {t("adminLiveSessions.editSession", "Edit session")}
     </ButtonBase>
   );
+  // Wise-parity "Add session": Zoom cannot grow a series ad-hoc, so an extra date is a linked
+  // SINGLE session with the same topic/audience/trainer, provisioned right here.
+  const addDateButton = isRecurring && isZoom && !isCancelled ? (
+    <ButtonBase
+      onClick={() => setAddDateOpen(true)}
+      sx={{
+        px: 2.25, py: 1, borderRadius: 999, fontWeight: 700, fontSize: "0.82rem",
+        color: "var(--success-500)", display: "inline-flex", alignItems: "center", gap: 0.5,
+        border: "1px solid color-mix(in srgb, var(--success-500) 35%, transparent)",
+        "&:hover": { background: "color-mix(in srgb, var(--success-500) 8%, transparent)" },
+      }}
+    >
+      <IconWrapper icon="mdi:calendar-plus" size={16} />
+      {t("adminLiveSessions.addADate", "Add a date")}
+    </ButtonBase>
+  ) : null;
   const headerActions = (
     <Box sx={{ display: "flex", gap: 1, alignItems: "center", flexWrap: "wrap" }}>
+      {addDateButton}
       {editSessionButton}
       {noticeButton}
       {deleteSessionButton}
@@ -774,7 +800,125 @@ export default function LiveSessionDetailPage() {
           onSaved={load}
         />
       )}
+
+      {activity && addDateOpen && (
+        <AddDateDialog
+          activity={activity}
+          onClose={() => setAddDateOpen(false)}
+          onCreated={(newId, warning) => {
+            setAddDateOpen(false);
+            showToast(
+              warning
+                ? t("adminLiveSessions.addDateZoomWarn", "Session created, but Zoom setup failed: {{msg}} You can retry from the new session.", { msg: warning })
+                : t("adminLiveSessions.addDateDone", "Date added as a linked session."),
+              warning ? "warning" : "success"
+            );
+            // The link to the new session: it opens directly.
+            router.push(`/admin/live-sessions/${newId}`);
+          }}
+        />
+      )}
     </MainLayout>
+  );
+}
+
+/**
+ * Add one extra date to a recurring series. Zoom's API cannot append an ad-hoc occurrence to an
+ * existing series, so this creates a linked SINGLE session carrying the series' topic, audience
+ * (cohort/course/adaptive course), trainer and meeting type - the same createSession→zoom/create
+ * chain the create page uses, minus the recurrence. The caller navigates to the new session.
+ */
+function AddDateDialog({ activity, onClose, onCreated }: {
+  activity: LiveActivity;
+  onClose: () => void;
+  onCreated: (newSessionId: number, zoomWarning?: string) => void;
+}) {
+  const { t } = useTranslation("common");
+  const { showToast } = useToast();
+  const [when, setWhen] = useState("");
+  const [duration, setDuration] = useState(activity.duration_minutes || 60);
+  const [creating, setCreating] = useState(false);
+
+  const valid = Boolean(when) && duration >= 1 && duration <= 480;
+
+  const submit = async () => {
+    if (!valid || creating) return;
+    try {
+      setCreating(true);
+      const created = await liveClassService.createSession({
+        topic_name: activity.topic_name,
+        description: activity.description || undefined,
+        class_datetime: when,
+        timezone: activity.timezone || undefined,
+        duration_minutes: duration,
+        instructor_id: currentInstructorId(activity) ?? undefined,
+        course: activity.course ?? undefined,
+        cohort: activity.cohort ?? undefined,
+        adaptive_course: activity.adaptive_course ?? undefined,
+        zoom_meeting_type: activity.zoom_meeting_type ?? "meeting",
+      });
+      // Single session: no recurrence. A Zoom failure here still leaves the session row, where
+      // the normal "Create Zoom" retry lives - so report it as a warning, not a dead end.
+      const result = await adminLiveActivitiesService.createZoom(created.id, {});
+      onCreated(created.id, result.status === "error" ? result.message || "Zoom refused." : undefined);
+    } catch (e) {
+      showToast(getLiveSessionErrorMessage(e, "zoom_create"), "error");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Dialog open onClose={creating ? undefined : onClose} maxWidth="xs" fullWidth
+      PaperProps={{ sx: { borderRadius: "18px", border: "1px solid var(--border-default)", backgroundColor: "var(--card-bg)", backgroundImage: "none" } }}>
+      <DialogTitle sx={{ fontWeight: 700, fontSize: "1.02rem", color: "var(--font-primary)" }}>
+        {t("adminLiveSessions.addADate", "Add a date")}
+      </DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+            {t(
+              "adminLiveSessions.addADateHint",
+              "Creates a linked one-off session with this series' topic, audience and trainer - Zoom can't add a single extra date to the series itself."
+            )}
+          </Typography>
+          <TextField
+            label={t("adminLiveSessions.classDateAndTime", "Date and time")}
+            type="datetime-local"
+            value={when}
+            onChange={(e) => setWhen(e.target.value)}
+            fullWidth
+            size="small"
+            InputLabelProps={{ shrink: true }}
+            helperText={t("adminLiveSessions.occurrenceTimeInZone", "Wall-clock time in {{zone}}. Zoom and students are updated.", {
+              zone: activity.timezone || t("adminLiveSessions.theSessionZone", "the session's timezone"),
+            })}
+          />
+          <TextField
+            label={t("adminLiveSessions.durationMinutes", "Duration (minutes)")}
+            type="number"
+            value={duration}
+            onChange={(e) => setDuration(Math.min(480, Math.max(1, Number(e.target.value) || 60)))}
+            fullWidth
+            size="small"
+            inputProps={{ min: 1, max: 480 }}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={creating} sx={{ borderRadius: "12px", textTransform: "none", color: "var(--font-secondary)" }}>
+          {t("adminLiveSessions.cancel", "Cancel")}
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void submit()}
+          disabled={!valid || creating}
+          sx={{ borderRadius: "12px", textTransform: "none", fontWeight: 700, background: "var(--accent-indigo)", color: "#fff", "&:hover": { background: "var(--accent-indigo-dark)" } }}
+        >
+          {creating ? <CircularProgress size={20} color="inherit" /> : t("adminLiveSessions.addADate", "Add a date")}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 

--- a/app/admin/live-sessions/page.tsx
+++ b/app/admin/live-sessions/page.tsx
@@ -36,7 +36,7 @@ import { ViewToggle, type ListView } from "@/components/common/list";
 import { useToast } from "@/components/common/Toast";
 import type { LiveActivity } from "@/lib/services/admin/admin-live-activities.service";
 import { zoomService } from "@/lib/services/zoom.service";
-import { ScheduleCalendar, type CalendarEvent } from "@/components/live-sessions/ScheduleCalendar";
+import { ScheduleCalendar, dayKey, type CalendarEvent } from "@/components/live-sessions/ScheduleCalendar";
 import { getAssessments, type Assessment } from "@/lib/services/admin/admin-assessment.service";
 import adminMockInterviewService, { type AdminInterviewListItem } from "@/lib/services/admin/admin-mock-interview.service";
 import { config } from "@/lib/config";
@@ -51,6 +51,44 @@ function adminHhmm(iso?: string | null): string {
 }
 
 const PAST = new Set(["ended", "expired"]);
+
+/**
+ * Every way a session is targeted, as namespaced facet keys ('c:' cohort, 'a:' adaptive course,
+ * 'l:' legacy course + id) so the three id spaces can never collide. A session matches a selected
+ * facet if ANY of its mappings does.
+ */
+function adminFacetsOf(s: LiveActivity): { key: string; label: string; kind: "cohort" | "course" }[] {
+  const out: { key: string; label: string; kind: "cohort" | "course" }[] = [];
+  if (s.cohort_detail?.id != null && s.cohort_detail.name) {
+    out.push({ key: `c:${s.cohort_detail.id}`, label: s.cohort_detail.name, kind: "cohort" });
+  }
+  if (s.adaptive_course_detail?.id != null && s.adaptive_course_detail.title) {
+    out.push({ key: `a:${s.adaptive_course_detail.id}`, label: s.adaptive_course_detail.title, kind: "course" });
+  }
+  if (s.course_detail?.id != null && s.course_detail.title) {
+    out.push({ key: `l:${s.course_detail.id}`, label: s.course_detail.title, kind: "course" });
+  }
+  return out;
+}
+
+/** The concrete local days a session sits on: every non-cancelled occurrence for a recurring
+ *  series (its class_datetime is frozen at occurrence #1), else its own start. */
+function sessionDayKeys(s: LiveActivity): string[] {
+  const occs = (s.zoom_is_recurring ? s.occurrences : undefined) ?? [];
+  const dates =
+    occs.length > 0
+      ? occs
+          .filter((o) => o.status !== "cancelled" && o.meeting_status !== "cancelled")
+          .map((o) => o.occurrence_datetime)
+      : [s.class_datetime];
+  const out: string[] = [];
+  for (const iso of dates) {
+    if (!iso) continue;
+    const d = new Date(iso);
+    if (!isNaN(d.getTime())) out.push(dayKey(d));
+  }
+  return out;
+}
 
 export default function AdminLiveSessionsPage() {
   const { t } = useTranslation("common");
@@ -117,6 +155,10 @@ export default function AdminLiveSessionsPage() {
   const [viewMode, setViewMode] = useState<"list" | "calendar">("list");
   // Card ↔ compact-row layout for the (non-calendar) sessions list.
   const [listView, setListView] = useState<ListView>("cards");
+  // Calendar day filter (local YYYY-MM-DD from dayKey); null = show everything.
+  const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  // Batch/course facet filter (namespaced key from adminFacetsOf); null = everything.
+  const [facetFilter, setFacetFilter] = useState<string | null>(null);
   // Extra calendar sources (best-effort — a failure just leaves those dots off the calendar).
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [interviews, setInterviews] = useState<AdminInterviewListItem[]>([]);
@@ -240,21 +282,40 @@ export default function AdminLiveSessionsPage() {
     return { upcoming, live, past, webinars, total: sessions.length };
   }, [sessions]);
 
+  // The distinct batch/course facets across all sessions - the chips render only when >= 2.
+  const facetOptions = useMemo(() => {
+    const map = new Map<string, { key: string; label: string; kind: "cohort" | "course" }>();
+    for (const s of sessions) {
+      for (const f of adminFacetsOf(s)) if (!map.has(f.key)) map.set(f.key, f);
+    }
+    return Array.from(map.values()).sort(
+      (a, b) => (a.kind === b.kind ? a.label.localeCompare(b.label) : a.kind === "cohort" ? -1 : 1)
+    );
+  }, [sessions]);
+  const selectedDayLabel = useMemo(() => {
+    if (!selectedDay) return "";
+    const [y, m, d] = selectedDay.split("-").map(Number);
+    return new Date(y, m - 1, d).toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+  }, [selectedDay]);
+
   const filteredSessions = useMemo(() => {
-    if (filter === "all") return sessions;
-    if (filter === "upcoming") return sessions.filter((s) => s.meeting_status === "scheduled");
-    if (filter === "live") return sessions.filter((s) => s.meeting_status === "live");
-    if (filter === "past") return sessions.filter((s) => PAST.has(s.meeting_status ?? ""));
-    return sessions;
-  }, [sessions, filter]);
+    let list = sessions;
+    if (filter === "upcoming") list = list.filter((s) => s.meeting_status === "scheduled");
+    else if (filter === "live") list = list.filter((s) => s.meeting_status === "live");
+    else if (filter === "past") list = list.filter((s) => PAST.has(s.meeting_status ?? ""));
+    if (facetFilter) list = list.filter((s) => adminFacetsOf(s).some((f) => f.key === facetFilter));
+    // Day filter is occurrence-aware: a recurring series matches on any of its sitting days.
+    if (selectedDay) list = list.filter((s) => sessionDayKeys(s).includes(selectedDay));
+    return list;
+  }, [sessions, filter, facetFilter, selectedDay]);
 
   const pageCount = Math.max(1, Math.ceil(filteredSessions.length / rowsPerPage));
   const pagedSessions = filteredSessions.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
 
-  // Reset to first page when the filter changes.
+  // Reset to first page when any filter changes.
   useEffect(() => {
     setPage(0);
-  }, [filter, setPage]);
+  }, [filter, facetFilter, selectedDay, setPage]);
 
   const openDetail = useCallback(
     (s: LiveActivity) => router.push(`/admin/live-sessions/${s.id}`),
@@ -262,18 +323,38 @@ export default function AdminLiveSessionsPage() {
   );
 
   // Unified calendar feed: live sessions (click → detail) + assessment windows (start=assessment,
-  // end=deadline) + scheduled mock interviews.
+  // end=deadline) + scheduled mock interviews. Recurring series are expanded into one event per
+  // non-cancelled occurrence - fed raw, a 50-date series got a single dot on occurrence #1's day
+  // (class_datetime is frozen there) and none on the other 49.
   const calendarEvents = useMemo<CalendarEvent[]>(() => {
     const evs: CalendarEvent[] = [];
     for (const s of sessions) {
+      const subtitle = s.cohort_detail?.name || s.adaptive_course_detail?.title || s.course_detail?.title || undefined;
+      const occs = (s.zoom_is_recurring ? s.occurrences : undefined) ?? [];
+      if (occs.length > 0) {
+        for (const o of occs) {
+          if (o.status === "cancelled" || o.meeting_status === "cancelled") continue;
+          if (!o.occurrence_datetime) continue;
+          evs.push({
+            id: `live-${s.id}-${o.id}`,
+            date: o.occurrence_datetime,
+            title: o.topic_name || s.topic_name || "Live session",
+            type: "live",
+            note: o.meeting_status === "live" ? "live now" : undefined,
+            subtitle,
+            onClick: () => openDetail(s),
+          });
+        }
+        continue;
+      }
       if (!s.class_datetime) continue;
       evs.push({
-        id: `live-${s.id}`,
+        id: `live-${s.id}-0`,
         date: s.class_datetime,
         title: s.topic_name || "Live session",
         type: "live",
         note: s.meeting_status === "live" ? "live now" : undefined,
-        subtitle: s.cohort_detail?.name || s.course_detail?.title || undefined,
+        subtitle,
         onClick: () => openDetail(s),
       });
     }
@@ -460,9 +541,58 @@ export default function AdminLiveSessionsPage() {
                   </Box>
                 </Box>
 
+                {/* Batch/course facet filter - only when the tenant actually spans several. */}
+                {facetOptions.length >= 2 && (
+                  <SessionFilterChips
+                    options={[
+                      { key: "", label: t("adminLiveSessions.filterAllFacets", "All batches & courses"), color: "var(--accent-indigo)" },
+                      ...facetOptions.map((f) => ({
+                        key: f.key,
+                        label: f.label,
+                        color: f.kind === "cohort" ? "var(--accent-indigo)" : "var(--font-tertiary)",
+                      })),
+                    ]}
+                    value={facetFilter ?? ""}
+                    onChange={(k) => setFacetFilter(k === "" ? null : k)}
+                  />
+                )}
+
+                {/* Calendar day filter chip - dismissible; clicking the same day again also clears. */}
+                {selectedDay && (
+                  <Box>
+                    <Box
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setSelectedDay(null)}
+                      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setSelectedDay(null); }}
+                      sx={{
+                        display: "inline-flex", alignItems: "center", gap: 0.6, px: 1.5, py: 0.6, borderRadius: 999,
+                        cursor: "pointer", fontSize: "0.8rem", fontWeight: 700, color: "var(--accent-indigo)",
+                        bgcolor: "color-mix(in srgb, var(--accent-indigo) 12%, transparent)",
+                        border: "1px solid color-mix(in srgb, var(--accent-indigo) 30%, transparent)",
+                        "&:hover": { bgcolor: "color-mix(in srgb, var(--accent-indigo) 18%, transparent)" },
+                      }}
+                    >
+                      <IconWrapper icon="mdi:calendar-search" size={15} />
+                      {t("adminLiveSessions.showingDay", "Showing {{day}}", { day: selectedDayLabel })}
+                      <IconWrapper icon="mdi:close-circle" size={16} />
+                    </Box>
+                  </Box>
+                )}
+
                 {viewMode === "calendar" ? (
                   <Box sx={{ maxWidth: 460, mx: "auto", width: "100%" }}>
-                    <ScheduleCalendar events={calendarEvents} title="Schedule" />
+                    <ScheduleCalendar
+                      events={calendarEvents}
+                      title="Schedule"
+                      selectedKey={selectedDay}
+                      onSelectDay={(k) => {
+                        setSelectedDay(k);
+                        // Picking a day is a request to SEE that day's sessions - the filtered
+                        // list is where they are, so jump straight to it.
+                        if (k) setViewMode("list");
+                      }}
+                    />
                   </Box>
                 ) : filteredSessions.length === 0 ? (
                   <Box sx={{ textAlign: "center", py: 6 }}>

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -347,6 +347,8 @@ export default function InstructorLiveSessionsPage() {
             onClick={() => {
               setAddDateInit({
                 topic: occMenu.s.topic_name,
+                cohortId: occMenu.s.cohort_id ?? null,
+                adaptiveCourseId: occMenu.s.adaptive_course_id ?? null,
                 audienceName: occMenu.s.cohort_name || null,
                 sessionType: occMenu.s.is_webinar ? "webinar" : "meeting",
               });
@@ -589,11 +591,14 @@ function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCo
 
 /* --------------------------- create session dialog -------------------------- */
 
-/** Prefill for "Add a date" on a recurring series: same topic + meeting type; the audience is
- *  matched by NAME once the cohort list loads, because the instructor list item carries only
- *  cohort_name - no cohort/course ids (falls back to a manual pick when nothing matches). */
+/** Prefill for "Add a date" on a recurring series: same topic + meeting type + the EXACT
+ *  audience via cohort_id/adaptive_course_id. `audienceName` is only the fallback for a stale
+ *  payload that predates those fields (matched by name once the cohort list loads; a miss just
+ *  leaves the picker for the user). */
 interface CreateSessionInitial {
   topic?: string;
+  cohortId?: number | null;
+  adaptiveCourseId?: number | null;
   audienceName?: string | null;
   sessionType?: "meeting" | "webinar";
 }
@@ -636,13 +641,26 @@ function CreateSessionDialog({ open, initial = null, onClose, onCreated }: {
     if (initial.topic) setTopic((prev) => prev || initial.topic!);
     if (initial.sessionType) setSessionType(initial.sessionType);
   }, [open, initial]);
-  // The audience can only be matched once the cohort list has arrived (by name - see the
-  // CreateSessionInitial note). A course-targeted series has no cohort_name; the user picks.
+  // Audience prefill: the exact id when the row carries one (set only once the fetched list
+  // actually contains it, so the Select never holds an option it can't render), else the
+  // name-matching fallback for stale payloads. A miss leaves the picker to the user.
   useEffect(() => {
-    if (!open || !initial?.audienceName) return;
-    const m = cohorts.find((c) => c.name === initial.audienceName);
-    if (m) setAudience((prev) => prev || `c:${m.id}`);
-  }, [open, initial, cohorts]);
+    if (!open || !initial) return;
+    setAudience((prev) => {
+      if (prev) return prev;
+      if (initial.cohortId != null && cohorts.some((c) => c.id === initial.cohortId)) {
+        return `c:${initial.cohortId}`;
+      }
+      if (initial.adaptiveCourseId != null && courses.some((c) => c.id === initial.adaptiveCourseId)) {
+        return `a:${initial.adaptiveCourseId}`;
+      }
+      if (initial.cohortId == null && initial.adaptiveCourseId == null && initial.audienceName) {
+        const m = cohorts.find((c) => c.name === initial.audienceName);
+        if (m) return `c:${m.id}`;
+      }
+      return prev;
+    });
+  }, [open, initial, cohorts, courses]);
 
   const reset = () => {
     setTopic(""); setDescription(""); setWhen(""); setDuration(60); setAudience("");

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -128,6 +128,9 @@ export default function InstructorLiveSessionsPage() {
   const [editOcc, setEditOcc] = useState<InstructorLiveSession | null>(null);
   const [cancelOcc, setCancelOcc] = useState<InstructorLiveSession | null>(null);
   const [cancellingOcc, setCancellingOcc] = useState(false);
+  // "Add a date": Zoom cannot grow a series ad-hoc, so an extra date is a linked SINGLE session
+  // with the same topic/audience - the create dialog opens prefilled from the series.
+  const [addDateInit, setAddDateInit] = useState<CreateSessionInitial | null>(null);
 
   const reload = useCallback(async () => {
     try {
@@ -307,9 +310,9 @@ export default function InstructorLiveSessionsPage() {
             onRecording={() => s.recording_url && window.open(s.recording_url, "_blank", "noopener")}
             onDelete={() => removeSession(s)}
             // Per-date controls for a trainer hosting this sitting (a past date has nothing to
-            // move or call off).
+            // move or call off), plus "Add a date" on any recurring row they host.
             onMenu={
-              s.hostable && s.occurrence_id != null && status !== "ended"
+              s.hostable && ((s.occurrence_id != null && status !== "ended") || s.is_recurring)
                 ? (e) => setOccMenu({ anchor: e.currentTarget, s })
                 : undefined
             }
@@ -323,18 +326,37 @@ export default function InstructorLiveSessionsPage() {
         anchorEl={occMenu?.anchor ?? null}
         onClose={() => setOccMenu(null)}
       >
-        <MenuItem
-          onClick={() => { if (occMenu) setEditOcc(occMenu.s); setOccMenu(null); }}
-          sx={{ fontSize: "0.86rem", fontWeight: 600 }}
-        >
-          <Icon icon="mdi:calendar-edit" width={16} style={{ marginRight: 8 }} /> Edit this date
-        </MenuItem>
-        <MenuItem
-          onClick={() => { if (occMenu) setCancelOcc(occMenu.s); setOccMenu(null); }}
-          sx={{ fontSize: "0.86rem", fontWeight: 600, color: "#ef4444" }}
-        >
-          <Icon icon="mdi:calendar-remove" width={16} style={{ marginRight: 8 }} /> Cancel this date
-        </MenuItem>
+        {occMenu && occMenu.s.occurrence_id != null && statusOf(occMenu.s, now) !== "ended" && (
+          <MenuItem
+            onClick={() => { setEditOcc(occMenu.s); setOccMenu(null); }}
+            sx={{ fontSize: "0.86rem", fontWeight: 600 }}
+          >
+            <Icon icon="mdi:calendar-edit" width={16} style={{ marginRight: 8 }} /> Edit this date
+          </MenuItem>
+        )}
+        {occMenu && occMenu.s.occurrence_id != null && statusOf(occMenu.s, now) !== "ended" && (
+          <MenuItem
+            onClick={() => { setCancelOcc(occMenu.s); setOccMenu(null); }}
+            sx={{ fontSize: "0.86rem", fontWeight: 600, color: "#ef4444" }}
+          >
+            <Icon icon="mdi:calendar-remove" width={16} style={{ marginRight: 8 }} /> Cancel this date
+          </MenuItem>
+        )}
+        {occMenu?.s.is_recurring && (
+          <MenuItem
+            onClick={() => {
+              setAddDateInit({
+                topic: occMenu.s.topic_name,
+                audienceName: occMenu.s.cohort_name || null,
+                sessionType: occMenu.s.is_webinar ? "webinar" : "meeting",
+              });
+              setOccMenu(null);
+            }}
+            sx={{ fontSize: "0.86rem", fontWeight: 600 }}
+          >
+            <Icon icon="mdi:calendar-plus" width={16} style={{ marginRight: 8 }} /> Add a date
+          </MenuItem>
+        )}
       </Menu>
 
       <EditOccurrenceDateDialog
@@ -361,7 +383,8 @@ export default function InstructorLiveSessionsPage() {
         </Typography>
       )}
 
-      <CreateSessionDialog open={createOpen} onClose={() => setCreateOpen(false)}
+      <CreateSessionDialog open={createOpen || Boolean(addDateInit)} initial={addDateInit}
+        onClose={() => { setCreateOpen(false); setAddDateInit(null); }}
         onCreated={(msg) => { setToast({ text: msg, sev: "success" }); void reload(); }} />
       <EditSessionDialog session={editing} onClose={() => setEditing(null)}
         onSaved={() => { setToast({ text: "Session updated.", sev: "success" }); void reload(); }} />
@@ -566,8 +589,17 @@ function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCo
 
 /* --------------------------- create session dialog -------------------------- */
 
-function CreateSessionDialog({ open, onClose, onCreated }: {
-  open: boolean; onClose: () => void; onCreated: (msg: string) => void;
+/** Prefill for "Add a date" on a recurring series: same topic + meeting type; the audience is
+ *  matched by NAME once the cohort list loads, because the instructor list item carries only
+ *  cohort_name - no cohort/course ids (falls back to a manual pick when nothing matches). */
+interface CreateSessionInitial {
+  topic?: string;
+  audienceName?: string | null;
+  sessionType?: "meeting" | "webinar";
+}
+
+function CreateSessionDialog({ open, initial = null, onClose, onCreated }: {
+  open: boolean; initial?: CreateSessionInitial | null; onClose: () => void; onCreated: (msg: string) => void;
 }) {
   const [cohorts, setCohorts] = useState<InstructorCohort[]>([]);
   const [courses, setCourses] = useState<InstructorCourse[]>([]);
@@ -596,6 +628,21 @@ function CreateSessionDialog({ open, onClose, onCreated }: {
     // Default the session zone to the instructor's own zone (client-only).
     setSessionTz((prev) => prev || tenantTz);
   }, [open]);
+
+  // "Add a date" prefill: topic + meeting type from the series. Only fills empty fields, so a
+  // user's own typing is never clobbered by a re-render.
+  useEffect(() => {
+    if (!open || !initial) return;
+    if (initial.topic) setTopic((prev) => prev || initial.topic!);
+    if (initial.sessionType) setSessionType(initial.sessionType);
+  }, [open, initial]);
+  // The audience can only be matched once the cohort list has arrived (by name - see the
+  // CreateSessionInitial note). A course-targeted series has no cohort_name; the user picks.
+  useEffect(() => {
+    if (!open || !initial?.audienceName) return;
+    const m = cohorts.find((c) => c.name === initial.audienceName);
+    if (m) setAudience((prev) => prev || `c:${m.id}`);
+  }, [open, initial, cohorts]);
 
   const reset = () => {
     setTopic(""); setDescription(""); setWhen(""); setDuration(60); setAudience("");

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   FormControlLabel,
   IconButton,
+  Menu,
   MenuItem,
   Snackbar,
   Stack,
@@ -36,7 +37,8 @@ import {
 } from "@/lib/services/instructor.service";
 import { adminLiveActivitiesService } from "@/lib/services/admin/admin-live-activities.service";
 import { RoleChip } from "@/components/live-sessions/ui/LiveSessionUI";
-import { viewerTimeZone, timezoneOptions, sessionTimeParts } from "@/lib/utils/session-time";
+import { ConfirmDialog } from "@/components/common/ConfirmDialog";
+import { viewerTimeZone, timezoneOptions, sessionTimeParts, toLocalInputInZone } from "@/lib/utils/session-time";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 
 type SessionStatus = "live" | "scheduled" | "ended";
@@ -120,6 +122,12 @@ export default function InstructorLiveSessionsPage() {
   const [editing, setEditing] = useState<InstructorLiveSession | null>(null);
   const [attendanceFor, setAttendanceFor] = useState<InstructorLiveSession | null>(null);
   const [materialsFor, setMaterialsFor] = useState<InstructorLiveSession | null>(null);
+  // Per-date (occurrence) controls: the ⋮ menu's anchor+row, the row being edited/cancelled.
+  // The occurrence endpoints authorize the session's hosting instructor now, not only admins.
+  const [occMenu, setOccMenu] = useState<{ anchor: HTMLElement; s: InstructorLiveSession } | null>(null);
+  const [editOcc, setEditOcc] = useState<InstructorLiveSession | null>(null);
+  const [cancelOcc, setCancelOcc] = useState<InstructorLiveSession | null>(null);
+  const [cancellingOcc, setCancellingOcc] = useState(false);
 
   const reload = useCallback(async () => {
     try {
@@ -192,6 +200,26 @@ export default function InstructorLiveSessionsPage() {
       setHostingId(null);
     }
   };
+  const cancelOccurrence = async () => {
+    if (!cancelOcc?.occurrence_id) return;
+    try {
+      setCancellingOcc(true);
+      const res = await adminLiveActivitiesService.cancelOccurrence(cancelOcc.id, cancelOcc.occurrence_id);
+      const warnings = res.data?.warnings ?? [];
+      setToast({
+        text: warnings.length ? `This date was cancelled. ${warnings.join(" ")}` : "This date was cancelled.",
+        sev: warnings.length ? "warning" : "success",
+      });
+      setCancelOcc(null);
+      void reload();
+    } catch (e) {
+      // 409 = unsafe to edit, 502 = Zoom refused; both carry their reason in the body.
+      setToast({ text: getAxiosErrorDetail(e, "Couldn't cancel this date."), sev: "error" });
+    } finally {
+      setCancellingOcc(false);
+    }
+  };
+
   const removeSession = async (s: InstructorLiveSession) => {
     if (!window.confirm(`Delete "${s.topic_name}"? This also removes the Zoom session.`)) return;
     try {
@@ -278,9 +306,54 @@ export default function InstructorLiveSessionsPage() {
             onMaterials={() => setMaterialsFor(s)}
             onRecording={() => s.recording_url && window.open(s.recording_url, "_blank", "noopener")}
             onDelete={() => removeSession(s)}
+            // Per-date controls for a trainer hosting this sitting (a past date has nothing to
+            // move or call off).
+            onMenu={
+              s.hostable && s.occurrence_id != null && status !== "ended"
+                ? (e) => setOccMenu({ anchor: e.currentTarget, s })
+                : undefined
+            }
           />
         ))}
       </Stack>
+
+      {/* Per-date ⋮ menu */}
+      <Menu
+        open={Boolean(occMenu)}
+        anchorEl={occMenu?.anchor ?? null}
+        onClose={() => setOccMenu(null)}
+      >
+        <MenuItem
+          onClick={() => { if (occMenu) setEditOcc(occMenu.s); setOccMenu(null); }}
+          sx={{ fontSize: "0.86rem", fontWeight: 600 }}
+        >
+          <Icon icon="mdi:calendar-edit" width={16} style={{ marginRight: 8 }} /> Edit this date
+        </MenuItem>
+        <MenuItem
+          onClick={() => { if (occMenu) setCancelOcc(occMenu.s); setOccMenu(null); }}
+          sx={{ fontSize: "0.86rem", fontWeight: 600, color: "#ef4444" }}
+        >
+          <Icon icon="mdi:calendar-remove" width={16} style={{ marginRight: 8 }} /> Cancel this date
+        </MenuItem>
+      </Menu>
+
+      <EditOccurrenceDateDialog
+        session={editOcc}
+        onClose={() => setEditOcc(null)}
+        onSaved={() => { setToast({ text: "This date was updated.", sev: "success" }); void reload(); }}
+        onError={(text) => setToast({ text, sev: "error" })}
+      />
+
+      <ConfirmDialog
+        open={Boolean(cancelOcc)}
+        title="Cancel this date?"
+        message="Only this date is cancelled - the series and its other dates stay. Zoom is updated and students stop seeing this sitting. This can't be undone."
+        confirmText={cancellingOcc ? "Cancelling…" : "Cancel this date"}
+        cancelText="Keep it"
+        confirmColor="error"
+        onConfirm={() => void cancelOccurrence()}
+        onCancel={() => setCancelOcc(null)}
+      />
 
       {showTruncation && (
         <Typography sx={{ textAlign: "center", color: "text.secondary", fontSize: "0.82rem", mt: 2.5 }}>
@@ -341,9 +414,10 @@ function TurnoutBlock({ label, attendance, registered, turnout, unidentified = 0
   );
 }
 
-function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCopyPanelist, onEdit, onAttendance, onMaterials, onRecording, onDelete }: {
+function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCopyPanelist, onEdit, onAttendance, onMaterials, onRecording, onDelete, onMenu }: {
   s: InstructorLiveSession; status: SessionStatus; now: number; hosting: boolean; panelistUrl?: string;
   onHost: () => void; onCopy: () => void; onCopyPanelist: () => void; onEdit: () => void; onAttendance: () => void; onMaterials: () => void; onRecording: () => void; onDelete: () => void;
+  onMenu?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
   const m = STATUS_META[status];
   const p = PROVIDER_META[s.provider] ?? PROVIDER_META.manual;
@@ -469,6 +543,11 @@ function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCo
           {s.created_by_me && (
             <IconButton size="small" onClick={onDelete} sx={{ color: "text.secondary", "&:hover": { color: "#ef4444" } }} aria-label="Delete session">
               <Icon icon="mdi:trash-can-outline" width={18} />
+            </IconButton>
+          )}
+          {onMenu && (
+            <IconButton size="small" onClick={onMenu} sx={{ color: "text.secondary" }} aria-label="Options for this date">
+              <Icon icon="mdi:dots-vertical" width={18} />
             </IconButton>
           )}
         </Stack>
@@ -857,6 +936,88 @@ function AttendanceDialog({ session, onClose }: { session: InstructorLiveSession
       </DialogContent>
       <DialogActions sx={{ px: 3, pb: 2 }}>
         <Button onClick={onClose} sx={{ textTransform: "none", fontWeight: 700 }}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/* ------------------------- edit-one-date dialog (occurrence) ------------------------- */
+
+/**
+ * Move/retitle ONE sitting of a recurring series. The row's class_datetime IS this occurrence's
+ * start (the list returns one row per sitting), so the wall-clock prefills from it in the
+ * session's own zone. The occurrence endpoints authorize the hosting instructor now - the same
+ * URL the admin timeline uses.
+ */
+function EditOccurrenceDateDialog({ session, onClose, onSaved, onError }: {
+  session: InstructorLiveSession | null;
+  onClose: () => void;
+  onSaved: () => void;
+  onError: (text: string) => void;
+}) {
+  const [when, setWhen] = useState("");
+  const [duration, setDuration] = useState(60);
+  const [title, setTitle] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (session) {
+      setWhen(toLocalInputInZone(session.class_datetime, session.timezone || undefined));
+      setDuration(session.duration_minutes || 60);
+      // Deliberately blank: the list does not say whether the row's title is the series' or this
+      // date's own, so an untouched field sends nothing and overwrites nothing.
+      setTitle("");
+    }
+  }, [session]);
+
+  const valid = Boolean(when) && duration >= 1 && duration <= 600;
+
+  const submit = async () => {
+    if (!session?.occurrence_id || !valid || saving) return;
+    try {
+      setSaving(true);
+      await adminLiveActivitiesService.updateOccurrence(session.id, session.occurrence_id, {
+        occurrence_datetime: when,
+        ...(session.timezone ? { timezone: session.timezone } : {}),
+        duration_minutes: duration,
+        ...(title.trim() ? { topic_name: title.trim() } : {}),
+      });
+      onSaved();
+      onClose();
+    } catch (e) {
+      // 502 = Zoom refused the time change (its own words), 409 = unsafe to edit.
+      onError(getAxiosErrorDetail(e, "Couldn't update this date."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={Boolean(session)} onClose={saving ? undefined : onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ fontWeight: 800 }}>Edit this date</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>
+            Only this sitting moves - the rest of the series stays where it is.
+          </Typography>
+          <TextField label="Starts" type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
+            fullWidth size="small" InputLabelProps={{ shrink: true }}
+            helperText={`Wall-clock time in ${session?.timezone || "the session's timezone"}`} />
+          <TextField label="Duration (min)" type="number" value={duration}
+            onChange={(e) => setDuration(Math.max(1, Math.min(600, Number(e.target.value) || 0)))}
+            size="small" inputProps={{ min: 1, max: 600 }} />
+          <TextField label="Title for this date (optional)" value={title} onChange={(e) => setTitle(e.target.value)}
+            fullWidth size="small" placeholder={session?.topic_name}
+            helperText="Leave blank to keep the current title." />
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={saving} sx={{ textTransform: "none", fontWeight: 700 }}>Cancel</Button>
+        <Button onClick={() => void submit()} disabled={!valid || saving}
+          startIcon={saving ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:content-save" width={16} />}
+          sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, borderRadius: 2, background: "linear-gradient(135deg,#7c3aed,#ec4899)" }}>
+          {saving ? "Saving…" : "Save changes"}
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -46,30 +46,65 @@ function courseOf(s: StudentLiveSession): string {
 /** Course title only - for cards that already show the batch as its own chip, so the batch name
  *  isn't printed twice. */
 function courseTextOf(s: StudentLiveSession): string {
-  return s.adaptive_course_detail?.title || s.course_detail?.title || "";
+  return s.adaptive_course_detail?.title || s.course_detail?.title || s.course_detail?.name || "";
 }
 /** Stable per-batch accent so the same cohort always wears the same color across cards. */
 const COHORT_CHIP_COLORS = ["#6366f1", "#0ea5e9", "#f59e0b", "#10b981", "#ec4899", "#8b5cf6", "#14b8a6", "#f43f5e"];
 function cohortColorOf(id: number): string {
   return COHORT_CHIP_COLORS[Math.abs(id) % COHORT_CHIP_COLORS.length];
 }
-/** The batch a session belongs to, as a prominent colored chip. Null-safe: renders nothing when
- *  the session has no cohort (course-targeted sessions). */
+/** Courses are a facet too, but a muted one - batches keep the loud colors. */
+const COURSE_FACET_COLOR = "#64748b";
+
+/**
+ * Every way this session is targeted, as namespaced facet keys ('c:' cohort, 'a:' adaptive
+ * course, 'l:' legacy course + id) so the three id spaces can never collide. A session matches a
+ * selected facet if ANY of its mappings does.
+ */
+function facetsOf(s: StudentLiveSession): { key: string; label: string; kind: "cohort" | "course" }[] {
+  const out: { key: string; label: string; kind: "cohort" | "course" }[] = [];
+  if (s.cohort_detail?.id != null && s.cohort_detail.name) {
+    out.push({ key: `c:${s.cohort_detail.id}`, label: s.cohort_detail.name, kind: "cohort" });
+  }
+  if (s.adaptive_course_detail?.id != null && s.adaptive_course_detail.title) {
+    out.push({ key: `a:${s.adaptive_course_detail.id}`, label: s.adaptive_course_detail.title, kind: "course" });
+  }
+  const cd = s.course_detail;
+  const cdLabel = cd?.title || cd?.name;
+  if (cd?.id != null && cdLabel) {
+    out.push({ key: `l:${cd.id}`, label: cdLabel, kind: "course" });
+  }
+  return out;
+}
+function facetColorOf(key: string): string {
+  return key.startsWith("c:") ? cohortColorOf(Number(key.slice(2))) : COURSE_FACET_COLOR;
+}
+/** Card text next to the chip: never repeat what the chip already says. */
+function cardCourseText(s: StudentLiveSession): string {
+  if (s.cohort_detail?.id != null && s.cohort_detail?.name) return courseTextOf(s); // chip = batch
+  if (courseTextOf(s)) return ""; // chip = the course itself
+  return courseOf(s); // no chip at all - keep the old text
+}
+/** What this session belongs to, as a prominent colored chip: the batch when there is one, else
+ *  the course (muted color). Renders nothing for a fully untargeted session. */
 function CohortChip({ s, small }: { s: StudentLiveSession; small?: boolean }) {
-  const id = s.cohort_detail?.id;
-  const name = s.cohort_detail?.name;
-  if (id == null || !name) return null;
-  const c = cohortColorOf(id);
+  const cohortId = s.cohort_detail?.id;
+  const cohortName = s.cohort_detail?.name;
+  const courseTitle = courseTextOf(s);
+  const isCohort = cohortId != null && Boolean(cohortName);
+  if (!isCohort && !courseTitle) return null;
+  const label = isCohort ? cohortName! : courseTitle;
+  const c = isCohort ? cohortColorOf(cohortId!) : COURSE_FACET_COLOR;
   return (
     <Box
-      title={name}
+      title={label}
       sx={{ display: "inline-flex", alignItems: "center", gap: 0.4, px: small ? 0.8 : 1, py: 0.2, borderRadius: 999,
         fontSize: small ? "0.64rem" : "0.68rem", fontWeight: 800, color: c, flexShrink: 0,
         bgcolor: `color-mix(in srgb, ${c} 13%, transparent)`,
         border: `1px solid color-mix(in srgb, ${c} 30%, transparent)`, maxWidth: 170 }}
     >
-      <Icon icon="mdi:account-group" width={small ? 11 : 12} style={{ flexShrink: 0 }} />
-      <Box component="span" sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{name}</Box>
+      <Icon icon={isCohort ? "mdi:account-group" : "mdi:bookmark-outline"} width={small ? 11 : 12} style={{ flexShrink: 0 }} />
+      <Box component="span" sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{label}</Box>
     </Box>
   );
 }
@@ -201,8 +236,9 @@ export default function LiveSessionsPage() {
   const [feedbackFor, setFeedbackFor] = useState<StudentLiveSession | null>(null);
   // Calendar day filter (local YYYY-MM-DD from dayKey); null = show everything.
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
-  // Batch filter (cohort id); null = all batches. Only rendered when >= 2 batches exist.
-  const [batchFilter, setBatchFilter] = useState<number | null>(null);
+  // Batch/course facet filter (namespaced key from facetsOf); null = everything. Only rendered
+  // when >= 2 distinct facets exist.
+  const [facetFilter, setFacetFilter] = useState<string | null>(null);
   const { enabled: communityEnabled } = useClientFeature(COMMUNITY_FEATURE);
   const hideCounts = useClientOptIn(HIDE_PARTICIPANT_COUNTS);
   // Extra calendar sources (best-effort — a failure just leaves those dots off the calendar).
@@ -406,27 +442,29 @@ export default function LiveSessionsPage() {
   }, [liveId, liveKey, loadSessions]);
 
 
-  // Calendar day + batch filters, applied to all three tabs (and therefore the tab counts).
+  // Calendar day + facet filters, applied to all three tabs (and therefore the tab counts).
   const matchesSelectedDay = useCallback(
     (s: StudentLiveSession) => {
-      if (batchFilter != null && s.cohort_detail?.id !== batchFilter) return false;
+      if (facetFilter != null && !facetsOf(s).some((f) => f.key === facetFilter)) return false;
       if (!selectedDay) return true;
       if (!s.class_datetime) return false;
       const d = new Date(s.class_datetime);
       return !isNaN(d.getTime()) && dayKey(d) === selectedDay;
     },
-    [selectedDay, batchFilter],
+    [selectedDay, facetFilter],
   );
-  // The distinct batches across this student's sessions - a filter is only worth its pixels when
-  // there are at least two.
-  const batchOptions = useMemo(() => {
-    const map = new Map<number, string>();
+  // The distinct batch/course facets across this student's sessions - a filter is only worth its
+  // pixels when there are at least two. Sessions mapped via a course (cohort_detail null) get a
+  // facet too, which cohort-only keying missed entirely.
+  const facetOptions = useMemo(() => {
+    const map = new Map<string, { key: string; label: string; kind: "cohort" | "course" }>();
     for (const s of sessions) {
-      const id = s.cohort_detail?.id;
-      const name = s.cohort_detail?.name;
-      if (id != null && name && !map.has(id)) map.set(id, name);
+      for (const f of facetsOf(s)) if (!map.has(f.key)) map.set(f.key, f);
     }
-    return Array.from(map, ([id, name]) => ({ id, name }));
+    // Batches first, then courses, alphabetical within each - a stable, scannable row.
+    return Array.from(map.values()).sort(
+      (a, b) => (a.kind === b.kind ? a.label.localeCompare(b.label) : a.kind === "cohort" ? -1 : 1)
+    );
   }, [sessions]);
   const selectedDayLabel = useMemo(() => {
     if (!selectedDay) return "";
@@ -624,40 +662,40 @@ export default function LiveSessionsPage() {
           {/* Main grid */}
           <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", lg: "1fr 320px" }, gap: 2.5, alignItems: "start" }}>
             <Box>
-              {/* Batch filter - only when this student actually spans several batches. */}
-              {batchOptions.length >= 2 && (
+              {/* Batch/course facet filter - only when this student actually spans several. */}
+              {facetOptions.length >= 2 && (
                 <Stack direction="row" spacing={0.75} sx={{ mb: 1.5, flexWrap: "wrap", gap: 0.75, alignItems: "center" }}>
-                  <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "text.secondary" }}>BATCH</Typography>
+                  <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: 0.8, color: "text.secondary" }}>BATCH / COURSE</Typography>
                   <Box
-                    onClick={() => setBatchFilter(null)}
+                    onClick={() => setFacetFilter(null)}
                     role="button"
                     tabIndex={0}
-                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setBatchFilter(null); }}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setFacetFilter(null); }}
                     sx={{ px: 1.25, py: 0.4, borderRadius: 999, cursor: "pointer", fontSize: "0.74rem", fontWeight: 700,
-                      color: batchFilter === null ? "#fff" : "text.secondary",
-                      background: batchFilter === null ? "linear-gradient(135deg,#7c3aed,#a855f7)" : "var(--card-bg)",
-                      border: batchFilter === null ? "1px solid transparent" : "1px solid var(--border-default)" }}
+                      color: facetFilter === null ? "#fff" : "text.secondary",
+                      background: facetFilter === null ? "linear-gradient(135deg,#7c3aed,#a855f7)" : "var(--card-bg)",
+                      border: facetFilter === null ? "1px solid transparent" : "1px solid var(--border-default)" }}
                   >
                     All
                   </Box>
-                  {batchOptions.map((b) => {
-                    const active = batchFilter === b.id;
-                    const c = cohortColorOf(b.id);
+                  {facetOptions.map((b) => {
+                    const active = facetFilter === b.key;
+                    const c = facetColorOf(b.key);
                     return (
                       <Box
-                        key={b.id}
-                        onClick={() => setBatchFilter(active ? null : b.id)}
+                        key={b.key}
+                        onClick={() => setFacetFilter(active ? null : b.key)}
                         role="button"
                         tabIndex={0}
-                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setBatchFilter(active ? null : b.id); }}
+                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") setFacetFilter(active ? null : b.key); }}
                         sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, px: 1.25, py: 0.4, borderRadius: 999,
                           cursor: "pointer", fontSize: "0.74rem", fontWeight: 700,
                           color: active ? "#fff" : c,
                           bgcolor: active ? c : `color-mix(in srgb, ${c} 12%, transparent)`,
                           border: `1px solid color-mix(in srgb, ${c} ${active ? "100%" : "30%"}, transparent)` }}
                       >
-                        <Box sx={{ width: 7, height: 7, borderRadius: "50%", bgcolor: active ? "#fff" : c }} />
-                        {b.name}
+                        <Icon icon={b.kind === "cohort" ? "mdi:account-group" : "mdi:bookmark-outline"} width={12} />
+                        {b.label}
                       </Box>
                     );
                   })}
@@ -906,7 +944,7 @@ function UpcomingCard({ s, isNext, reminderOn, prepDone, onAddCalendar, onRemind
   const doneCount = prepItems.filter((_, i) => prepDone.includes(i)).length;
   const countdown = useCountdown(isNext ? s.class_datetime : null);
   const recurring = Boolean(s.zoom_is_recurring && (s.occurrences?.length ?? 0) > 0);
-  const courseText = s.cohort_detail?.name ? courseTextOf(s) : courseOf(s);
+  const courseText = cardCourseText(s);
   const [open, setOpen] = useState(false);
 
   return (
@@ -1019,7 +1057,7 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
           <CohortChip s={s} small />
         </Stack>
         <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>
-          {(s.cohort_detail?.name ? courseTextOf(s) : courseOf(s)) || "Recording available"}
+          {cardCourseText(s) || "Recording available"}
         </Typography>
       </Box>
       <Stack direction="row" spacing={1}>
@@ -1041,8 +1079,8 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
 
 function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedback?: () => void }) {
   const attended = Boolean(s.my_attendance?.attended);
-  // The batch gets its own chip, so the text line is course-only when a batch exists.
-  const courseText = s.cohort_detail?.name ? courseTextOf(s) : courseOf(s);
+  // The chip says what this session belongs to, so the text line never repeats it.
+  const courseText = cardCourseText(s);
   return (
     <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 1.75 }}>
     <Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>

--- a/components/admin/live-sessions/EditSessionDialog.tsx
+++ b/components/admin/live-sessions/EditSessionDialog.tsx
@@ -34,7 +34,7 @@ interface Props {
 }
 
 /** The serializer sends `instructor` as an id or a nested object depending on the endpoint. */
-function currentInstructorId(a: LiveActivity): number | null {
+export function currentInstructorId(a: LiveActivity): number | null {
   const ins = a.instructor;
   if (typeof ins === "number") return ins;
   if (ins && typeof ins === "object" && "id" in ins && typeof (ins as { id: unknown }).id === "number") {

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -116,6 +116,8 @@ export interface LiveActivity {
   course_detail?: CourseDetail | null;
   cohort?: number | null;
   cohort_detail?: { id: number; name: string; status: string } | null;
+  adaptive_course?: number | null;
+  adaptive_course_detail?: { id: number; title: string; is_published?: boolean } | null;
   attendance_count?: number;
   zoom_attendance_synced_at?: string | null;
   zoom_transcript_synced_at?: string | null;

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -269,6 +269,10 @@ export interface InstructorLiveSession {
   is_webinar: boolean;
   is_google_meet: boolean;
   cohort_name: string;
+  /** Exact audience ids (one is set for a targeted session; both null on untargeted ones).
+   *  Optional so a stale payload still type-checks - callers fall back to cohort_name matching. */
+  cohort_id?: number | null;
+  adaptive_course_id?: number | null;
   password: string;
   hostable: boolean;
   created_by_me: boolean;

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -53,10 +53,12 @@ export interface StudentLiveSession {
   recording_link?: string | null;
   /** Provider-neutral flag from the serializer: something is watchable for this session. */
   has_recording?: boolean;
-  course_detail?: { title?: string } | null;
+  /** Legacy-course mapping; `id` drives the course facet (`l:` namespace). */
+  course_detail?: { id?: number; title?: string; name?: string } | null;
   /** The batch this session belongs to; `id` drives the batch filter + stable chip color. */
   cohort_detail?: { id?: number; name?: string } | null;
-  adaptive_course_detail?: { title?: string } | null;
+  /** Adaptive-course mapping; `id` drives the course facet (`a:` namespace). */
+  adaptive_course_detail?: { id?: number; title?: string } | null;
   /** Instructor as shown to a student: their public CODE (real name hidden server-side). */
   instructor?: string | null;
   attendance_count?: number;


### PR DESCRIPTION
Counterpart of ai-linc-backend wave-7 PR. Student page: batch AND course facets (course/adaptive-mapped sessions get chips + filtering). Admin list: occurrence-expanded calendar with day-click filtering + the same facet filter. Instructor list: per-date Edit/Cancel on their own series' dates, and "Add a date" (creates a linked single session, exact-target prefill). tsc clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)