### PR TITLE
fix(live-sessions): Add-a-date grows its series; live rows say Join as host; the row menu never vanishes

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -58,8 +58,8 @@ import { LiveSessionNoticeDialog } from "@/components/admin/live-sessions/LiveSe
 import { RecordingPlayerDialog } from "@/components/live-sessions/RecordingPlayerDialog";
 import { StudyMaterialManager } from "@/components/live-sessions/StudyMaterialManager";
 import { EditWebinarDialog } from "@/components/admin/live-sessions/EditWebinarDialog";
-import { EditSessionDialog, currentInstructorId } from "@/components/admin/live-sessions/EditSessionDialog";
-import { liveClassService } from "@/lib/services/live-class.service";
+import { EditSessionDialog } from "@/components/admin/live-sessions/EditSessionDialog";
+import { getAxiosErrorDetail } from "@/lib/utils/api-error";
 import { formatSessionTime } from "@/lib/utils/session-time";
 
 function formatDateTime(s?: string | null, timezone?: string | null) {
@@ -100,6 +100,8 @@ export default function LiveSessionDetailPage() {
   const [editOpen, setEditOpen] = useState(false);
   const [editSessionOpen, setEditSessionOpen] = useState(false);
   const [addDateOpen, setAddDateOpen] = useState(false);
+  // Bumped when a date is added so a MOUNTED Timeline tab refetches (it otherwise loads once).
+  const [timelineRefresh, setTimelineRefresh] = useState(0);
   const [creatingGoogle, setCreatingGoogle] = useState(false);
   const [updatingGoogle, setUpdatingGoogle] = useState(false);
   const [cancellingGoogle, setCancellingGoogle] = useState(false);
@@ -654,6 +656,7 @@ export default function LiveSessionDetailPage() {
                 {tabKey === "timeline" && (
                   <SectionCard>
                     <LiveSessionOccurrenceTimeline
+                      key={timelineRefresh}
                       liveClassId={activity.id}
                       seriesTitle={activity.topic_name}
                       timezone={activity.timezone}
@@ -814,16 +817,14 @@ export default function LiveSessionDetailPage() {
         <AddDateDialog
           activity={activity}
           onClose={() => setAddDateOpen(false)}
-          onCreated={(newId, warning) => {
+          onAdded={() => {
             setAddDateOpen(false);
-            showToast(
-              warning
-                ? t("adminLiveSessions.addDateZoomWarn", "Session created, but Zoom setup failed: {{msg}} You can retry from the new session.", { msg: warning })
-                : t("adminLiveSessions.addDateDone", "Date added as a linked session."),
-              warning ? "warning" : "success"
-            );
-            // The link to the new session: it opens directly.
-            router.push(`/admin/live-sessions/${newId}`);
+            showToast(t("adminLiveSessions.addDateDone", "Date added to the series."), "success");
+            // Stay HERE: the date belongs to this series, so this page (occurrences + Timeline)
+            // is where it appears. Navigating onto a separate session was the tenant's bug -
+            // the series scattered and this page's controls "disappeared" with it.
+            setTimelineRefresh((n) => n + 1);
+            void load();
           }}
         />
       )}
@@ -832,15 +833,16 @@ export default function LiveSessionDetailPage() {
 }
 
 /**
- * Add one extra date to a recurring series. Zoom's API cannot append an ad-hoc occurrence to an
- * existing series, so this creates a linked SINGLE session carrying the series' topic, audience
- * (cohort/course/adaptive course), trainer and meeting type - the same createSession→zoom/create
- * chain the create page uses, minus the recurrence. The caller navigates to the new session.
+ * Add one extra date to THIS series. Zoom cannot grow a series ad-hoc, so the backend stores the
+ * date as a LOCAL occurrence of the same session ("local-" zoom_occurrence_id) - students see it
+ * like any other sitting, it lives on this page's timeline, and editing/cancelling it never
+ * involves Zoom. Replaces the create-a-separate-single-session chain that scattered the series
+ * across pages when a tenant tried it live.
  */
-function AddDateDialog({ activity, onClose, onCreated }: {
+function AddDateDialog({ activity, onClose, onAdded }: {
   activity: LiveActivity;
   onClose: () => void;
-  onCreated: (newSessionId: number, zoomWarning?: string) => void;
+  onAdded: () => void;
 }) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
@@ -854,24 +856,15 @@ function AddDateDialog({ activity, onClose, onCreated }: {
     if (!valid || creating) return;
     try {
       setCreating(true);
-      const created = await liveClassService.createSession({
-        topic_name: activity.topic_name,
-        description: activity.description || undefined,
-        class_datetime: when,
-        timezone: activity.timezone || undefined,
+      await adminLiveActivitiesService.addOccurrence(activity.id, {
+        occurrence_datetime: when,
+        ...(activity.timezone ? { timezone: activity.timezone } : {}),
         duration_minutes: duration,
-        instructor_id: currentInstructorId(activity) ?? undefined,
-        course: activity.course ?? undefined,
-        cohort: activity.cohort ?? undefined,
-        adaptive_course: activity.adaptive_course ?? undefined,
-        zoom_meeting_type: activity.zoom_meeting_type ?? "meeting",
       });
-      // Single session: no recurrence. A Zoom failure here still leaves the session row, where
-      // the normal "Create Zoom" retry lives - so report it as a warning, not a dead end.
-      const result = await adminLiveActivitiesService.createZoom(created.id, {});
-      onCreated(created.id, result.status === "error" ? result.message || "Zoom refused." : undefined);
+      onAdded();
     } catch (e) {
-      showToast(getLiveSessionErrorMessage(e, "zoom_create"), "error");
+      // 400 on non-recurring, and any refusal reason, in the server's own words.
+      showToast(getAxiosErrorDetail(e, t("adminLiveSessions.addDateFailed", "Couldn't add this date.")), "error");
     } finally {
       setCreating(false);
     }
@@ -888,7 +881,7 @@ function AddDateDialog({ activity, onClose, onCreated }: {
           <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
             {t(
               "adminLiveSessions.addADateHint",
-              "Creates a linked one-off session with this series' topic, audience and trainer - Zoom can't add a single extra date to the series itself."
+              "Adds one extra date to this series. Students see it like any other sitting, and it appears on the timeline here."
             )}
           </Typography>
           <TextField
@@ -899,7 +892,7 @@ function AddDateDialog({ activity, onClose, onCreated }: {
             fullWidth
             size="small"
             InputLabelProps={{ shrink: true }}
-            helperText={t("adminLiveSessions.occurrenceTimeInZone", "Wall-clock time in {{zone}}. Zoom and students are updated.", {
+            helperText={t("adminLiveSessions.addDateTimeInZone", "Wall-clock time in {{zone}}.", {
               zone: activity.timezone || t("adminLiveSessions.theSessionZone", "the session's timezone"),
             })}
           />

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -309,10 +309,13 @@ export default function InstructorLiveSessionsPage() {
             onMaterials={() => setMaterialsFor(s)}
             onRecording={() => s.recording_url && window.open(s.recording_url, "_blank", "noopener")}
             onDelete={() => removeSession(s)}
-            // Per-date controls for a trainer hosting this sitting (a past date has nothing to
-            // move or call off), plus "Add a date" on any recurring row they host.
+            // The ⋮ shows whenever ANY item applies, and each item gates itself. Gating the whole
+            // menu on per-date actions alone made it vanish on ended dates and non-recurring
+            // rows - taking "Add a date" and session-level Edit with it ("sometimes I can't see
+            // the 3 dots that edit the webinar").
             onMenu={
-              s.hostable && ((s.occurrence_id != null && status !== "ended") || s.is_recurring)
+              s.hostable &&
+              ((s.occurrence_id != null && status !== "ended") || s.is_recurring || s.editable)
                 ? (e) => setOccMenu({ anchor: e.currentTarget, s })
                 : undefined
             }
@@ -320,12 +323,23 @@ export default function InstructorLiveSessionsPage() {
         ))}
       </Stack>
 
-      {/* Per-date ⋮ menu */}
+      {/* Row ⋮ menu: session-level actions + per-date (occurrence) actions, each self-gated. */}
       <Menu
         open={Boolean(occMenu)}
         anchorEl={occMenu?.anchor ?? null}
         onClose={() => setOccMenu(null)}
       >
+        {/* Session-level edit (topic/schedule/duration) via the existing dialog - the row's own
+            Edit button only appears while scheduled, which left live and ended rows with no way
+            in at all. */}
+        {occMenu?.s.editable && (
+          <MenuItem
+            onClick={() => { setEditing(occMenu.s); setOccMenu(null); }}
+            sx={{ fontSize: "0.86rem", fontWeight: 600 }}
+          >
+            <Icon icon="mdi:pencil-outline" width={16} style={{ marginRight: 8 }} /> Edit session
+          </MenuItem>
+        )}
         {occMenu && occMenu.s.occurrence_id != null && statusOf(occMenu.s, now) !== "ended" && (
           <MenuItem
             onClick={() => { setEditOcc(occMenu.s); setOccMenu(null); }}

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -128,9 +128,9 @@ export default function InstructorLiveSessionsPage() {
   const [editOcc, setEditOcc] = useState<InstructorLiveSession | null>(null);
   const [cancelOcc, setCancelOcc] = useState<InstructorLiveSession | null>(null);
   const [cancellingOcc, setCancellingOcc] = useState(false);
-  // "Add a date": Zoom cannot grow a series ad-hoc, so an extra date is a linked SINGLE session
-  // with the same topic/audience - the create dialog opens prefilled from the series.
-  const [addDateInit, setAddDateInit] = useState<CreateSessionInitial | null>(null);
+  // "Add a date": grows the SAME series via the occurrences/ endpoint (a LOCAL date, no Zoom
+  // involvement). The old path created a separate single session and scattered the series.
+  const [addDateFor, setAddDateFor] = useState<InstructorLiveSession | null>(null);
 
   const reload = useCallback(async () => {
     try {
@@ -345,13 +345,7 @@ export default function InstructorLiveSessionsPage() {
         {occMenu?.s.is_recurring && (
           <MenuItem
             onClick={() => {
-              setAddDateInit({
-                topic: occMenu.s.topic_name,
-                cohortId: occMenu.s.cohort_id ?? null,
-                adaptiveCourseId: occMenu.s.adaptive_course_id ?? null,
-                audienceName: occMenu.s.cohort_name || null,
-                sessionType: occMenu.s.is_webinar ? "webinar" : "meeting",
-              });
+              setAddDateFor(occMenu.s);
               setOccMenu(null);
             }}
             sx={{ fontSize: "0.86rem", fontWeight: 600 }}
@@ -365,6 +359,13 @@ export default function InstructorLiveSessionsPage() {
         session={editOcc}
         onClose={() => setEditOcc(null)}
         onSaved={() => { setToast({ text: "This date was updated.", sev: "success" }); void reload(); }}
+        onError={(text) => setToast({ text, sev: "error" })}
+      />
+
+      <AddSeriesDateDialog
+        session={addDateFor}
+        onClose={() => setAddDateFor(null)}
+        onSaved={() => { setToast({ text: "Date added to the series.", sev: "success" }); void reload(); }}
         onError={(text) => setToast({ text, sev: "error" })}
       />
 
@@ -385,8 +386,7 @@ export default function InstructorLiveSessionsPage() {
         </Typography>
       )}
 
-      <CreateSessionDialog open={createOpen || Boolean(addDateInit)} initial={addDateInit}
-        onClose={() => { setCreateOpen(false); setAddDateInit(null); }}
+      <CreateSessionDialog open={createOpen} onClose={() => setCreateOpen(false)}
         onCreated={(msg) => { setToast({ text: msg, sev: "success" }); void reload(); }} />
       <EditSessionDialog session={editing} onClose={() => setEditing(null)}
         onSaved={() => { setToast({ text: "Session updated.", sev: "success" }); void reload(); }} />
@@ -513,13 +513,17 @@ function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCo
               gates student Join on the host actually starting, this button is the only thing that
               produces that signal. */}
           {(status === "live" || (status === "scheduled" && canStartEarly)) && s.hostable && (
-            <Button onClick={onHost} disabled={hosting}
-              startIcon={hosting ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:video" width={16} />}
-              sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2, py: 0.9, borderRadius: 2,
-                background: "linear-gradient(135deg,#10b981,#059669)", "&:hover": { filter: "brightness(1.06)" },
-                "&.Mui-disabled": { color: "rgba(255,255,255,0.8)" } }}>
-              {status === "live" ? "Start hosting" : "Start early"}
-            </Button>
+            <Tooltip title="The host link joins a running room as host - or starts the room if it hasn't begun.">
+              <Button onClick={onHost} disabled={hosting}
+                startIcon={hosting ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:video" width={16} />}
+                sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2, py: 0.9, borderRadius: 2,
+                  background: "linear-gradient(135deg,#10b981,#059669)", "&:hover": { filter: "brightness(1.06)" },
+                  "&.Mui-disabled": { color: "rgba(255,255,255,0.8)" } }}>
+                {/* A LIVE room is already started - "Start hosting" read as if the trainer's own
+                    earlier start hadn't taken, so they clicked it again fearing the class was down. */}
+                {status === "live" ? "Join as host" : "Start early"}
+              </Button>
+            </Tooltip>
           )}
           {/* Only known after a host-link fetch. The panelist link is for CO-PRESENTERS — handing
               out the attendee link put trainers in the audience with no screen share. */}
@@ -595,16 +599,8 @@ function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCo
  *  audience via cohort_id/adaptive_course_id. `audienceName` is only the fallback for a stale
  *  payload that predates those fields (matched by name once the cohort list loads; a miss just
  *  leaves the picker for the user). */
-interface CreateSessionInitial {
-  topic?: string;
-  cohortId?: number | null;
-  adaptiveCourseId?: number | null;
-  audienceName?: string | null;
-  sessionType?: "meeting" | "webinar";
-}
-
-function CreateSessionDialog({ open, initial = null, onClose, onCreated }: {
-  open: boolean; initial?: CreateSessionInitial | null; onClose: () => void; onCreated: (msg: string) => void;
+function CreateSessionDialog({ open, onClose, onCreated }: {
+  open: boolean; onClose: () => void; onCreated: (msg: string) => void;
 }) {
   const [cohorts, setCohorts] = useState<InstructorCohort[]>([]);
   const [courses, setCourses] = useState<InstructorCourse[]>([]);
@@ -633,34 +629,6 @@ function CreateSessionDialog({ open, initial = null, onClose, onCreated }: {
     // Default the session zone to the instructor's own zone (client-only).
     setSessionTz((prev) => prev || tenantTz);
   }, [open]);
-
-  // "Add a date" prefill: topic + meeting type from the series. Only fills empty fields, so a
-  // user's own typing is never clobbered by a re-render.
-  useEffect(() => {
-    if (!open || !initial) return;
-    if (initial.topic) setTopic((prev) => prev || initial.topic!);
-    if (initial.sessionType) setSessionType(initial.sessionType);
-  }, [open, initial]);
-  // Audience prefill: the exact id when the row carries one (set only once the fetched list
-  // actually contains it, so the Select never holds an option it can't render), else the
-  // name-matching fallback for stale payloads. A miss leaves the picker to the user.
-  useEffect(() => {
-    if (!open || !initial) return;
-    setAudience((prev) => {
-      if (prev) return prev;
-      if (initial.cohortId != null && cohorts.some((c) => c.id === initial.cohortId)) {
-        return `c:${initial.cohortId}`;
-      }
-      if (initial.adaptiveCourseId != null && courses.some((c) => c.id === initial.adaptiveCourseId)) {
-        return `a:${initial.adaptiveCourseId}`;
-      }
-      if (initial.cohortId == null && initial.adaptiveCourseId == null && initial.audienceName) {
-        const m = cohorts.find((c) => c.name === initial.audienceName);
-        if (m) return `c:${m.id}`;
-      }
-      return prev;
-    });
-  }, [open, initial, cohorts, courses]);
 
   const reset = () => {
     setTopic(""); setDescription(""); setWhen(""); setDuration(60); setAudience("");
@@ -1082,6 +1050,79 @@ function EditOccurrenceDateDialog({ session, onClose, onSaved, onError }: {
           startIcon={saving ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:content-save" width={16} />}
           sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, borderRadius: 2, background: "linear-gradient(135deg,#7c3aed,#ec4899)" }}>
           {saving ? "Saving…" : "Save changes"}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+/* --------------------------- add-a-date dialog (series) --------------------------- */
+
+/**
+ * Add one extra date to THIS series via the occurrences/ endpoint (a LOCAL date - Zoom is not
+ * involved, and the URL authorizes the hosting instructor). The old flow created a separate
+ * single session, which scattered the series across pages when a tenant tried it live.
+ */
+function AddSeriesDateDialog({ session, onClose, onSaved, onError }: {
+  session: InstructorLiveSession | null;
+  onClose: () => void;
+  onSaved: () => void;
+  onError: (text: string) => void;
+}) {
+  const [when, setWhen] = useState("");
+  const [duration, setDuration] = useState(60);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (session) {
+      setWhen("");
+      setDuration(session.duration_minutes || 60);
+    }
+  }, [session]);
+
+  const valid = Boolean(when) && duration >= 1 && duration <= 600;
+
+  const submit = async () => {
+    if (!session || !valid || saving) return;
+    try {
+      setSaving(true);
+      await adminLiveActivitiesService.addOccurrence(session.id, {
+        occurrence_datetime: when,
+        ...(session.timezone ? { timezone: session.timezone } : {}),
+        duration_minutes: duration,
+      });
+      onSaved();
+      onClose();
+    } catch (e) {
+      // 400 on non-recurring, and any refusal reason, in the server's own words.
+      onError(getAxiosErrorDetail(e, "Couldn't add this date."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={Boolean(session)} onClose={saving ? undefined : onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ fontWeight: 800 }}>Add a date</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>
+            Adds one extra sitting to this series. Students see it like any other date.
+          </Typography>
+          <TextField label="Starts" type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
+            fullWidth size="small" InputLabelProps={{ shrink: true }}
+            helperText={`Wall-clock time in ${session?.timezone || "the session's timezone"}`} />
+          <TextField label="Duration (min)" type="number" value={duration}
+            onChange={(e) => setDuration(Math.max(1, Math.min(600, Number(e.target.value) || 0)))}
+            size="small" inputProps={{ min: 1, max: 600 }} />
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={saving} sx={{ textTransform: "none", fontWeight: 700 }}>Cancel</Button>
+        <Button onClick={() => void submit()} disabled={!valid || saving}
+          startIcon={saving ? <CircularProgress size={15} color="inherit" /> : <Icon icon="mdi:calendar-plus" width={16} />}
+          sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2.5, borderRadius: 2, background: "linear-gradient(135deg,#7c3aed,#ec4899)" }}>
+          {saving ? "Adding…" : "Add date"}
         </Button>
       </DialogActions>
     </Dialog>

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -707,6 +707,24 @@ export const adminLiveActivitiesService = {
     return response.data;
   },
 
+  /**
+   * Add a LOCAL date to the SAME series (admin or the hosting instructor; 400 on non-recurring).
+   * Zoom cannot grow a series ad-hoc, so the date lives platform-side: its zoom_occurrence_id
+   * starts with "local-", and its PATCH/DELETE involve no Zoom round-trip and return no warnings.
+   * `occurrence_datetime` is a naive wall-clock interpreted in `timezone`; duration defaults to
+   * the series'.
+   */
+  addOccurrence: async (
+    liveClassId: number,
+    payload: { occurrence_datetime: string; timezone?: string; duration_minutes?: number; topic_name?: string }
+  ): Promise<{ data: LiveClassOccurrence }> => {
+    const response = await apiClient.post<{ data: LiveClassOccurrence }>(
+      `${BASE}/live-activities/${liveClassId}/occurrences/`,
+      payload
+    );
+    return response.data;
+  },
+
   /** Cancel just ONE date of a recurring series (the series and its other dates stay). */
   cancelOccurrence: async (
     liveClassId: number,


### PR DESCRIPTION
FE half of ai-linc-backend#671, from the tenant's live recurring-series testing:

- **Add a date** now grows the SAME series (new occurrences/ endpoint) on both the admin detail (stays on the page, timeline refreshes) and the instructor list — the create-a-separate-single flow is deleted.
- **Live rows** read "Join as host" (the host link joins a running room as host; the label finally says so).
- **The ⋮ menu never vanishes** while any action applies: items self-gate (Edit session for editable rows — surfacing the existing dialog that was only reachable on scheduled rows; Edit/Cancel this date; Add a date incl. on ended rows).

tsc clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)