### PR TITLE
fix(admin): Cancel vanished the moment a class went live

### DIFF
--- a/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
+++ b/components/admin/live-sessions/LiveSessionOccurrenceTimeline.tsx
@@ -519,29 +519,36 @@ export function LiveSessionOccurrenceTimeline({ liveClassId, seriesTitle, timezo
                       >
                         {t("adminLiveSessions.renameOccurrence", "Rename")}
                       </Button>
-                      {/* Moving or cancelling only makes sense for a date that hasn't happened. */}
+                      {/* Moving a class only makes sense before it starts. */}
                       {occ.status === "scheduled" && (
-                        <>
-                          <Button
-                            size="small"
-                            variant="outlined"
-                            onClick={() => setEditing({ occ, mode: "reschedule" })}
-                            startIcon={<IconWrapper icon="mdi:calendar-clock" size={15} />}
-                            sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700, borderRadius: 999 }}
-                          >
-                            {t("adminLiveSessions.rescheduleOccurrence", "Reschedule")}
-                          </Button>
-                          <Button
-                            size="small"
-                            variant="outlined"
-                            color="error"
-                            onClick={() => setCancelTarget(occ)}
-                            startIcon={<IconWrapper icon="mdi:calendar-remove" size={15} />}
-                            sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700, borderRadius: 999 }}
-                          >
-                            {t("adminLiveSessions.cancelOccurrence", "Cancel this date")}
-                          </Button>
-                        </>
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          onClick={() => setEditing({ occ, mode: "reschedule" })}
+                          startIcon={<IconWrapper icon="mdi:calendar-clock" size={15} />}
+                          sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700, borderRadius: 999 }}
+                        >
+                          {t("adminLiveSessions.rescheduleOccurrence", "Reschedule")}
+                        </Button>
+                      )}
+                      {/* Cancelling a LIVE class is the case an admin needs most — a session
+                          running with a broken join link, or one that should not be happening.
+                          This used to be gated on "scheduled" alongside Reschedule, so the moment
+                          a class went live both buttons vanished and the admin was stuck watching
+                          it. The backend has always accepted it. */}
+                      {(occ.status === "scheduled" || occ.status === "live") && (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          color="error"
+                          onClick={() => setCancelTarget(occ)}
+                          startIcon={<IconWrapper icon="mdi:calendar-remove" size={15} />}
+                          sx={{ textTransform: "none", fontSize: "0.74rem", fontWeight: 700, borderRadius: 999 }}
+                        >
+                          {occ.status === "live"
+                            ? t("adminLiveSessions.cancelLiveOccurrence", "End and cancel this date")
+                            : t("adminLiveSessions.cancelOccurrence", "Cancel this date")}
+                        </Button>
                       )}
                       {ended && (
                         <Button


### PR DESCRIPTION
Reported live by the tenant admin: a session was running with a dead Zoom join link and there was no way to stop it — *"I cannot cancel it from my side when it is live."*

## Cause

Reschedule and Cancel shared one gate:

```tsx
{/* Moving or cancelling only makes sense for a date that hasn't happened. */}
{occ.status === "scheduled" && ( <Reschedule/> <Cancel/> )}
```

That reasoning is right for Reschedule and exactly backwards for Cancel. A class that is **currently running** is the case an admin most needs to stop — a session with a broken link, or one that shouldn't be happening. The moment the status flipped from `scheduled` to `live`, both buttons disappeared.

The backend has always accepted it; the endpoint is what I used to clear the stuck date on prod.

## Change

The two are now gated separately. Reschedule stays pre-start. Cancel covers `scheduled` and `live`, and relabels to **"End and cancel this date"** while a class is running so it's clear what it does.

## Correcting the record

An earlier note on backend PR #696 said the admin UI had *no* per-date cancel control at all. That was wrong — I grepped a stale working tree instead of `origin/main`. The control exists and ships in `77149f56`, the commit the tenant is serving; it was simply hidden by this status gate.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)