### PR TITLE
fix(admin): the builder said "Week" on a course the admin had just set to modules

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { unitCount, unitLabel, unitNoun, unitWord, unitWordPlural } from "@/lib/utils/unit-labels";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { CoursePricingDialog } from "@/components/admin/adaptive-course/CoursePricingDialog";
@@ -557,10 +558,10 @@ export default function AdminAdaptiveCourseDetailPage() {
     try {
       await adminAdaptiveCourseService.updateModule(course.id, moduleId, { title });
     } catch (e) {
-      showToast(getAxiosErrorDetail(e, "Couldn't rename this week."), "error");
+      showToast(getAxiosErrorDetail(e, `Couldn't rename this ${unitWord(course)}.`), "error");
       throw e;
     }
-    showToast("Week renamed.", "success");
+    showToast(`${unitNoun(course)} renamed.`, "success");
     await load();
   }
 
@@ -585,8 +586,8 @@ export default function AdminAdaptiveCourseDetailPage() {
         const res = await adminAdaptiveCourseService.deleteModule(course.id, target.moduleId);
         done =
           res.submodules_removed > 0
-            ? `Week deleted, along with ${res.submodules_removed} topic${res.submodules_removed === 1 ? "" : "s"}.`
-            : "Week deleted.";
+            ? `${unitNoun(course)} deleted, along with ${res.submodules_removed} topic${res.submodules_removed === 1 ? "" : "s"}.`
+            : `${unitNoun(course)} deleted.`;
         if (activeModuleId === target.moduleId) setActiveModuleId(null);
         // Deleting the only week on the last page would otherwise leave the admin
         // parked on a page that no longer exists, i.e. an empty tree.
@@ -687,7 +688,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                   sx={pillBtnSx("outline")}
                 >
                   <Icon icon="mdi:auto-fix" width={16} />
-                  Generate a week with AI
+                  Generate a {unitWord(course)} with AI
                 </ButtonBase>
               </Box>
 
@@ -839,8 +840,8 @@ export default function AdminAdaptiveCourseDetailPage() {
               <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
                 {course.modules.length === 0 && (
                   <Typography sx={{ color: "text.secondary", textAlign: "center", py: 4 }}>
-                    No weeks yet. Use <strong>Add week</strong> below to build this course
-                    yourself, or <strong>Generate a week with AI</strong> to have one written
+                    No {unitWordPlural(course)} yet. Use <strong>Add {unitWord(course)}</strong> below to build this course
+                    yourself, or <strong>Generate a {unitWord(course)} with AI</strong> to have one written
                     for you.
                   </Typography>
                 )}
@@ -896,11 +897,11 @@ export default function AdminAdaptiveCourseDetailPage() {
                               week title wraps mid-word. */}
                           <Box sx={{ minWidth: 0, flex: 1 }}>
                             <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.1em", textTransform: "uppercase", color: "#a855f7" }}>
-                              Week {mod.weekno}
+                              {unitLabel(course, mod.weekno)}
                             </Typography>
                             <InlineEditableTitle
                               value={mod.title}
-                              label="Rename this week"
+                              label={`Rename this ${unitWord(course)}`}
                               fontSize="1.05rem"
                               fontWeight={800}
                               onSave={(title) => handleRenameModule(mod.id, title)}
@@ -919,9 +920,9 @@ export default function AdminAdaptiveCourseDetailPage() {
                             Generate topics with AI
                           </ButtonBase>
                           <RowDeleteButton
-                            label="Delete this week"
+                            label={`Delete this ${unitWord(course)}`}
                             width={18}
-                            onClick={() => setPendingDelete(moduleDeleteTarget(mod))}
+                            onClick={() => setPendingDelete(moduleDeleteTarget(mod, course))}
                           />
                         </Box>
                       </Box>
@@ -954,7 +955,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                               </ButtonBase>
                               <RowDeleteButton
                                 label="Delete this topic"
-                                onClick={() => setPendingDelete(submoduleDeleteTarget(sub, mod.weekno))}
+                                onClick={() => setPendingDelete(submoduleDeleteTarget(sub, mod.weekno, course))}
                               />
                             </Box>
                             <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mt: 1 }}>
@@ -1254,7 +1255,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                         ))}
                         {mod.submodules.length === 0 && (
                           <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", px: 0.25 }}>
-                            No topics in this week yet. Add one by hand below, or use{" "}
+                            No topics in this {unitWord(course)} yet. Add one by hand below, or use{" "}
                             <strong>Generate topics with AI</strong> above.
                           </Typography>
                         )}
@@ -1271,7 +1272,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                     </Box>
                   </Reveal>
                 ))}
-                  <AddModuleRow courseId={course.id} onAdded={() => void load()} />
+                  <AddModuleRow courseId={course.id} onAdded={() => void load()} course={course} />
               </Box>
               )}
             </>
@@ -1640,20 +1641,29 @@ function describeSubmoduleContents(sub: AdminAdaptiveCourseSubModule): string {
   return `${said.slice(0, -1).join(", ")} and ${said[said.length - 1]}`;
 }
 
-function moduleDeleteTarget(mod: AdminAdaptiveCourseModule): TreeDeleteTarget {
+function moduleDeleteTarget(
+  mod: AdminAdaptiveCourseModule,
+  course: { module_only_structure?: boolean } | null,
+): TreeDeleteTarget {
   const n = mod.submodules.length;
+  const Unit = unitNoun(course);
+  const unit = unitWord(course);
   return {
     kind: "module",
     moduleId: mod.id,
-    heading: "Delete this week",
+    heading: `Delete this ${unit}`,
     message:
       n === 0
-        ? `Week ${mod.weekno}, "${mod.title}", has no topics yet - deleting it just removes the week from the course.`
-        : `Week ${mod.weekno}, "${mod.title}", goes away with ${n === 1 ? "its 1 topic" : `all ${n} topics`} inside it and every article, quiz, coding set and video those topics hold. Students stop seeing this content; work they have already submitted stays in their records.`,
+        ? `${Unit} ${mod.weekno}, "${mod.title}", has no topics yet - deleting it just removes the ${unit} from the course.`
+        : `${Unit} ${mod.weekno}, "${mod.title}", goes away with ${n === 1 ? "its 1 topic" : `all ${n} topics`} inside it and every article, quiz, coding set and video those topics hold. Students stop seeing this content; work they have already submitted stays in their records.`,
   };
 }
 
-function submoduleDeleteTarget(sub: AdminAdaptiveCourseSubModule, weekno: number): TreeDeleteTarget {
+function submoduleDeleteTarget(
+  sub: AdminAdaptiveCourseSubModule,
+  weekno: number,
+  course: { module_only_structure?: boolean } | null,
+): TreeDeleteTarget {
   const inventory = describeSubmoduleContents(sub);
   return {
     kind: "submodule",
@@ -1661,7 +1671,7 @@ function submoduleDeleteTarget(sub: AdminAdaptiveCourseSubModule, weekno: number
     heading: "Delete this topic",
     message: inventory
       ? `"${sub.title}" goes away with its ${inventory}. Students stop seeing this content; work they have already submitted stays in their records.`
-      : `"${sub.title}" is empty - deleting it just removes the topic from week ${weekno}.`,
+      : `"${sub.title}" is empty - deleting it just removes the topic from ${unitWord(course)} ${weekno}.`,
   };
 }
 

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { unitCount, unitWordPlural } from "@/lib/utils/unit-labels";
 import { PriceTag } from "@/components/common/PriceTag";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
@@ -359,7 +360,7 @@ export default function AdminAdaptiveCoursesPage() {
                       <Typography sx={{ fontWeight: 800, fontSize: "0.86rem" }} noWrap>{c.title}</Typography>
                       <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }} noWrap>
                         Built by {c.authored_by?.name || "an instructor"} ·{" "}
-                        {c.module_count} week{c.module_count === 1 ? "" : "s"} ·{" "}
+                        {unitCount(c, c.module_count)} ·{" "}
                         {c.submodule_count} topic{c.submodule_count === 1 ? "" : "s"}
                       </Typography>
                     </Box>
@@ -648,7 +649,7 @@ function CourseCard({
           </Typography>
         )}
         <Box sx={{ display: "flex", gap: 2, mt: 1.5, flexWrap: "wrap" }}>
-          <Metric icon="mdi:view-module-outline" value={course.module_count} label="weeks" />
+          <Metric icon="mdi:view-module-outline" value={course.module_count} label={unitWordPlural(course)} />
           <Metric icon="mdi:file-tree-outline" value={course.submodule_count} label="topics" />
           <Metric icon="mdi:book-open-variant" value={course.article_count} label="articles" />
           <Metric icon="mdi:tune-vertical" value={course.quiz_count} label="quizzes" />

--- a/components/admin/adaptive-course/ManualTreeControls.tsx
+++ b/components/admin/adaptive-course/ManualTreeControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { unitNoun, unitWord } from "@/lib/utils/unit-labels";
 import { Box, TextField, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { LoadingButton } from "@/components/common/LoadingButton";
@@ -222,9 +223,12 @@ function GhostAddRow({
 export function AddModuleRow({
   courseId,
   onAdded,
+  course,
 }: {
   courseId: number;
   onAdded: () => void;
+  /** Carries module_only_structure, so the control says "module" on a module-framed course. */
+  course?: { module_only_structure?: boolean } | null;
 }) {
   const onCreate = useCallback(
     async (title: string) => {
@@ -235,14 +239,16 @@ export function AddModuleRow({
     [courseId]
   );
 
+  const Unit = unitNoun(course);
+  const unit = unitWord(course);
   return (
     <GhostAddRow
-      ghostLabel="Add week"
-      successMessage="Week added — it goes at the end of the course."
-      placeholder="Name this week, e.g. Functions and scope"
+      ghostLabel={`Add ${unit}`}
+      successMessage={`${Unit} added, it goes at the end of the course.`}
+      placeholder={`Name this ${unit}, e.g. Functions and scope`}
       onCreate={onCreate}
       onAdded={onAdded}
-      errorFallback="Could not add the week. Please try again."
+      errorFallback={`Could not add the ${unit}. Please try again.`}
     />
   );
 }

--- a/lib/utils/unit-labels.ts
+++ b/lib/utils/unit-labels.ts
@@ -1,0 +1,39 @@
+/**
+ * What one unit of a course is called, on the ADMIN side.
+ *
+ * A course carries `module_only_structure`. It is vocabulary only: gating, scheduling and points
+ * are identical either way. The learner board already respects it, because the API hands it the
+ * computed `unitNoun`. The admin surfaces did not: they hardcoded "Week" in about a dozen strings,
+ * so an admin could flip the course to modules, watch the learner view change, and still be told
+ * "Week 7" by the builder they had just used to flip it.
+ *
+ * Mirrors `adaptive_quiz/structure_labels.py` on the backend. Keep the two in step.
+ */
+
+/** Something carrying the flag: a course detail, a list row, or a bare boolean holder. */
+export type UnitStructured = { module_only_structure?: boolean } | null | undefined;
+
+/** "Module" or "Week", capitalised for a heading or an eyebrow. */
+export function unitNoun(course: UnitStructured): "Module" | "Week" {
+  return course?.module_only_structure ? "Module" : "Week";
+}
+
+/** "module" or "week", for the middle of a sentence. */
+export function unitWord(course: UnitStructured): "module" | "week" {
+  return course?.module_only_structure ? "module" : "week";
+}
+
+/** "modules" or "weeks". */
+export function unitWordPlural(course: UnitStructured): "modules" | "weeks" {
+  return `${unitWord(course)}s` as "modules" | "weeks";
+}
+
+/** "Week 7" / "Module 7". Unit 0 is the entry step in both framings. */
+export function unitLabel(course: UnitStructured, n: number): string {
+  return n ? `${unitNoun(course)} ${n}` : "Get started";
+}
+
+/** "3 weeks" / "1 module". */
+export function unitCount(course: UnitStructured, n: number): string {
+  return `${n} ${n === 1 ? unitWord(course) : unitWordPlural(course)}`;
+}


### PR DESCRIPTION
## The report

> when i am switching to module it should also show module at admin side. currently it shows week at admin and also in admin course builder cards as well showing week

## What was wrong

A course carries `module_only_structure`. It is **vocabulary only** — gating, scheduling and points are identical either way. The learner board already respects it, because the API hands it a computed `unitNoun`.

The admin surfaces did not. They hardcoded `"Week"` in about a dozen strings. So an admin could flip a course to modules, watch the learner view change, and still be told **"Week 7"** by the very builder they had just used to flip it.

The one place that *did* read the flag was the toggle's own confirmation text ("Students now see modules instead of weeks"). That made it look like the toggle was broken, when the toggle was the only part working.

## The fix

`lib/utils/unit-labels.ts` derives the noun once, mirroring `adaptive_quiz/structure_labels.py` on the backend so the two stay in step. The admin surfaces now read it:

| surface | before | after |
|---|---|---|
| course list card | `32 weeks` | `32 weeks` / `32 modules` |
| course header metric | `weeks` tile | follows the flag |
| tree card eyebrow | `WEEK 7` | `WEEK 7` / `MODULE 7` |
| add control | `Add week` | `Add week` / `Add module`, plus placeholder and success text |
| rename / delete | `Rename this week` | follows the flag, including toasts |
| empty states | `No weeks yet` | `No weeks yet` / `No modules yet` |

The two delete-confirmation builders now take the course, because a dialog reading *"this removes the week from the course"* on a module-framed course is precisely the sentence an admin reads twice before clicking a destructive button.

## Scope

No behaviour change: nothing here touches gating, points, or the API. The backend already returns `module_only_structure` on both the list and detail serializers, so this is purely the frontend catching up.

`tsc --noEmit` clean against a cleared `.next` cache. `eslint` clean on all four files; the two warnings on the course list page are pre-existing and were verified against the unmodified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)