### PR TITLE
Promote stagging: in-platform viewing, live-only calendar, timeline controls

### DIFF
--- a/app/admin/live-sessions/[liveClassId]/page.tsx
+++ b/app/admin/live-sessions/[liveClassId]/page.tsx
@@ -673,7 +673,9 @@ export default function LiveSessionDetailPage() {
                       liveClassId={activity.id}
                       seriesTitle={activity.topic_name}
                       timezone={activity.timezone}
-                      onOpenRecording={(url) => window.open(url, "_blank", "noopener,noreferrer")}
+                      // In-platform, like the Recording tab: the timeline used to hand the row's
+                      // recording_url to window.open, which is Zoom's HTML share page.
+                      onPlayOccurrence={(occ) => { setPlayerOccurrenceId(occ.id); setPlayerOpen(true); }}
                       onChanged={() => void load()}
                     />
                   </SectionCard>

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -108,6 +108,17 @@ function initials(name: string): string {
 function cardKeyOf(s: StudentLiveSession): string {
   return `${s.id}:${s.occurrence_id ?? 0}`;
 }
+/** A sitting kept for its recording even though it is marked cancelled. Says so plainly rather
+ *  than passing it off as a class that ran normally. */
+function CancelledSittingChip({ s }: { s: StudentLiveSession }) {
+  if (!s.occurrence_cancelled) return null;
+  return (
+    <Box sx={{ px: 0.8, py: 0.2, borderRadius: 999, flexShrink: 0, fontSize: "0.64rem", fontWeight: 800,
+      color: "#64748b", bgcolor: "color-mix(in srgb,#64748b 12%,transparent)" }}>
+      Cancelled sitting
+    </Box>
+  );
+}
 /** Notes exist when the date/series has an AI summary OR a synced transcript - a transcript with
  *  no summary must still open the dialog (it renders whatever exists for the clicked date). */
 function hasNotesOf(s: StudentLiveSession): boolean {
@@ -258,8 +269,14 @@ export default function LiveSessionsPage() {
         out.push(s);
         continue;
       }
-      const live = occs.filter(
-        (o) => o.status !== "cancelled" && o.meeting_status !== "cancelled"
+      // Cancelled sittings drop out - EXCEPT one that left artifacts behind. A class that ran,
+      // recorded and produced a summary is sometimes still marked cancelled (a post-edit Zoom
+      // resync can re-cancel a date that already happened), and dropping it here made three real
+      // recorded classes invisible to every enrolled student while admins could play them.
+      const kept = occs.filter(
+        (o) =>
+          (o.status !== "cancelled" && o.meeting_status !== "cancelled") ||
+          o.has_recording || o.zoom_recording_url || o.zoom_ai_summary
       );
 
       // A recurring series' own zoom_recording_url is the SERIES-LATEST recording: Zoom returns the
@@ -273,22 +290,23 @@ export default function LiveSessionsPage() {
       // KPI counts parents, so it said 1 while this list said 0 for the same session.
       //
       // Not `||` either — that would claim every one of the 50 occurrences has a recording.
-      const noneCarryTheirOwn = !live.some((o) => o.has_recording || o.zoom_recording_url);
+      const noneCarryTheirOwn = !kept.some((o) => o.has_recording || o.zoom_recording_url);
       const inheritIdx =
         noneCarryTheirOwn && s.has_recording
-          ? live.reduce((best, o, i) => {
+          ? kept.reduce((best, o, i) => {
               const t = new Date(o.occurrence_datetime ?? s.class_datetime ?? 0).getTime();
               if (t > Date.now()) return best;
               const bt =
                 best < 0
                   ? -Infinity
-                  : new Date(live[best].occurrence_datetime ?? s.class_datetime ?? 0).getTime();
+                  : new Date(kept[best].occurrence_datetime ?? s.class_datetime ?? 0).getTime();
               return t > bt ? i : best;
             }, -1)
           : -1;
 
-      live.forEach((o, i) => {
+      kept.forEach((o, i) => {
         const inherits = i === inheritIdx;
+        const cancelled = o.status === "cancelled" || o.meeting_status === "cancelled";
         out.push({
           ...s,
           // Keep the parent id for API calls (feedback, reminders) but make the key unique per date.
@@ -298,12 +316,16 @@ export default function LiveSessionsPage() {
           topic_name: o.topic_name || s.topic_name,
           class_datetime: o.occurrence_datetime ?? s.class_datetime,
           duration_minutes: o.duration_minutes ?? s.duration_minutes,
-          // `live` has already excluded cancelled occurrences, but .filter() does not narrow the
-          // union the way the old `continue` did — so exclude it explicitly rather than casting.
+          // A retained cancelled sitting is forced PAST rather than inheriting the series status:
+          // the series is often still "scheduled", which would list a class that already happened
+          // as a joinable future one and let it drive the LIVE hero.
           meeting_status:
             o.meeting_status && o.meeting_status !== "cancelled"
               ? o.meeting_status
-              : s.meeting_status,
+              : cancelled
+                ? "ended"
+                : s.meeting_status,
+          occurrence_cancelled: cancelled,
           has_recording: Boolean(o.has_recording || (inherits && s.has_recording)),
           zoom_recording_url:
             o.zoom_recording_url ?? (inherits ? s.zoom_recording_url : undefined),
@@ -954,6 +976,7 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
         <Stack direction="row" spacing={0.75} alignItems="center" sx={{ minWidth: 0 }}>
           <Typography sx={{ fontWeight: 800, fontSize: "1rem" }} noWrap>{s.topic_name}</Typography>
           <CohortChip s={s} small />
+          <CancelledSittingChip s={s} />
         </Stack>
         <Typography sx={{ fontSize: "0.8rem", color: "text.secondary" }}>
           {cardCourseText(s) || (s.has_recording ? "Recording available" : "Transcript available")}
@@ -996,6 +1019,7 @@ function HistoryRow({ s, watching, onWatch, onGiveFeedback }: {
         </Typography>
       </Box>
       <CohortChip s={s} small />
+      <CancelledSittingChip s={s} />
       <Box sx={{ px: 1, py: 0.3, borderRadius: 999, fontSize: "0.68rem", fontWeight: 800,
         color: attended ? "#059669" : "#64748b", bgcolor: attended ? "color-mix(in srgb,#10b981 12%,transparent)" : "color-mix(in srgb,#64748b 12%,transparent)" }}>
         {attended ? "Attended" : "Missed"}

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -19,15 +19,6 @@ import { studentLiveSessionsService } from "@/lib/services/live-sessions";
 import type { StudentLiveSession, MyLiveStats } from "@/lib/services/live-sessions";
 import { formatSessionClock, formatSessionTime } from "@/lib/utils/session-time";
 import { ScheduleCalendar, dayKey, type CalendarEvent } from "@/components/live-sessions/ScheduleCalendar";
-import { assessmentService, type Assessment } from "@/lib/services/assessment.service";
-import mockInterviewService, { type MockInterview } from "@/lib/services/mock-interview.service";
-
-/** "HH:MM" (24h) for an ISO datetime, or "" when unparseable. */
-function hhmm(iso?: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  return isNaN(d.getTime()) ? "" : d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false });
-}
 
 /* --------------------------------- helpers -------------------------------- */
 
@@ -245,14 +236,9 @@ export default function LiveSessionsPage() {
   const [facetFilter, setFacetFilter] = useState<string | null>(null);
   const { enabled: communityEnabled } = useClientFeature(COMMUNITY_FEATURE);
   const hideCounts = useClientOptIn(HIDE_PARTICIPANT_COUNTS);
-  // Extra calendar sources (best-effort — a failure just leaves those dots off the calendar).
-  const [assessments, setAssessments] = useState<Assessment[]>([]);
-  const [interviews, setInterviews] = useState<MockInterview[]>([]);
 
   useEffect(() => {
     studentLiveSessionsService.getMyStats().then(setStats).catch(() => undefined);
-    assessmentService.getActiveAssessments().then(setAssessments).catch(() => undefined);
-    mockInterviewService.listInterviews().then(setInterviews).catch(() => undefined);
   }, []);
 
   /**
@@ -368,10 +354,11 @@ export default function LiveSessionsPage() {
     });
   }, [instances]);
 
-  // Unified calendar feed: live sessions + assessment windows (start=assessment, end=deadline) +
-  // scheduled mock interviews. Built from the occurrence-expanded `instances`, not the raw
-  // sessions - a recurring series is one row whose class_datetime is frozen at occurrence #1, so
-  // feeding sessions gave the whole series a single dot on its first date and none on the rest.
+  // This calendar shows live sessions and nothing else - it is the Live Sessions page, and the
+  // assessment/interview dots it also carried belonged to other modules' surfaces. Built from the
+  // occurrence-expanded `instances`, not the raw sessions - a recurring series is one row whose
+  // class_datetime is frozen at occurrence #1, so feeding sessions gave the whole series a single
+  // dot on its first date and none on the rest.
   const calendarEvents = useMemo<CalendarEvent[]>(() => {
     const evs: CalendarEvent[] = [];
     for (const s of instances) {
@@ -385,15 +372,8 @@ export default function LiveSessionsPage() {
         subtitle: courseOf(s) || undefined,
       });
     }
-    for (const a of assessments) {
-      if (a.start_time) evs.push({ id: `assess-${a.id}`, date: a.start_time, title: a.title, type: "assessment" });
-      if (a.end_time) evs.push({ id: `deadline-${a.id}`, date: a.end_time, title: a.title, type: "deadline", time: `Due ${hhmm(a.end_time)}` });
-    }
-    for (const iv of interviews) {
-      if (iv.scheduled_date_time) evs.push({ id: `iv-${iv.id}`, date: iv.scheduled_date_time, title: iv.title || iv.topic || "Mock interview", type: "interview", subtitle: iv.topic });
-    }
     return evs;
-  }, [instances, assessments, interviews]);
+  }, [instances]);
 
   // While a session is live, poll Zoom for the CURRENT participant count (the stored
   // attendance_count only lands after the meeting ends — that's why it read '0 joined').
@@ -737,7 +717,7 @@ export default function LiveSessionsPage() {
 
             {/* Right rail */}
             <Stack spacing={2.5}>
-              <ScheduleCalendar events={calendarEvents} selectedKey={selectedDay} onSelectDay={setSelectedDay} />
+              <ScheduleCalendar events={calendarEvents} legendTypes={["live"]} selectedKey={selectedDay} onSelectDay={setSelectedDay} />
               {stats && <AttendanceRail stats={stats} />}
             </Stack>
           </Box>

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, IconButton, Stack, Tooltip, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { PageShell } from "@/components/common/PageShell";
 import { AnimatedRing } from "@/components/scorecard/shared";
@@ -724,7 +724,12 @@ export default function LiveSessionsPage() {
               {tab === "history" && (
                 history.length === 0 ? <Empty text="No past sessions yet." /> : (
                   <Stack spacing={1.25}>
-                    {history.map((s) => <HistoryRow key={s.occurrence_id ?? s.id} s={s} onGiveFeedback={() => setFeedbackFor(s)} />)}
+                    {history.map((s) => (
+                      <HistoryRow key={s.occurrence_id ?? s.id} s={s}
+                        watching={watchingRecordingId === s.id}
+                        onWatch={() => handleWatchRecording(s)}
+                        onGiveFeedback={() => setFeedbackFor(s)} />
+                    ))}
                   </Stack>
                 )
               )}
@@ -993,7 +998,9 @@ function RecordingCard({ s, watching, onWatch, onSummary }: { s: StudentLiveSess
   );
 }
 
-function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedback?: () => void }) {
+function HistoryRow({ s, watching, onWatch, onGiveFeedback }: {
+  s: StudentLiveSession; watching?: boolean; onWatch?: () => void; onGiveFeedback?: () => void;
+}) {
   const attended = Boolean(s.my_attendance?.attended);
   // The chip says what this session belongs to, so the text line never repeats it.
   const courseText = cardCourseText(s);
@@ -1013,7 +1020,17 @@ function HistoryRow({ s, onGiveFeedback }: { s: StudentLiveSession; onGiveFeedba
         color: attended ? "#059669" : "#64748b", bgcolor: attended ? "color-mix(in srgb,#10b981 12%,transparent)" : "color-mix(in srgb,#64748b 12%,transparent)" }}>
         {attended ? "Attended" : "Missed"}
       </Box>
-      {s.has_recording && <Icon icon="mdi:play-circle-outline" width={18} style={{ color: "#7c3aed" }} />}
+      {/* This glyph always looked like a play button; now it is one, opening the same in-app
+          player the Recordings tab uses for this date. */}
+      {s.has_recording && onWatch && (
+        <Tooltip title="Watch recording">
+          <IconButton size="small" aria-label="Watch recording" disabled={watching} onClick={onWatch}>
+            {watching
+              ? <CircularProgress size={16} sx={{ color: "#7c3aed" }} />
+              : <Icon icon="mdi:play-circle-outline" width={18} style={{ color: "#7c3aed" }} />}
+          </IconButton>
+        </Tooltip>
+      )}
       {/* Nothing to rate on a session that was called off. */}
       {onGiveFeedback && s.notice_type !== "cancelled" && (
         <Button onClick={onGiveFeedback} size="small" startIcon={<Icon icon="mdi:star-outline" width={16} />}

--- a/components/admin/course-builder/AttachmentPreview.tsx
+++ b/components/admin/course-builder/AttachmentPreview.tsx
@@ -9,6 +9,7 @@ import { OfficeDocPreview } from "./previews/OfficeDocPreview";
 import { TextPreview } from "./previews/TextPreview";
 import { DocxPreview } from "./previews/DocxPreview";
 import { CsvPreview } from "./previews/CsvPreview";
+import { MediaPreview } from "./previews/MediaPreview";
 import { FallbackPreview } from "./previews/FallbackPreview";
 
 // Re-export so callers can keep importing the type from this module.
@@ -16,13 +17,20 @@ export type { PreviewableAttachment } from "./previews/shared";
 
 interface AttachmentPreviewProps {
   attachment: PreviewableAttachment;
+  /**
+   * Whether an Office format may be rendered by the Office Online viewer. That viewer is the one
+   * route where the file leaves the platform - Microsoft's servers fetch the presigned URL - so a
+   * surface that has not accepted that trade sets this false and gets the download card instead.
+   * .docx is unaffected either way: mammoth renders it client-side, with no third party.
+   */
+  allowExternalViewer?: boolean;
 }
 
 /**
  * Dispatcher that picks the right renderer for a given attachment's MIME / extension.
  * Each renderer lives in ./previews/ to keep this file focused on routing logic.
  */
-export function AttachmentPreview({ attachment }: AttachmentPreviewProps) {
+export function AttachmentPreview({ attachment, allowExternalViewer = true }: AttachmentPreviewProps) {
   const { t } = useTranslation("common");
   const { file_url, file_type, original_filename, mime_type } = attachment;
 
@@ -44,7 +52,14 @@ export function AttachmentPreview({ attachment }: AttachmentPreviewProps) {
     return <PdfPreview url={file_url} filename={original_filename} />;
   }
 
-  if (file_type === "text" || mime_type?.startsWith("text/")) {
+  if (file_type === "video" || file_type === "audio") {
+    return <MediaPreview kind={file_type} url={file_url} filename={original_filename} />;
+  }
+
+  // `code` covers json/ipynb/py/js/ts/java/cpp/sql/sh/html/css. Routing it here keeps an .html
+  // material in a <pre> and never in an iframe, and stops .json/.ipynb (whose MIME is not text/*)
+  // falling through to the download card.
+  if (file_type === "text" || file_type === "code" || mime_type?.startsWith("text/")) {
     const lower = original_filename.toLowerCase();
     if (lower.endsWith(".csv")) {
       return <CsvPreview url={file_url} />;
@@ -52,12 +67,21 @@ export function AttachmentPreview({ attachment }: AttachmentPreviewProps) {
     return <TextPreview url={file_url} />;
   }
 
-  if (file_type === "document" || isOfficeDoc(original_filename)) {
+  // A CSV classified as `spreadsheet` reaches neither the text branch (its MIME may be
+  // application/vnd.ms-excel) nor isOfficeDoc, so it needs its own guard.
+  if (original_filename.toLowerCase().endsWith(".csv")) {
+    return <CsvPreview url={file_url} />;
+  }
+
+  if (file_type === "document" || file_type === "spreadsheet" || file_type === "presentation" || isOfficeDoc(original_filename)) {
     const lower = original_filename.toLowerCase();
-    // mammoth handles .docx (not .doc). Use it for instant inline rendering;
-    // fall back to Office Online Viewer for other formats.
+    // mammoth handles .docx (not .doc) entirely in the browser. Use it for instant inline
+    // rendering; other Office formats need the external viewer, where it is permitted.
     if (lower.endsWith(".docx")) {
       return <DocxPreview url={file_url} filename={original_filename} />;
+    }
+    if (!allowExternalViewer) {
+      return <FallbackPreview url={file_url} filename={original_filename} />;
     }
     return <OfficeDocPreview url={file_url} filename={original_filename} />;
   }

--- a/components/admin/course-builder/previews/MediaPreview.tsx
+++ b/components/admin/course-builder/previews/MediaPreview.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import { PREVIEW_HEIGHT } from "./shared";
+import { FallbackPreview } from "./FallbackPreview";
+
+/**
+ * Inline audio/video playback for an uploaded file.
+ *
+ * The error fallback is not optional: the backend classifies .mkv and .avi as `video`, and no
+ * browser plays either - without onError those render as a silent black box with no way out.
+ */
+export function MediaPreview({
+  kind,
+  url,
+  filename,
+}: {
+  kind: "video" | "audio";
+  url: string;
+  filename: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) return <FallbackPreview url={url} filename={filename} />;
+
+  // No autoPlay: a materials list is not a video page.
+  if (kind === "audio") {
+    return <audio src={url} controls onError={() => setFailed(true)} style={{ width: "100%" }} />;
+  }
+  return (
+    <video
+      src={url}
+      controls
+      playsInline
+      onError={() => setFailed(true)}
+      style={{ width: "100%", maxHeight: PREVIEW_HEIGHT, borderRadius: 4, backgroundColor: "#000" }}
+    />
+  );
+}

--- a/components/admin/course-builder/previews/shared.ts
+++ b/components/admin/course-builder/previews/shared.ts
@@ -1,9 +1,12 @@
-import type { SubmoduleAttachmentType } from "@/lib/services/admin/admin-course-builder.service";
-
-/** Minimal shape required for preview - both admin and student types satisfy this. */
+/**
+ * Minimal shape required for preview - the course-builder attachment types and the live-session
+ * material types all satisfy it. `file_type` is a plain string rather than one backend's enum
+ * because two different backends classify files here (course attachments: 5 buckets, session
+ * materials: 11); the dispatcher routes on the value, and an unknown one falls back safely.
+ */
 export interface PreviewableAttachment {
   file_url: string | null;
-  file_type: SubmoduleAttachmentType;
+  file_type: string;
   original_filename: string;
   mime_type: string;
 }

--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -21,13 +21,17 @@ import {
   TableHead,
   TableRow,
   Paper,
+  IconButton,
+  Tooltip,
 } from "@mui/material";
 import { IconWrapper } from "@/components/common/IconWrapper";
+import { TranscriptContent } from "./LiveSessionTranscriptSection";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { MeetingStatusChip, RoleChip } from "@/components/live-sessions/ui/LiveSessionUI";
 import { AssignParticipantDialog } from "./AssignParticipantDialog";
 import {
   adminLiveActivitiesService,
+  LiveSessionTranscriptResponse,
   OccurrenceTimelineResponse,
   TimelineOccurrence,
   RosterStudent,
@@ -75,7 +79,12 @@ interface Props {
   seriesTitle?: string;
   /** The series' scheduling zone - reschedules are entered and sent in this zone. */
   timezone?: string | null;
-  onOpenRecording?: (url: string) => void;
+  /**
+   * Play ONE date's recording. Deliberately an occurrence, not a URL: `recording_url` is Zoom's
+   * HTML share page (share_url + ?pwd=), which can only ever be navigated to - the playable MP4 is
+   * resolved server-side from the occurrence id by the streaming proxy.
+   */
+  onPlayOccurrence?: (occ: TimelineOccurrence) => void;
   /** Called after a date was renamed/rescheduled/cancelled, so the parent can refresh. */
   onChanged?: () => void;
 }
@@ -85,7 +94,7 @@ interface Props {
  * specific date (per-occurrence roster) vs missed, and whether its own recording / transcript is
  * ready. Renders nothing for a single (non-recurring) session - the series roster covers those.
  */
-export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezone, onOpenRecording, onChanged }: Props) {
+export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezone, onPlayOccurrence, onChanged }: Props) {
   const { t } = useTranslation("common");
   const { showToast } = useToast();
   const [data, setData] = useState<OccurrenceTimelineResponse | null>(null);
@@ -99,6 +108,9 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
   // being attached to a student (dialog carries its occurrence for occurrence_id).
   const [markingKey, setMarkingKey] = useState<string | null>(null);
   const [assign, setAssign] = useState<{ occ: TimelineOccurrence; participant: UnmatchedParticipant } | null>(null);
+  // Which date's notes are open, and that date's transcript once fetched (per-date, never the
+  // series-level one - a series' transcript belongs to whichever sitting synced last).
+  const [notesFor, setNotesFor] = useState<TimelineOccurrence | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -294,11 +306,30 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                       color: occ.joined_count > 0 ? "var(--success-500)" : "var(--font-secondary)",
                     }}
                   />
+                  {/* These read as buttons, so they are buttons. stopPropagation is required: the
+                      header Box is the row's expand/collapse toggle, and without it a click would
+                      also open the accordion underneath the dialog. */}
                   {occ.has_recording && (
-                    <IconWrapper icon="mdi:play-circle" size={16} color="var(--accent-indigo)" />
+                    <Tooltip title={t("adminLiveSessions.playRecording", "Play recording")}>
+                      <IconButton
+                        size="small"
+                        aria-label={t("adminLiveSessions.playRecording", "Play recording")}
+                        onClick={(e) => { e.stopPropagation(); onPlayOccurrence?.(occ); }}
+                      >
+                        <IconWrapper icon="mdi:play-circle" size={16} color="var(--accent-indigo)" />
+                      </IconButton>
+                    </Tooltip>
                   )}
-                  {occ.has_transcript && (
-                    <IconWrapper icon="mdi:text-box-check" size={16} color="var(--accent-indigo)" />
+                  {(occ.has_transcript || occ.has_summary) && (
+                    <Tooltip title={t("adminLiveSessions.sessionNotes", "Session notes")}>
+                      <IconButton
+                        size="small"
+                        aria-label={t("adminLiveSessions.sessionNotes", "Session notes")}
+                        onClick={(e) => { e.stopPropagation(); setNotesFor(occ); }}
+                      >
+                        <IconWrapper icon="mdi:text-box-check" size={16} color="var(--accent-indigo)" />
+                      </IconButton>
+                    </Tooltip>
                   )}
                   <IconWrapper icon={open ? "mdi:chevron-up" : "mdi:chevron-down"} size={18} color="var(--font-secondary)" />
                 </Box>
@@ -514,11 +545,13 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                           {t("adminLiveSessions.syncAttendance", "Sync attendance")}
                         </Button>
                       )}
-                      {occ.has_recording && occ.recording_url && (
+                      {/* Not gated on recording_url: that field is Zoom's share PAGE, while in-app
+                          playback resolves the MP4 server-side from the occurrence id. */}
+                      {occ.has_recording && (
                         <Button
                           size="small"
                           variant="text"
-                          onClick={() => onOpenRecording?.(occ.recording_url as string)}
+                          onClick={() => onPlayOccurrence?.(occ)}
                           startIcon={<IconWrapper icon="mdi:play-circle-outline" size={15} />}
                           sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700 }}
                         >
@@ -579,6 +612,15 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
         />
       )}
 
+      {notesFor && (
+        <OccurrenceNotesDialog
+          liveClassId={liveClassId}
+          occ={notesFor}
+          seriesTitle={seriesTitle}
+          onClose={() => setNotesFor(null)}
+        />
+      )}
+
       <ConfirmDialog
         open={Boolean(cancelTarget)}
         title={t("adminLiveSessions.cancelOccurrenceTitle", "Cancel this date?")}
@@ -593,6 +635,68 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
         onCancel={() => setCancelTarget(null)}
       />
     </Box>
+  );
+}
+
+/** One date's AI summary + transcript, fetched per occurrence. Reuses the transcript tab's own
+ *  renderer so the two admin surfaces can never drift apart. */
+function OccurrenceNotesDialog({
+  liveClassId,
+  occ,
+  seriesTitle,
+  onClose,
+}: {
+  liveClassId: number;
+  occ: TimelineOccurrence;
+  seriesTitle?: string;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation("common");
+  const [data, setData] = useState<LiveSessionTranscriptResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await adminLiveActivitiesService.getTranscript(liveClassId, occ.id);
+        if (!cancelled) setData(res);
+      } catch {
+        if (!cancelled) setData(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [liveClassId, occ.id]);
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ fontWeight: 700 }}>
+        {occ.topic_name?.trim() || seriesTitle || t("adminLiveSessions.sessionNotes", "Session notes")}
+        <Typography variant="caption" sx={{ display: "block", color: "var(--font-secondary)", fontWeight: 500 }}>
+          {fmtDate(occ.date)}
+        </Typography>
+      </DialogTitle>
+      <DialogContent dividers>
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <CircularProgress size={26} />
+          </Box>
+        ) : data ? (
+          <TranscriptContent data={data} />
+        ) : (
+          <Typography variant="body2" sx={{ color: "var(--font-secondary)" }}>
+            {t("adminLiveSessions.transcriptLoadFailed", "Couldn't load this date's transcript.")}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} sx={{ textTransform: "none" }}>
+          {t("adminLiveSessions.close", "Close")}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }
 

--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -527,7 +527,12 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                       )}
                       {occ.attendance_synced_at && (
                         <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-                          {t("adminLiveSessions.lastSynced", "Synced")} {fmtDate(occ.attendance_synced_at)}
+                          {/* The locale string is "Last synced: {{date}}" - the timestamp must go in
+                              the VALUES argument; passing it as the 2nd arg makes it a defaultValue
+                              and leaves the raw {{date}} token on screen. */}
+                          {t("adminLiveSessions.lastSynced", "Last synced: {{date}}", {
+                            date: fmtDate(occ.attendance_synced_at),
+                          })}
                         </Typography>
                       )}
                     </Box>

--- a/components/admin/live-sessions/LiveSessionTranscriptSection.tsx
+++ b/components/admin/live-sessions/LiveSessionTranscriptSection.tsx
@@ -32,8 +32,9 @@ interface LiveSessionTranscriptSectionProps {
   seriesTitle?: string | null;
 }
 
-/** The loaded summary + searchable transcript (shared by the single view and each per-date row). */
-function TranscriptContent({ data }: { data: LiveSessionTranscriptResponse }) {
+/** The loaded summary + searchable transcript (shared by the single view, each per-date row, and
+ *  the timeline's per-date notes dialog). */
+export function TranscriptContent({ data }: { data: LiveSessionTranscriptResponse }) {
   const { t } = useTranslation("common");
   const [query, setQuery] = useState("");
 

--- a/components/live-sessions/MaterialViewerDialog.tsx
+++ b/components/live-sessions/MaterialViewerDialog.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from "@mui/material";
+import { AttachmentPreview } from "@/components/admin/course-builder/AttachmentPreview";
+import { formatFileSize, type LiveSessionMaterial } from "@/lib/services/live-session-materials.service";
+
+/**
+ * Reads a session's study material without leaving the platform.
+ *
+ * The body is the existing AttachmentPreview dispatcher rather than a new iframe viewer: a bare
+ * `<iframe src="...pptx">` downloads the file instead of rendering it, which is the behaviour this
+ * dialog exists to fix. `allowExternalViewer={false}` keeps tenant material off Microsoft's Office
+ * Online servers - PDFs, images, video/audio, text and .docx all still render in-app, and the
+ * formats that would need a third party get the download card instead.
+ */
+export function MaterialViewerDialog({
+  material,
+  onClose,
+}: {
+  material: LiveSessionMaterial | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={Boolean(material)} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ fontWeight: 700 }}>
+        {material?.title}
+        <Typography variant="caption" sx={{ display: "block", color: "var(--font-secondary)", fontWeight: 500 }}>
+          {material?.original_filename}
+          {material?.file_size ? ` · ${formatFileSize(material.file_size)}` : ""}
+        </Typography>
+      </DialogTitle>
+      <DialogContent dividers>
+        {material && <AttachmentPreview attachment={material} allowExternalViewer={false} />}
+      </DialogContent>
+      <DialogActions>
+        {material?.file_url && (
+          <Button component="a" href={material.file_url} target="_blank" rel="noopener noreferrer" sx={{ textTransform: "none" }}>
+            Open in new tab
+          </Button>
+        )}
+        <Button onClick={onClose} sx={{ textTransform: "none" }}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/components/live-sessions/ScheduleCalendar.tsx
+++ b/components/live-sessions/ScheduleCalendar.tsx
@@ -48,15 +48,21 @@ function clock(ev: CalendarEvent): string {
  * A month calendar that aggregates live sessions, deadlines, assessments and interviews as
  * type-colored dots, with a day-agenda panel below. Pure: fed a normalized `CalendarEvent[]`, so
  * both the student and admin live-session pages share it. Theme-aware (CSS-var driven).
+ *
+ * A mount that only ever supplies one kind of event passes `legendTypes` to say so - the legend is
+ * a key to what is on this calendar, not a catalogue of what the component can draw.
  */
 export function ScheduleCalendar({
   events,
   title = "Your calendar",
   selectedKey: controlledKey,
   onSelectDay,
+  legendTypes,
 }: {
   events: CalendarEvent[];
   title?: string;
+  /** Which types the legend explains. Defaults to all four. */
+  legendTypes?: CalendarEventType[];
   /** Controlled selection (pass with onSelectDay): the parent owns the selected day; null = no
    *  day selected. Omit for the original self-contained behavior (admin page is untouched). */
   selectedKey?: string | null;
@@ -276,7 +282,7 @@ export function ScheduleCalendar({
 
       {/* Legend */}
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1.5, pt: 0.5 }}>
-        {(Object.keys(CALENDAR_TYPE_META) as CalendarEventType[]).map((t) => (
+        {(legendTypes ?? (Object.keys(CALENDAR_TYPE_META) as CalendarEventType[])).map((t) => (
           <Box key={t} sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
             <Box sx={{ width: 9, height: 9, borderRadius: "50%", bgcolor: CALENDAR_TYPE_META[t].color }} />
             <Typography sx={{ fontSize: "0.74rem", color: "var(--font-secondary)", fontWeight: 500 }}>

--- a/components/live-sessions/SessionMaterialsDisclosure.tsx
+++ b/components/live-sessions/SessionMaterialsDisclosure.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { Box, Button, Collapse } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { StudyMaterialList } from "./StudyMaterialList";
+import { MaterialViewerDialog } from "./MaterialViewerDialog";
 import {
   liveSessionMaterialsService,
   type LiveSessionMaterial,
@@ -30,6 +31,7 @@ export function SessionMaterialsDisclosure({
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<LiveSessionMaterial[] | null>(null);
   const [loading, setLoading] = useState(false);
+  const [viewing, setViewing] = useState<LiveSessionMaterial | null>(null);
 
   const toggle = useCallback(async () => {
     const next = !open;
@@ -73,9 +75,13 @@ export function SessionMaterialsDisclosure({
             materials={items ?? []}
             dense={dense}
             emptyLabel={loading ? "Loading…" : "No material shared for this session."}
+            onOpen={setViewing}
           />
         </Box>
       </Collapse>
+      {/* Mounted here rather than per row: one dialog for whichever material was clicked, and it
+          portals to body so it escapes the card it hangs off. */}
+      <MaterialViewerDialog material={viewing} onClose={() => setViewing(null)} />
     </Box>
   );
 }

--- a/components/live-sessions/StudyMaterialList.tsx
+++ b/components/live-sessions/StudyMaterialList.tsx
@@ -23,10 +23,13 @@ export function StudyMaterialList({
   materials,
   emptyLabel,
   dense = false,
+  onOpen,
 }: {
   materials: LiveSessionMaterial[];
   emptyLabel?: string;
   dense?: boolean;
+  /** Open the material in-app. Without it the row keeps its old open-in-a-new-tab behaviour. */
+  onOpen?: (m: LiveSessionMaterial) => void;
 }) {
   if (!materials.length) {
     return emptyLabel ? (
@@ -43,8 +46,18 @@ export function StudyMaterialList({
           key={m.id}
           component="a"
           href={m.file_url ?? undefined}
-          target="_blank"
           rel="noopener noreferrer"
+          // Stays an anchor on purpose: a plain click previews in-app, but cmd/ctrl/shift/middle
+          // click must keep opening a new tab, which converting to a button would destroy.
+          {...(onOpen
+            ? {
+                onClick: (e: React.MouseEvent) => {
+                  if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+                  e.preventDefault();
+                  onOpen(m);
+                },
+              }
+            : { target: "_blank" })}
           sx={{
             display: "flex",
             alignItems: "flex-start",
@@ -93,8 +106,18 @@ export function StudyMaterialList({
               {m.file_size ? ` · ${formatFileSize(m.file_size)}` : ""}
             </Typography>
           </Box>
+          {/* The download glyph was decorative; it is now the deliberate way out of the platform,
+              and must not also trigger the row's preview. */}
           {m.file_url && (
-            <Box sx={{ flexShrink: 0, mt: "1px" }}>
+            <Box
+              component="a"
+              href={m.file_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Download"
+              onClick={(e: React.MouseEvent) => e.stopPropagation()}
+              sx={{ flexShrink: 0, mt: "1px", display: "inline-flex", color: "inherit" }}
+            >
               <IconWrapper icon="mdi:download-outline" size={18} />
             </Box>
           )}

--- a/components/live-sessions/StudyMaterialManager.tsx
+++ b/components/live-sessions/StudyMaterialManager.tsx
@@ -14,6 +14,7 @@ import {
   liveSessionMaterialsService,
   type LiveSessionMaterial,
 } from "@/lib/services/live-session-materials.service";
+import { MaterialViewerDialog } from "./MaterialViewerDialog";
 
 /**
  * Staff-side management of a session's study materials: upload, retitle, re-describe, remove.
@@ -31,6 +32,7 @@ export function StudyMaterialManager({ liveClassId }: { liveClassId: number }) {
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState(false);
   const [editing, setEditing] = useState<LiveSessionMaterial | null>(null);
+  const [preview, setPreview] = useState<LiveSessionMaterial | null>(null);
   const [form, setForm] = useState({ title: "", description: "" });
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -155,6 +157,14 @@ export function StudyMaterialManager({ liveClassId }: { liveClassId: number }) {
               </Box>
               <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
                 {m.file_url && (
+                  <Tooltip title="Preview">
+                    <IconButton size="small" onClick={() => setPreview(m)}>
+                      <IconWrapper icon="mdi:eye-outline" size={16} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+                {/* Kept as the deliberate escape hatch, now second so Preview reads as primary. */}
+                {m.file_url && (
                   <Tooltip title="Open">
                     <IconButton size="small" component="a" href={m.file_url} target="_blank" rel="noopener noreferrer">
                       <IconWrapper icon="mdi:open-in-new" size={16} />
@@ -182,6 +192,10 @@ export function StudyMaterialManager({ liveClassId }: { liveClassId: number }) {
           ))}
         </Stack>
       )}
+
+      {/* Rendered here, never inside a row: MUI portals it to body, so it escapes the instructor
+          page's own maxWidth="sm" materials dialog. */}
+      <MaterialViewerDialog material={preview} onClose={() => setPreview(null)} />
 
       {/* Upload — title/description are captured up front so a learner never sees a bare filename. */}
       <Dialog open={Boolean(pendingFile)} onClose={() => !uploading && setPendingFile(null)} maxWidth="sm" fullWidth>

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -77,6 +77,9 @@ export interface StudentLiveSession {
    * the UI which dated instance it is looking at.
    */
   occurrence_id?: number;
+  /** Client-side expansions only: this dated sitting is marked cancelled but kept because it left
+   *  a recording or summary behind, so the card can say so instead of implying a normal class. */
+  occurrence_cancelled?: boolean;
   /** AI-generated (Phase 2A): planned agenda + 'come prepared' checklist + the student's ticks. */
   agenda?: string[];
   prep_items?: string[];


### PR DESCRIPTION
Carries #1407: timeline play/notes glyphs become real controls, {{date}} interpolation fixed, in-platform recording playback + study-material viewer, calendar scoped to live sessions, recorded-but-cancelled sittings visible to students.

🤖 Generated with [Claude Code](https://claude.com/claude-code)