### PR TITLE
fix(live-sessions): AI summary formatting + (BE) stranded per-date titles

### DIFF
--- a/components/admin/live-sessions/LiveSessionTranscriptSection.tsx
+++ b/components/admin/live-sessions/LiveSessionTranscriptSection.tsx
@@ -14,6 +14,7 @@ import {
   adminLiveActivitiesService,
   LiveSessionTranscriptResponse,
 } from "@/lib/services/admin/admin-live-activities.service";
+import { SummaryMarkdown } from "@/components/live-sessions/ui/SummaryMarkdown";
 
 interface LiveSessionTranscriptSectionProps {
   liveClassId: number;
@@ -100,13 +101,7 @@ export function LiveSessionTranscriptSection({ liveClassId, hasSummary }: LiveSe
               <Typography variant="caption" sx={{ fontWeight: 600, color: "var(--accent-indigo)", display: "block", mb: 0.5 }}>
                 {t("adminLiveSessions.aiSummary", "AI summary")}
               </Typography>
-              <Typography
-                variant="body2"
-                component="div"
-                sx={{ color: "var(--font-primary)", whiteSpace: "pre-wrap", fontSize: "0.8rem" }}
-              >
-                {summary}
-              </Typography>
+              <SummaryMarkdown text={summary} fontSize="0.8rem" />
             </Box>
           ) : (
             <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>

--- a/components/live-sessions/StudentSessionSummaryDialog.tsx
+++ b/components/live-sessions/StudentSessionSummaryDialog.tsx
@@ -16,6 +16,7 @@ import {
 import { IconWrapper } from "@/components/common/IconWrapper";
 import { studentLiveSessionsService } from "@/lib/services/live-sessions";
 import type { StudentLiveSessionTranscript } from "@/lib/services/live-sessions/types";
+import { SummaryMarkdown } from "@/components/live-sessions/ui/SummaryMarkdown";
 
 interface StudentSessionSummaryDialogProps {
   activityId: number;
@@ -145,9 +146,7 @@ export function StudentSessionSummaryDialog({ activityId, occurrenceId, topicNam
                   <Typography variant="caption" sx={{ fontWeight: 600, color: "var(--accent-indigo)", display: "block", mb: 0.5 }}>
                     {t("liveSessions.aiSummary", "AI summary")}
                   </Typography>
-                  <Typography variant="body2" sx={{ whiteSpace: "pre-wrap", color: "var(--font-primary)" }}>
-                    {data.summary}
-                  </Typography>
+                  <SummaryMarkdown text={data.summary} />
                 </Box>
               ) : (
                 <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>

--- a/components/live-sessions/ui/SummaryMarkdown.tsx
+++ b/components/live-sessions/ui/SummaryMarkdown.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import { Box } from "@mui/material";
+
+/** The AI session summary, rendered as the markdown it actually is.
+ *
+ *  The backend composes summaries as markdown — `**Key points:**` headings and `- ` bullet
+ *  lists — and every surface printed the raw string, asterisks and all. One renderer, styled to
+ *  sit inside the existing indigo summary card at either the student or the admin font size.
+ */
+export function SummaryMarkdown({ text, fontSize = "0.875rem" }: { text: string; fontSize?: string }) {
+  return (
+    <Box
+      sx={{
+        color: "var(--font-primary)",
+        fontSize,
+        lineHeight: 1.6,
+        "& p": { m: 0, mb: 1 },
+        "& p:last-child": { mb: 0 },
+        "& strong": { fontWeight: 700 },
+        "& ul, & ol": { m: 0, mb: 1, pl: 2.5 },
+        "& li": { mb: 0.25 },
+        "& li:last-child": { mb: 0 },
+      }}
+    >
+      <ReactMarkdown>{text}</ReactMarkdown>
+    </Box>
+  );
+}


### PR DESCRIPTION
FE half of the summary/title fixes reported from tonight's prod screenshots:

**Formatting** — the AI summary is composed as markdown and both the student dialog and admin transcript section printed it raw (`**Key points:**`, dash bullets as plain text). Shared SummaryMarkdown renderer (react-markdown, existing dependency).

The rename half is backend (title backfill for occurrences summarized before the per-date-title feature shipped — the once-only summary gate meant the inline writer never runs again for them). Ships separately in ai-linc-backend.

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)