### PR TITLE
fix(instructor): dead View students / View content buttons

### DIFF
--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -115,8 +115,10 @@ export default function InstructorCoursesPage() {
                   {c.student_count} student{c.student_count === 1 ? "" : "s"}
                 </Typography>
                 {c.authored_by_me && <AuthoredStatus course={c} />}
-                {/* Says where the card goes. Everything here was clickable and nothing was
-                    labelled, so "build your course" and "see who is on it" looked identical. */}
+                {/* Says where the CARD goes — which must match `href` above, not authorship.
+                    An assigned trainer with edit rights had a card labelled "View students"
+                    wired to the builder: the label keyed on authored_by_me while the href keyed
+                    on mayEdit, and the click landed somewhere the label never promised. */}
                 {href && (
                   <Stack
                     direction="row"
@@ -125,10 +127,30 @@ export default function InstructorCoursesPage() {
                     sx={{ mt: 1.5, fontSize: "0.82rem", fontWeight: 800, color: "#6366f1" }}
                   >
                     <Icon
-                      icon={c.authored_by_me ? "mdi:hammer-wrench" : "mdi:account-group-outline"}
+                      icon={mayEdit ? "mdi:hammer-wrench" : "mdi:account-group-outline"}
                       width={16}
                     />
-                    {c.authored_by_me ? "Open the builder" : "View students"}
+                    {mayEdit ? "Open the builder" : "View students"}
+                    <Icon icon="mdi:arrow-right" width={15} />
+                  </Stack>
+                )}
+                {/* The roster is its OWN action for editable courses — the card goes to the
+                    builder for them, and "who is on this course" must stay one click away. */}
+                {c.kind === "adaptive" && mayEdit && (
+                  <Stack
+                    direction="row"
+                    alignItems="center"
+                    spacing={0.5}
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => { e.stopPropagation(); push(`/instructor/courses/${c.id}`); }}
+                    onKeyDown={(e) => { if (e.key === "Enter") { e.stopPropagation(); push(`/instructor/courses/${c.id}`); } }}
+                    onMouseEnter={() => prefetch(`/instructor/courses/${c.id}`)}
+                    sx={{ mt: 0.75, fontSize: "0.82rem", fontWeight: 800, color: "#6366f1", width: "fit-content",
+                      "&:hover": { textDecoration: "underline" } }}
+                  >
+                    <Icon icon="mdi:account-group-outline" width={16} />
+                    View students
                     <Icon icon="mdi:arrow-right" width={15} />
                   </Stack>
                 )}

--- a/proxy.ts
+++ b/proxy.ts
@@ -47,8 +47,27 @@ function normalizeRole(role?: string): string {
  */
 const INSTRUCTOR_ALLOWED_ADMIN_PATH = /^\/admin\/adaptive-courses\/\d+(\/|$)/;
 
+/**
+ * ONE adaptive course's learner view, e.g. `/adaptive-courses/18` and everything nested under it
+ * (journey, submodules, video, coding) — plus the quiz-taking flow those pages open.
+ *
+ * Trainers read the material they teach through the learner surface: students ask doubts from
+ * AI-generated content, and the backend deliberately grants staff preview (tenant-scoped, journey
+ * lock bypassed for staff). Without this hole the "View content" card action navigated and was
+ * bounced straight back to the dashboard — a button that visibly did nothing.
+ *
+ * Deliberately NOT the bare `/adaptive-courses` hub or `/adaptive-quizzes` hub — those are the
+ * student home surfaces and stay blocked. One course by id; quiz start/session by object. The
+ * backend enforces per-object access either way (staff_may_preview is tenant-scoped).
+ */
+const INSTRUCTOR_ALLOWED_LEARNER_PATHS = [
+  /^\/adaptive-courses\/\d+(\/|$)/,
+  /^\/adaptive-quizzes\/(start|session\/[^/]+)(\/|$)?/,
+];
+
 function instructorBlocked(pathname: string): boolean {
   if (INSTRUCTOR_ALLOWED_ADMIN_PATH.test(pathname)) return false;
+  if (INSTRUCTOR_ALLOWED_LEARNER_PATHS.some((re) => re.test(pathname))) return false;
   return (
     pathname === "/" ||
     INSTRUCTOR_BLOCKED_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))


### PR DESCRIPTION
Live-reproduced on prod with the tenant's instructor account before fixing.

**View content** navigated to `/adaptive-courses/<id>` and the instructor route confinement in proxy.ts bounced it straight back to the dashboard — a button that visibly did nothing. The proxy now holes ONE course's learner view (plus the quiz start/session flow its tree opens) for instructors, mirroring the existing builder hole. Hubs stay blocked; the backend's tenant-scoped staff preview enforces per-object access.

**View students** landed in the BUILDER for any assigned trainer with edit rights: the card's label keyed on `authored_by_me` while its destination keyed on `mayEdit`. The label now states where the card actually goes, and the roster is its own explicit action on editable courses.

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)