### PR TITLE
feat(admin): assign a ticket to a trainer from the tenant LMS

### DIFF
--- a/app/admin/tickets/[id]/page.tsx
+++ b/app/admin/tickets/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   Divider,
   Chip,
   IconButton,
+  MenuItem,
 } from "@mui/material";
 import { MainLayout } from "@/components/layout/MainLayout";
 import { useToast } from "@/components/common/Toast";
@@ -26,6 +27,10 @@ import { useAuth } from "@/lib/auth/auth-context";
 import { canAccessAdminArea } from "@/lib/auth/role-utils";
 import { uploadFile } from "@/lib/services/file-upload.service";
 import { ticketService, Ticket } from "@/lib/services/ticket.service";
+import {
+  adminInstructorsService,
+  InstructorRow,
+} from "@/lib/services/admin/admin-instructors.service";
 
 const MAX_ATTACHMENTS = 5;
 const MAX_FILE_MB = 50; // matches the backend cap for the report_issue module (images + video)
@@ -69,6 +74,8 @@ export default function AdminTicketDetailPage() {
   const [resolving, setResolving] = useState(false);
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const [reminding, setReminding] = useState(false);
+  const [staff, setStaff] = useState<InstructorRow[]>([]);
+  const [assigning, setAssigning] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const load = useCallback(async () => {
@@ -92,6 +99,51 @@ export default function AdminTicketDetailPage() {
   useEffect(() => {
     load();
   }, [load]);
+
+  // Who this ticket can be handed to. Approved teaching staff only — the same set the backend
+  // will accept, so the dropdown can't offer a choice the POST would reject.
+  useEffect(() => {
+    if (!isAdmin) return;
+    let cancelled = false;
+    adminInstructorsService
+      .listInstructors("approved")
+      .then((rows) => {
+        if (!cancelled) setStaff(rows);
+      })
+      .catch(() => {
+        // A failed staff list must not break the page — it just means no dropdown.
+        if (!cancelled) setStaff([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isAdmin]);
+
+  const handleAssign = async (instructorId: number | null) => {
+    if (!clientId || !ticket) return;
+    setAssigning(true);
+    try {
+      const updated = await ticketService.assignTicket(
+        clientId,
+        ticket.id,
+        instructorId,
+      );
+      setTicket(updated);
+      showToast(
+        instructorId
+          ? `Assigned to ${updated.assigned_to_user?.full_name || "staff"}`
+          : "Returned to the admin queue",
+        "success",
+      );
+    } catch (err) {
+      showToast(
+        err instanceof Error ? err.message : "Failed to assign ticket",
+        "error",
+      );
+    } finally {
+      setAssigning(false);
+    }
+  };
 
   const handleAddFiles = (incoming: FileList | null) => {
     if (!incoming) return;
@@ -442,17 +494,60 @@ export default function AdminTicketDetailPage() {
                     </Typography>
                   </Stack>
                 )}
-                {ticket.assigned_to_user && (
+                {/* Assignment was read-only here, and auto-routing only ever assigns content,
+                    video and quiz tickets — so a technical ticket could never acquire an owner
+                    from inside the tenant, and the Remind button (which needs one) never appeared.
+                    An admin can now hand any ticket to a member of staff, or take it back. */}
+                {isAdmin && staff.length > 0 ? (
                   <Stack direction="row" spacing={0.75} alignItems="center">
                     <IconWrapper icon="mdi:account-check-outline" size={14} color="var(--font-tertiary)" />
-                    <Typography variant="caption" sx={{ fontSize: "0.75rem" }}>
-                      Assigned to {ticket.assigned_to_user.full_name}
-                      {/* No assigner means the system auto-routed it rather than a human triaging. */}
-                      {ticket.assigned_by_user === null
-                        ? " (auto-routed)"
-                        : ` by ${ticket.assigned_by_user.full_name}`}
-                    </Typography>
+                    <TextField
+                      select
+                      size="small"
+                      variant="standard"
+                      value={ticket.assigned_to_user?.id ?? ""}
+                      disabled={assigning}
+                      onChange={(e) =>
+                        handleAssign(e.target.value === "" ? null : Number(e.target.value))
+                      }
+                      slotProps={{ input: { disableUnderline: true } }}
+                      sx={{
+                        minWidth: 180,
+                        "& .MuiInputBase-input": {
+                          fontSize: "0.75rem",
+                          color: "var(--font-secondary)",
+                          py: 0,
+                        },
+                      }}
+                    >
+                      <MenuItem value="">
+                        <em>Unassigned</em>
+                      </MenuItem>
+                      {staff.map((s) => (
+                        <MenuItem key={s.id} value={s.id} sx={{ fontSize: "0.8rem" }}>
+                          {s.full_name || s.email}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                    {ticket.assigned_to_user && ticket.assigned_by_user === null && (
+                      /* No assigner means the system routed it rather than a human triaging. */
+                      <Typography variant="caption" sx={{ fontSize: "0.7rem", color: "var(--font-tertiary)" }}>
+                        auto-routed
+                      </Typography>
+                    )}
                   </Stack>
+                ) : (
+                  ticket.assigned_to_user && (
+                    <Stack direction="row" spacing={0.75} alignItems="center">
+                      <IconWrapper icon="mdi:account-check-outline" size={14} color="var(--font-tertiary)" />
+                      <Typography variant="caption" sx={{ fontSize: "0.75rem" }}>
+                        Assigned to {ticket.assigned_to_user.full_name}
+                        {ticket.assigned_by_user === null
+                          ? " (auto-routed)"
+                          : ` by ${ticket.assigned_by_user.full_name}`}
+                      </Typography>
+                    </Stack>
+                  )
                 )}
                 {ticket.resolved_at && (
                   <Stack direction="row" spacing={0.75} alignItems="center">

--- a/lib/services/ticket.service.ts
+++ b/lib/services/ticket.service.ts
@@ -328,6 +328,24 @@ export const ticketService = {
     }
   },
 
+  /** Hand a ticket to a member of staff, or pass `null` to send it back to the admin queue.
+   *  The backend rejects a target outside this tenant or without a teaching role. */
+  async assignTicket(
+    clientId: number,
+    ticketId: number,
+    instructorId: number | null,
+  ): Promise<Ticket> {
+    try {
+      const { data } = await apiClient.post<Ticket>(
+        `/api/clients/${clientId}/tickets/${ticketId}/assign/`,
+        { instructor_id: instructorId },
+      );
+      return data;
+    } catch (e) {
+      throw unwrapError(e, "Failed to assign ticket");
+    }
+  },
+
   async listAssignees(clientId: number): Promise<TicketAssignee[]> {
     try {
       const { data } = await apiClient.get<{


### PR DESCRIPTION
Closes the second half of the ticket escalation complaint ("if the trainer didn't resolve the ticket, admin should be able to alert the trainer").

## The gap

The **Remind assignee** button shipped and works — but it only renders for a ticket that *has* an assignee, and a technical ticket can never acquire one from inside the tenant:

- auto-routing assigns `content`, `video` and `quiz` only (`apis/ticket_routing.py`);
- the tenant admin ticket surface **displays** the assignee but has no control to set one;
- the only assign UI in the product is in the super-admin portal, and that portal has no Remind.

Both of client 33's open tickets are technical and unassigned, so an admin looking at them today has no reachable path to the button built for their complaint.

The backend endpoint has existed all along: `POST /api/clients/<id>/tickets/<id>/assign/` with `{instructor_id}`, admin-gated, validating that the target is in the tenant and holds a teaching role.

## The change

The assignee line on the ticket detail page becomes a picker over **approved teaching staff** — the same set the backend will accept, so the dropdown can't offer a choice the POST would reject. `Unassigned` sends the ticket back to the admin queue. Auto-routed tickets still say so.

If the staff lookup fails the page degrades to the previous read-only line rather than breaking.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)