### PR TITLE
feat(interview): Strands instead of an avatar, a visible start, and a way in

### DIFF
--- a/app/interview/room/page.tsx
+++ b/app/interview/room/page.tsx
@@ -8,6 +8,10 @@ import { Icon } from "@iconify/react";
 import { QuestionCard } from "@/components/interview/room/QuestionCard";
 import { InterviewTranscript } from "@/components/interview/room/InterviewTranscript";
 import {
+  INTERVIEW_PHASE_LABEL,
+  InterviewPresence,
+} from "@/components/interview/room/InterviewPresence";
+import {
   ROOM_BG,
   ROOM_BORDER,
   ROOM_GREEN,
@@ -18,29 +22,27 @@ import {
   ROOM_TEXT_FAINT,
   ROOM_VIOLET,
 } from "@/components/ai-tutor/room/roomTokens";
-import { useRealtimeInterview } from "@/lib/hooks/useRealtimeInterview";
+import { LIVE_PHASES, useRealtimeInterview } from "@/lib/hooks/useRealtimeInterview";
 
 /**
  * The live interview room.
  *
  * **The URL never changes while the call is up.** `/interview/room?template=<id>` is where the
- * whole interview happens, including after the real session id is known. The global camera
- * route guard tears media streams down on pathname change, so rewriting the URL mid-call would
- * kill the microphone and the interviewer's voice. The same constraint shapes the tutor room.
+ * whole interview happens, including after the session id is known: the global camera route
+ * guard tears media streams down on pathname change, so rewriting the URL mid-call would kill
+ * the microphone and the interviewer's voice.
  *
- * Dark, matching the tutor's session room and importing the same tokens, because the two are
- * the same kind of surface: a place you talk to something, not a page of content.
+ * The interviewer is the Strands ribbon, not an avatar. A static face with a lip-sync loop
+ * drifts out of sync with the audio, which is one of the things that made the old room feel
+ * wrong; a ribbon driven by the actual waveform has no mouth to fall out of sync.
  */
 
-const PHASE_COPY: Record<string, string> = {
-  idle: "Ready when you are.",
-  starting: "Setting up your interview...",
-  connecting: "Connecting...",
-  live: "Live",
-  ending: "Wrapping up...",
-  ended: "Finished",
-  failed: "Something went wrong",
-};
+/** Reassurance while the paper is authored and the call is dialled. */
+const BOOT_STEPS = [
+  "Setting up your interview",
+  "Preparing questions",
+  "Connecting to the interviewer",
+];
 
 function InterviewRoom() {
   const router = useRouter();
@@ -53,33 +55,47 @@ function InterviewRoom() {
     transcript,
     currentQuestion,
     questionCount,
-    candidateSpeaking,
     sessionId,
     connect,
     end,
     setMuted: setMicMuted,
+    getLevels,
   } = useRealtimeInterview();
 
   const [muted, setMuted] = useState(false);
+  const [bootStep, setBootStep] = useState(0);
   const startedRef = useRef(false);
   const finishedSessionRef = useRef<string>("");
 
-  // Auto-start once. A candidate arriving here has already agreed to sit the interview on the
-  // previous screen, so a second "begin" click is friction in a timed exercise.
+  const live = LIVE_PHASES.includes(phase);
+  const booting = phase === "starting" || phase === "connecting";
+
   useEffect(() => {
     if (!templateId || startedRef.current) return;
     startedRef.current = true;
     void connect(templateId);
   }, [connect, templateId]);
 
-  // Capture the session id while it is still available, so the redirect below survives the
-  // hook resetting its refs during teardown.
+  // Something visibly moves while the paper is authored and the call is dialled. The first
+  // build showed a bare status word for the whole wait and read as a hung page.
+  useEffect(() => {
+    if (!booting) {
+      setBootStep(0);
+      return;
+    }
+    const timer = setInterval(
+      () => setBootStep((i) => Math.min(i + 1, BOOT_STEPS.length - 1)),
+      1600,
+    );
+    return () => clearInterval(timer);
+  }, [booting]);
+
   useEffect(() => {
     if (sessionId) finishedSessionRef.current = sessionId;
   }, [sessionId]);
 
-  // Navigate only AFTER teardown, never during. Leaving while the call is live would trip the
-  // route guard and cut the audio mid-question.
+  // Navigate only AFTER teardown. Leaving while the call is live trips the route guard and
+  // cuts the audio mid-question.
   useEffect(() => {
     if (phase === "ended" && finishedSessionRef.current) {
       router.push(`/interview/result/${finishedSessionRef.current}`);
@@ -94,29 +110,58 @@ function InterviewRoom() {
     });
   }, [setMicMuted]);
 
-  const live = phase === "live";
-
   return (
-    <Box sx={{ minHeight: "100vh", background: ROOM_BG, color: ROOM_TEXT, px: { xs: 2, md: 4 }, py: { xs: 3, md: 4 } }}>
+    <Box
+      sx={{
+        minHeight: "100vh",
+        background: ROOM_BG,
+        color: ROOM_TEXT,
+        px: { xs: 2, md: 4 },
+        py: { xs: 3, md: 4 },
+      }}
+    >
       <Box sx={{ maxWidth: 1100, mx: "auto" }}>
-        {/* Header */}
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 3 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 2 }}>
           <Box
             sx={{
               width: 8,
               height: 8,
               borderRadius: "50%",
-              bgcolor: live ? ROOM_GREEN : phase === "failed" ? ROOM_RED : ROOM_TEXT_FAINT,
               flexShrink: 0,
+              bgcolor: live ? ROOM_GREEN : phase === "failed" ? ROOM_RED : ROOM_TEXT_FAINT,
+              animation: booting ? "interviewPulse 1.2s ease-in-out infinite" : "none",
+              "@keyframes interviewPulse": {
+                "0%,100%": { opacity: 0.35 },
+                "50%": { opacity: 1 },
+              },
             }}
           />
           <Typography sx={{ fontSize: "0.9rem", color: ROOM_TEXT_DIM }}>
-            {PHASE_COPY[phase] ?? phase}
+            {booting ? BOOT_STEPS[bootStep] : INTERVIEW_PHASE_LABEL[phase]}
           </Typography>
           <Box sx={{ flex: 1 }} />
-          {candidateSpeaking ? (
-            <Typography sx={{ fontSize: "0.8rem", color: ROOM_VIOLET }}>Listening</Typography>
+          {questionCount > 0 && currentQuestion?.position ? (
+            <Typography
+              sx={{
+                fontSize: "0.82rem",
+                color: ROOM_TEXT_FAINT,
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              Question {currentQuestion.position} of {questionCount}
+            </Typography>
           ) : null}
+        </Box>
+
+        {/* The interviewer. Owns the stage before the first question lands, then makes room. */}
+        <Box
+          sx={{
+            height: currentQuestion?.question ? { xs: 96, md: 128 } : { xs: 220, md: 300 },
+            transition: "height 320ms cubic-bezier(.175,.885,.32,1.1)",
+            mb: 2.5,
+          }}
+        >
+          <InterviewPresence phase={phase} getLevels={getLevels} />
         </Box>
 
         {error ? (
@@ -142,12 +187,13 @@ function InterviewRoom() {
           </Box>
         ) : null}
 
-        <Box sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1.4fr 1fr" }, gap: 3 }}>
+        <Box
+          sx={{ display: "grid", gridTemplateColumns: { xs: "1fr", md: "1.4fr 1fr" }, gap: 3 }}
+        >
           <QuestionCard question={currentQuestion} total={questionCount} />
           <InterviewTranscript entries={transcript} />
         </Box>
 
-        {/* Controls */}
         <Box
           sx={{
             mt: 3,

--- a/app/interview/room/page.tsx
+++ b/app/interview/room/page.tsx
@@ -65,6 +65,7 @@ function InterviewRoom() {
   const [muted, setMuted] = useState(false);
   const [bootStep, setBootStep] = useState(0);
   const startedRef = useRef(false);
+  const bootStartedRef = useRef(0);
   const finishedSessionRef = useRef<string>("");
 
   const live = LIVE_PHASES.includes(phase);
@@ -78,15 +79,20 @@ function InterviewRoom() {
 
   // Something visibly moves while the paper is authored and the call is dialled. The first
   // build showed a bare status word for the whole wait and read as a hung page.
+  //
+  // Driven from elapsed time rather than an incrementing counter, so no setState happens
+  // synchronously inside the effect: doing that can cascade renders, and the reset-on-exit
+  // branch is what would have triggered it.
   useEffect(() => {
     if (!booting) {
-      setBootStep(0);
+      bootStartedRef.current = 0;
       return;
     }
-    const timer = setInterval(
-      () => setBootStep((i) => Math.min(i + 1, BOOT_STEPS.length - 1)),
-      1600,
-    );
+    if (!bootStartedRef.current) bootStartedRef.current = Date.now();
+    const timer = setInterval(() => {
+      const elapsed = Date.now() - bootStartedRef.current;
+      setBootStep(Math.min(Math.floor(elapsed / 1600), BOOT_STEPS.length - 1));
+    }, 400);
     return () => clearInterval(timer);
   }, [booting]);
 

--- a/components/interview/room/InterviewPresence.tsx
+++ b/components/interview/room/InterviewPresence.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { TutorVoice } from "@/components/ai-tutor/room/TutorVoice";
+import type { TutorPhase } from "@/lib/hooks/useRealtimeTutor";
+import type { InterviewPhase } from "@/lib/hooks/useRealtimeInterview";
+
+/**
+ * The interviewer's presence: the AI Tutor's Strands ribbon, driven by whoever is talking.
+ *
+ * This replaces the old module's interviewer avatar. The avatar was a static image with a
+ * lip-sync loop bolted on, and the drift between the two was one of the things that made the
+ * old room feel wrong. The ribbon has no mouth to fall out of sync, and it reacts to the
+ * actual audio on both sides, so it reads as presence rather than as a picture of a person.
+ *
+ * `TutorVoice` is reused wholesale rather than reimplemented: it already owns the rAF loop
+ * that writes to the shader outside React, the reduced-motion fallback, and the dynamic import
+ * that keeps WebGL off the room's first paint.
+ */
+
+/** Interview phases map onto the tutor's, which is what TutorVoice's visuals are tuned for. */
+const PHASE_MAP: Record<InterviewPhase, TutorPhase> = {
+  idle: "idle",
+  starting: "starting",
+  connecting: "connecting",
+  listening: "listening",
+  "candidate-speaking": "student-speaking",
+  thinking: "thinking",
+  "interviewer-speaking": "speaking",
+  ending: "ending",
+  ended: "ended",
+  failed: "failed",
+};
+
+/** What the status line says. Interview wording, not lesson wording. */
+export const INTERVIEW_PHASE_LABEL: Record<InterviewPhase, string> = {
+  idle: "Ready",
+  starting: "Preparing your interview",
+  connecting: "Connecting",
+  listening: "Listening",
+  "candidate-speaking": "You're speaking",
+  thinking: "Thinking",
+  "interviewer-speaking": "Interviewer speaking",
+  ending: "Wrapping up",
+  ended: "Interview finished",
+  failed: "Could not connect",
+};
+
+export function InterviewPresence({
+  phase,
+  getLevels,
+  height = "100%",
+}: {
+  phase: InterviewPhase;
+  getLevels: () => { mic: number; tutor: number };
+  height?: number | string;
+}) {
+  return (
+    <TutorVoice
+      phase={PHASE_MAP[phase]}
+      getLevels={getLevels}
+      height={height}
+      showLabel={false}
+    />
+  );
+}
+
+export default InterviewPresence;

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -495,6 +495,19 @@ export const Sidebar: React.FC<SidebarProps> = ({
       descKey: "navDesc.assessments",
     },
     {
+      // The rebuilt interview. Gated on `interview_realtime`, a key no tenant holds by
+      // default, so this entry is invisible until someone is deliberately switched on. Both
+      // entries coexist until the old module is deleted at cutover; a tenant sees exactly one
+      // of them, because the flags are mutually exclusive in practice.
+      label: "Mock Interview",
+      labelKey: "nav.interviewRealtime",
+      path: "/interview",
+      icon: "mdi:microphone-message",
+      featureName: "interview_realtime",
+      descKey: "navDesc.interviewRealtime",
+      gateKey: "interview",
+    },
+    {
       label: "Mock Interview",
       labelKey: "nav.mockInterview",
       path: "/mock-interview",

--- a/lib/hooks/useRealtimeInterview.ts
+++ b/lib/hooks/useRealtimeInterview.ts
@@ -36,10 +36,21 @@ export type InterviewPhase =
   | "idle"
   | "starting"
   | "connecting"
-  | "live"
+  | "listening"
+  | "candidate-speaking"
+  | "thinking"
+  | "interviewer-speaking"
   | "ending"
   | "ended"
   | "failed";
+
+/** Phases where the session is actually up, whatever is happening within it. */
+export const LIVE_PHASES: InterviewPhase[] = [
+  "listening",
+  "candidate-speaking",
+  "thinking",
+  "interviewer-speaking",
+];
 
 export interface InterviewTranscriptEntry {
   role: "interviewer" | "candidate";
@@ -70,6 +81,14 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
   const dcRef = useRef<RTCDataChannel | null>(null);
   const audioElRef = useRef<HTMLAudioElement | null>(null);
   const micStreamRef = useRef<MediaStream | null>(null);
+  // Two analysers, one per voice, so the visual reacts to whoever is actually speaking
+  // rather than to a phase flag. Read at frame rate by the presence component, never
+  // through React state.
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const micAnalyserRef = useRef<AnalyserNode | null>(null);
+  const remoteAnalyserRef = useRef<AnalyserNode | null>(null);
+  const micBufRef = useRef<Uint8Array | null>(null);
+  const remoteBufRef = useRef<Uint8Array | null>(null);
   const closedRef = useRef(false);
 
   // Turn buffer, flushed on a timer rather than per turn, so a long interview is a handful of
@@ -191,11 +210,12 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
 
       switch (type) {
         case "session.created":
-          setPhaseSafe("live");
+          setPhaseSafe("listening");
           break;
 
         case "input_audio_buffer.speech_started":
           setCandidateSpeaking(true);
+          setPhaseSafe("candidate-speaking");
           // Drop audio already buffered in the browser so barge-in is immediate. The old
           // stack had no barge-in at all and candidates could not interrupt.
           sendEvent({ type: "output_audio_buffer.clear" });
@@ -203,6 +223,16 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
 
         case "input_audio_buffer.speech_stopped":
           setCandidateSpeaking(false);
+          setPhaseSafe("thinking");
+          break;
+
+        case "output_audio_buffer.started":
+          setPhaseSafe("interviewer-speaking");
+          break;
+
+        case "output_audio_buffer.stopped":
+        case "output_audio_buffer.cleared":
+          setPhaseSafe("listening");
           break;
 
         case "response.done": {
@@ -270,9 +300,25 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
         (audioEl as HTMLAudioElement & { playsInline?: boolean }).playsInline = true;
         audioElRef.current = audioEl;
 
+        const audioCtx = new AudioContext();
+        audioCtxRef.current = audioCtx;
+        const remoteAnalyser = audioCtx.createAnalyser();
+        remoteAnalyser.fftSize = 256;
+        const micAnalyser = audioCtx.createAnalyser();
+        micAnalyser.fftSize = 256;
+        remoteAnalyserRef.current = remoteAnalyser;
+        micAnalyserRef.current = micAnalyser;
+        remoteBufRef.current = new Uint8Array(remoteAnalyser.frequencyBinCount);
+        micBufRef.current = new Uint8Array(micAnalyser.frequencyBinCount);
+
         pc.ontrack = (e) => {
           audioEl.srcObject = e.streams[0];
           void audioEl.play().catch(() => undefined);
+          try {
+            audioCtx.createMediaStreamSource(e.streams[0]).connect(remoteAnalyser);
+          } catch {
+            /* the analyser is decorative; never block audio on it */
+          }
         };
 
         const micStream = await navigator.mediaDevices.getUserMedia({
@@ -281,6 +327,11 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
         micStreamRef.current = micStream;
         registerMediaStream(micStream);
         micStream.getTracks().forEach((track) => pc.addTrack(track, micStream));
+        try {
+          audioCtx.createMediaStreamSource(micStream).connect(micAnalyser);
+        } catch {
+          /* as above */
+        }
 
         const dc = pc.createDataChannel(OAI_EVENTS_CHANNEL);
         dcRef.current = dc;
@@ -313,7 +364,7 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
           .catch(() => undefined);
 
         flushTimerRef.current = setInterval(() => void flushTurns(), TURN_FLUSH_MS);
-        setPhaseSafe("live");
+        setPhaseSafe("listening");
       } catch {
         fail("Could not connect. Check your microphone and network, then try again.");
       }
@@ -328,6 +379,29 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
    * keep hearing everything while the UI said otherwise. Disabling the track is what stops
    * audio leaving, and semantic VAD then stops taking turns on it.
    */
+  /**
+   * Instantaneous RMS for each voice, for the presence component's own rAF loop.
+   *
+   * Deliberately NOT React state. This is read every frame; routing it through a setState
+   * would re-render the room sixty times a second for a decorative effect.
+   */
+  const getLevels = useCallback(() => {
+    const rms = (analyser: AnalyserNode | null, buf: Uint8Array | null) => {
+      if (!analyser || !buf) return 0;
+      analyser.getByteTimeDomainData(buf as Uint8Array<ArrayBuffer>);
+      let sum = 0;
+      for (let i = 0; i < buf.length; i += 1) {
+        const v = (buf[i] - 128) / 128;
+        sum += v * v;
+      }
+      return Math.sqrt(sum / buf.length);
+    };
+    return {
+      mic: rms(micAnalyserRef.current, micBufRef.current),
+      tutor: rms(remoteAnalyserRef.current, remoteBufRef.current),
+    };
+  }, []);
+
   const setMuted = useCallback((muted: boolean) => {
     micStreamRef.current?.getAudioTracks().forEach((track) => {
       track.enabled = !muted;
@@ -354,6 +428,7 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
       dcRef.current?.close();
       pcRef.current?.close();
       if (audioElRef.current) audioElRef.current.srcObject = null;
+      void audioCtxRef.current?.close().catch(() => undefined);
     } catch {
       /* teardown is best effort */
     }
@@ -396,6 +471,7 @@ export function useRealtimeInterview(options: UseRealtimeInterviewOptions = {}) 
     connect,
     end,
     setMuted,
+    getLevels,
   };
 }
 

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -33,7 +33,8 @@
     "adaptiveQuizzes": "الاختبارات التكيفية",
     "adminAdaptiveQuizzes": "الاختبارات التكيفية",
     "roadmaps": "خرائط التعلم",
-    "aiTutor": "المعلم الذكي"
+    "aiTutor": "المعلم الذكي",
+    "interviewRealtime": "مقابلة تجريبية"
   },
   "certificatesUpload": {
     "heroBadge": "إدارة · التخزين",
@@ -2333,5 +2334,8 @@
     "savingLocked": "الحفظ مقفل",
     "downloadLocked": "التنزيل مقفل",
     "sidebarTooltip": "أكمل ملفك الشخصي لفتح هذه الميزة"
+  },
+  "navDesc": {
+    "interviewRealtime": ""
   }
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -37,7 +37,8 @@
     "adaptiveQuizzes": "Adaptive Course",
     "adminAdaptiveQuizzes": "Adaptive Course Builder",
     "roadmaps": "Roadmaps",
-    "aiTutor": "AI Tutor"
+    "aiTutor": "AI Tutor",
+    "interviewRealtime": "Interview"
   },
   "navSection": {
     "learn": "Learn",
@@ -82,7 +83,8 @@
     "admin_jobs_v2": "Post jobs and curate opportunities for students.",
     "admin_attendance": "Review attendance across live sessions and cohorts.",
     "roadmaps": "Curated paths through our verified courses, so you always know what to learn next.",
-    "aiTutor": "Say what you want to learn and talk it through with a tutor that listens, shows you things and asks you questions."
+    "aiTutor": "Say what you want to learn and talk it through with a tutor that listens, shows you things and asks you questions.",
+    "interviewRealtime": "Practise a spoken interview with an AI interviewer."
   },
   "certificatesUpload": {
     "heroBadge": "Admin · Storage",


### PR DESCRIPTION
Four of the seven problems from the first real session. All frontend; the backend fixes shipped separately in #661.

## The interviewer is the Strands ribbon now

The old module's avatar was a static face with a lip-sync loop bolted on, and the drift between the two was one of the things that made the room feel wrong. A ribbon driven by the actual waveform on both sides has no mouth to fall out of sync.

`TutorVoice` is **reused wholesale** rather than reimplemented — it already owns the rAF loop that writes to the shader outside React, the reduced-motion fallback, and the dynamic import that keeps WebGL off first paint. Interview phases map onto the tutor's, which is what its visuals are tuned for.

## The start no longer looks stuck

It showed one static status word for the entire wait. There's now a pulsing indicator and a three-step progression, so something visibly moves while the paper is authored and the call is dialled. Driven from elapsed time, so no `setState` fires synchronously inside the effect.

## The hook actually drives it

Two analysers, one per voice, read at frame rate via `getLevels` and deliberately **not** through React state — routing a decorative signal through `setState` would re-render the room sixty times a second.

The single `live` phase became `listening` / `candidate-speaking` / `thinking` / `interviewer-speaking`, so the ribbon reacts to who is actually talking rather than to a flag.

## There is a way in

A sidebar entry gated on `interview_realtime` — a key no tenant holds by default, so it stays invisible until someone is deliberately switched on. Until now the only route in was a hand-typed URL and **every link in the app pointed at the old module**, which is why the first test session landed there and looked unchanged.

## Still outstanding

The coding panel and pop-quiz overlay. The backend already mints both from the verified bank, but the room has nowhere to render them. That's the remaining half of "the UI is too blank".

Typecheck and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)