### PR TITLE
Promote stagging: per-date recordings and transcripts inline

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -97,6 +97,8 @@ export default function LiveSessionDetailPage() {
   const [deletingSession, setDeletingSession] = useState(false);
   const [syncingRecording, setSyncingRecording] = useState(false);
   const [playerOpen, setPlayerOpen] = useState(false);
+  // Which DATE of a recurring series the player streams; null = the series-level recording.
+  const [playerOccurrenceId, setPlayerOccurrenceId] = useState<number | null>(null);
   const [editOpen, setEditOpen] = useState(false);
   const [editSessionOpen, setEditSessionOpen] = useState(false);
   const [addDateOpen, setAddDateOpen] = useState(false);
@@ -311,6 +313,17 @@ export default function LiveSessionDetailPage() {
   );
 
   const isGoogleMeet = Boolean(activity?.is_google_meet);
+  // A recurring series' dates, oldest first - the Recording tab lists each inline with its own
+  // Play (the series-level player can only stream the series-latest file).
+  const recordingDates = useMemo(
+    () =>
+      isRecurring
+        ? [...(activity?.occurrences ?? [])].sort((a, b) =>
+            (a.occurrence_datetime || "").localeCompare(b.occurrence_datetime || "")
+          )
+        : [],
+    [isRecurring, activity?.occurrences]
+  );
   const tabs = useMemo(() => {
     const overview = { key: "overview", icon: "mdi:information-outline", label: t("adminLiveSessions.tabOverview", "Overview") };
     // Study material is platform state, not provider state — every session type gets this tab,
@@ -677,28 +690,53 @@ export default function LiveSessionDetailPage() {
                 {/* Recording */}
                 {tabKey === "recording" && (
                   <SectionCard title={t("adminLiveSessions.recording", "Recording")} icon="mdi:play-circle-outline">
+                    {/* A recurring series has one recording PER DATE - asking by the series id
+                        resolves to the series-latest file, matching none of the dates - so each
+                        date lists inline with its own Play, wired through the occurrence-
+                        parameterized playback flow. */}
+                    {recordingDates.length > 0 && (
+                      <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mb: 1.5 }}>
+                        {recordingDates.map((o) => (
+                          <Box
+                            key={o.id}
+                            sx={{
+                              display: "flex", alignItems: "center", gap: 1.25, flexWrap: "wrap",
+                              p: 1.25, borderRadius: 2, border: "1px solid var(--border-default)", bgcolor: "var(--surface)",
+                            }}
+                          >
+                            <Box sx={{ flex: 1, minWidth: 200 }}>
+                              <Typography sx={{ fontWeight: 700, fontSize: "0.88rem", color: "var(--font-primary)" }}>
+                                {formatDateTime(o.occurrence_datetime, activity.timezone)}
+                              </Typography>
+                              <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                                {(o.topic_name?.trim() || activity.topic_name)} · {o.duration_minutes}m
+                              </Typography>
+                            </Box>
+                            <MeetingStatusChip status={o.meeting_status} />
+                            {o.has_recording ? (
+                              <ControlButton
+                                icon="mdi:play"
+                                label={t("adminLiveSessions.playRecording", "Play recording")}
+                                tone="primary"
+                                onClick={() => { setPlayerOccurrenceId(o.id); setPlayerOpen(true); }}
+                              />
+                            ) : (
+                              <Typography variant="caption" sx={{ color: "var(--font-tertiary)" }}>
+                                {t("adminLiveSessions.noRecordingForDate", "No recording")}
+                              </Typography>
+                            )}
+                          </Box>
+                        ))}
+                      </Box>
+                    )}
                     <Box sx={{ display: "flex", gap: 1.25, flexWrap: "wrap", alignItems: "center" }}>
-                      {/* A recurring series has one recording PER DATE, and this button can only ask
-                          for the series — which resolves to the series-level file, matching none of
-                          the dates. Sending the trainer to the Timeline is the only honest answer;
-                          each row there plays its own date. Students already get the per-date video. */}
-                      {hasRecording && isRecurring ? (
-                        <ControlButton
-                          icon="mdi:calendar-multiselect"
-                          label={t("adminLiveSessions.viewPerDateRecordings", "View recordings by date")}
-                          tone="primary"
-                          onClick={() => {
-                            const i = tabsWithFeedback.findIndex((x) => x.key === "timeline");
-                            if (i >= 0) setTab(i);
-                          }}
-                        />
-                      ) : hasRecording ? (
+                      {recordingDates.length === 0 && (hasRecording ? (
                         <ControlButton icon="mdi:play" label={t("adminLiveSessions.playRecording", "Play recording")} tone="primary" onClick={() => setPlayerOpen(true)} />
                       ) : (
                         <InfoCallout icon="mdi:cloud-clock-outline" color="var(--font-tertiary)">
                           {t("liveSessions.recordingNotAvailable")}
                         </InfoCallout>
-                      )}
+                      ))}
                       {isZoom && (
                         <ControlButton icon="mdi:cloud-download" label={t("adminLiveSessions.syncRecording")} tone="outline" loading={syncingRecording} onClick={handleSyncRecording} />
                       )}
@@ -791,8 +829,15 @@ export default function LiveSessionDetailPage() {
         allowDownload={isClientOrgAdminRole(user?.role)}
         open={playerOpen}
         liveClassId={activity?.id ?? null}
-        title={activity?.topic_name ?? undefined}
-        onClose={() => setPlayerOpen(false)}
+        // The occurrence is what selects the clicked DATE's file - the series id alone streams
+        // the series-latest recording, whichever row was clicked.
+        occurrenceId={playerOccurrenceId}
+        title={
+          (playerOccurrenceId != null
+            ? recordingDates.find((o) => o.id === playerOccurrenceId)?.topic_name?.trim()
+            : undefined) || activity?.topic_name || undefined
+        }
+        onClose={() => { setPlayerOpen(false); setPlayerOccurrenceId(null); }}
       />
 
       {activity && isWebinar && (

--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -752,10 +752,17 @@ export default function LiveSessionDetailPage() {
                   </SectionCard>
                 )}
 
-                {/* Transcript */}
+                {/* Transcript. A recurring series stores transcripts per DATE, so it renders one
+                    lazy row per occurrence instead of the single series view. */}
                 {tabKey === "transcript" && (
                   <SectionCard>
-                    <LiveSessionTranscriptSection liveClassId={activity.id} hasSummary={Boolean(activity.zoom_ai_summary?.trim() || (activity as { google_ai_summary?: string }).google_ai_summary?.trim())} />
+                    <LiveSessionTranscriptSection
+                      liveClassId={activity.id}
+                      hasSummary={Boolean(activity.zoom_ai_summary?.trim() || (activity as { google_ai_summary?: string }).google_ai_summary?.trim())}
+                      occurrences={isRecurring ? activity.occurrences ?? null : null}
+                      timezone={activity.timezone}
+                      seriesTitle={activity.topic_name}
+                    />
                   </SectionCard>
                 )}
 

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -117,6 +117,13 @@ function initials(name: string): string {
 function cardKeyOf(s: StudentLiveSession): string {
   return `${s.id}:${s.occurrence_id ?? 0}`;
 }
+/** Notes exist when the date/series has an AI summary OR a synced transcript - a transcript with
+ *  no summary must still open the dialog (it renders whatever exists for the clicked date). */
+function hasNotesOf(s: StudentLiveSession): boolean {
+  return Boolean(
+    s.zoom_ai_summary || s.google_ai_summary || s.zoom_transcript_synced_at || s.google_transcript_synced_at
+  );
+}
 /** The backend's reminder state for THIS card: a dated occurrence is "on" only when its own id is
  *  in the armed set; a single session keeps the series-level flag. */
 function seededReminder(s: StudentLiveSession): boolean {
@@ -468,7 +475,9 @@ export default function LiveSessionsPage() {
     [instances, live, matchesSelectedDay],
   );
   const recordings = useMemo(
-    () => instances.filter((s) => s.has_recording && matchesSelectedDay(s)),
+    // An ended date can carry a transcript but no recording (recording failed, or only the
+    // transcript synced) - it lists too, with Notes and no Watch, instead of vanishing.
+    () => instances.filter((s) => (s.has_recording || (PAST.has(s.meeting_status ?? "") && hasNotesOf(s))) && matchesSelectedDay(s)),
     [instances, matchesSelectedDay],
   );
   const history = useMemo(
@@ -950,7 +959,9 @@ function UpcomingCard({ s, isNext, reminderOn, onAddCalendar, onRemind }: {
 }
 
 function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSession; watching: boolean; onWatch: () => void; onSummary: () => void }) {
-  const hasSummary = Boolean(s.zoom_ai_summary || s.google_ai_summary);
+  // Not gated on the AI summary: a date with a transcript but no summary still has notes to show,
+  // and the dialog renders whatever exists for the clicked date.
+  const hasNotes = hasNotesOf(s);
   return (
     <Box sx={{ borderRadius: 3, bgcolor: "var(--card-bg)", border: "1px solid var(--border-default)", p: 2, display: "flex", gap: 1.75, alignItems: "center", flexWrap: "wrap" }}>
       <DateBadge dt={s.class_datetime} tz={s.timezone} />
@@ -960,21 +971,23 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
           <CohortChip s={s} small />
         </Stack>
         <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>
-          {cardCourseText(s) || "Recording available"}
+          {cardCourseText(s) || (s.has_recording ? "Recording available" : "Transcript available")}
         </Typography>
       </Box>
       <Stack direction="row" spacing={1}>
-        {hasSummary && (
+        {hasNotes && (
           <Button onClick={onSummary} startIcon={<Icon icon="mdi:text-box-outline" width={16} />}
             sx={{ textTransform: "none", fontWeight: 700, color: "#6366f1", px: 1.5, py: 0.8, borderRadius: 2, border: "1px solid var(--border-default)" }}>
             Notes
           </Button>
         )}
-        <Button onClick={onWatch} disabled={watching}
-          startIcon={watching ? <CircularProgress size={14} color="inherit" /> : <Icon icon="mdi:play" width={16} />}
-          sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2, py: 0.8, borderRadius: 2, background: AI_GRAD }}>
-          Watch
-        </Button>
+        {s.has_recording && (
+          <Button onClick={onWatch} disabled={watching}
+            startIcon={watching ? <CircularProgress size={14} color="inherit" /> : <Icon icon="mdi:play" width={16} />}
+            sx={{ textTransform: "none", fontWeight: 800, color: "#fff", px: 2, py: 0.8, borderRadius: 2, background: AI_GRAD }}>
+            Watch
+          </Button>
+        )}
       </Stack>
     </Box>
   );

--- a/components/admin/live-sessions/LiveSessionTranscriptSection.tsx
+++ b/components/admin/live-sessions/LiveSessionTranscriptSection.tsx
@@ -4,6 +4,8 @@ import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Box,
+  ButtonBase,
+  Collapse,
   Typography,
   Button,
   TextField,
@@ -13,22 +15,195 @@ import { IconWrapper } from "@/components/common/IconWrapper";
 import {
   adminLiveActivitiesService,
   LiveSessionTranscriptResponse,
+  LiveClassOccurrence,
 } from "@/lib/services/admin/admin-live-activities.service";
 import { SummaryMarkdown } from "@/components/live-sessions/ui/SummaryMarkdown";
+import { formatSessionTime } from "@/lib/utils/session-time";
 
 interface LiveSessionTranscriptSectionProps {
   liveClassId: number;
   /** Whether a summary already exists (from the list/detail payload) - gates showing the section. */
   hasSummary?: boolean;
+  /** Recurring series: its dated occurrences. Transcripts/summaries live on the occurrence rows,
+   *  so when present the section renders one lazy per-date row instead of the single series view. */
+  occurrences?: LiveClassOccurrence[] | null;
+  timezone?: string | null;
+  /** Series title fallback for dates without a per-date title. */
+  seriesTitle?: string | null;
 }
 
-/** AI summary + searchable transcript for a recorded Zoom session. Transcript is lazy-loaded. */
-export function LiveSessionTranscriptSection({ liveClassId, hasSummary }: LiveSessionTranscriptSectionProps) {
+/** The loaded summary + searchable transcript (shared by the single view and each per-date row). */
+function TranscriptContent({ data }: { data: LiveSessionTranscriptResponse }) {
+  const { t } = useTranslation("common");
+  const [query, setQuery] = useState("");
+
+  const hasTranscript = Boolean(data.transcript_text?.trim());
+  const summary = data.summary?.trim() || "";
+
+  if (!hasTranscript && !summary) {
+    return (
+      <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+        {t("adminLiveSessions.transcriptUnavailable", "Transcript not available for this session yet.")}
+      </Typography>
+    );
+  }
+
+  const filteredLines = (() => {
+    const text = data.transcript_text ?? "";
+    if (!text) return [] as string[];
+    const lines = text.split("\n");
+    if (!query.trim()) return lines;
+    const q = query.trim().toLowerCase();
+    return lines.filter((l) => l.toLowerCase().includes(q));
+  })();
+
+  return (
+    <>
+      {summary ? (
+        <Box
+          sx={{
+            p: 1.5,
+            mb: 2,
+            borderRadius: 1,
+            bgcolor: "color-mix(in srgb, var(--accent-indigo) 8%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--accent-indigo) 24%, transparent)",
+          }}
+        >
+          <Typography variant="caption" sx={{ fontWeight: 600, color: "var(--accent-indigo)", display: "block", mb: 0.5 }}>
+            {t("adminLiveSessions.aiSummary", "AI summary")}
+          </Typography>
+          <SummaryMarkdown text={summary} fontSize="0.8rem" />
+        </Box>
+      ) : (
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>
+          {t("adminLiveSessions.summaryPending", "AI summary not generated yet.")}
+        </Typography>
+      )}
+
+      {hasTranscript ? (
+        <>
+          <TextField
+            size="small"
+            fullWidth
+            placeholder={t("adminLiveSessions.transcriptSearch", "Search transcript…")}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            sx={{ mb: 1 }}
+            InputProps={{
+              startAdornment: <IconWrapper icon="mdi:magnify" size={18} />,
+            }}
+          />
+          <Box
+            sx={{
+              maxHeight: 280,
+              overflowY: "auto",
+              p: 1.5,
+              borderRadius: 1,
+              border: "1px solid var(--border-default)",
+              bgcolor: "var(--surface)",
+              fontSize: "0.78rem",
+              lineHeight: 1.5,
+              color: "var(--font-primary)",
+            }}
+          >
+            {filteredLines.length === 0 ? (
+              <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
+                {t("adminLiveSessions.transcriptNoMatch", "No lines match your search.")}
+              </Typography>
+            ) : (
+              filteredLines.map((line, idx) => (
+                <div key={idx} style={{ marginBottom: 2 }}>{line}</div>
+              ))
+            )}
+          </Box>
+        </>
+      ) : (
+        <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+          {t("adminLiveSessions.transcriptUnavailable", "Transcript not available for this session yet.")}
+        </Typography>
+      )}
+    </>
+  );
+}
+
+/** One date of a recurring series. Loads its transcript on first open, not on render - a series
+ *  can hold dozens of dates, and fetching every transcript up front would cost dozens of requests
+ *  for rows most admins never expand. Once opened it stays loaded. */
+function OccurrenceTranscriptRow({
+  liveClassId,
+  occurrence,
+  timezone,
+  seriesTitle,
+}: {
+  liveClassId: number;
+  occurrence: LiveClassOccurrence;
+  timezone?: string | null;
+  seriesTitle?: string | null;
+}) {
+  const { t } = useTranslation("common");
+  const [open, setOpen] = useState(false);
+  const [data, setData] = useState<LiveSessionTranscriptResponse | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const toggle = useCallback(async () => {
+    const next = !open;
+    setOpen(next);
+    if (next && !loaded && !loading) {
+      setLoading(true);
+      try {
+        setData(await adminLiveActivitiesService.getTranscript(liveClassId, occurrence.id));
+      } catch {
+        setData(null);
+      } finally {
+        setLoaded(true);
+        setLoading(false);
+      }
+    }
+  }, [open, loaded, loading, liveClassId, occurrence.id]);
+
+  return (
+    <Box sx={{ border: "1px solid var(--border-default)", borderRadius: 2, overflow: "hidden" }}>
+      <ButtonBase
+        onClick={toggle}
+        sx={{ width: "100%", display: "flex", alignItems: "center", gap: 1, px: 1.5, py: 1.1, textAlign: "start" }}
+      >
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "0.85rem", color: "var(--font-primary)" }}>
+            {formatSessionTime(occurrence.occurrence_datetime, timezone)}
+          </Typography>
+          <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {occurrence.topic_name?.trim() || seriesTitle || ""}
+          </Typography>
+        </Box>
+        {loading ? (
+          <CircularProgress size={16} />
+        ) : (
+          <IconWrapper icon={open ? "mdi:chevron-up" : "mdi:chevron-down"} size={18} color="var(--font-secondary)" />
+        )}
+      </ButtonBase>
+      <Collapse in={open} unmountOnExit>
+        <Box sx={{ px: 1.5, pb: 1.5 }}>
+          {!loaded ? null : data ? (
+            <TranscriptContent data={data} />
+          ) : (
+            <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+              {t("adminLiveSessions.transcriptLoadFailed", "Couldn't load this date's transcript.")}
+            </Typography>
+          )}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+/** AI summary + searchable transcript for a recorded Zoom session. Transcript is lazy-loaded.
+ *  For a recurring series (occurrences given) each date gets its own lazy row instead. */
+export function LiveSessionTranscriptSection({ liveClassId, hasSummary, occurrences, timezone, seriesTitle }: LiveSessionTranscriptSectionProps) {
   const { t } = useTranslation("common");
   const [data, setData] = useState<LiveSessionTranscriptResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
-  const [query, setQuery] = useState("");
 
   const load = useCallback(async () => {
     if (loaded) return;
@@ -44,17 +219,33 @@ export function LiveSessionTranscriptSection({ liveClassId, hasSummary }: LiveSe
     }
   }, [liveClassId, loaded]);
 
-  const hasTranscript = Boolean(data?.transcript_text?.trim());
-  const summary = data?.summary?.trim() || "";
+  const perDate = [...(occurrences ?? [])].sort((a, b) =>
+    (a.occurrence_datetime || "").localeCompare(b.occurrence_datetime || "")
+  );
 
-  const filteredLines = (() => {
-    const text = data?.transcript_text ?? "";
-    if (!text) return [] as string[];
-    const lines = text.split("\n");
-    if (!query.trim()) return lines;
-    const q = query.trim().toLowerCase();
-    return lines.filter((l) => l.toLowerCase().includes(q));
-  })();
+  if (perDate.length > 0) {
+    return (
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: "var(--font-primary)", mb: 0.5 }}>
+          {t("adminLiveSessions.transcriptTitle", "Transcript & AI summary")}
+        </Typography>
+        <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>
+          {t("adminLiveSessions.transcriptPerDateHint", "Each date of this series keeps its own transcript and summary - expand a date to read it.")}
+        </Typography>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          {perDate.map((o) => (
+            <OccurrenceTranscriptRow
+              key={o.id}
+              liveClassId={liveClassId}
+              occurrence={o}
+              timezone={timezone}
+              seriesTitle={seriesTitle}
+            />
+          ))}
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ mt: 3 }}>
@@ -86,73 +277,7 @@ export function LiveSessionTranscriptSection({ liveClassId, hasSummary }: LiveSe
         </Typography>
       )}
 
-      {loaded && (
-        <>
-          {summary ? (
-            <Box
-              sx={{
-                p: 1.5,
-                mb: 2,
-                borderRadius: 1,
-                bgcolor: "color-mix(in srgb, var(--accent-indigo) 8%, transparent)",
-                border: "1px solid color-mix(in srgb, var(--accent-indigo) 24%, transparent)",
-              }}
-            >
-              <Typography variant="caption" sx={{ fontWeight: 600, color: "var(--accent-indigo)", display: "block", mb: 0.5 }}>
-                {t("adminLiveSessions.aiSummary", "AI summary")}
-              </Typography>
-              <SummaryMarkdown text={summary} fontSize="0.8rem" />
-            </Box>
-          ) : (
-            <Typography variant="caption" sx={{ color: "var(--font-secondary)", display: "block", mb: 1.5 }}>
-              {t("adminLiveSessions.summaryPending", "AI summary not generated yet.")}
-            </Typography>
-          )}
-
-          {hasTranscript ? (
-            <>
-              <TextField
-                size="small"
-                fullWidth
-                placeholder={t("adminLiveSessions.transcriptSearch", "Search transcript…")}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                sx={{ mb: 1 }}
-                InputProps={{
-                  startAdornment: <IconWrapper icon="mdi:magnify" size={18} />,
-                }}
-              />
-              <Box
-                sx={{
-                  maxHeight: 280,
-                  overflowY: "auto",
-                  p: 1.5,
-                  borderRadius: 1,
-                  border: "1px solid var(--border-default)",
-                  bgcolor: "var(--surface)",
-                  fontSize: "0.78rem",
-                  lineHeight: 1.5,
-                  color: "var(--font-primary)",
-                }}
-              >
-                {filteredLines.length === 0 ? (
-                  <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-                    {t("adminLiveSessions.transcriptNoMatch", "No lines match your search.")}
-                  </Typography>
-                ) : (
-                  filteredLines.map((line, idx) => (
-                    <div key={idx} style={{ marginBottom: 2 }}>{line}</div>
-                  ))
-                )}
-              </Box>
-            </>
-          ) : (
-            <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
-              {t("adminLiveSessions.transcriptUnavailable", "Transcript not available for this session yet.")}
-            </Typography>
-          )}
-        </>
-      )}
+      {loaded && data && <TranscriptContent data={data} />}
     </Box>
   );
 }

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -871,11 +871,15 @@ export const adminLiveActivitiesService = {
     return response.data;
   },
 
+  /** `occurrenceId` selects one date of a recurring series - transcripts/summaries live on the
+   *  occurrence rows, so the bare series id only ever answers with the series-level fields. */
   getTranscript: async (
-    liveClassId: number
+    liveClassId: number,
+    occurrenceId?: number | null
   ): Promise<LiveSessionTranscriptResponse> => {
     const response = await apiClient.get<LiveSessionTranscriptResponse>(
-      `${BASE}/live-activities/${liveClassId}/transcript/`
+      `${BASE}/live-activities/${liveClassId}/transcript/`,
+      occurrenceId ? { params: { occurrence_id: occurrenceId } } : undefined
     );
     return response.data;
   },


### PR DESCRIPTION
Carries #1404 (admin inline per-date recordings + lazy per-date transcripts, student Notes ungating). BE counterpart #673 deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)