### PR TITLE
fix(admin): turnout chips counted students who had not enrolled, and a 0% column nobody earned

### DIFF
--- a/app/admin/manage-students/page.tsx
+++ b/app/admin/manage-students/page.tsx
@@ -844,7 +844,11 @@ export default function ManageStudentsPage() {
         escapeCsvValue(student.enrollment_count ?? 0),
         escapeCsvValue(student.most_active_course ?? t("adminManageStudents.noActivity")),
         stats ? escapeCsvValue(stats.completion_percentage.toFixed(1)) : t("adminManageStudents.na"),
-        stats ? escapeCsvValue(stats.attendance_percentage.toFixed(1)) : t("adminManageStudents.na"),
+        // Same rule as the table cell: a tenant with no roll-call activities has no attendance
+        // figure, and exporting "0.0" reads as a fact about the student rather than about us.
+        stats && stats.total_attendance_activities > 0
+          ? escapeCsvValue(stats.attendance_percentage.toFixed(1))
+          : t("adminManageStudents.na"),
         student.has_saved_resume
           ? t("adminManageStudents.resumeYes")
           : t("adminManageStudents.resumeNo"),

--- a/app/instructor/live-sessions/page.tsx
+++ b/app/instructor/live-sessions/page.tsx
@@ -64,7 +64,11 @@ const PROVIDER_META: Record<LiveSessionProvider, { label: string; icon: string; 
   manual: { label: "Online", icon: "mdi:web", color: "#6b7280" },
 };
 
+// The server decides. Its rule is evidence-first — cancelled, then "the host hung up", then the
+// clock — so a class the trainer has already ended reads Ended instead of staying Live until its
+// scheduled finish. The clock is only a fallback for a payload that predates the server field.
 function statusOf(s: InstructorLiveSession, now: number): SessionStatus {
+  if (s.status === "live" || s.status === "scheduled" || s.status === "ended") return s.status;
   const start = new Date(s.class_datetime).getTime();
   const end = start + (s.duration_minutes || 0) * 60_000;
   if (now >= start && now <= end) return "live";

--- a/components/admin/live-sessions/AttendanceCenter.tsx
+++ b/components/admin/live-sessions/AttendanceCenter.tsx
@@ -361,7 +361,7 @@ export function AttendanceCenter({ liveClassId, isRecurring, occurrences, meetin
         <Chip
           label={t("adminLiveSessions.rosterJoinedOfEnrolled", "{{joined}} of {{enrolled}} joined", {
             joined: roster.joined_count,
-            enrolled: roster.enrolled_count,
+            enrolled: roster.eligible_count ?? roster.enrolled_count,
           })}
           size="small"
           sx={{ fontWeight: 700, fontSize: "0.75rem", bgcolor: "color-mix(in srgb, var(--success-500) 16%, transparent)", color: "var(--success-500)" }}

--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -309,7 +309,7 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                   <Chip
                     label={t("adminLiveSessions.rosterJoinedOfEnrolled", "{{joined}} of {{enrolled}} joined", {
                       joined: occ.joined_count,
-                      enrolled: occ.enrolled_count,
+                      enrolled: occ.eligible_count ?? occ.enrolled_count,
                     })}
                     size="small"
                     sx={{

--- a/components/admin/live-sessions/LiveSessionRosterSection.tsx
+++ b/components/admin/live-sessions/LiveSessionRosterSection.tsx
@@ -149,7 +149,7 @@ export function LiveSessionRosterSection({
         <Chip
           label={t("adminLiveSessions.rosterJoinedOfEnrolled", "{{joined}} of {{enrolled}} joined", {
             joined: data.joined_count,
-            enrolled: data.enrolled_count,
+            enrolled: data.eligible_count ?? data.enrolled_count,
           })}
           size="small"
           sx={{

--- a/components/admin/manage-students/StudentsTable.tsx
+++ b/components/admin/manage-students/StudentsTable.tsx
@@ -703,7 +703,12 @@ export function StudentsTable({
                     >
                       {loadingStats ? (
                         <CircularProgress size={16} />
-                      ) : stats ? (
+                      ) : /* This column is fed by the roll-call activity system, not by live
+                             sessions. A tenant that has never created a roll-call activity has a
+                             zero denominator, and the cell rendered that as a red 0% bar for every
+                             student — a number no one had earned and no one could improve. With no
+                             activities there is nothing to report, so report nothing. */
+                      stats && stats.total_attendance_activities > 0 ? (
                         <Box sx={{ minWidth: { xs: 80, sm: 120 } }}>
                           <Box
                             sx={{

--- a/lib/services/admin/admin-live-activities.service.ts
+++ b/lib/services/admin/admin-live-activities.service.ts
@@ -173,6 +173,9 @@ export interface StaffParticipant {
 export interface LiveSessionRosterResponse {
   course_tagged: boolean;
   enrolled_count: number;
+  /** enrolled_count minus the students who joined the batch after this date. The honest
+   *  denominator for a turnout chip: "12 of 51" was really 12 of the 42 who could have come. */
+  eligible_count?: number;
   joined_count: number;
   missed_count: number;
   /** Whether the session has started / ended - so a non-attendee reads as Upcoming vs Missed. */
@@ -224,6 +227,9 @@ export interface TimelineOccurrence {
   ended_at: string | null;
   attendance_synced_at: string | null;
   enrolled_count: number;
+  /** enrolled_count minus the students who joined the batch after this date. The honest
+   *  denominator for a turnout chip: "12 of 51" was really 12 of the 42 who could have come. */
+  eligible_count?: number;
   joined_count: number;
   missed_count: number;
   students: RosterStudent[];
@@ -241,6 +247,9 @@ export interface OccurrenceTimelineResponse {
   is_recurring: boolean;
   course_tagged: boolean;
   enrolled_count: number;
+  /** enrolled_count minus the students who joined the batch after this date. The honest
+   *  denominator for a turnout chip: "12 of 51" was really 12 of the 42 who could have come. */
+  eligible_count?: number;
   occurrence_count: number;
   occurrences: TimelineOccurrence[];
   reliability_note: string;

--- a/lib/services/instructor.service.ts
+++ b/lib/services/instructor.service.ts
@@ -265,7 +265,9 @@ export interface InstructorLiveSession {
   join_link: string;
   is_upcoming: boolean;
   provider: LiveSessionProvider;
-  status: "live" | "scheduled" | "ended";
+  /** Server verdict: cancelled > ended (host hung up) > clock. "cancelled" only reaches the
+   *  create/detail responses — the list drops cancelled dates entirely. */
+  status: "live" | "scheduled" | "ended" | "cancelled";
   is_zoom: boolean;
   is_webinar: boolean;
   is_google_meet: boolean;


### PR DESCRIPTION
Frontend half of backend PR #689 / #690.

## 1. The turnout chip counted students who had not enrolled yet

`{joined} of {enrolled} joined` used `enrolled_count` — the roster **today**. On session 194's first sitting the admin read `12 of 51 joined` when 9 of those 51 had not joined the batch yet; the true figure is 12 of 42. The per-row "Not yet enrolled" label already existed, but no aggregate reflected it.

All three chips — roster, occurrence timeline, attendance centre — now render `eligible_count`, with `?? enrolled_count` so a payload from before the backend change still renders.

## 2. The trainer's status chip recomputed live/ended from the clock

`statusOf()` was `now >= start && now <= end` — pure wall clock, ticking every 30s, never refetching. A class the trainer had already hung up on stayed **Live** until its scheduled finish. The server's `status` is now authoritative (its rule is cancelled → ended → clock); the local clock stays only as a fallback for a payload without the field.

## 3. Manage Students showed a red 0% attendance bar for every student

That column is fed by the legacy roll-call **activity** system, not by live sessions. Client 33 has never created a roll-call activity, so `total_attendance_activities` is 0 for all 257 rows and the cell rendered a red `0%` progress bar for every student — and the CSV export shipped `0.0`. That is a statement about our data collection, not about the student.

With a zero denominator, the cell and the CSV field now read n/a.

## Verification

`tsc --noEmit` clean (this repo's CI does not typecheck, so it was run locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)