### PR TITLE
Promote stagging: per-date attendance, dashboard next-sitting, IST labels

### DIFF
--- a/app/admin/adaptive-courses/[courseId]/page.tsx
+++ b/app/admin/adaptive-courses/[courseId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { unitCount, unitLabel, unitNoun, unitWord, unitWordPlural } from "@/lib/utils/unit-labels";
 import { useAuth } from "@/lib/auth/auth-context";
 import { useClientInfo } from "@/lib/contexts/ClientInfoContext";
 import { CoursePricingDialog } from "@/components/admin/adaptive-course/CoursePricingDialog";
@@ -557,10 +558,10 @@ export default function AdminAdaptiveCourseDetailPage() {
     try {
       await adminAdaptiveCourseService.updateModule(course.id, moduleId, { title });
     } catch (e) {
-      showToast(getAxiosErrorDetail(e, "Couldn't rename this week."), "error");
+      showToast(getAxiosErrorDetail(e, `Couldn't rename this ${unitWord(course)}.`), "error");
       throw e;
     }
-    showToast("Week renamed.", "success");
+    showToast(`${unitNoun(course)} renamed.`, "success");
     await load();
   }
 
@@ -585,8 +586,8 @@ export default function AdminAdaptiveCourseDetailPage() {
         const res = await adminAdaptiveCourseService.deleteModule(course.id, target.moduleId);
         done =
           res.submodules_removed > 0
-            ? `Week deleted, along with ${res.submodules_removed} topic${res.submodules_removed === 1 ? "" : "s"}.`
-            : "Week deleted.";
+            ? `${unitNoun(course)} deleted, along with ${res.submodules_removed} topic${res.submodules_removed === 1 ? "" : "s"}.`
+            : `${unitNoun(course)} deleted.`;
         if (activeModuleId === target.moduleId) setActiveModuleId(null);
         // Deleting the only week on the last page would otherwise leave the admin
         // parked on a page that no longer exists, i.e. an empty tree.
@@ -687,7 +688,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                   sx={pillBtnSx("outline")}
                 >
                   <Icon icon="mdi:auto-fix" width={16} />
-                  Generate a week with AI
+                  Generate a {unitWord(course)} with AI
                 </ButtonBase>
               </Box>
 
@@ -839,8 +840,8 @@ export default function AdminAdaptiveCourseDetailPage() {
               <Box sx={{ display: "flex", flexDirection: "column", gap: 2.5 }}>
                 {course.modules.length === 0 && (
                   <Typography sx={{ color: "text.secondary", textAlign: "center", py: 4 }}>
-                    No weeks yet. Use <strong>Add week</strong> below to build this course
-                    yourself, or <strong>Generate a week with AI</strong> to have one written
+                    No {unitWordPlural(course)} yet. Use <strong>Add {unitWord(course)}</strong> below to build this course
+                    yourself, or <strong>Generate a {unitWord(course)} with AI</strong> to have one written
                     for you.
                   </Typography>
                 )}
@@ -896,11 +897,11 @@ export default function AdminAdaptiveCourseDetailPage() {
                               week title wraps mid-word. */}
                           <Box sx={{ minWidth: 0, flex: 1 }}>
                             <Typography sx={{ fontSize: "0.66rem", fontWeight: 800, letterSpacing: "0.1em", textTransform: "uppercase", color: "#a855f7" }}>
-                              Week {mod.weekno}
+                              {unitLabel(course, mod.weekno)}
                             </Typography>
                             <InlineEditableTitle
                               value={mod.title}
-                              label="Rename this week"
+                              label={`Rename this ${unitWord(course)}`}
                               fontSize="1.05rem"
                               fontWeight={800}
                               onSave={(title) => handleRenameModule(mod.id, title)}
@@ -919,9 +920,9 @@ export default function AdminAdaptiveCourseDetailPage() {
                             Generate topics with AI
                           </ButtonBase>
                           <RowDeleteButton
-                            label="Delete this week"
+                            label={`Delete this ${unitWord(course)}`}
                             width={18}
-                            onClick={() => setPendingDelete(moduleDeleteTarget(mod))}
+                            onClick={() => setPendingDelete(moduleDeleteTarget(mod, course))}
                           />
                         </Box>
                       </Box>
@@ -954,7 +955,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                               </ButtonBase>
                               <RowDeleteButton
                                 label="Delete this topic"
-                                onClick={() => setPendingDelete(submoduleDeleteTarget(sub, mod.weekno))}
+                                onClick={() => setPendingDelete(submoduleDeleteTarget(sub, mod.weekno, course))}
                               />
                             </Box>
                             <Box sx={{ display: "flex", flexDirection: "column", gap: 0.75, mt: 1 }}>
@@ -1254,7 +1255,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                         ))}
                         {mod.submodules.length === 0 && (
                           <Typography sx={{ fontSize: "0.8rem", color: "text.secondary", px: 0.25 }}>
-                            No topics in this week yet. Add one by hand below, or use{" "}
+                            No topics in this {unitWord(course)} yet. Add one by hand below, or use{" "}
                             <strong>Generate topics with AI</strong> above.
                           </Typography>
                         )}
@@ -1271,7 +1272,7 @@ export default function AdminAdaptiveCourseDetailPage() {
                     </Box>
                   </Reveal>
                 ))}
-                  <AddModuleRow courseId={course.id} onAdded={() => void load()} />
+                  <AddModuleRow courseId={course.id} onAdded={() => void load()} course={course} />
               </Box>
               )}
             </>
@@ -1640,20 +1641,29 @@ function describeSubmoduleContents(sub: AdminAdaptiveCourseSubModule): string {
   return `${said.slice(0, -1).join(", ")} and ${said[said.length - 1]}`;
 }
 
-function moduleDeleteTarget(mod: AdminAdaptiveCourseModule): TreeDeleteTarget {
+function moduleDeleteTarget(
+  mod: AdminAdaptiveCourseModule,
+  course: { module_only_structure?: boolean } | null,
+): TreeDeleteTarget {
   const n = mod.submodules.length;
+  const Unit = unitNoun(course);
+  const unit = unitWord(course);
   return {
     kind: "module",
     moduleId: mod.id,
-    heading: "Delete this week",
+    heading: `Delete this ${unit}`,
     message:
       n === 0
-        ? `Week ${mod.weekno}, "${mod.title}", has no topics yet - deleting it just removes the week from the course.`
-        : `Week ${mod.weekno}, "${mod.title}", goes away with ${n === 1 ? "its 1 topic" : `all ${n} topics`} inside it and every article, quiz, coding set and video those topics hold. Students stop seeing this content; work they have already submitted stays in their records.`,
+        ? `${Unit} ${mod.weekno}, "${mod.title}", has no topics yet - deleting it just removes the ${unit} from the course.`
+        : `${Unit} ${mod.weekno}, "${mod.title}", goes away with ${n === 1 ? "its 1 topic" : `all ${n} topics`} inside it and every article, quiz, coding set and video those topics hold. Students stop seeing this content; work they have already submitted stays in their records.`,
   };
 }
 
-function submoduleDeleteTarget(sub: AdminAdaptiveCourseSubModule, weekno: number): TreeDeleteTarget {
+function submoduleDeleteTarget(
+  sub: AdminAdaptiveCourseSubModule,
+  weekno: number,
+  course: { module_only_structure?: boolean } | null,
+): TreeDeleteTarget {
   const inventory = describeSubmoduleContents(sub);
   return {
     kind: "submodule",
@@ -1661,7 +1671,7 @@ function submoduleDeleteTarget(sub: AdminAdaptiveCourseSubModule, weekno: number
     heading: "Delete this topic",
     message: inventory
       ? `"${sub.title}" goes away with its ${inventory}. Students stop seeing this content; work they have already submitted stays in their records.`
-      : `"${sub.title}" is empty - deleting it just removes the topic from week ${weekno}.`,
+      : `"${sub.title}" is empty - deleting it just removes the topic from ${unitWord(course)} ${weekno}.`,
   };
 }
 

--- a/app/admin/adaptive-courses/page.tsx
+++ b/app/admin/adaptive-courses/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { unitCount, unitWordPlural } from "@/lib/utils/unit-labels";
 import { PriceTag } from "@/components/common/PriceTag";
 import { useInstantNavigation } from "@/lib/hooks/useInstantNavigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
@@ -359,7 +360,7 @@ export default function AdminAdaptiveCoursesPage() {
                       <Typography sx={{ fontWeight: 800, fontSize: "0.86rem" }} noWrap>{c.title}</Typography>
                       <Typography sx={{ fontSize: "0.76rem", color: "text.secondary" }} noWrap>
                         Built by {c.authored_by?.name || "an instructor"} ·{" "}
-                        {c.module_count} week{c.module_count === 1 ? "" : "s"} ·{" "}
+                        {unitCount(c, c.module_count)} ·{" "}
                         {c.submodule_count} topic{c.submodule_count === 1 ? "" : "s"}
                       </Typography>
                     </Box>
@@ -648,7 +649,7 @@ function CourseCard({
           </Typography>
         )}
         <Box sx={{ display: "flex", gap: 2, mt: 1.5, flexWrap: "wrap" }}>
-          <Metric icon="mdi:view-module-outline" value={course.module_count} label="weeks" />
+          <Metric icon="mdi:view-module-outline" value={course.module_count} label={unitWordPlural(course)} />
           <Metric icon="mdi:file-tree-outline" value={course.submodule_count} label="topics" />
           <Metric icon="mdi:book-open-variant" value={course.article_count} label="articles" />
           <Metric icon="mdi:tune-vertical" value={course.quiz_count} label="quizzes" />

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -463,7 +463,7 @@ function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCo
   const p = PROVIDER_META[s.provider] ?? PROVIDER_META.manual;
   const isLive = status === "live";
   const today = isToday(s.class_datetime, now);
-  const viewerTime = sessionTimeParts(s.class_datetime, s.timezone).viewerTime;
+  const { viewerTime, viewerZoneAbbr } = sessionTimeParts(s.class_datetime, s.timezone);
   // Thirty minutes is enough to open the room, share a screen and settle before students arrive,
   // without putting a Start button on every session in next month's list.
   const minutesToStart = (new Date(s.class_datetime).getTime() - now) / 60000;
@@ -502,7 +502,7 @@ function SessionRow({ s, status, now, hosting, panelistUrl, onHost, onCopy, onCo
           </Stack>
           <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>{s.duration_minutes}m</Typography>
           {viewerTime && (
-            <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>· {viewerTime} your time</Typography>
+            <Typography sx={{ fontSize: "0.72rem", color: "text.secondary" }}>· {viewerTime}{viewerZoneAbbr ? ` ${viewerZoneAbbr}` : ""} your time</Typography>
           )}
         </Stack>
         <Typography sx={{ fontWeight: 800, fontSize: "1.05rem", lineHeight: 1.2 }} noWrap>{s.topic_name}</Typography>

--- a/app/live-sessions/page.tsx
+++ b/app/live-sessions/page.tsx
@@ -307,6 +307,17 @@ export default function LiveSessionsPage() {
       kept.forEach((o, i) => {
         const inherits = i === inheritIdx;
         const cancelled = o.status === "cancelled" || o.meeting_status === "cancelled";
+        // Attendance is PER SITTING. `my_attendance` is series-level - it means "attended at least
+        // one date" - so every dated card inherited it and a student who joined one sitting was
+        // marked Attended on all of them, contradicting the admin roster. Absent from the map =
+        // not attended. An older backend sends no map at all; keep the previous (imperfect) value
+        // there rather than marking every past date Missed.
+        const mine = s.my_attendance_by_occurrence?.[String(o.id)];
+        const myAttendance = s.my_attendance_by_occurrence
+          ? mine
+            ? { attended: mine.attended, duration_seconds: mine.duration_seconds ?? 0 }
+            : null
+          : s.my_attendance;
         out.push({
           ...s,
           // Keep the parent id for API calls (feedback, reminders) but make the key unique per date.
@@ -333,6 +344,7 @@ export default function LiveSessionsPage() {
           // may only surface on the occurrence that inherits the series artifacts — otherwise
           // every date would advertise notes that belong to one sitting.
           zoom_ai_summary: o.zoom_ai_summary ?? (inherits ? s.zoom_ai_summary : null),
+          my_attendance: myAttendance,
         });
       });
     }

--- a/components/admin/adaptive-course/ManualTreeControls.tsx
+++ b/components/admin/adaptive-course/ManualTreeControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { unitNoun, unitWord } from "@/lib/utils/unit-labels";
 import { Box, TextField, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
 import { LoadingButton } from "@/components/common/LoadingButton";
@@ -222,9 +223,12 @@ function GhostAddRow({
 export function AddModuleRow({
   courseId,
   onAdded,
+  course,
 }: {
   courseId: number;
   onAdded: () => void;
+  /** Carries module_only_structure, so the control says "module" on a module-framed course. */
+  course?: { module_only_structure?: boolean } | null;
 }) {
   const onCreate = useCallback(
     async (title: string) => {
@@ -235,14 +239,16 @@ export function AddModuleRow({
     [courseId]
   );
 
+  const Unit = unitNoun(course);
+  const unit = unitWord(course);
   return (
     <GhostAddRow
-      ghostLabel="Add week"
-      successMessage="Week added — it goes at the end of the course."
-      placeholder="Name this week, e.g. Functions and scope"
+      ghostLabel={`Add ${unit}`}
+      successMessage={`${Unit} added, it goes at the end of the course.`}
+      placeholder={`Name this ${unit}, e.g. Functions and scope`}
       onCreate={onCreate}
       onAdded={onAdded}
-      errorFallback="Could not add the week. Please try again."
+      errorFallback={`Could not add the ${unit}. Please try again.`}
     />
   );
 }

--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -39,19 +39,35 @@ import {
 } from "@/lib/services/admin/admin-live-activities.service";
 import { formatDurationSeconds } from "@/lib/utils/date-utils";
 import { getAxiosErrorDetail } from "@/lib/utils/api-error";
-import { toLocalInputInZone } from "@/lib/utils/session-time";
+import { formatSessionTime, toLocalInputInZone } from "@/lib/utils/session-time";
 import { useToast } from "@/components/common/Toast";
 
-function fmtDate(s: string | null) {
+const OCC_FORMAT: Intl.DateTimeFormatOptions = {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+/**
+ * One sitting's date, in the SESSION's zone — the same formatter the detail page's header uses.
+ * This list previously rendered in the admin's browser zone with no label, directly under a header
+ * stamped with the session's zone, so one page showed occurrence times two different ways.
+ */
+function fmtOccurrence(s: string | null, timezone?: string | null) {
+  return formatSessionTime(s, timezone, { format: OCC_FORMAT });
+}
+
+/**
+ * A SYSTEM timestamp (when a sync ran), deliberately left in the admin's own browser zone and
+ * deliberately unlabelled: stamping an audit event with the session's timezone would assert
+ * something false about when it happened.
+ */
+function fmtSyncedAt(s: string | null) {
   if (!s) return "-";
-  return new Date(s).toLocaleString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  return new Date(s).toLocaleString("en-US", OCC_FORMAT);
 }
 
 /** Per-student status for one occurrence - "Missed" only once THAT occurrence has ended, and
@@ -271,7 +287,7 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                   }}
                 >
                   <Typography sx={{ fontWeight: 700, fontSize: "0.82rem", color: "var(--font-primary)" }}>
-                    {fmtDate(occ.date)}
+                    {fmtOccurrence(occ.date, timezone)}
                   </Typography>
                   {/* Per-date title (AI-titled after transcript sync, or renamed by an admin);
                       blank inherits the series title. */}
@@ -564,7 +580,7 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                               the VALUES argument; passing it as the 2nd arg makes it a defaultValue
                               and leaves the raw {{date}} token on screen. */}
                           {t("adminLiveSessions.lastSynced", "Last synced: {{date}}", {
-                            date: fmtDate(occ.attendance_synced_at),
+                            date: fmtSyncedAt(occ.attendance_synced_at),
                           })}
                         </Typography>
                       )}
@@ -617,6 +633,7 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
           liveClassId={liveClassId}
           occ={notesFor}
           seriesTitle={seriesTitle}
+          timezone={timezone}
           onClose={() => setNotesFor(null)}
         />
       )}
@@ -644,11 +661,15 @@ function OccurrenceNotesDialog({
   liveClassId,
   occ,
   seriesTitle,
+  timezone,
   onClose,
 }: {
   liveClassId: number;
   occ: TimelineOccurrence;
   seriesTitle?: string;
+  /** The series' zone, so this date is stamped like every other surface. Unlike the edit dialog,
+   *  this one was never handed it. */
+  timezone?: string | null;
   onClose: () => void;
 }) {
   const { t } = useTranslation("common");
@@ -675,7 +696,7 @@ function OccurrenceNotesDialog({
       <DialogTitle sx={{ fontWeight: 700 }}>
         {occ.topic_name?.trim() || seriesTitle || t("adminLiveSessions.sessionNotes", "Session notes")}
         <Typography variant="caption" sx={{ display: "block", color: "var(--font-secondary)", fontWeight: 500 }}>
-          {fmtDate(occ.date)}
+          {fmtOccurrence(occ.date, timezone)}
         </Typography>
       </DialogTitle>
       <DialogContent dividers>
@@ -786,7 +807,7 @@ function EditOccurrenceDialog({ liveClassId, occ, mode, seriesTitle, timezone, o
       <DialogContent>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 1 }}>
           <Typography variant="caption" sx={{ color: "var(--font-secondary)" }}>
-            {fmtDate(occ.date)}
+            {fmtOccurrence(occ.date, timezone)}
           </Typography>
           {rename ? (
             <TextField

--- a/components/dashboard/v2/modules/LiveSessionsPanel.tsx
+++ b/components/dashboard/v2/modules/LiveSessionsPanel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import { Icon } from "@iconify/react";
-import { studentLiveSessionsService, type StudentLiveSession } from "@/lib/services/live-sessions";
+import { nextSitting, studentLiveSessionsService, type NextSitting, type StudentLiveSession } from "@/lib/services/live-sessions";
 import { ModuleEmpty, ModuleHeader, ModulePanel, ModuleRowsSkeleton, Pill, fmtDateTime, timeUntil } from "./shared";
 
 const GRADIENT = "linear-gradient(135deg, #06b6d4, #3b82f6)";
@@ -13,33 +13,64 @@ function joinUrl(s: StudentLiveSession): string | null {
   return (s.is_google_meet ? s.join_link : s.zoom_join_url) ?? null;
 }
 
-/** Live sessions first, then soonest scheduled. */
-function selectSessions(list: StudentLiveSession[]): StudentLiveSession[] {
-  const relevant = list.filter((s) => s.meeting_status === "live" || s.meeting_status === "scheduled");
-  return relevant
+/** One row of the card: the session plus the sitting it is actually about. */
+interface SessionRow {
+  session: StudentLiveSession;
+  next: NextSitting;
+}
+
+/**
+ * Live sittings first, then soonest.
+ *
+ * Everything here is ranked and labelled by the resolved NEXT SITTING, never by the series'
+ * `class_datetime` - that field is frozen at occurrence #1, so ordering by it ordered series by
+ * when they STARTED and pushed the genuinely imminent session to the bottom (and, past three rows,
+ * off the card). A session with no sitting left to come, or one cancelled by notice, drops out:
+ * this is a "what's next" rail, and the live-sessions page carries the cancellation banner and its
+ * reason.
+ */
+function selectSessions(list: StudentLiveSession[], now: number): SessionRow[] {
+  const rows: SessionRow[] = [];
+  for (const s of list) {
+    if (s.meeting_status !== "live" && s.meeting_status !== "scheduled") continue;
+    const next = nextSitting(s, now);
+    if (next) rows.push({ session: s, next });
+  }
+  return rows
     .sort((a, b) => {
-      const rank = (s: StudentLiveSession) => (s.meeting_status === "live" ? 0 : 1);
+      const rank = (r: SessionRow) => (r.next.live ? 0 : 1);
       if (rank(a) !== rank(b)) return rank(a) - rank(b);
-      const at = a.class_datetime ? new Date(a.class_datetime).getTime() : Infinity;
-      const bt = b.class_datetime ? new Date(b.class_datetime).getTime() : Infinity;
-      return at - bt;
+      return a.next.startMs - b.next.startMs;
     })
     .slice(0, 3);
 }
 
 export function LiveSessionsPanel() {
   const router = useRouter();
-  const [items, setItems] = useState<StudentLiveSession[] | null>(null);
+  const [sessions, setSessions] = useState<StudentLiveSession[] | null>(null);
   const [hidden, setHidden] = useState(false);
+  // The labels are relative, so they go stale where nothing re-renders: the card used to fetch
+  // once on mount and freeze, never counting down or flipping to LIVE.
+  const [tick, setTick] = useState(() => Date.now());
 
   useEffect(() => {
     let cancelled = false;
     studentLiveSessionsService
       .getSessions()
-      .then((list) => { if (!cancelled) setItems(selectSessions(list ?? [])); })
+      .then((list) => { if (!cancelled) setSessions(list ?? []); })
       .catch(() => { if (!cancelled) setHidden(true); });
     return () => { cancelled = true; };
   }, []);
+
+  useEffect(() => {
+    const h = setInterval(() => setTick(Date.now()), 60_000);
+    return () => clearInterval(h);
+  }, []);
+
+  const items = useMemo(
+    () => (sessions ? selectSessions(sessions, tick) : null),
+    [sessions, tick],
+  );
 
   if (hidden) return null;
 
@@ -52,13 +83,15 @@ export function LiveSessionsPanel() {
         <ModuleEmpty icon="mdi:calendar-blank-outline" message="No live sessions scheduled right now." />
       ) : (
         <Stack spacing={1}>
-          {items.map((s) => {
-            const live = s.meeting_status === "live";
+          {items.map(({ session: s, next: n }) => {
+            // LIVE comes from the resolved sitting, not the series status: those disagreed, so a
+            // row could be styled LIVE while its own label read "in 3d".
+            const live = n.live;
             const url = joinUrl(s);
-            const t = timeUntil(s.class_datetime);
+            const t = timeUntil(n.startIso, n.durationMin);
             return (
               <ButtonBase
-                key={s.id}
+                key={`${s.id}:${n.id ?? 0}`}
                 onClick={() => router.push("/live-sessions")}
                 sx={{ width: "100%", justifyContent: "flex-start", textAlign: "left", p: 1, borderRadius: 2.5, border: "1px solid", borderColor: live ? "#a5f3fc" : "#eef2f7", bgcolor: live ? "#ecfeff" : "transparent", "&:hover": { bgcolor: live ? "#cffafe" : "#f0f9ff" } }}
               >
@@ -72,7 +105,7 @@ export function LiveSessionsPanel() {
                       {live ? (
                         <Pill icon="mdi:circle" color="#dc2626" bg="#fef2f2">LIVE NOW</Pill>
                       ) : (
-                        <Pill icon="mdi:calendar-clock" color="#0e7490" bg="#ecfeff">{t?.text ?? fmtDateTime(s.class_datetime)}</Pill>
+                        <Pill icon="mdi:calendar-clock" color="#0e7490" bg="#ecfeff">{t?.text ?? fmtDateTime(n.startIso)}</Pill>
                       )}
                       {s.course_detail?.title && (
                         <Typography noWrap sx={{ fontSize: "0.68rem", color: "#94a3b8", fontWeight: 600, maxWidth: 120 }}>{s.course_detail.title}</Typography>

--- a/components/dashboard/v2/modules/shared.tsx
+++ b/components/dashboard/v2/modules/shared.tsx
@@ -90,13 +90,28 @@ export function Pill({ icon, children, color, bg }: { icon?: string; children: R
 }
 
 /** "in 2d" / "in 3h" / "in 12m" / "now" until an ISO datetime, with a `soon`
- *  flag when it's close (drives amber/red urgency). Null if no/invalid date. */
-export function timeUntil(iso?: string | null): { text: string; soon: boolean; overdue: boolean } | null {
+ *  flag when it's close (drives amber/red urgency). Null if no/invalid date.
+ *
+ *  `durationMin` gives the past a floor: without it every timestamp that has passed reads "now",
+ *  so something that ended days ago claims to be happening. With it, "now" means the clock is
+ *  inside [start, start + duration] and anything past the end returns null, letting the caller
+ *  fall back to an absolute date. Callers that measure a deadline rather than a window (an
+ *  assessment close, a job cut-off) omit it and keep the old open-ended "now". */
+export function timeUntil(
+  iso?: string | null,
+  durationMin?: number,
+): { text: string; soon: boolean; overdue: boolean } | null {
   if (!iso) return null;
-  const ms = new Date(iso).getTime() - Date.now();
-  if (Number.isNaN(ms)) return null;
-  if (ms <= 0) return { text: "now", soon: true, overdue: true };
-  const mins = Math.floor(ms / 60000);
+  const start = new Date(iso).getTime();
+  if (Number.isNaN(start)) return null;
+  const ms = start - Date.now();
+  if (ms <= 0) {
+    if (durationMin == null) return { text: "now", soon: true, overdue: true };
+    const endedMsAgo = -ms - durationMin * 60_000;
+    return endedMsAgo > 0 ? null : { text: "now", soon: true, overdue: true };
+  }
+  // Never "in 0m": the final minute counts down to "in 1m", then flips to "now".
+  const mins = Math.max(1, Math.floor(ms / 60000));
   if (mins < 60) return { text: `in ${mins}m`, soon: true, overdue: false };
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return { text: `in ${hrs}h`, soon: hrs < 6, overdue: false };

--- a/components/live-sessions/ui/LiveSessionCard.tsx
+++ b/components/live-sessions/ui/LiveSessionCard.tsx
@@ -362,7 +362,9 @@ export function LiveSessionCard<T extends LiveSessionCardData>({
 
       {timeParts.viewerTime && (
         <Typography sx={{ mt: -0.75, textAlign: "center", fontSize: "0.72rem", color: "var(--font-tertiary)" }}>
-          {t("liveSessions.yourTimeIs", "{{time}} your time", { time: timeParts.viewerTime })}
+          {t("liveSessions.yourTimeIs", "{{time}} your time", {
+            time: timeParts.viewerZoneAbbr ? `${timeParts.viewerTime} ${timeParts.viewerZoneAbbr}` : timeParts.viewerTime,
+          })}
         </Typography>
       )}
 

--- a/lib/services/live-sessions/index.ts
+++ b/lib/services/live-sessions/index.ts
@@ -1,2 +1,3 @@
 export * from "./types";
 export { studentLiveSessionsService } from "./student-live-sessions.service";
+export { nextSitting, type NextSitting } from "./next-sitting";

--- a/lib/services/live-sessions/next-sitting.test.ts
+++ b/lib/services/live-sessions/next-sitting.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { nextSitting } from "./next-sitting";
+import type { StudentLiveSession, StudentLiveOccurrence } from "./types";
+
+/** The wall clock the reported dashboard screenshot was taken at (16:16 IST, 21 Aug 2026). */
+const NOW = new Date("2026-08-21T10:46:00Z").getTime();
+
+function occ(id: number, iso: string, extra: Partial<StudentLiveOccurrence> = {}): StudentLiveOccurrence {
+  return { id, occurrence_datetime: iso, duration_minutes: 20, ...extra };
+}
+
+function series(occurrences: StudentLiveOccurrence[], extra: Partial<StudentLiveSession> = {}): StudentLiveSession {
+  return {
+    id: 1,
+    time_remaining_minutes: 0,
+    zoom_is_recurring: true,
+    duration_minutes: 20,
+    // Frozen at occurrence #1 by the backend's contract - deliberately stale here.
+    class_datetime: "2026-08-13T14:30:00Z",
+    occurrences,
+    ...extra,
+  };
+}
+
+describe("nextSitting", () => {
+  it("ignores the stale series class_datetime and picks the next occurrence", () => {
+    // Series 197 in prod: class_datetime 7.9 days past, real next sitting today 20:00 IST.
+    const s = series([occ(373, "2026-08-21T14:30:00Z", { duration_minutes: 60 })]);
+    const n = nextSitting(s, NOW);
+    expect(n?.id).toBe(373);
+    expect(n?.startIso).toBe("2026-08-21T14:30:00Z");
+    expect(n?.live).toBe(false);
+  });
+
+  it("skips cancelled sittings", () => {
+    // Series 203: 11:46 already ended, 22 Aug 11:45 cancelled, so 22 Aug 14:50 is next.
+    const s = series([
+      occ(472, "2026-08-21T06:16:00Z"),
+      occ(473, "2026-08-22T06:15:00Z", { status: "cancelled" }),
+      occ(478, "2026-08-22T09:20:00Z"),
+    ]);
+    expect(nextSitting(s, NOW)?.id).toBe(478);
+  });
+
+  it("prefers a sitting in progress and marks it live", () => {
+    const s = series([
+      occ(479, "2026-08-21T10:40:00Z", { duration_minutes: 30 }), // started 6 min ago
+      occ(478, "2026-08-22T09:20:00Z"),
+    ]);
+    const n = nextSitting(s, NOW);
+    expect(n?.id).toBe(479);
+    expect(n?.live).toBe(true);
+  });
+
+  it("returns null when every sitting is in the past", () => {
+    expect(nextSitting(series([occ(472, "2026-08-20T06:16:00Z")]), NOW)).toBeNull();
+  });
+
+  it("returns null for a session cancelled by notice", () => {
+    const s = series([occ(373, "2026-08-21T14:30:00Z")], { notice_type: "cancelled" });
+    expect(nextSitting(s, NOW)).toBeNull();
+  });
+
+  it("uses a single session's own datetime", () => {
+    const s: StudentLiveSession = {
+      id: 2,
+      time_remaining_minutes: 0,
+      class_datetime: "2026-08-21T14:30:00Z",
+      duration_minutes: 45,
+    };
+    const n = nextSitting(s, NOW);
+    expect(n).toMatchObject({ id: null, durationMin: 45, live: false });
+  });
+
+  it("orders series by their next sitting, not by when they started", () => {
+    // The reported bug: the soonest session rendered last, below one three days out.
+    const soon = series([occ(479, "2026-08-21T11:45:00Z")], { id: 203 });
+    const later = series([occ(222, "2026-08-24T14:30:00Z")], { id: 194 });
+    const order = [later, soon]
+      .map((s) => ({ id: s.id, at: nextSitting(s, NOW)!.startMs }))
+      .sort((a, b) => a.at - b.at)
+      .map((r) => r.id);
+    expect(order).toEqual([203, 194]);
+  });
+});

--- a/lib/services/live-sessions/next-sitting.ts
+++ b/lib/services/live-sessions/next-sitting.ts
@@ -1,0 +1,71 @@
+import type { StudentLiveSession } from "./types";
+
+export interface NextSitting {
+  /** The occurrence this resolves to; null for a single (non-recurring) session. */
+  id: number | null;
+  startIso: string;
+  startMs: number;
+  durationMin: number;
+  /** The clock is inside [start, start + duration] right now. */
+  live: boolean;
+}
+
+const DEFAULT_DURATION_MIN = 60;
+
+/**
+ * When this session next sits, resolved against its occurrences.
+ *
+ * A recurring series is ONE row whose `class_datetime` is frozen at occurrence #1 by the backend's
+ * documented contract, so it is usually long past - reading it as "the time of the class" makes a
+ * months-old series read as starting now, forever. The dates that can actually arrive are the
+ * occurrences'.
+ *
+ * Returns the sitting in progress if there is one, otherwise the soonest future sitting, otherwise
+ * null (nothing left to come). A session cancelled by notice returns null: the meeting still exists
+ * and is joinable, so anything offering a Join button must drop it rather than advertise a class
+ * that is off.
+ */
+export function nextSitting(s: StudentLiveSession, now: number = Date.now()): NextSitting | null {
+  if (s.notice_type === "cancelled") return null;
+
+  const occs = s.occurrences ?? [];
+  const candidates: { id: number | null; iso: string; durationMin: number }[] = [];
+
+  if (s.zoom_is_recurring && occs.length > 0) {
+    for (const o of occs) {
+      if (o.status === "cancelled" || o.meeting_status === "cancelled") continue;
+      if (!o.occurrence_datetime) continue;
+      candidates.push({
+        id: o.id,
+        iso: o.occurrence_datetime,
+        durationMin: o.duration_minutes ?? s.duration_minutes ?? DEFAULT_DURATION_MIN,
+      });
+    }
+  } else if (s.class_datetime) {
+    candidates.push({
+      id: null,
+      iso: s.class_datetime,
+      durationMin: s.duration_minutes ?? DEFAULT_DURATION_MIN,
+    });
+  }
+
+  let inProgress: NextSitting | null = null;
+  let upcoming: NextSitting | null = null;
+
+  for (const c of candidates) {
+    const startMs = new Date(c.iso).getTime();
+    if (Number.isNaN(startMs)) continue;
+    const endMs = startMs + c.durationMin * 60_000;
+
+    if (startMs <= now && now <= endMs) {
+      // Earliest sitting still running wins, so overlapping dates cannot flap.
+      if (!inProgress || startMs < inProgress.startMs) {
+        inProgress = { id: c.id, startIso: c.iso, startMs, durationMin: c.durationMin, live: true };
+      }
+    } else if (startMs > now && (!upcoming || startMs < upcoming.startMs)) {
+      upcoming = { id: c.id, startIso: c.iso, startMs, durationMin: c.durationMin, live: false };
+    }
+  }
+
+  return inProgress ?? upcoming;
+}

--- a/lib/services/live-sessions/student-live-sessions.service.ts
+++ b/lib/services/live-sessions/student-live-sessions.service.ts
@@ -55,6 +55,9 @@ function toStudentSession(item: LiveActivityListItem): StudentLiveSession {
     meeting_status: item.meeting_status,
     time_remaining_minutes: item.time_remaining_minutes ?? 0,
     my_attendance: item.my_attendance ?? null,
+    my_attendance_by_occurrence:
+      (item.my_attendance_by_occurrence as StudentLiveSession["my_attendance_by_occurrence"]) ??
+      undefined,
     zoom_ai_summary: item.zoom_ai_summary ?? null,
     zoom_transcript_synced_at: item.zoom_transcript_synced_at ?? null,
     join_gated: Boolean(item.join_gated),

--- a/lib/services/live-sessions/types.ts
+++ b/lib/services/live-sessions/types.ts
@@ -21,6 +21,15 @@ export interface StudentLiveSession {
   has_marked_attendance?: boolean;
   /** The student's own Zoom attendance (from the live-activities serializer). */
   my_attendance?: { attended: boolean; duration_seconds: number } | null;
+  /**
+   * Recurring series: the student's attendance PER SITTING, keyed by occurrence id (as a string -
+   * JSON object keys). An occurrence ABSENT from the object was not attended. `my_attendance` is
+   * series-level and says only "attended at least one date", so a dated card must never read it.
+   */
+  my_attendance_by_occurrence?: Record<
+    string,
+    { attended: boolean; source?: "zoom" | "manual"; duration_seconds?: number }
+  >;
   zoom_ai_summary?: string | null;
   zoom_transcript_synced_at?: string | null;
   /**

--- a/lib/utils/session-time.test.ts
+++ b/lib/utils/session-time.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { formatSessionTime, sessionTimeParts, zoneLabel } from "./session-time";
+
+/** Aug 21 2026, 11:00 UTC = 4:30 PM in Kolkata — the instant from the reported header. */
+const AUG = new Date("2026-08-21T11:00:00Z");
+/** Northern-hemisphere winter, to pin the DST half of each label. */
+const JAN = new Date("2026-01-15T11:00:00Z");
+
+describe("zoneLabel", () => {
+  it("gives IST for Asia/Kolkata, not GMT+5:30", () => {
+    expect(zoneLabel(AUG, "Asia/Kolkata")).toBe("IST");
+  });
+
+  it("stays DST-correct rather than pinning one locale", () => {
+    // The guard against 'just switch everything to en-IN', which renders these as GMT-4 / GMT.
+    expect(zoneLabel(AUG, "America/New_York")).toBe("EDT");
+    expect(zoneLabel(JAN, "America/New_York")).toBe("EST");
+    expect(zoneLabel(AUG, "Europe/London")).toBe("BST");
+    expect(zoneLabel(JAN, "Europe/London")).toBe("GMT");
+  });
+
+  it("uses the curated map for zones no English locale abbreviates", () => {
+    expect(zoneLabel(AUG, "Asia/Riyadh")).toBe("AST");
+    expect(zoneLabel(AUG, "Asia/Dubai")).toBe("GST");
+    expect(zoneLabel(AUG, "Asia/Karachi")).toBe("PKT");
+    expect(zoneLabel(AUG, "Asia/Dhaka")).toBe("BST");
+    expect(zoneLabel(AUG, "Asia/Singapore")).toBe("SGT");
+  });
+
+  it("maps Asia/Manila to PHT, never its own PST", () => {
+    // Manila's abbreviation is Philippine Standard Time — passing it through would print a
+    // Philippine class as US Pacific.
+    expect(zoneLabel(AUG, "Asia/Manila")).toBe("PHT");
+  });
+
+  it("keeps the label compact for zones with no abbreviation", () => {
+    // These have no abbreviation anywhere, and the label is rendered as a compact column header,
+    // so a long name ("Japan Time") would overflow it.
+    for (const z of ["Asia/Tokyo", "Asia/Seoul", "Europe/Moscow", "America/Sao_Paulo"]) {
+      const label = zoneLabel(AUG, z);
+      expect(label.length).toBeLessThanOrEqual(8);
+      expect(label).not.toMatch(/Time/);
+    }
+  });
+
+  it("returns nothing for a blank or unknown zone", () => {
+    expect(zoneLabel(AUG, "")).toBe("");
+    expect(zoneLabel(AUG, null)).toBe("");
+    expect(zoneLabel(AUG, "Not/AZone")).toBe("");
+  });
+});
+
+describe("formatSessionTime", () => {
+  it("stamps the session's own zone", () => {
+    expect(formatSessionTime(AUG.toISOString(), "Asia/Kolkata")).toContain("4:30 PM IST");
+  });
+
+  it("labels a cross-zone viewer's half with its own date and zone", () => {
+    // A Kolkata 8:00 AM class is the PREVIOUS day for a Los Angeles viewer, so the viewer half has
+    // to carry a date - "7:30 PM your time" alone named the right clock on the wrong day.
+    const tz = process.env.TZ;
+    process.env.TZ = "America/Los_Angeles";
+    try {
+      const out = formatSessionTime("2026-08-21T02:30:00Z", "Asia/Kolkata");
+      expect(out).toContain("8:00 AM IST");
+      expect(out).toContain("Aug 20");
+      expect(out).toContain("PDT, your time");
+    } finally {
+      // `= undefined` would set the literal string "undefined" and leak a broken zone into the
+      // rest of the file.
+      if (tz === undefined) delete process.env.TZ;
+      else process.env.TZ = tz;
+    }
+  });
+
+  it("adds no zone label when the session has no stored zone", () => {
+    // Previously stamped the VIEWER's zone as if it were the session's.
+    const out = formatSessionTime(AUG.toISOString(), "");
+    expect(out).not.toMatch(/GMT|UTC|IST/);
+  });
+
+  it("honours showZone: false", () => {
+    expect(formatSessionTime(AUG.toISOString(), "Asia/Kolkata", { showZone: false })).not.toContain("IST");
+  });
+});
+
+describe("sessionTimeParts", () => {
+  it("exposes the session label and the viewer's own", () => {
+    const parts = sessionTimeParts(AUG.toISOString(), "Asia/Kolkata");
+    expect(parts.zoneAbbr).toBe("IST");
+    expect(parts.date).toBe("Aug 21");
+    expect(parts.time).toBe("4:30 PM");
+    // Same zone as the test runner or not, the two labels must never contradict each other.
+    if (parts.viewerTime) expect(parts.viewerZoneAbbr).not.toBe("");
+    else expect(parts.viewerZoneAbbr).toBe("");
+  });
+
+  it("leaves the label empty for a session with no zone", () => {
+    expect(sessionTimeParts(AUG.toISOString(), "").zoneAbbr).toBe("");
+  });
+});

--- a/lib/utils/session-time.ts
+++ b/lib/utils/session-time.ts
@@ -20,17 +20,106 @@ export function viewerTimeZone(): string {
   }
 }
 
+/**
+ * Formatter cache, keyed locale|zone|style.
+ *
+ * `new Intl.DateTimeFormat(...)` is the expensive part, and zoneLabel probes several locales per
+ * call - uncached that is ~300us, so a 50-row list pays ~15ms for nothing. Caching the FORMATTER
+ * rather than the result keeps DST correctness intact: each call still formats the real instant.
+ * A null entry memoises "this zone is invalid" so a bad id is not re-thrown on every render.
+ */
+const FORMATTER_CACHE = new Map<string, Intl.DateTimeFormat | null>();
+
+function formatter(locale: string, tz: string | undefined, style?: Intl.DateTimeFormatOptions["timeZoneName"]): Intl.DateTimeFormat | null {
+  const key = `${locale}|${tz ?? ""}|${style ?? ""}`;
+  const hit = FORMATTER_CACHE.get(key);
+  if (hit !== undefined) return hit;
+  let made: Intl.DateTimeFormat | null = null;
+  try {
+    // Throws RangeError on an unknown IANA id.
+    made = new Intl.DateTimeFormat(locale, {
+      hour: "numeric",
+      ...(tz ? { timeZone: tz } : {}),
+      ...(style ? { timeZoneName: style } : {}),
+    });
+  } catch {
+    made = null;
+  }
+  FORMATTER_CACHE.set(key, made);
+  return made;
+}
+
 /** Validate/normalize a session tz; returns undefined for blank or unknown zones. */
 function safeZone(tz?: string | null): string | undefined {
   const z = (tz || "").trim();
   if (!z) return undefined;
-  try {
-    // Throws RangeError on an unknown IANA id.
-    new Intl.DateTimeFormat("en-US", { timeZone: z });
-    return z;
-  } catch {
-    return undefined;
+  return formatter("en-US", z) ? z : undefined;
+}
+
+/**
+ * Zones that no English locale abbreviates, so CLDR gives a bare offset. Keyed on the ZONE, never
+ * on the shape of the offset string: Asia/Manila's own abbreviation is "PST" (Philippine Standard
+ * Time), which every reader parses as US Pacific, so it must be mapped explicitly rather than
+ * passed through because it "looks like" a real abbreviation.
+ *
+ * Asia/Dhaka's BST knowingly collides with Europe/London's; that ambiguity is in the abbreviations
+ * themselves, not in this table.
+ */
+const ZONE_ABBR_FALLBACK: Record<string, string> = {
+  "Asia/Riyadh": "AST",
+  "Asia/Qatar": "AST",
+  "Asia/Kuwait": "AST",
+  "Asia/Bahrain": "AST",
+  "Asia/Dubai": "GST",
+  "Asia/Karachi": "PKT",
+  "Asia/Dhaka": "BST",
+  "Asia/Singapore": "SGT",
+  "Asia/Manila": "PHT",
+};
+
+/**
+ * Locales probed for a real abbreviation, in order. Whether you get "IST" or "GMT+5:30" is a
+ * property of the LOCALE's CLDR data, not of the timeZoneName style: en-US says "GMT+5:30" for
+ * Asia/Kolkata while en-IN says "IST". Probing several beats switching to any single one, which
+ * would just move the problem (en-IN renders America/New_York as "GMT-4" instead of "EDT").
+ */
+const ABBR_LOCALES = ["en-US", "en-GB", "en-IN", "en-AU", "en-SG"];
+const REAL_ABBR = /^[A-Za-z]{2,5}$/;
+
+function abbrFrom(locale: string, d: Date, tz: string, style: Intl.DateTimeFormatOptions["timeZoneName"]): string {
+  const f = formatter(locale, tz, style);
+  if (!f) return "";
+  return f.formatToParts(d).find((p) => p.type === "timeZoneName")?.value || "";
+}
+
+/**
+ * The session zone as a human label at this instant: "IST", "EDT", "AST", or a compact offset for
+ * the ~half of IANA zones that have no abbreviation in any English locale. Returns "" for a blank
+ * or unknown zone, so callers can append it unconditionally.
+ *
+ * DST-correct by construction - the label is derived from the instant, so August gives EDT/BST and
+ * January gives EST/GMT.
+ */
+export function zoneLabel(d: Date, tz?: string | null): string {
+  const z = safeZone(tz);
+  if (!z) return "";
+
+  for (const locale of ABBR_LOCALES) {
+    const v = abbrFrom(locale, d, z, "short");
+    if (REAL_ABBR.test(v)) return v;
   }
+
+  const curated = ZONE_ABBR_FALLBACK[z];
+  if (curated) return curated;
+
+  // shortGeneric is the last resort, and it is only useful when it stays compact: for a zone with
+  // no abbreviation it returns a LONG name ("Japan Time", "São Paulo Time"), and zoneAbbr is
+  // rendered as a column header in the card's compact strip, where that overflows. A short offset
+  // is what ships today, so falling back to it is not a regression.
+  const generic = abbrFrom("en-US", d, z, "shortGeneric");
+  if (generic && generic.length <= 6 && !/^(GMT|UTC)/.test(generic)) return generic;
+
+  return abbrFrom("en-US", d, z, "short");
 }
 
 const DEFAULT_FORMAT: Intl.DateTimeFormatOptions = {
@@ -71,10 +160,15 @@ export function formatSessionTime(
   const vTz = viewerTimeZone();
 
   // Primary: rendered in the session's own zone (or the viewer's when none is stored).
+  // The label comes from zoneLabel, not from timeZoneName:"short" — en-US's CLDR short name for
+  // Asia/Kolkata is literally "GMT+5:30", which is what put that string in the session header.
+  // A session with no stored zone gets NO label: it is being drawn in the viewer's zone, and
+  // stamping it with one would assert the class is scheduled in a zone nobody chose.
   const primaryOpts: Intl.DateTimeFormatOptions = { ...fmt };
   if (sTz) primaryOpts.timeZone = sTz;
-  if (showZone) primaryOpts.timeZoneName = "short";
-  const primary = new Intl.DateTimeFormat("en-US", primaryOpts).format(d);
+  const base = new Intl.DateTimeFormat("en-US", primaryOpts).format(d);
+  const sLabel = showZone ? zoneLabel(d, sTz) : "";
+  const primary = sLabel ? `${base} ${sLabel}` : base;
 
   if (!dual || !sTz) return primary;
 
@@ -83,12 +177,27 @@ export function formatSessionTime(
   const inViewer = new Intl.DateTimeFormat("en-US", { ...fmt, timeZone: vTz || undefined }).format(d);
   if (inSession === inViewer) return primary;
 
-  const localTimeOnly = new Intl.DateTimeFormat("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    timeZone: vTz || undefined,
-  }).format(d);
-  return `${primary} (${localTimeOnly} your time)`;
+  // Include the viewer's DATE when their calendar day differs: an 8:00 AM Kolkata class read
+  // "(7:30 PM your time)" to a Los Angeles student under an Aug 21 header, when their instant is
+  // Aug 20 — the right clock on the wrong day.
+  const localOpts: Intl.DateTimeFormatOptions = sameCalendarDay(d, sTz, vTz)
+    ? { hour: "numeric", minute: "2-digit", timeZone: vTz || undefined }
+    : { month: "short", day: "numeric", hour: "numeric", minute: "2-digit", timeZone: vTz || undefined };
+  const localTime = new Intl.DateTimeFormat("en-US", localOpts).format(d);
+  const vLabel = zoneLabel(d, vTz);
+  return `${primary} (${localTime}${vLabel ? ` ${vLabel}` : ""}, your time)`;
+}
+
+/** Whether an instant falls on the same calendar date in both zones. */
+function sameCalendarDay(d: Date, aTz?: string, bTz?: string): boolean {
+  const key = (tz?: string) =>
+    new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      timeZone: tz || undefined,
+    }).format(d);
+  return key(aTz) === key(bTz);
 }
 
 export interface SessionTimeParts {
@@ -96,15 +205,18 @@ export interface SessionTimeParts {
   date: string;
   /** "6:00 PM" in the session zone. */
   time: string;
-  /** Session zone short label ("GMT+4", "IST") — "" when the session has no stored zone. */
+  /** Session zone short label ("IST", "EDT", "GMT+9") — "" when the session has no stored zone. */
   zoneAbbr: string;
   /** Viewer's local "8:30 PM", only when it differs from the session time; else null. */
   viewerTime: string | null;
+  /** Label for the VIEWER's own zone, so their half of the clock is stamped too; "" when there is
+   *  no viewer time to label. */
+  viewerZoneAbbr: string;
 }
 
 /** Split a session's time into pieces for compact strips (date / time / zone / viewer conversion). */
 export function sessionTimeParts(iso: string | null | undefined, sessionTz?: string | null): SessionTimeParts {
-  const empty: SessionTimeParts = { date: "-", time: "-", zoneAbbr: "", viewerTime: null };
+  const empty: SessionTimeParts = { date: "-", time: "-", zoneAbbr: "", viewerTime: null, viewerZoneAbbr: "" };
   if (!iso) return empty;
   const d = new Date(iso);
   if (isNaN(d.getTime())) return empty;
@@ -114,18 +226,15 @@ export function sessionTimeParts(iso: string | null | undefined, sessionTz?: str
   const date = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: sTz }).format(d);
   const time = new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit", timeZone: sTz }).format(d);
 
-  let zoneAbbr = "";
-  if (sTz) {
-    const parts = new Intl.DateTimeFormat("en-US", { hour: "numeric", timeZoneName: "short", timeZone: sTz }).formatToParts(d);
-    zoneAbbr = parts.find((p) => p.type === "timeZoneName")?.value || "";
-  }
+  // zoneLabel returns "" for a blank/unknown zone, so it subsumes the old `if (sTz)` guard.
+  const zoneAbbr = zoneLabel(d, sTz);
 
   let viewerTime: string | null = null;
   if (sTz) {
     const inViewer = new Intl.DateTimeFormat("en-US", { hour: "numeric", minute: "2-digit", timeZone: vTz || undefined }).format(d);
     if (inViewer !== time) viewerTime = inViewer;
   }
-  return { date, time, zoneAbbr, viewerTime };
+  return { date, time, zoneAbbr, viewerTime, viewerZoneAbbr: viewerTime ? zoneLabel(d, vTz) : "" };
 }
 
 /** Compact "H:MM AM" in the session zone + viewer suffix — for card chips where the date is elsewhere. */

--- a/lib/utils/unit-labels.ts
+++ b/lib/utils/unit-labels.ts
@@ -1,0 +1,39 @@
+/**
+ * What one unit of a course is called, on the ADMIN side.
+ *
+ * A course carries `module_only_structure`. It is vocabulary only: gating, scheduling and points
+ * are identical either way. The learner board already respects it, because the API hands it the
+ * computed `unitNoun`. The admin surfaces did not: they hardcoded "Week" in about a dozen strings,
+ * so an admin could flip the course to modules, watch the learner view change, and still be told
+ * "Week 7" by the builder they had just used to flip it.
+ *
+ * Mirrors `adaptive_quiz/structure_labels.py` on the backend. Keep the two in step.
+ */
+
+/** Something carrying the flag: a course detail, a list row, or a bare boolean holder. */
+export type UnitStructured = { module_only_structure?: boolean } | null | undefined;
+
+/** "Module" or "Week", capitalised for a heading or an eyebrow. */
+export function unitNoun(course: UnitStructured): "Module" | "Week" {
+  return course?.module_only_structure ? "Module" : "Week";
+}
+
+/** "module" or "week", for the middle of a sentence. */
+export function unitWord(course: UnitStructured): "module" | "week" {
+  return course?.module_only_structure ? "module" : "week";
+}
+
+/** "modules" or "weeks". */
+export function unitWordPlural(course: UnitStructured): "modules" | "weeks" {
+  return `${unitWord(course)}s` as "modules" | "weeks";
+}
+
+/** "Week 7" / "Module 7". Unit 0 is the entry step in both framings. */
+export function unitLabel(course: UnitStructured, n: number): string {
+  return n ? `${unitNoun(course)} ${n}` : "Get started";
+}
+
+/** "3 weeks" / "1 module". */
+export function unitCount(course: UnitStructured, n: number): string {
+  return `${n} ${n === 1 ? unitWord(course) : unitWordPlural(course)}`;
+}


### PR DESCRIPTION
Carries #1410: each dated card reads its own attendance, dashboard shows the next real sitting, timezone labels read IST/AST/GST etc. instead of raw offsets. BE counterpart #681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)